### PR TITLE
Prevent instantiation of std::vectors in wait_for_work

### DIFF
--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -262,7 +262,9 @@ protected:
         has_invalid_weak_nodes = false;
         continue;
       }
-      for (auto & weak_group : node->callback_groups_) {
+
+      for (auto & weak_group : node->callback_groups_)
+      {
         auto group = weak_group.lock();
         if (!group || !group->can_be_taken_from_.load()) {
           continue;
@@ -284,7 +286,7 @@ protected:
           }));
     }
     // Use the number of subscriptions to allocate memory in the handles
-    size_t number_of_subscriptions = subs.size();
+    size_t number_of_subscriptions = subs->size();
     rmw_subscriptions_t subscriber_handles;
     subscriber_handles.subscriber_count = number_of_subscriptions;
     // TODO(wjwwood): Avoid redundant malloc's
@@ -342,6 +344,7 @@ protected:
     // Add 2 to the number for the ctrl-c guard cond and the executor's
     size_t start_of_timer_guard_conds = 2;
     size_t number_of_guard_conds = timers.size() + start_of_timer_guard_conds;
+
     rmw_guard_conditions_t guard_condition_handles;
     guard_condition_handles.guard_condition_count = number_of_guard_conds;
     guard_condition_handles.guard_conditions =

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -251,10 +251,17 @@ protected:
     // Collect the subscriptions and timers to be waited on
     bool has_invalid_weak_nodes = false;
 
+    /*
     auto subs = memory_strategy_->get_container_interface<rclcpp::subscription::SubscriptionBase::SharedPtr>();
     auto timers = memory_strategy_->get_container_interface<rclcpp::timer::TimerBase::SharedPtr>();
     auto services = memory_strategy_->get_container_interface<rclcpp::service::ServiceBase::SharedPtr>();
     auto clients = memory_strategy_->get_container_interface<rclcpp::client::ClientBase::SharedPtr>();
+    */
+    ContainerInterface<rclcpp::subscription::SubscriptionBase::SharedPtr> subs;
+    ContainerInterface<rclcpp::timer::TimerBase::SharedPtr> timers;
+    ContainerInterface<rclcpp::service::ServiceBase::SharedPtr> services;
+    ContainerInterface<rclcpp::client::ClientBase::SharedPtr>() clients;
+
 
     for (auto & weak_node : weak_nodes_) {
       auto node = weak_node.lock();

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -263,8 +263,7 @@ protected:
         continue;
       }
 
