### PR TITLE
add missing checks of the return for rmw publish / send calls

### DIFF
--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <utility>
 
+#include <rmw/error_handling.h>
 #include <rmw/rmw.h>
 
 #include <rclcpp/macros.hpp>
@@ -134,7 +135,14 @@ public:
   {
     int64_t sequence_number;
     // TODO(wjwwood): Check the return code.
-    rmw_send_request(get_client_handle(), request.get(), &sequence_number);
+    rmw_ret_t status = rmw_send_request(get_client_handle(), request.get(), &sequence_number);
+    if (status != RMW_RET_OK) {
+      // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+      throw std::runtime_error(
+        std::string("failed to send request: ") +
+        (rmw_get_error_string() ? rmw_get_error_string() : ""));
+      // *INDENT-ON*
+    }
 
     SharedPromise call_promise = std::make_shared<Promise>();
     SharedFuture f(call_promise->get_future());

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -162,8 +162,9 @@ protected:
         subscription->handle_message(message);
       }
     } else {
-      std::cout << "[rclcpp::error] take failed for subscription on topic: " <<
-        subscription->get_topic_name() << std::endl;
+      fprintf(stderr, "[rclcpp::error] take failed for subscription on topic '%s': %s\n",
+        subscription->get_topic_name().c_str(),
+        rmw_get_error_string() ? rmw_get_error_string() : "");
     }
   }
 
@@ -191,8 +192,8 @@ protected:
         service->handle_request(request_header, request);
       }
     } else {
-      std::cout << "[rclcpp::error] take failed for service on service: " <<
-        service->get_service_name() << std::endl;
+      fprintf(stderr, "[rclcpp::error] take failed for service '%s': %s\n",
+        service->get_service_name().c_str(), rmw_get_error_string() ? rmw_get_error_string() : "");
     }
   }
 
@@ -211,7 +212,8 @@ protected:
     if (taken) {
       client->handle_response(request_header, response);
     } else {
-      std::cout << "[rclcpp::error] take failed for service on client" << std::endl;
+      fprintf(stderr, "[rclcpp::error] take failed for service on client: %s\n",
+        rmw_get_error_string() ? rmw_get_error_string() : "");
     }
   }
 

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -17,6 +17,7 @@
 
 #include <memory>
 
+#include <rmw/error_handling.h>
 #include <rmw/rmw.h>
 
 #include <rclcpp/macros.hpp>
@@ -46,7 +47,14 @@ public:
   void
   publish(std::shared_ptr<MessageT> & msg)
   {
-    rmw_publish(publisher_handle_, msg.get());
+    rmw_ret_t status = rmw_publish(publisher_handle_, msg.get());
+    if (status != RMW_RET_OK) {
+      // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+      throw std::runtime_error(
+        std::string("failed to publish message: ") +
+        (rmw_get_error_string() ? rmw_get_error_string() : ""));
+      // *INDENT-ON*
+    }
   }
 
 private:

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <string>
 
+#include <rmw/error_handling.h>
 #include <rmw/rmw.h>
 
 #include <rclcpp/macros.hpp>
@@ -141,7 +142,14 @@ public:
     std::shared_ptr<rmw_request_id_t> & req_id,
     std::shared_ptr<typename ServiceT::Response> & response)
   {
-    rmw_send_response(get_service_handle(), req_id.get(), response.get());
+    rmw_ret_t status = rmw_send_response(get_service_handle(), req_id.get(), response.get());
+    if (status != RMW_RET_OK) {
+      // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+      throw std::runtime_error(
+        std::string("failed to send response: ") +
+        (rmw_get_error_string() ? rmw_get_error_string() : ""));
+      // *INDENT-ON*
+    }
   }
 
 private:


### PR DESCRIPTION
This was necessary to debug ros2/system_tests#14.

The change could be rolled into #51 or this change should be updated to use the new function `rmw_get_error_string_safe` introduced with #51.