### PR TITLE
Broken promise

### DIFF
--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -383,8 +383,8 @@ Node::list_parameters(
       size_t last_separator = kv.first.find_last_of('.');
       if (std::string::npos != last_separator) {
         std::string prefix = kv.first.substr(0, last_separator);
-        if (std::find(result.prefixes.cbegin(), result.prefixes.cend(),
-          prefix) == result.prefixes.cend())
+        if (std::find(result.prefixes.cbegin(), result.prefixes.cend(), prefix) ==
+          result.prefixes.cend())
         {
           result.prefixes.push_back(prefix);
         }

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -368,7 +368,9 @@ Node::list_parameters(
   // TODO(esteve): define parameter separator, use "." for now
   for (auto & kv : parameters_) {
     if (std::any_of(prefixes.cbegin(), prefixes.cend(), [&kv, &depth](const std::string & prefix) {
-      if (kv.first.find(prefix + ".") == 0) {
+      if (kv.first == prefix) {
+        return true;
+      } else if (kv.first.find(prefix + ".") == 0) {
         size_t length = prefix.length();
         std::string substr = kv.first.substr(length);
         // Cast as unsigned integer to avoid warning
@@ -379,11 +381,13 @@ Node::list_parameters(
     {
       result.names.push_back(kv.first);
       size_t last_separator = kv.first.find_last_of('.');
-      std::string prefix = kv.first.substr(0, last_separator);
-      if (std::find(result.prefixes.cbegin(), result.prefixes.cend(),
-        prefix) == result.prefixes.cend())
-      {
-        result.prefixes.push_back(prefix);
+      if (std::string::npos != last_separator) {
+        std::string prefix = kv.first.substr(0, last_separator);
+        if (std::find(result.prefixes.cbegin(), result.prefixes.cend(),
+          prefix) == result.prefixes.cend())
+        {
+          result.prefixes.push_back(prefix);
+        }
       }
     }
   }

--- a/rclcpp/include/rclcpp/parameter_service.hpp
+++ b/rclcpp/include/rclcpp/parameter_service.hpp
@@ -124,7 +124,7 @@ public:
       );
 
     list_parameters_service_ = node_->create_service<rcl_interfaces::srv::ListParameters>(
-      node_->get_name() + "__describe_parameters", [&node](
+      node_->get_name() + "__list_parameters", [&node](
         const std::shared_ptr<rmw_request_id_t> request_header,
         const std::shared_ptr<rcl_interfaces::srv::ListParameters::Request> request,
         std::shared_ptr<rcl_interfaces::srv::ListParameters::Response> response)


### PR DESCRIPTION
This PR makes sure that promises are not destroyed too early, adds more cases to the list_parameters verb and fixes the parameters service to listen on the appropriate topic.

Fixes #44 