### PR TITLE
Remove thread and guard condition from Timer

### DIFF
--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -99,6 +99,11 @@ public:
     last_interval_ = Clock::now();
   }
 
+  std::chrono::nanoseconds period() const
+  {
+    return period_;
+  }
+
 private:
   RCLCPP_DISABLE_COPY(GenericRate);
 


### PR DESCRIPTION
Connects to #6 

Depends on ros2/rclcpp/pull/66 and related PRs

Removes the 1 thread, 1 guard condition per timer scheme. Instead, the executor checks if a timer callback is eligible to be executed in `get_next_timer` based on the timer period and the last time the callback was triggered.

Initial CI run builds for all, and tests pass for all but Windows:

http://ci.ros2.org/job/ros2_batch_ci_linux/104/
http://ci.ros2.org/job/ros2_batch_ci_osx/45/
http://ci.ros2.org/job/ros2_batch_ci_windows/78/

I'm open to feedback regarding any tests that should be added to check timing correctness.