### PR TITLE
Virtual functions to handle memory allocation in Executor::wait_for_work

### DIFF
--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -219,10 +219,10 @@ protected:
 
   /* The default implementation of Executor::get_allocated_handles dynamically
      allocates the requested handle array, and ignores the parent pointer. */
-  virtual void **get_allocated_handles(executor_handle_t /*handle_type*/,
-                                       size_t size)
+  virtual void ** get_allocated_handles(executor_handle_t /*handle_type*/,
+    size_t size)
   {
-    void **handles = static_cast<void **>(std::malloc(sizeof(void *) * size));
+    void ** handles = static_cast<void **>(std::malloc(sizeof(void *) * size));
     if (handles == NULL) {
       // TODO(wjwwood): Use a different error here? maybe std::bad_alloc?
       throw std::runtime_error("Could not malloc for handle pointers.");
@@ -232,7 +232,7 @@ protected:
 
   /* The default implementation of Executor::remove_allocated_handles uses
      dynamic memory deallocation. */
-  virtual void remove_allocated_handles(void **handle, size_t /*size*/)
+  virtual void remove_allocated_handles(void ** handle, size_t /*size*/)
   {
     std::free(handle);
   }
@@ -287,7 +287,7 @@ protected:
     rmw_subscriptions_t subscriber_handles;
     subscriber_handles.subscriber_count = number_of_subscriptions;
     subscriber_handles.subscribers =
-        get_allocated_handles(subscriber_handle, number_of_subscriptions);
+      get_allocated_handles(subscriber_handle, number_of_subscriptions);
     // Then fill the SubscriberHandles with ready subscriptions
     size_t subscriber_handle_index = 0;
     for (auto & subscription : subs) {
@@ -301,7 +301,7 @@ protected:
     rmw_services_t service_handles;
     service_handles.service_count = number_of_services;
     service_handles.services =
-        get_allocated_handles(service_handle, number_of_services);
+      get_allocated_handles(service_handle, number_of_services);
     // Then fill the ServiceHandles with ready services
     size_t service_handle_index = 0;
     for (auto & service : services) {
@@ -315,7 +315,7 @@ protected:
     rmw_clients_t client_handles;
     client_handles.client_count = number_of_clients;
     client_handles.clients =
-        get_allocated_handles(client_handle, number_of_clients);
+      get_allocated_handles(client_handle, number_of_clients);
 
     // Then fill the ServiceHandles with ready clients
     size_t client_handle_index = 0;
@@ -333,7 +333,7 @@ protected:
     rmw_guard_conditions_t guard_condition_handles;
     guard_condition_handles.guard_condition_count = number_of_guard_conds;
     guard_condition_handles.guard_conditions =
-        get_allocated_handles(guard_cond_handle, number_of_guard_conds);
+      get_allocated_handles(guard_cond_handle, number_of_guard_conds);
 
     // Put the global ctrl-c guard condition in
     assert(guard_condition_handles.guard_condition_count > 1);
@@ -360,10 +360,12 @@ protected:
     // If ctrl-c guard condition, return directly
     if (guard_condition_handles.guard_conditions[0] != 0) {
       // Make sure to free memory
-      remove_allocated_handles(subscriber_handles.subscribers, subscriber_handles.subscriber_count);
+      remove_allocated_handles(subscriber_handles.subscribers,
+        subscriber_handles.subscriber_count);
       remove_allocated_handles(service_handles.services, service_handles.service_count);
       remove_allocated_handles(client_handles.clients, client_handles.client_count);
-      remove_allocated_handles(guard_condition_handles.guard_conditions, guard_condition_handles.guard_condition_count);
+      remove_allocated_handles(guard_condition_handles.guard_conditions,
+        guard_condition_handles.guard_condition_count);
       return;
     }
     // Add the new work to the class's list of things waiting to be executed
@@ -400,7 +402,8 @@ protected:
     remove_allocated_handles(subscriber_handles.subscribers, subscriber_handles.subscriber_count);
     remove_allocated_handles(service_handles.services, service_handles.service_count);
     remove_allocated_handles(client_handles.clients, client_handles.client_count);
-    remove_allocated_handles(guard_condition_handles.guard_conditions, guard_condition_handles.guard_condition_count);
+    remove_allocated_handles(guard_condition_handles.guard_conditions,
+      guard_condition_handles.guard_condition_count);
   }
 
 /******************************/

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -219,7 +219,8 @@ protected:
 
   /* The default implementation of Executor::get_allocated_handles dynamically
      allocates the requested handle array, and ignores the parent pointer. */
-  virtual void **get_allocated_handles(executor_handle_t /*handle_type*/, unsigned long size)
+  virtual void **get_allocated_handles(executor_handle_t /*handle_type*/,
+                                       size_t size)
   {
     void **handles = static_cast<void **>(std::malloc(sizeof(void *) * size));
     if (handles == NULL) {

--- a/rclcpp/include/rclcpp/executors.hpp
+++ b/rclcpp/include/rclcpp/executors.hpp
@@ -18,6 +18,7 @@
 #include <future>
 #include <rclcpp/executors/multi_threaded_executor.hpp>
 #include <rclcpp/executors/single_threaded_executor.hpp>
+#include <rclcpp/executors/static_memory_executor.hpp>
 #include <rclcpp/node.hpp>
 #include <rclcpp/utilities.hpp>
 
@@ -28,6 +29,7 @@ namespace executors
 
 using rclcpp::executors::multi_threaded_executor::MultiThreadedExecutor;
 using rclcpp::executors::single_threaded_executor::SingleThreadedExecutor;
+using rclcpp::executors::static_memory_executor::StaticMemoryExecutor;
 
 template<typename FutureT>
 std::shared_future<FutureT> &

--- a/rclcpp/include/rclcpp/executors/static_memory_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/static_memory_executor.hpp
@@ -1,0 +1,132 @@
+// Copyright 2014 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP_RCLCPP_EXECUTORS_STATIC_MEMORY_EXECUTOR_HPP_
+#define RCLCPP_RCLCPP_EXECUTORS_STATIC_MEMORY_EXECUTOR_HPP_
+
+#include <cassert>
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+#include <rmw/rmw.h>
+
+#include <rclcpp/executor.hpp>
+#include <rclcpp/macros.hpp>
+#include <rclcpp/node.hpp>
+#include <rclcpp/utilities.hpp>
+#include <rclcpp/rate.hpp>
+
+#define MAX_SUBSCRIPTIONS 16
+#define MAX_SERVICES 8
+#define MAX_CLIENTS 16
+#define MAX_GUARD_CONDS 100
+
+namespace rclcpp
+{
+namespace executors
+{
+namespace static_memory_executor
+{
+
+/* StaticMemoryExecutor provides separate statically allocated arrays
+   for subscriptions, services, clients, and guard conditions and reimplements
+   get_allocated_handles and remove_allocated_handles.
+   The size of these arrays is defined at compile time. */
+class StaticMemoryExecutor : public executor::Executor
+{
+public:
+  RCLCPP_MAKE_SHARED_DEFINITIONS(StaticMemoryExecutor);
+
+  StaticMemoryExecutor()
+  {
+    memset(subscriptions, 0, MAX_SUBSCRIPTIONS);
+    memset(services, 0, MAX_SERVICES);
+    memset(clients, 0, MAX_CLIENTS);
+    memset(guard_conds, 0, MAX_GUARD_CONDS);
+  }
+
+  ~StaticMemoryExecutor() {}
+
+  virtual void spin()
+  {
+    while (rclcpp::utilities::ok()) {
+      auto any_exec = get_next_executable();
+      execute_any_executable(any_exec);
+    }
+  }
+
+protected:
+  void **get_allocated_handles(executor::executor_handle_t handle_type, unsigned long size)
+  {
+    switch(handle_type)
+    {
+      case executor::subscriber_handle:
+        if (size > MAX_SUBSCRIPTIONS)
+        {
+          std::cout << "subscriber error" << std::endl;
+          throw std::runtime_error("Size of requested handle pointer exceeded allocated memory for subscribers.");
+        }
+        return this->subscriptions;
+      case executor::service_handle:
+        if (size > MAX_SERVICES)
+        {
+          // TODO(jacquelinekay) change error if default impl is changed
+          throw std::runtime_error("Size of requested handle pointer exceeded allocated memory for services.");
+        }
+        return this->services;
+      case executor::client_handle:
+        if (size > MAX_CLIENTS)
+        {
+          // TODO(jacquelinekay) change error if default impl is changed
+          throw std::runtime_error("Size of requested handle pointer exceeded allocated memory for clients.");
+        }
+        return this->clients;
+      case executor::guard_cond_handle:
+        if (size > MAX_GUARD_CONDS)
+        {
+          // TODO(jacquelinekay) change error if default impl is changed
+          throw std::runtime_error("Size of requested handle pointer exceeded allocated memory for guard conditions.");
+        }
+        return this->guard_conds;
+      default:
+        break;
+    }
+    throw std::runtime_error("Invalid enum type in StaticMemoryExecutor::get_allocated_handles");
+  }
+
+  void remove_allocated_handles(void **handle, size_t size)
+  {
+    if (handle == NULL)
+    {
+      std::cout << "warning: Null pointer passed to StaticMemoryAllocator::remove_allocated_handles" << std::endl;
+      return;
+    }
+
+    memset(handle, 0, size);
+  }
+
+private:
+  RCLCPP_DISABLE_COPY(StaticMemoryExecutor);
+  void *subscriptions[MAX_SUBSCRIPTIONS];
+  void *services[MAX_SERVICES];
+  void *clients[MAX_CLIENTS];
+  void *guard_conds[MAX_GUARD_CONDS];
+};
+
+} /* namespace static_memory_executor */
+} /* namespace executors */
+} /* namespace rclcpp */
+
+#endif /* RCLCPP_RCLCPP_EXECUTORS_STATIC_MEMORY_EXECUTOR_HPP_ */

--- a/rclcpp/include/rclcpp/executors/static_memory_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/static_memory_executor.hpp
@@ -17,10 +17,10 @@
 
 #include <cassert>
 #include <cstdlib>
-#include <memory>
-#include <vector>
 
 #include <rmw/rmw.h>
+#include <memory>
+#include <vector>
 
 #include <rclcpp/executor.hpp>
 #include <rclcpp/macros.hpp>
@@ -33,24 +33,19 @@
 #define MAX_CLIENTS 16
 #define MAX_GUARD_CONDS 100
 
-namespace rclcpp
-{
-namespace executors
-{
-namespace static_memory_executor
-{
+namespace rclcpp {
+namespace executors {
+namespace static_memory_executor {
 
 /* StaticMemoryExecutor provides separate statically allocated arrays
    for subscriptions, services, clients, and guard conditions and reimplements
    get_allocated_handles and remove_allocated_handles.
    The size of these arrays is defined at compile time. */
-class StaticMemoryExecutor : public executor::Executor
-{
-public:
+class StaticMemoryExecutor : public executor::Executor {
+ public:
   RCLCPP_MAKE_SHARED_DEFINITIONS(StaticMemoryExecutor);
 
-  StaticMemoryExecutor()
-  {
+  StaticMemoryExecutor() {
     memset(subscriptions, 0, MAX_SUBSCRIPTIONS);
     memset(services, 0, MAX_SERVICES);
     memset(clients, 0, MAX_CLIENTS);
@@ -59,65 +54,63 @@ public:
 
   ~StaticMemoryExecutor() {}
 
-  virtual void spin()
-  {
+  virtual void spin() {
     while (rclcpp::utilities::ok()) {
       auto any_exec = get_next_executable();
       execute_any_executable(any_exec);
     }
   }
 
-protected:
-  void **get_allocated_handles(executor::executor_handle_t handle_type, unsigned long size)
-  {
-    switch(handle_type)
-    {
+ protected:
+  void **get_allocated_handles(executor::executor_handle_t handle_type,
+                               size_t size) {
+    switch (handle_type) {
       case executor::subscriber_handle:
-        if (size > MAX_SUBSCRIPTIONS)
-        {
+        if (size > MAX_SUBSCRIPTIONS) {
           std::cout << "subscriber error" << std::endl;
-          throw std::runtime_error("Size of requested handle pointer exceeded allocated memory for subscribers.");
+          throw std::runtime_error("Size of requested handle pointer exceeded" +
+                                   " allocated memory for subscribers.");
         }
         return this->subscriptions;
       case executor::service_handle:
-        if (size > MAX_SERVICES)
-        {
+        if (size > MAX_SERVICES) {
           // TODO(jacquelinekay) change error if default impl is changed
-          throw std::runtime_error("Size of requested handle pointer exceeded allocated memory for services.");
+          throw std::runtime_error("Size of requested handle pointer exceeded" +
+                                   " allocated memory for services.");
         }
         return this->services;
       case executor::client_handle:
-        if (size > MAX_CLIENTS)
-        {
+        if (size > MAX_CLIENTS) {
           // TODO(jacquelinekay) change error if default impl is changed
-          throw std::runtime_error("Size of requested handle pointer exceeded allocated memory for clients.");
+          throw std::runtime_error("Size of requested handle pointer exceeded" +
+                                   " allocated memory for clients.");
         }
         return this->clients;
       case executor::guard_cond_handle:
-        if (size > MAX_GUARD_CONDS)
-        {
+        if (size > MAX_GUARD_CONDS) {
           // TODO(jacquelinekay) change error if default impl is changed
-          throw std::runtime_error("Size of requested handle pointer exceeded allocated memory for guard conditions.");
+          throw std::runtime_error("Size of requested handle pointer exceeded" +
+                                   " allocated memory for guard conditions.");
         }
         return this->guard_conds;
       default:
         break;
     }
-    throw std::runtime_error("Invalid enum type in StaticMemoryExecutor::get_allocated_handles");
+    throw std::runtime_error
+        ("Invalid enum type in StaticMemoryExecutor::get_allocated_handles");
   }
 
-  void remove_allocated_handles(void **handle, size_t size)
-  {
-    if (handle == NULL)
-    {
-      std::cout << "warning: Null pointer passed to StaticMemoryAllocator::remove_allocated_handles" << std::endl;
+  void remove_allocated_handles(void **handle, size_t size) {
+    if (handle == NULL) {
+      std::cout << "warning: Null pointer passed to remove_allocated_handles."
+                << std::endl;
       return;
     }
 
     memset(handle, 0, size);
   }
 
-private:
+ private:
   RCLCPP_DISABLE_COPY(StaticMemoryExecutor);
   void *subscriptions[MAX_SUBSCRIPTIONS];
   void *services[MAX_SERVICES];

--- a/rclcpp/include/rclcpp/executors/static_memory_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/static_memory_executor.hpp
@@ -33,19 +33,24 @@
 #define MAX_CLIENTS 16
 #define MAX_GUARD_CONDS 100
 
-namespace rclcpp {
-namespace executors {
-namespace static_memory_executor {
+namespace rclcpp
+{
+namespace executors
+{
+namespace static_memory_executor
+{
 
 /* StaticMemoryExecutor provides separate statically allocated arrays
    for subscriptions, services, clients, and guard conditions and reimplements
    get_allocated_handles and remove_allocated_handles.
    The size of these arrays is defined at compile time. */
-class StaticMemoryExecutor : public executor::Executor {
- public:
+class StaticMemoryExecutor : public executor::Executor
+{
+public:
   RCLCPP_MAKE_SHARED_DEFINITIONS(StaticMemoryExecutor);
 
-  StaticMemoryExecutor() {
+  StaticMemoryExecutor()
+  {
     memset(subscriptions, 0, MAX_SUBSCRIPTIONS);
     memset(services, 0, MAX_SERVICES);
     memset(clients, 0, MAX_CLIENTS);
@@ -54,68 +59,71 @@ class StaticMemoryExecutor : public executor::Executor {
 
   ~StaticMemoryExecutor() {}
 
-  virtual void spin() {
+  virtual void spin()
+  {
     while (rclcpp::utilities::ok()) {
       auto any_exec = get_next_executable();
       execute_any_executable(any_exec);
     }
   }
 
- protected:
-  void **get_allocated_handles(executor::executor_handle_t handle_type,
-                               size_t size) {
+protected:
+  void ** get_allocated_handles(executor::executor_handle_t handle_type,
+    size_t size)
+  {
     switch (handle_type) {
       case executor::subscriber_handle:
         if (size > MAX_SUBSCRIPTIONS) {
           std::cout << "subscriber error" << std::endl;
           throw std::runtime_error("Size of requested handle pointer exceeded" +
-                                   " allocated memory for subscribers.");
+                  " allocated memory for subscribers.");
         }
         return this->subscriptions;
       case executor::service_handle:
         if (size > MAX_SERVICES) {
           // TODO(jacquelinekay) change error if default impl is changed
           throw std::runtime_error("Size of requested handle pointer exceeded" +
-                                   " allocated memory for services.");
+                  " allocated memory for services.");
         }
         return this->services;
       case executor::client_handle:
         if (size > MAX_CLIENTS) {
           // TODO(jacquelinekay) change error if default impl is changed
           throw std::runtime_error("Size of requested handle pointer exceeded" +
-                                   " allocated memory for clients.");
+                  " allocated memory for clients.");
         }
         return this->clients;
       case executor::guard_cond_handle:
         if (size > MAX_GUARD_CONDS) {
           // TODO(jacquelinekay) change error if default impl is changed
           throw std::runtime_error("Size of requested handle pointer exceeded" +
-                                   " allocated memory for guard conditions.");
+                  " allocated memory for guard conditions.");
         }
         return this->guard_conds;
       default:
         break;
     }
     throw std::runtime_error
-        ("Invalid enum type in StaticMemoryExecutor::get_allocated_handles");
+            ("Invalid enum type in StaticMemoryExecutor::get_allocated_handles");
   }
 
-  void remove_allocated_handles(void **handle, size_t size) {
+  void remove_allocated_handles(void ** handle, size_t size)
+  {
     if (handle == NULL) {
-      std::cout << "warning: Null pointer passed to remove_allocated_handles."
-                << std::endl;
+      std::cout << "warning: Null pointer passed to remove_allocated_handles." <<
+        std::endl;
       return;
     }
 
     memset(handle, 0, size);
   }
 
- private:
+private:
   RCLCPP_DISABLE_COPY(StaticMemoryExecutor);
-  void *subscriptions[MAX_SUBSCRIPTIONS];
-  void *services[MAX_SERVICES];
-  void *clients[MAX_CLIENTS];
-  void *guard_conds[MAX_GUARD_CONDS];
+  void * subscriptions[MAX_SUBSCRIPTIONS];
+  void * services[MAX_SERVICES];
+  void * clients[MAX_CLIENTS];
+  void * guard_conds[MAX_GUARD_CONDS];
 };
 
 } /* namespace static_memory_executor */


### PR DESCRIPTION
This PR places the `malloc` and `free` calls in `Executor::wait_for_work()` in two new virtual functions, `get_allocated_handles` and `remove_allocated_handles`. It also creates an example executor, `StaticMemoryExecutor`, which overrides the functions to provide statically allocated arrays for the handles.