### PR TITLE
Publish parameter events

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -22,6 +22,7 @@
 
 #include <rcl_interfaces/msg/list_parameters_result.hpp>
 #include <rcl_interfaces/msg/parameter_descriptor.hpp>
+#include <rcl_interfaces/msg/parameter_event.hpp>
 #include <rcl_interfaces/msg/set_parameters_result.hpp>
 
 #include <rclcpp/callback_group.hpp>
@@ -200,6 +201,8 @@ private:
   mutable std::mutex mutex_;
 
   std::map<std::string, rclcpp::parameter::ParameterVariant> parameters_;
+
+  publisher::Publisher::SharedPtr events_publisher_;
 
   template<
     typename ServiceT,

--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -25,6 +25,7 @@
 #include <rclcpp/parameter.hpp>
 
 #include <rcl_interfaces/msg/parameter.hpp>
+#include <rcl_interfaces/msg/parameter_event.hpp>
 #include <rcl_interfaces/msg/parameter_value.hpp>
 #include <rcl_interfaces/srv/describe_parameters.hpp>
 #include <rcl_interfaces/srv/get_parameters.hpp>
@@ -136,9 +137,8 @@ public:
   std::shared_future<std::vector<rcl_interfaces::msg::SetParametersResult>>
   set_parameters(
     std::vector<rclcpp::parameter::ParameterVariant> parameters,
-    std::function<
-      void(std::shared_future<std::vector<rcl_interfaces::msg::SetParametersResult>>)
-    > callback = nullptr)
+    std::function<void(std::shared_future<std::vector<rcl_interfaces::msg::SetParametersResult>>)> callback =
+    nullptr)
   {
     std::promise<std::vector<rcl_interfaces::msg::SetParametersResult>> promise_result;
     auto future_result = promise_result.get_future().share();
@@ -166,8 +166,8 @@ public:
   std::shared_future<rcl_interfaces::msg::SetParametersResult>
   set_parameters_atomically(
     std::vector<rclcpp::parameter::ParameterVariant> parameters,
-    std::function<void(
-      std::shared_future<rcl_interfaces::msg::SetParametersResult>)> callback = nullptr)
+    std::function<void(std::shared_future<rcl_interfaces::msg::SetParametersResult>)> callback =
+    nullptr)
   {
     std::promise<rcl_interfaces::msg::SetParametersResult> promise_result;
     auto future_result = promise_result.get_future().share();
@@ -196,8 +196,8 @@ public:
   list_parameters(
     std::vector<std::string> prefixes,
     uint64_t depth,
-    std::function<void(
-      std::shared_future<rcl_interfaces::msg::ListParametersResult>)> callback = nullptr)
+    std::function<void(std::shared_future<rcl_interfaces::msg::ListParametersResult>)> callback =
+    nullptr)
   {
     std::promise<rcl_interfaces::msg::ListParametersResult> promise_result;
     auto future_result = promise_result.get_future().share();
@@ -218,6 +218,15 @@ public:
     );
 
     return future_result;
+  }
+
+  template<typename FunctorT>
+  typename rclcpp::subscription::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr
+  on_parameter_event(FunctorT callback)
+  {
+    // TODO(esteve): remove hardcoded values
+    return node_->create_subscription<rcl_interfaces::msg::ParameterEvent>("parameter_events",
+             1000, callback);
   }
 
 private:


### PR DESCRIPTION
This PR publishes events whenever a parameters are updated, created or deleted.

I wasn't sure if this was only intended for `Node::set_parameters_atomically` or for any method that modifies parameters. See comment about "atomic" in https://github.com/ros2/rcl_interfaces/blob/master/rcl_interfaces/msg/ParameterEvent.msg

Connects to ros2/ros2#28

@dirk-thomas @jacquelinekay @tfoote @wjwwood 