### PR TITLE
Sync parameter events callbacks

### DIFF
--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -229,7 +229,7 @@ public:
 
   template<typename FunctorT>
   typename rclcpp::subscription::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr
-  on_parameter_event(FunctorT callback)
+  on_parameter_event(FunctorT & callback)
   {
     // TODO(esteve): remove hardcoded values
     return node_->create_subscription<rcl_interfaces::msg::ParameterEvent>("parameter_events",
@@ -306,6 +306,13 @@ public:
   {
     auto f = async_parameters_client_->list_parameters(parameter_prefixes, depth);
     return rclcpp::executors::spin_node_until_future_complete(*executor_, node_, f).get();
+  }
+
+  template<typename FunctorT>
+  typename rclcpp::subscription::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr
+  on_parameter_event(FunctorT & callback)
+  {
+    return async_parameters_client_->on_parameter_event(callback);
   }
 
 private:


### PR DESCRIPTION
Adds support for `on_parameter_event` to the `SyncParametersClient`

Connects to ros2/rclcpp#49