### PR TITLE
ensure type of third argument of service method

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -163,15 +163,21 @@ private:
     typename ServiceT,
     typename FunctorT,
     typename std::enable_if<
-      function_traits<FunctorT>::arity == 2 &&
+      function_traits<FunctorT>::arity == 2
+      >::type * = nullptr,
+    typename std::enable_if<
       std::is_same<
         typename function_traits<FunctorT>::template argument_type<0>,
         typename std::shared_ptr<typename ServiceT::Request>
-        >::value &&
+        >::value
+      >::type * = nullptr,
+    typename std::enable_if<
       std::is_same<
         typename function_traits<FunctorT>::template argument_type<1>,
         typename std::shared_ptr<typename ServiceT::Response>
-        >::value>::type * = nullptr>
+        >::value
+      >::type * = nullptr
+    >
   typename rclcpp::service::Service<ServiceT>::SharedPtr
   create_service_internal(
     rmw_service_t * service_handle,
@@ -188,15 +194,27 @@ private:
     typename ServiceT,
     typename FunctorT,
     typename std::enable_if<
-      function_traits<FunctorT>::arity == 3 &&
+      function_traits<FunctorT>::arity == 3
+      >::type * = nullptr,
+    typename std::enable_if<
       std::is_same<
         typename function_traits<FunctorT>::template argument_type<0>,
         std::shared_ptr<rmw_request_id_t>
-        >::value &&
+        >::value
+      >::type * = nullptr,
+    typename std::enable_if<
       std::is_same<
         typename function_traits<FunctorT>::template argument_type<1>,
         typename std::shared_ptr<typename ServiceT::Request>
-        >::value>::type * = nullptr>
+        >::value
+      >::type * = nullptr,
+    typename std::enable_if<
+      std::is_same<
+        typename function_traits<FunctorT>::template argument_type<2>,
+        typename std::shared_ptr<typename ServiceT::Response>
+        >::value
+      >::type * = nullptr
+    >
   typename rclcpp::service::Service<ServiceT>::SharedPtr
   create_service_internal(
     rmw_service_t * service_handle,


### PR DESCRIPTION
This will add the check of the type for the third argument of the `create_service_internal` method.

Required for ros2/rclcpp#29.

Passes on the farm (at least for the platforms which currently work):
* http://54.183.26.131:8080/view/ros2/job/ros2_batch_ci_linux/116/
* http://54.183.26.131:8080/view/ros2/job/ros2_batch_ci_osx/122/

@esteve @tfoote @wjwwood Please review.