### PR TITLE
callback group must only store weak ptrs

### DIFF
--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -87,8 +87,8 @@ private:
   }
 
   CallbackGroupType type_;
-  std::vector<subscription::SubscriptionBase::SharedPtr> subscription_ptrs_;
-  std::vector<timer::TimerBase::SharedPtr> timer_ptrs_;
+  std::vector<subscription::SubscriptionBase::WeakPtr> subscription_ptrs_;
+  std::vector<timer::TimerBase::WeakPtr> timer_ptrs_;
   std::vector<service::ServiceBase::SharedPtr> service_ptrs_;
   std::vector<client::ClientBase::SharedPtr> client_ptrs_;
   std::atomic_bool can_be_taken_from_;

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -260,11 +260,17 @@ protected:
         if (!group || !group->can_be_taken_from_.load()) {
           continue;
         }
-        for (auto & subscription : group->subscription_ptrs_) {
-          subs.push_back(subscription);
+        for (auto & weak_subscription : group->subscription_ptrs_) {
+          auto subscription = weak_subscription.lock();
+          if (subscription) {
+            subs.push_back(subscription);
+          }
         }
-        for (auto & timer : group->timer_ptrs_) {
-          timers.push_back(timer);
+        for (auto & weak_timer : group->timer_ptrs_) {
+          auto timer = weak_timer.lock();
+          if (timer) {
+            timers.push_back(timer);
+          }
         }
         for (auto & service : group->service_ptrs_) {
           services.push_back(service);
@@ -444,8 +450,9 @@ protected:
         if (!group) {
           continue;
         }
-        for (auto subscription : group->subscription_ptrs_) {
-          if (subscription->subscription_handle_->data == subscriber_handle) {
+        for (auto weak_subscription : group->subscription_ptrs_) {
+          auto subscription = weak_subscription.lock();
+          if (subscription && subscription->subscription_handle_->data == subscriber_handle) {
             return subscription;
           }
         }
@@ -467,8 +474,9 @@ protected:
         if (!group) {
           continue;
         }
-        for (auto timer : group->timer_ptrs_) {
-          if (timer->guard_condition_->data == guard_condition_handle) {
+        for (auto weak_timer : group->timer_ptrs_) {
+          auto timer = weak_timer.lock();
+          if (timer && timer->guard_condition_->data == guard_condition_handle) {
             return timer;
           }
         }
@@ -583,7 +591,8 @@ protected:
       }
       for (auto & weak_group : node->callback_groups_) {
         auto group = weak_group.lock();
-        for (auto & t : group->timer_ptrs_) {
+        for (auto & weak_timer : group->timer_ptrs_) {
+          auto t = weak_timer.lock();
           if (t == timer) {
             return group;
           }
@@ -635,7 +644,8 @@ protected:
       }
       for (auto & weak_group : node->callback_groups_) {
         auto group = weak_group.lock();
-        for (auto & sub : group->subscription_ptrs_) {
+        for (auto & weak_sub : group->subscription_ptrs_) {
+          auto sub = weak_sub.lock();
           if (sub == subscription) {
             return group;
           }

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -44,6 +44,7 @@ class SubscriptionBase
   friend class rclcpp::executor::Executor;
 
 public:
+  typedef std::weak_ptr<SubscriptionBase> WeakPtr;
   RCLCPP_MAKE_SHARED_DEFINITIONS(SubscriptionBase);
 
   SubscriptionBase(
@@ -97,6 +98,7 @@ class Subscription : public SubscriptionBase
 public:
   typedef std::function<void (const std::shared_ptr<MessageT> &)> CallbackType;
   RCLCPP_MAKE_SHARED_DEFINITIONS(Subscription);
+  typedef std::weak_ptr<Subscription> WeakPtr;
 
   Subscription(
     std::shared_ptr<rmw_node_t> node_handle,

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -48,6 +48,7 @@ class TimerBase
 
 public:
   RCLCPP_MAKE_SHARED_DEFINITIONS(TimerBase);
+  typedef std::weak_ptr<TimerBase> WeakPtr;
 
   TimerBase(std::chrono::nanoseconds period, CallbackType callback)
   : period_(period),
@@ -100,6 +101,7 @@ class GenericTimer : public TimerBase
 
 public:
   RCLCPP_MAKE_SHARED_DEFINITIONS(GenericTimer);
+  typedef std::weak_ptr<GenericTimer> WeakPtr;
 
   GenericTimer(std::chrono::nanoseconds period, CallbackType callback)
   : TimerBase(period, callback), loop_rate_(period)


### PR DESCRIPTION
This is necessary to fix ros2/system_tests#26. Before the callback group was always keeping subscriptions and timer alive even when they ran out-of-scope in the user land code.