### PR TITLE
Fixes to support proper lifecycle of the rmw objects and other tear down issues

### DIFF
--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -54,7 +54,7 @@ public:
   : node_handle_(node_handle), client_handle_(client_handle), service_name_(service_name)
   {}
 
-  ~ClientBase()
+  virtual ~ClientBase()
   {
     if (client_handle_) {
       if (rmw_destroy_client(client_handle_) != RMW_RET_OK) {

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -57,9 +57,11 @@ public:
   {
     if (client_handle_) {
       if (rmw_destroy_client(client_handle_) == RMW_RET_ERROR) {
-        std::cerr << "Error in destruction of rmw client handle: " <<
-        (rmw_get_error_string() ? rmw_get_error_string() : "") <<
-          std::endl;
+        // *INDENT-OFF*
+        std::cerr << "Error in destruction of rmw client handle: "
+                  << (rmw_get_error_string() ? rmw_get_error_string() : "")
+                  << std::endl;
+        // *INDENT-ON*
       }
     }
   }

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <sstream>
 #include <utility>
 
 #include <rmw/error_handling.h>
@@ -56,12 +57,9 @@ public:
   ~ClientBase()
   {
     if (client_handle_) {
-      if (rmw_destroy_client(client_handle_) == RMW_RET_ERROR) {
-        // *INDENT-OFF*
-        std::cerr << "Error in destruction of rmw client handle: "
-                  << rmw_get_error_string_safe()
-                  << std::endl;
-        // *INDENT-ON*
+      if (rmw_destroy_client(client_handle_) != RMW_RET_OK) {
+        fprintf(stderr,
+          "Error in destruction of rmw client handle: %s\n", rmw_get_error_string_safe());
       }
     }
   }

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -59,7 +59,7 @@ public:
       if (rmw_destroy_client(client_handle_) == RMW_RET_ERROR) {
         // *INDENT-OFF*
         std::cerr << "Error in destruction of rmw client handle: "
-                  << (rmw_get_error_string() ? rmw_get_error_string() : "")
+                  << rmw_get_error_string_safe()
                   << std::endl;
         // *INDENT-ON*
       }

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -146,8 +146,12 @@ public:
     CallbackType cb)
   {
     int64_t sequence_number;
-    // TODO(wjwwood): Check the return code.
-    rmw_send_request(get_client_handle(), request.get(), &sequence_number);
+    if (RMW_RET_OK != rmw_send_request(get_client_handle(), request.get(), &sequence_number)) {
+      // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+      throw std::runtime_error(
+        std::string("failed to send request: ") + rmw_get_error_string_safe());
+      // *INDENT-ON*
+    }
 
     SharedPromise call_promise = std::make_shared<Promise>();
     SharedFuture f(call_promise->get_future());

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -162,8 +162,9 @@ protected:
         subscription->handle_message(message);
       }
     } else {
-      std::cout << "[rclcpp::error] take failed for subscription on topic: " <<
-        subscription->get_topic_name() << std::endl;
+      fprintf(stderr,
+        "[rclcpp::error] take failed for subscription on topic '%s': %s\n",
+        subscription->get_topic_name().c_str(), rmw_get_error_string_safe());
     }
   }
 
@@ -191,8 +192,9 @@ protected:
         service->handle_request(request_header, request);
       }
     } else {
-      std::cout << "[rclcpp::error] take failed for service on service: " <<
-        service->get_service_name() << std::endl;
+      fprintf(stderr,
+        "[rclcpp::error] take request failed for server of service '%s': %s\n",
+        service->get_service_name().c_str(), rmw_get_error_string_safe());
     }
   }
 
@@ -203,15 +205,19 @@ protected:
     std::shared_ptr<void> request_header = client->create_request_header();
     std::shared_ptr<void> response = client->create_response();
     bool taken = false;