-      for (auto & weak_group : node->callback_groups_)
-      {
+      for (auto & weak_group : node->callback_groups_) {
         auto group = weak_group.lock();
         if (!group || !group->can_be_taken_from_.load()) {
           continue;
@@ -298,7 +297,7 @@ protected:
     }
     // Then fill the SubscriberHandles with ready subscriptions
     size_t subscriber_handle_index = 0;
-    for (auto & subscription : *subs) {
+    for (auto & subscription : * subs) {
       subscriber_handles.subscribers[subscriber_handle_index] = \
         subscription->subscription_handle_->data;
       subscriber_handle_index += 1;
@@ -316,7 +315,7 @@ protected:
     }
     // Then fill the ServiceHandles with ready services
     size_t service_handle_index = 0;
-    for (auto & service : *services) {
+    for (auto & service : * services) {
       service_handles.services[service_handle_index] = \
         service->service_handle_->data;
       service_handle_index += 1;
@@ -334,7 +333,7 @@ protected:
     }
     // Then fill the ServiceHandles with ready clients
     size_t client_handle_index = 0;
-    for (auto & client : *clients) {
+    for (auto & client : * clients) {
       client_handles.clients[client_handle_index] = \
         client->client_handle_->data;
       client_handle_index += 1;
@@ -361,7 +360,7 @@ protected:
       interrupt_guard_condition_->data;
     // Then fill the SubscriberHandles with ready subscriptions
     size_t guard_cond_handle_index = start_of_timer_guard_conds;
-    for (auto & timer : *timers) {
+    for (auto & timer : * timers) {
       guard_condition_handles.guard_conditions[guard_cond_handle_index] = \
         timer->guard_condition_->data;
       guard_cond_handle_index += 1;

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -303,7 +303,7 @@ protected:
     }
 
     // Use the number of services to allocate memory in the handles
-    size_t number_of_services = services.size();
+    size_t number_of_services = services->size();
     rmw_services_t service_handles;
     service_handles.service_count = number_of_services;
     service_handles.services =
@@ -321,7 +321,7 @@ protected:
     }
 
     // Use the number of clients to allocate memory in the handles
-    size_t number_of_clients = clients.size();
+    size_t number_of_clients = clients->size();
     rmw_clients_t client_handles;
     client_handles.client_count = number_of_clients;
     client_handles.clients =
@@ -341,8 +341,7 @@ protected:
     // Use the number of guard conditions to allocate memory in the handles
     // Add 2 to the number for the ctrl-c guard cond and the executor's
     size_t start_of_timer_guard_conds = 2;
-    size_t number_of_guard_conds = timers.size() + start_of_timer_guard_conds;
-
+    size_t number_of_guard_conds = timers->size() + start_of_timer_guard_conds;
     rmw_guard_conditions_t guard_condition_handles;
     guard_condition_handles.guard_condition_count = number_of_guard_conds;
     guard_condition_handles.guard_conditions =

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -255,12 +255,6 @@ protected:
     auto timers = memory_strategy_->get_timer_container_interface();
     auto services = memory_strategy_->get_service_container_interface();
     auto clients = memory_strategy_->get_client_container_interface();
-    /*
-    ContainerInterface<rclcpp::subscription::SubscriptionBase::SharedPtr> subs;
-    ContainerInterface<rclcpp::timer::TimerBase::SharedPtr> timers;
-    ContainerInterface<rclcpp::service::ServiceBase::SharedPtr> services;
-    ContainerInterface<rclcpp::client::ClientBase::SharedPtr>() clients;
-    */
 
     for (auto & weak_node : weak_nodes_) {
       auto node = weak_node.lock();
@@ -447,6 +441,10 @@ protected:
     memory_strategy_->return_handles(HandleType::guard_condition_handle,
       guard_condition_handles.guard_conditions);
 
+    subs->reset_container();
+    timers->reset_container();
+    services->reset_container();
+    clients->reset_container();
   }
 
 /******************************/

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -262,7 +262,6 @@ protected:
         has_invalid_weak_nodes = false;
         continue;
       }
-
       for (auto & weak_group : node->callback_groups_) {
         auto group = weak_group.lock();
         if (!group || !group->can_be_taken_from_.load()) {

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -263,8 +263,7 @@ protected:
         continue;
       }
 
-      for (auto & weak_group : node->callback_groups_)
-      {
+      for (auto & weak_group : node->callback_groups_) {
         auto group = weak_group.lock();
         if (!group || !group->can_be_taken_from_.load()) {
           continue;

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -251,17 +251,16 @@ protected:
     // Collect the subscriptions and timers to be waited on
     bool has_invalid_weak_nodes = false;
 
+    auto subs = memory_strategy_->get_subscription_container_interface();
+    auto timers = memory_strategy_->get_timer_container_interface();
+    auto services = memory_strategy_->get_service_container_interface();
+    auto clients = memory_strategy_->get_client_container_interface();
     /*
-    auto subs = memory_strategy_->get_container_interface<rclcpp::subscription::SubscriptionBase::SharedPtr>();
-    auto timers = memory_strategy_->get_container_interface<rclcpp::timer::TimerBase::SharedPtr>();
-    auto services = memory_strategy_->get_container_interface<rclcpp::service::ServiceBase::SharedPtr>();
-    auto clients = memory_strategy_->get_container_interface<rclcpp::client::ClientBase::SharedPtr>();
-    */
     ContainerInterface<rclcpp::subscription::SubscriptionBase::SharedPtr> subs;
     ContainerInterface<rclcpp::timer::TimerBase::SharedPtr> timers;
     ContainerInterface<rclcpp::service::ServiceBase::SharedPtr> services;
     ContainerInterface<rclcpp::client::ClientBase::SharedPtr>() clients;
-
+    */
 
     for (auto & weak_node : weak_nodes_) {
       auto node = weak_node.lock();

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -48,13 +48,15 @@ public:
   virtual void add_vector(std::vector<T> &vec) = 0;
 
 protected:
-
+  MemoryStrategy::SharedPtr memory_strategy_;
 };
 
+
 template<typename T>
-class ContainerInterface<T, MemoryStrategy>
+class DefaultContainerInterface : ContainerInterface<T>
 {
 public:
+
   T& operator[](size_t pos)
   {
     return container_[pos];
@@ -134,19 +136,36 @@ public:
     return std::free(ptr);
   }
 
-  /*
-  template<typename T>
-  typename std::shared_ptr<ContainerInterface<T>> get_container_interface()
+  virtual std::shared_ptr<ContainerInterface<subscription::SubscriptionBase::SharedPtr>> get_subscription_container_interface()
   {
-    return std::shared_ptr<ContainerInterface<T>>(new DefaultContainerInterface<T>);
+    return get_default_container_interface<subscription::SubscriptionBase::SharedPtr>();
   }
 
-  template<typename T>
-  void return_container_interface(std::shared_ptr<ContainerInterface<T>> container)
+  virtual std::shared_ptr<ContainerInterface<service::ServiceBase::SharedPtr>> get_service_container_interface()
+  {
+    return get_default_container_interface<service::ServiceBase::SharedPtr>();
+  }
+
+  virtual std::shared_ptr<ContainerInterface<client::ClientBase::SharedPtr>> get_client_container_interface()
+  {
+    return get_default_container_interface<client::ClientBase::SharedPtr>();
+  }
+
+  virtual std::shared_ptr<ContainerInterface<timer::TimerBase::SharedPtr>> get_timer_container_interface()
+  {
+    return get_default_container_interface<timer::TimerBase::SharedPtr>();
+  }
+
+  virtual void return_container_interface(std::shared_ptr<void> container)
   {
     container.reset();
   }
-  */
+
+  template<typename T>
+  std::shared_ptr<ContainerInterface<T>> get_default_container_interface()
+  {
+    return std::shared_ptr<ContainerInterface<T>>(new DefaultContainerInterface<T>);
+  }
 };
 
 

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -46,14 +46,11 @@ public:
   virtual T* begin() = 0;
   virtual T* end() = 0;
   virtual void add_vector(std::vector<T> &vec) = 0;
-
-protected:
-  MemoryStrategy::SharedPtr memory_strategy_;
 };
 
 
 template<typename T>
-class DefaultContainerInterface : ContainerInterface<T>
+class DefaultContainerInterface : public ContainerInterface<T>
 {
 public:
 
@@ -156,7 +153,7 @@ public:
     return get_default_container_interface<timer::TimerBase::SharedPtr>();
   }
 
-  virtual void return_container_interface(std::shared_ptr<void> container)
+  virtual void return_container_interface(std::shared_ptr<void*> & container)
   {
     container.reset();
   }

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -35,32 +35,32 @@ namespace memory_strategy
 {
 
 template<typename T>
-class ContainerInterface
+class SharedPtrContainer
 {
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(ContainerInterface);
-  virtual T& operator[](size_t pos) = 0;
-  virtual T& at(size_t pos) = 0;
+  RCLCPP_MAKE_SHARED_DEFINITIONS(SharedPtrContainer);
+  virtual std::shared_ptr<T> & operator[](size_t pos) = 0;
+  virtual std::shared_ptr<T> & at(size_t pos) = 0;
   virtual size_t size() const = 0;
-  virtual T* data() = 0;
-  virtual T* begin() = 0;
-  virtual T* end() = 0;
-  virtual void add_vector(const std::vector<T> &vec) = 0;
+  virtual std::shared_ptr<T> * data() = 0;
+  virtual std::shared_ptr<T> * begin() = 0;
+  virtual std::shared_ptr<T> * end() = 0;
+  virtual void add_vector(const std::vector<std::shared_ptr<T>> & vec) = 0;
   virtual void reset_container() = 0;
 };
 
 
 template<typename T>
-class DefaultContainerInterface : public ContainerInterface<T>
+class DefaultSharedPtrContainer : public SharedPtrContainer<T>
 {
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(DefaultContainerInterface);
+  RCLCPP_MAKE_SHARED_DEFINITIONS(DefaultSharedPtrContainer);
 
-  T& operator[](size_t pos)
+  std::shared_ptr<T> & operator[](size_t pos)
   {
     return container_[pos];
   }
-  T& at(size_t pos)
+  std::shared_ptr<T> & at(size_t pos)
   {
     return container_.at(pos);
   }
@@ -69,25 +69,24 @@ public:
     return container_.size();
   }
 
-  T* data()
+  std::shared_ptr<T> * data()
   {
     return container_.data();
   }
 
-  T* begin()
+  std::shared_ptr<T> * begin()
   {
     return data();
   }
 
-  T* end()
+  std::shared_ptr<T> * end()
   {
     return data() + size();
   }
 
-  void add_vector(const std::vector<T> &vec)
+  void add_vector(const std::vector<std::shared_ptr<T>> & vec)
   {
-    for (auto & entry : vec)
-    {
+    for (auto & entry : vec) {
       container_.push_back(entry);
     }
   }
@@ -98,7 +97,7 @@ public:
   }
 
 private:
-  std::vector<T> container_;
+  std::vector<std::shared_ptr<T>> container_;
 };
 
 class MemoryStrategy
@@ -135,32 +134,32 @@ public:
     return std::free(ptr);
   }
 
-  virtual ContainerInterface<subscription::SubscriptionBase::SharedPtr>::SharedPtr get_subscription_container_interface()
+  virtual SharedPtrContainer<subscription::SubscriptionBase>::SharedPtr
+  get_subscription_container_interface()
   {
-    return get_default_container_interface<subscription::SubscriptionBase::SharedPtr>();
+    return get_default_container_interface<subscription::SubscriptionBase>();
   }
 
-  virtual ContainerInterface<service::ServiceBase::SharedPtr>::SharedPtr get_service_container_interface()
+  virtual SharedPtrContainer<service::ServiceBase>::SharedPtr get_service_container_interface()
   {
-    return get_default_container_interface<service::ServiceBase::SharedPtr>();
+    return get_default_container_interface<service::ServiceBase>();
   }
 
-  virtual ContainerInterface<client::ClientBase::SharedPtr>::SharedPtr get_client_container_interface()
+  virtual SharedPtrContainer<client::ClientBase>::SharedPtr get_client_container_interface()
   {
-    return get_default_container_interface<client::ClientBase::SharedPtr>();
+    return get_default_container_interface<client::ClientBase>();
   }
 
-  virtual ContainerInterface<timer::TimerBase::SharedPtr>::SharedPtr get_timer_container_interface()
+  virtual SharedPtrContainer<timer::TimerBase>::SharedPtr get_timer_container_interface()
   {
-    return get_default_container_interface<timer::TimerBase::SharedPtr>();
+    return get_default_container_interface<timer::TimerBase>();
   }
 
 private:
   template<typename T>
-  typename ContainerInterface<T>::SharedPtr get_default_container_interface()
+  typename SharedPtrContainer<T>::SharedPtr get_default_container_interface()
   {
-    printf("Got default container interface\n");
-    return std::shared_ptr<ContainerInterface<T>>(new DefaultContainerInterface<T>);
+    return std::shared_ptr<SharedPtrContainer<T>>(new DefaultSharedPtrContainer<T>);
   }
 };
 

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -52,10 +52,9 @@ protected:
 };
 
 template<typename T>
-class DefaultContainerInterface : public ContainerInterface<T>
+class ContainerInterface<T, MemoryStrategy>
 {
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(DefaultContainerInterface);
   T& operator[](size_t pos)
   {
     return container_[pos];
@@ -135,6 +134,7 @@ public:
     return std::free(ptr);
   }
 
+  /*
   template<typename T>
   typename std::shared_ptr<ContainerInterface<T>> get_container_interface()
   {
@@ -146,6 +146,7 @@ public:
   {
     container.reset();
   }
+  */
 };
 
 

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -15,7 +15,6 @@
 #ifndef RCLCPP_RCLCPP_MEMORY_STRATEGY_HPP_
 #define RCLCPP_RCLCPP_MEMORY_STRATEGY_HPP_
 
-#include <iterator>
 #include <vector>
 
 #include <rclcpp/any_executable.hpp>

--- a/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
@@ -206,38 +206,60 @@ public:
   std::shared_ptr<memory_strategy::ContainerInterface<subscription::SubscriptionBase::SharedPtr>>
   get_subscription_container_interface()
   {
-    return std::make_shared<memory_strategy::ContainerInterface<subscription::SubscriptionBase::SharedPtr>>(subscription_container_);
+    return std::shared_ptr<memory_strategy::StaticContainerInterface<subscription::SubscriptionBase::SharedPtr, max_subscribers_>>(&subscription_container_);
   }
 
   std::shared_ptr<memory_strategy::ContainerInterface<service::ServiceBase::SharedPtr>>
   get_service_container_interface()
   {
-    return std::make_shared<memory_strategy::ContainerInterface<service::ServiceBase::SharedPtr>>(services_container_);
+    return std::shared_ptr<memory_strategy::StaticContainerInterface<service::ServiceBase::SharedPtr, max_services_>>(&services_container_);
   }
 
   std::shared_ptr<memory_strategy::ContainerInterface<client::ClientBase::SharedPtr>>
   get_client_container_interface()
   {
-    return std::make_shared<memory_strategy::ContainerInterface<client::ClientBase::SharedPtr>>(clients_container_);
+    return std::shared_ptr<memory_strategy::StaticContainerInterface<client::ClientBase::SharedPtr, max_clients_>>(&clients_container_);
   }
 
   std::shared_ptr<memory_strategy::ContainerInterface<timer::TimerBase::SharedPtr>>
   get_timer_container_interface()
   {
-    return std::make_shared<memory_strategy::ContainerInterface<timer::TimerBase::SharedPtr>>(timers_container_);
+    return std::shared_ptr<memory_strategy::StaticContainerInterface<timer::TimerBase::SharedPtr, max_guard_conditions_>>(&timers_container_);
   }
 
-  template<typename T>
-  void return_container_interface(std::shared_ptr<void> container)
+/*
+  void return_container_interface(std::shared_ptr<void*> &container)
   {
-    auto static_container = dynamic_cast<memory_strategy::StaticContainerInterface<T>>(container);
-    if (!static_container)
+    auto sub_container = dynamic_cast<memory_strategy::StaticContainerInterface<subscription::SubscriptionBase::SharedPtr, max_subscribers_>>(container);
+    if (sub_container)
     {
-      throw std::runtime_error("Failed to downcast container to static type");
+      sub_container->seq = 0;
+      return;
     }
-    static_container->seq = 0;
-  }
+    auto service_container = dynamic_cast<memory_strategy::StaticContainerInterface<service::ServiceBase::SharedPtr, max_services_>>(container);
+    if (service_container)
+    {
+      service_container->seq = 0;
+      return;
+    }
 
+    auto client_container = dynamic_cast<memory_strategy::StaticContainerInterface<client::ClientBase::SharedPtr, max_clients_>>(container);
+    if (client_container)
+    {
+      client_container->seq = 0;
+      return;
+    }
+
+    auto timer_container = dynamic_cast<memory_strategy::StaticContainerInterface<timer::TimerBase::SharedPtr, max_guard_conditions_>>(container);
+    if (timer_container)
+    {
+      timer_container->seq = 0;
+      return;
+    }
+
+    throw std::runtime_error("Failed to downcast container to static type");
+  }
+*/
 
 private:
   static const size_t pool_size_ = 1024;

--- a/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
@@ -241,7 +241,7 @@ public:
   std::shared_ptr<memory_strategy::SharedPtrContainer<service::ServiceBase>>
   get_service_container_interface()
   {
-    return std::shared_ptr<memory_strategy::StaticContainerInterface<service::ServiceBase::SharedPtr, max_services_>>(&services_container_);
+    return memory_strategy::StaticContainerInterface<service::ServiceBase::SharedPtr, max_services_>::SharedPtr(&services_container_);
   }
 
   memory_strategy::SharedPtrContainer<client::ClientBase>::SharedPtr
@@ -253,7 +253,7 @@ public:
   memory_strategy::SharedPtrContainer<timer::TimerBase>::SharedPtr
   get_timer_container_interface()
   {
-    return std::shared_ptr<memory_strategy::StaticContainerInterface<timer::TimerBase::SharedPtr, max_guard_conditions_>>(&timers_container_);
+    return std::shared_ptr<memory_strategy::StaticContainerInterface<timer::TimerBase::SharedPtr, max_timers_>>(&timers_container_);
   }
 
 private:
@@ -277,14 +277,10 @@ private:
 
   std::unordered_map<void *, size_t> memory_map_;
 
-  memory_strategy::StaticSharedPtrContainer<subscription::SubscriptionBase,
-  max_subscribers_>::SharedPtr subscription_container_;
-  memory_strategy::StaticSharedPtrContainer<service::ServiceBase,
-  max_services_>::SharedPtr services_container_;
-  memory_strategy::StaticSharedPtrContainer<client::ClientBase,
-  max_clients_>::SharedPtr clients_container_;
-  memory_strategy::StaticSharedPtrContainer<timer::TimerBase,
-  max_timers_>::SharedPtr timers_container_;
+  memory_strategy::StaticContainerInterface<subscription::SubscriptionBase::SharedPtr, max_subscribers_> subscription_container_;
+  memory_strategy::StaticContainerInterface<service::ServiceBase::SharedPtr, max_services_> services_container_;
+  memory_strategy::StaticContainerInterface<client::ClientBase::SharedPtr, max_clients_> clients_container_;
+  memory_strategy::StaticContainerInterface<timer::TimerBase::SharedPtr, max_timers_> timers_container_;
 };
 
 }  /* static_memory_strategy */

--- a/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
@@ -203,37 +203,32 @@ public:
     memset(ptr, 0, memory_map_[ptr]);
   }
 
-  /*
-  template<>
   std::shared_ptr<memory_strategy::ContainerInterface<subscription::SubscriptionBase::SharedPtr>>
-  get_container_interface()
+  get_subscription_container_interface()
   {
     return std::make_shared<memory_strategy::ContainerInterface<subscription::SubscriptionBase::SharedPtr>>(subscription_container_);
   }
 
-  template<>
   std::shared_ptr<memory_strategy::ContainerInterface<service::ServiceBase::SharedPtr>>
-  get_container_interface()
+  get_service_container_interface()
   {
     return std::make_shared<memory_strategy::ContainerInterface<service::ServiceBase::SharedPtr>>(services_container_);
   }
 
-  template<>
   std::shared_ptr<memory_strategy::ContainerInterface<client::ClientBase::SharedPtr>>
-  get_container_interface()
+  get_client_container_interface()
   {
     return std::make_shared<memory_strategy::ContainerInterface<client::ClientBase::SharedPtr>>(clients_container_);
   }
 
-  template<>
   std::shared_ptr<memory_strategy::ContainerInterface<timer::TimerBase::SharedPtr>>
-  get_container_interface()
+  get_timer_container_interface()
   {
     return std::make_shared<memory_strategy::ContainerInterface<timer::TimerBase::SharedPtr>>(timers_container_);
   }
 
   template<typename T>
-  void return_container_interface(std::shared_ptr<memory_strategy::ContainerInterface<T>> container)
+  void return_container_interface(std::shared_ptr<void> container)
   {
     auto static_container = dynamic_cast<memory_strategy::StaticContainerInterface<T>>(container);
     if (!static_container)
@@ -243,7 +238,6 @@ public:
     static_container->seq = 0;
   }
 
-*/
 
 private:
   static const size_t pool_size_ = 1024;

--- a/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
@@ -235,25 +235,25 @@ public:
   memory_strategy::SharedPtrContainer<subscription::SubscriptionBase>::SharedPtr
   get_subscription_container_interface()
   {
-    return subscription_container_;
+    return std::shared_ptr<memory_strategy::StaticContainerInterface<subscription::SubscriptionBase::SharedPtr, max_subscribers_>>(&subscription_container_);
   }
 
   std::shared_ptr<memory_strategy::SharedPtrContainer<service::ServiceBase>>
   get_service_container_interface()
   {
-    return services_container_;
+    return std::shared_ptr<memory_strategy::StaticContainerInterface<service::ServiceBase::SharedPtr, max_services_>>(&services_container_);
   }
 
   memory_strategy::SharedPtrContainer<client::ClientBase>::SharedPtr
   get_client_container_interface()
   {
-    return clients_container_;
+    return std::shared_ptr<memory_strategy::StaticContainerInterface<client::ClientBase::SharedPtr, max_clients_>>(&clients_container_);
   }
 
   memory_strategy::SharedPtrContainer<timer::TimerBase>::SharedPtr
   get_timer_container_interface()
   {
-    return timers_container_;
+    return std::shared_ptr<memory_strategy::StaticContainerInterface<timer::TimerBase::SharedPtr, max_guard_conditions_>>(&timers_container_);
   }
 
 private:

--- a/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
@@ -235,25 +235,25 @@ public:
   memory_strategy::SharedPtrContainer<subscription::SubscriptionBase>::SharedPtr
   get_subscription_container_interface()
   {
-    return std::shared_ptr<memory_strategy::StaticContainerInterface<subscription::SubscriptionBase::SharedPtr, max_subscribers_>>(&subscription_container_);
+    return subscription_container_;
   }
 
   std::shared_ptr<memory_strategy::SharedPtrContainer<service::ServiceBase>>
   get_service_container_interface()
   {
-    return memory_strategy::StaticContainerInterface<service::ServiceBase::SharedPtr, max_services_>::SharedPtr(&services_container_);
+    return services_container_;
   }
 
   memory_strategy::SharedPtrContainer<client::ClientBase>::SharedPtr
   get_client_container_interface()
   {
-    return std::shared_ptr<memory_strategy::StaticContainerInterface<client::ClientBase::SharedPtr, max_clients_>>(&clients_container_);
+    return clients_container_;
   }
 
   memory_strategy::SharedPtrContainer<timer::TimerBase>::SharedPtr
   get_timer_container_interface()
   {
-    return std::shared_ptr<memory_strategy::StaticContainerInterface<timer::TimerBase::SharedPtr, max_timers_>>(&timers_container_);
+    return timers_container_;
   }
 
 private:
@@ -277,10 +277,14 @@ private:
 
   std::unordered_map<void *, size_t> memory_map_;
 
-  memory_strategy::StaticContainerInterface<subscription::SubscriptionBase::SharedPtr, max_subscribers_> subscription_container_;
-  memory_strategy::StaticContainerInterface<service::ServiceBase::SharedPtr, max_services_> services_container_;
-  memory_strategy::StaticContainerInterface<client::ClientBase::SharedPtr, max_clients_> clients_container_;
-  memory_strategy::StaticContainerInterface<timer::TimerBase::SharedPtr, max_timers_> timers_container_;
+  memory_strategy::StaticSharedPtrContainer<subscription::SubscriptionBase,
+  max_subscribers_>::SharedPtr subscription_container_;
+  memory_strategy::StaticSharedPtrContainer<service::ServiceBase,
+  max_services_>::SharedPtr services_container_;
+  memory_strategy::StaticSharedPtrContainer<client::ClientBase,
+  max_clients_>::SharedPtr clients_container_;
+  memory_strategy::StaticSharedPtrContainer<timer::TimerBase,
+  max_timers_>::SharedPtr timers_container_;
 };
 
 }  /* static_memory_strategy */

