### PR TITLE
workaround for Windows build

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -122,6 +122,10 @@ public:
 
   /* Create and return a Subscription. */
 
+  /* TODO(jacquelinekay):
+     Windows build breaks when static member function passed as default
+     argument to msg_mem_strat, nullptr is a workaround.
+   */
   template<typename MessageT>
   typename rclcpp::subscription::Subscription<MessageT>::SharedPtr
   create_subscription(
@@ -131,8 +135,7 @@ public:
     rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr,
     bool ignore_local_publications = false,
     typename rclcpp::message_memory_strategy::MessageMemoryStrategy<MessageT>::SharedPtr
-    msg_mem_strat =
-    rclcpp::message_memory_strategy::MessageMemoryStrategy<MessageT>::create_default());
+    msg_mem_strat = nullptr);
 
   /* Create a timer. */
   rclcpp::timer::WallTimer::SharedPtr

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -125,6 +125,12 @@ Node::create_subscription(
   typename message_memory_strategy::MessageMemoryStrategy<MessageT>::SharedPtr msg_mem_strat)
 {
   using rosidl_generator_cpp::get_message_type_support_handle;
+
+  if (!msg_mem_strat) {
+    msg_mem_strat =
+      rclcpp::message_memory_strategy::MessageMemoryStrategy<MessageT>::create_default();
+  }
+
   auto type_support_handle = get_message_type_support_handle<MessageT>();
   rmw_subscription_t * subscriber_handle = rmw_create_subscription(
     node_handle_.get(), type_support_handle,


### PR DESCRIPTION
For some reason, passing the static member function `MessageMemoryStrategy::create_default` as a default argument to `Node::create_subscription` causes a compilation error on Windows. This is a workaround to fix the build until we figure out what the heck is happening