-    rmw_take_response(
+    rmw_ret_t status = rmw_take_response(
       client->client_handle_,
       request_header.get(),
       response.get(),
       &taken);
-    if (taken) {
-      client->handle_response(request_header, response);
+    if (status == RMW_RET_OK) {
+      if (taken) {
+        client->handle_response(request_header, response);
+      }
     } else {
-      std::cout << "[rclcpp::error] take failed for service on client" << std::endl;
+      fprintf(stderr,
+        "[rclcpp::error] take response failed for client of service '%s': %s\n",
+        client->get_service_name().c_str(), rmw_get_error_string_safe());
     }
   }
 

--- a/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
@@ -48,7 +48,7 @@ public:
     }
   }
 
-  ~MultiThreadedExecutor() {}
+  virtual ~MultiThreadedExecutor() {}
 
   void
   spin()

--- a/rclcpp/include/rclcpp/executors/single_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/single_threaded_executor.hpp
@@ -42,7 +42,7 @@ public:
 
   SingleThreadedExecutor() {}
 
-  ~SingleThreadedExecutor() {}
+  virtual ~SingleThreadedExecutor() {}
 
   void spin()
   {

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -187,7 +187,7 @@ private:
 
   std::string name_;
 
-  rmw_node_t * node_handle_;
+  std::shared_ptr<rmw_node_t> node_handle_;
 
   rclcpp::context::Context::SharedPtr context_;
 
@@ -226,6 +226,7 @@ private:
   >
   typename rclcpp::service::Service<ServiceT>::SharedPtr
   create_service_internal(
+    std::shared_ptr<rmw_node_t> node_handle,
     rmw_service_t * service_handle,
     const std::string & service_name,
     FunctorT callback)
@@ -233,7 +234,7 @@ private:
     typename rclcpp::service::Service<ServiceT>::CallbackType callback_without_header =
       callback;
     return service::Service<ServiceT>::make_shared(
-      service_handle, service_name, callback_without_header);
+      node_handle, service_handle, service_name, callback_without_header);
   }
 
   template<
@@ -271,6 +272,7 @@ private:
   >
   typename rclcpp::service::Service<ServiceT>::SharedPtr
   create_service_internal(
+    std::shared_ptr<rmw_node_t> node_handle,
     rmw_service_t * service_handle,
     const std::string & service_name,
     FunctorT callback)
@@ -284,7 +286,7 @@ private:
     typename rclcpp::service::Service<ServiceT>::CallbackWithHeaderType callback_with_header =
       callback;
     return service::Service<ServiceT>::make_shared(
-      service_handle, service_name, callback_with_header);
+      node_handle, service_handle, service_name, callback_with_header);
   }
 };
 

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 
@@ -51,10 +52,11 @@ Node::Node(std::string node_name, context::Context::SharedPtr context)
       auto ret = rmw_destroy_node(node);
       if (ret != RMW_RET_OK) {
         // *INDENT-OFF*
-        std::cerr << "Error in destruction of rmw node handle: "
-                  << rmw_get_error_string_safe()
-                  << std::endl;
+        std::stringstream ss;
+        ss << "Error in destruction of rmw node handle: "
+           << rmw_get_error_string_safe() << '\n';
         // *INDENT-ON*
+        (std::cerr << ss.str()).flush();
       }
     }
   });

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -16,6 +16,7 @@
 #define RCLCPP_RCLCPP_NODE_IMPL_HPP_
 
 #include <algorithm>