--- a/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
@@ -30,6 +30,7 @@ class StaticSharedPtrContainer : public SharedPtrContainer<T>
 {
 public:
   RCLCPP_MAKE_SHARED_DEFINITIONS(StaticSharedPtrContainer);
+
   std::shared_ptr<T> & operator[](size_t pos)
   {
     return container_[pos];
@@ -42,7 +43,7 @@ public:
 
   size_t size() const
   {
-    return seq;
+    return effective_size_;
   }
 
   std::shared_ptr<T> * data()
@@ -57,33 +58,33 @@ public:
 
   std::shared_ptr<T> * end()
   {
-    if (seq > container_.size()) {
+    if (effective_size_ > container_.size()) {
       throw std::runtime_error("End of data exceeded maximum.");
     }
-    return data() + seq;
+    return data() + effective_size_;
   }
 
   void add_vector(const std::vector<std::shared_ptr<T>> & vec)
   {
-    if (vec.size() + seq > container_.size()) {
+    if (vec.size() + effective_size_ > container_.size()) {
       throw std::runtime_error("Requested size exceeded maximum.");
     }
     for (size_t i = 0; i < vec.size(); ++i) {
-      at(i + seq) = vec[i];
+      at(i + effective_size_) = vec[i];
     }
-    seq += vec.size();
+    effective_size_ += vec.size();
   }
 
   void reset_container()
   {
-    seq = 0;
+    effective_size_ = 0;
     for (auto & entry : container_) {
       entry.reset();
     }
   }
 
 private:
-  size_t seq = 0;
+  size_t effective_size_ = 0;
   std::array<std::shared_ptr<T>, S> container_;
 };
 


### PR DESCRIPTION
For real-time performance completeness, there should be an alternative to instantiating and allocating dynamically sized data structures in `Executor::wait_for_work`, even if they contain small objects like shared pointers. This pull request abstracts out the vectors instantiated in `wait_for_work` and replaces them with a `SharedPtrContainer` interface. In the default memory strategy, this interface is implemented with a `std::vector`, and in the `StaticMemoryStrategy`, it is implemented with a `std::array`.