+#include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -44,7 +45,17 @@ Node::Node(std::string node_name, context::Context::SharedPtr context)
 : name_(node_name), context_(context),
   number_of_subscriptions_(0), number_of_timers_(0), number_of_services_(0)
 {
-  node_handle_ = rmw_create_node(name_.c_str());
+  // Initialize node handle shared_ptr with custom deleter.
+  node_handle_.reset(rmw_create_node(name_.c_str()), [ = ](rmw_node_t * node) {
+    if (node_handle_) {
+      auto ret = rmw_destroy_node(node);
+      if (ret != RMW_RET_OK) {
+        std::cerr << "Error in destruction of rmw node handle: "
+                  << (rmw_get_error_string() ? rmw_get_error_string() : "")
+                  << std::endl;
+      }
+    }
+  });
   if (!node_handle_) {
     // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
     throw std::runtime_error(
@@ -54,7 +65,7 @@ Node::Node(std::string node_name, context::Context::SharedPtr context)
   }
 
   using rclcpp::callback_group::CallbackGroupType;
-  default_callback_group_ = \
+  default_callback_group_ =
     create_callback_group(CallbackGroupType::MutuallyExclusive);
   // TODO(esteve): remove hardcoded values
   events_publisher_ =
@@ -79,7 +90,7 @@ Node::create_publisher(std::string topic_name, size_t queue_size)
   using rosidl_generator_cpp::get_message_type_support_handle;
   auto type_support_handle = get_message_type_support_handle<MessageT>();
   rmw_publisher_t * publisher_handle = rmw_create_publisher(
-    node_handle_, type_support_handle, topic_name.c_str(), queue_size);
+    node_handle_.get(), type_support_handle, topic_name.c_str(), queue_size);
   if (!publisher_handle) {
     // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
     throw std::runtime_error(
@@ -88,7 +99,7 @@ Node::create_publisher(std::string topic_name, size_t queue_size)
     // *INDENT-ON*
   }
 
-  return publisher::Publisher::make_shared(publisher_handle);
+  return publisher::Publisher::make_shared(node_handle_, publisher_handle);
 }
 
 bool
@@ -116,7 +127,7 @@ Node::create_subscription(
   using rosidl_generator_cpp::get_message_type_support_handle;
   auto type_support_handle = get_message_type_support_handle<MessageT>();
   rmw_subscription_t * subscriber_handle = rmw_create_subscription(
-    node_handle_, type_support_handle, topic_name.c_str(), queue_size, ignore_local_publications);
+    node_handle_.get(), type_support_handle, topic_name.c_str(), queue_size, ignore_local_publications);
   if (!subscriber_handle) {
     // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
     throw std::runtime_error(
@@ -128,6 +139,7 @@ Node::create_subscription(
   using namespace rclcpp::subscription;
 
   auto sub = Subscription<MessageT>::make_shared(
+    node_handle_,
     subscriber_handle,
     topic_name,
     ignore_local_publications,
@@ -189,7 +201,7 @@ Node::create_client(
     get_service_type_support_handle<ServiceT>();
 
   rmw_client_t * client_handle = rmw_create_client(
-    this->node_handle_, service_type_support_handle, service_name.c_str());
+    this->node_handle_.get(), service_type_support_handle, service_name.c_str());
   if (!client_handle) {
     // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
     throw std::runtime_error(
@@ -201,6 +213,7 @@ Node::create_client(
   using namespace rclcpp::client;
 
   auto cli = Client<ServiceT>::make_shared(
+    node_handle_,
     client_handle,
     service_name);
 
@@ -231,7 +244,7 @@ Node::create_service(
     get_service_type_support_handle<ServiceT>();
 
   rmw_service_t * service_handle = rmw_create_service(
-    this->node_handle_, service_type_support_handle, service_name.c_str());
+    node_handle_.get(), service_type_support_handle, service_name.c_str());
   if (!service_handle) {
     // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
     throw std::runtime_error(
@@ -241,7 +254,7 @@ Node::create_service(
   }
 
   auto serv = create_service_internal<ServiceT>(
-    service_handle, service_name, callback);
+    node_handle_, service_handle, service_name, callback);
   auto serv_base_ptr = std::dynamic_pointer_cast<service::ServiceBase>(serv);
   if (group) {
     if (!group_in_node(group)) {

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -52,7 +52,7 @@ Node::Node(std::string node_name, context::Context::SharedPtr context)
       if (ret != RMW_RET_OK) {
         // *INDENT-OFF*
         std::cerr << "Error in destruction of rmw node handle: "
-                  << (rmw_get_error_string() ? rmw_get_error_string() : "")
+                  << rmw_get_error_string_safe()
                   << std::endl;
         // *INDENT-ON*
       }
@@ -62,7 +62,7 @@ Node::Node(std::string node_name, context::Context::SharedPtr context)
     // *INDENT-OFF*
     throw std::runtime_error(
       std::string("could not create node: ") +
-      (rmw_get_error_string() ? rmw_get_error_string() : ""));
+      rmw_get_error_string_safe());
     // *INDENT-ON*
   }
 
@@ -97,7 +97,7 @@ Node::create_publisher(std::string topic_name, size_t queue_size)
     // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
     throw std::runtime_error(
       std::string("could not create publisher: ") +
-      (rmw_get_error_string() ? rmw_get_error_string() : ""));
+      rmw_get_error_string_safe());
     // *INDENT-ON*
   }
 
@@ -135,7 +135,7 @@ Node::create_subscription(
     // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
     throw std::runtime_error(
       std::string("could not create subscription: ") +
-      (rmw_get_error_string() ? rmw_get_error_string() : ""));
+      rmw_get_error_string_safe());
     // *INDENT-ON*
   }
 
@@ -209,7 +209,7 @@ Node::create_client(
     // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
     throw std::runtime_error(
       std::string("could not create client: ") +
-      (rmw_get_error_string() ? rmw_get_error_string() : ""));
+      rmw_get_error_string_safe());
     // *INDENT-ON*
   }
 
@@ -252,7 +252,7 @@ Node::create_service(
     // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
     throw std::runtime_error(
       std::string("could not create service: ") +
-      (rmw_get_error_string() ? rmw_get_error_string() : ""));
+      rmw_get_error_string_safe());
     // *INDENT-ON*
   }
 

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -50,14 +50,16 @@ Node::Node(std::string node_name, context::Context::SharedPtr context)
     if (node_handle_) {
       auto ret = rmw_destroy_node(node);
       if (ret != RMW_RET_OK) {
+        // *INDENT-OFF*
         std::cerr << "Error in destruction of rmw node handle: "
                   << (rmw_get_error_string() ? rmw_get_error_string() : "")
                   << std::endl;
+        // *INDENT-ON*
       }
     }
   });
   if (!node_handle_) {
-    // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+    // *INDENT-OFF*
     throw std::runtime_error(
       std::string("could not create node: ") +
       (rmw_get_error_string() ? rmw_get_error_string() : ""));
@@ -127,7 +129,8 @@ Node::create_subscription(
   using rosidl_generator_cpp::get_message_type_support_handle;
   auto type_support_handle = get_message_type_support_handle<MessageT>();
   rmw_subscription_t * subscriber_handle = rmw_create_subscription(
-    node_handle_.get(), type_support_handle, topic_name.c_str(), queue_size, ignore_local_publications);
+    node_handle_.get(), type_support_handle,
+    topic_name.c_str(), queue_size, ignore_local_publications);
   if (!subscriber_handle) {
     // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
     throw std::runtime_error(

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -50,7 +50,7 @@ public:
       if (rmw_destroy_publisher(node_handle_.get(), publisher_handle_) == RMW_RET_ERROR) {
         // *INDENT-OFF*
         std::cerr << "Error in destruction of rmw publisher handle: "
-                  << (rmw_get_error_string() ? rmw_get_error_string() : "")
+                  << rmw_get_error_string_safe()
                   << std::endl;
         // *INDENT-ON*
       }

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -45,7 +45,7 @@ public:
   : node_handle_(node_handle), publisher_handle_(publisher_handle)
   {}
 
-  ~Publisher()
+  virtual ~Publisher()
   {
     if (publisher_handle_) {
       if (rmw_destroy_publisher(node_handle_.get(), publisher_handle_) != RMW_RET_OK) {

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -48,9 +48,11 @@ public:
   {
     if (publisher_handle_) {
       if (rmw_destroy_publisher(node_handle_.get(), publisher_handle_) == RMW_RET_ERROR) {
+        // *INDENT-OFF*
         std::cerr << "Error in destruction of rmw publisher handle: "
                   << (rmw_get_error_string() ? rmw_get_error_string() : "")
                   << std::endl;
+        // *INDENT-ON*
       }
     }
   }

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -17,6 +17,7 @@
 
 #include <iostream>
 #include <memory>
+#include <sstream>
 
 #include <rmw/error_handling.h>
 #include <rmw/rmw.h>
@@ -47,12 +48,13 @@ public:
   ~Publisher()
   {
     if (publisher_handle_) {
-      if (rmw_destroy_publisher(node_handle_.get(), publisher_handle_) == RMW_RET_ERROR) {
+      if (rmw_destroy_publisher(node_handle_.get(), publisher_handle_) != RMW_RET_OK) {
         // *INDENT-OFF*
-        std::cerr << "Error in destruction of rmw publisher handle: "
-                  << rmw_get_error_string_safe()
-                  << std::endl;
+        std::stringstream ss;
+        ss << "Error in destruction of rmw publisher handle: "
+           << rmw_get_error_string_safe() << '\n';
         // *INDENT-ON*
+        (std::cerr << ss.str()).flush();
       }
     }
   }

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -63,7 +63,13 @@ public:
   void
   publish(std::shared_ptr<MessageT> & msg)
   {
-    rmw_publish(publisher_handle_, msg.get());
+    rmw_ret_t status = rmw_publish(publisher_handle_, msg.get());
+    if (status != RMW_RET_OK) {
+      // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+      throw std::runtime_error(
+        std::string("failed to publish message: ") + rmw_get_error_string_safe());
+      // *INDENT-ON*
+    }
   }
 
 private:

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -154,7 +154,13 @@ public:
     std::shared_ptr<rmw_request_id_t> & req_id,
     std::shared_ptr<typename ServiceT::Response> & response)
   {
-    rmw_send_response(get_service_handle(), req_id.get(), response.get());
+    rmw_ret_t status = rmw_send_response(get_service_handle(), req_id.get(), response.get());
+    if (status != RMW_RET_OK) {
+      // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+      throw std::runtime_error(
+        std::string("failed to send response: ") + rmw_get_error_string_safe());
+      // *INDENT-ON*
+    }
   }
 
 private:

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -53,7 +53,7 @@ public:
   : node_handle_(node_handle), service_handle_(service_handle), service_name_(service_name)
   {}
 
-  ~ServiceBase()
+  virtual ~ServiceBase()
   {
     if (service_handle_) {
       if (rmw_destroy_service(service_handle_) != RMW_RET_OK) {

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -18,6 +18,7 @@
 #include <functional>
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <string>
 
 #include <rmw/error_handling.h>
@@ -55,10 +56,11 @@ public:
   ~ServiceBase()
   {
     if (service_handle_) {
-      if (rmw_destroy_service(service_handle_) == RMW_RET_ERROR) {
-        std::cerr << "Error in destruction of rmw service_handle_ handle: " <<
-          rmw_get_error_string_safe() <<
-          std::endl;
+      if (rmw_destroy_service(service_handle_) != RMW_RET_OK) {
+        std::stringstream ss;
+        ss << "Error in destruction of rmw service_handle_ handle: " <<
+          rmw_get_error_string_safe() << '\n';
+        (std::cerr << ss.str()).flush();
       }
     }
   }

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -57,7 +57,7 @@ public:
     if (service_handle_) {
       if (rmw_destroy_service(service_handle_) == RMW_RET_ERROR) {
         std::cerr << "Error in destruction of rmw service_handle_ handle: " <<
-        (rmw_get_error_string() ? rmw_get_error_string() : "") <<
+          rmw_get_error_string_safe() <<
           std::endl;
       }
     }

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -59,7 +59,7 @@ public:
     (void)ignore_local_publications_;
   }
 
-  ~SubscriptionBase()
+  virtual ~SubscriptionBase()
   {
     if (subscription_handle_) {
       if (rmw_destroy_subscription(node_handle_.get(), subscription_handle_) != RMW_RET_OK) {

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -63,7 +63,7 @@ public:
     if (subscription_handle_) {
       if (rmw_destroy_subscription(node_handle_.get(), subscription_handle_) == RMW_RET_ERROR) {
         std::cerr << "Error in destruction of rmw subscription handle: " <<
-        (rmw_get_error_string() ? rmw_get_error_string() : "") <<
+          rmw_get_error_string_safe() <<
           std::endl;
       }
     }

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -18,6 +18,7 @@
 #include <functional>
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <string>
 
 #include <rmw/error_handling.h>
@@ -61,10 +62,11 @@ public:
   ~SubscriptionBase()
   {
     if (subscription_handle_) {
-      if (rmw_destroy_subscription(node_handle_.get(), subscription_handle_) == RMW_RET_ERROR) {
-        std::cerr << "Error in destruction of rmw subscription handle: " <<
-          rmw_get_error_string_safe() <<
-          std::endl;
+      if (rmw_destroy_subscription(node_handle_.get(), subscription_handle_) != RMW_RET_OK) {
+        std::stringstream ss;
+        ss << "Error in destruction of rmw subscription handle: " <<
+          rmw_get_error_string_safe() << '\n';
+        (std::cerr << ss.str()).flush();
       }
     }
   }

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -53,7 +53,10 @@ public:
     subscription_handle_(subscription_handle),
     topic_name_(topic_name),
     ignore_local_publications_(ignore_local_publications)
-  {}
+  {
+    // To avoid unused private member warnings.
+    (void)ignore_local_publications_;
+  }
 
   ~SubscriptionBase()
   {

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -64,7 +64,7 @@ public:
     }
   }
 
-  ~TimerBase()
+  virtual ~TimerBase()
   {
     if (guard_condition_) {
       if (rmw_destroy_guard_condition(guard_condition_) != RMW_RET_OK) {
@@ -107,7 +107,7 @@ public:
     thread_ = std::thread(&GenericTimer<Clock>::run, this);
   }
 
-  ~GenericTimer()
+  virtual ~GenericTimer()
   {
     cancel();
     thread_.join();

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -18,6 +18,7 @@
 #include <chrono>
 #include <functional>
 #include <memory>
+#include <sstream>
 #include <thread>
 
 #include <rmw/error_handling.h>
@@ -66,10 +67,11 @@ public:
   ~TimerBase()
   {
     if (guard_condition_) {
-      if (rmw_destroy_guard_condition(guard_condition_) == RMW_RET_ERROR) {
-        std::cerr << "Error in TimerBase destructor, rmw_destroy_guard_condition failed: " <<
-          rmw_get_error_string_safe() <<
-          std::endl;
+      if (rmw_destroy_guard_condition(guard_condition_) != RMW_RET_OK) {
+        std::stringstream ss;
+        ss << "Error in TimerBase destructor, rmw_destroy_guard_condition failed: " <<
+          rmw_get_error_string_safe() << '\n';
+        (std::cerr << ss.str()).flush();
       }
     }
   }

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -58,7 +58,7 @@ public:
       // TODO(wjwwood): use custom exception
       throw std::runtime_error(
               std::string("failed to create guard condition: ") +
-              (rmw_get_error_string() ? rmw_get_error_string() : "")
+              rmw_get_error_string_safe()
       );
     }
   }
@@ -68,7 +68,7 @@ public:
     if (guard_condition_) {
       if (rmw_destroy_guard_condition(guard_condition_) == RMW_RET_ERROR) {
         std::cerr << "Error in TimerBase destructor, rmw_destroy_guard_condition failed: " <<
-        (rmw_get_error_string() ? rmw_get_error_string() : "") <<
+          rmw_get_error_string_safe() <<
           std::endl;
       }
     }


### PR DESCRIPTION
While prototyping the intra-process system I ran into some blocking teardown issues that manifested in my multi node examples during runtime. So I had to fix them. This will be matched with pr's on rmw and the implementations.

Connects ros2/ros2#69