### PR TITLE
Memory and style cleanup in StaticMemoryStrategy

### DIFF
--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -169,6 +169,7 @@ protected:
     if (status != RMW_RET_OK) {
       throw std::runtime_error(rmw_get_error_string_safe());
     }
+    any_exec.reset();
   }
 
   static void
@@ -187,6 +188,7 @@ protected:
         "[rclcpp::error] take failed for subscription on topic '%s': %s\n",
         subscription->get_topic_name().c_str(), rmw_get_error_string_safe());
     }
+    subscription->return_message(message);
   }
 
   static void
@@ -791,13 +793,7 @@ protected:
   AnyExecutable::SharedPtr
   get_next_ready_executable()
   {
-    auto any_exec = AnyExecutable::SharedPtr(this->memory_strategy_->instantiate_next_executable());
-    return get_next_ready_executable(any_exec);
-  }
-
-  AnyExecutable::SharedPtr
-  get_next_ready_executable(AnyExecutable::SharedPtr any_exec)
-  {
+    auto any_exec = this->memory_strategy_->instantiate_next_executable();
     // Check the timers to see if there are any that are ready, if so return
     get_next_timer(any_exec);
     if (any_exec->timer) {
@@ -818,7 +814,7 @@ protected:
     if (any_exec->client) {
       return any_exec;
     }
-    // If there is neither a ready timer nor subscription, return a null ptr
+    // If there is no ready executable, return a null ptr
     any_exec.reset();
     return any_exec;
   }

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -169,7 +169,6 @@ protected:
     if (status != RMW_RET_OK) {
       throw std::runtime_error(rmw_get_error_string_safe());
     }
-    any_exec.reset();
   }
 
   static void
@@ -815,8 +814,7 @@ protected:
       return any_exec;
     }
     // If there is no ready executable, return a null ptr
-    any_exec.reset();
-    return any_exec;
+    return std::shared_ptr<AnyExecutable>();
   }
 
   template<typename T = std::milli>

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -791,7 +791,8 @@ protected:
   AnyExecutable::SharedPtr
   get_next_ready_executable()
   {
-    return get_next_ready_executable(this->memory_strategy_->instantiate_next_executable());
+    auto any_exec = AnyExecutable::SharedPtr(this->memory_strategy_->instantiate_next_executable());
+    return get_next_ready_executable(any_exec);
   }
 
   AnyExecutable::SharedPtr
@@ -842,7 +843,7 @@ protected:
     if (any_exec) {
       // If it is valid, check to see if the group is mutually exclusive or
       // not, then mark it accordingly
-      if (any_exec->callback_group->type_ == \
+      if (any_exec->callback_group && any_exec->callback_group->type_ == \
         callback_group::CallbackGroupType::MutuallyExclusive)
       {
         // It should not have been taken otherwise

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -49,9 +49,9 @@ public:
     this->free(handles);
   }
 
-  virtual executor::AnyExecutable * instantiate_next_executable()
+  virtual executor::AnyExecutable::SharedPtr instantiate_next_executable()
   {
-    return new executor::AnyExecutable;
+    return std::make_shared<executor::AnyExecutable>();
   }
 
   virtual void * alloc(size_t size)

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -49,9 +49,9 @@ public:
     this->free(handles);
   }
 
-  virtual executor::AnyExecutable::SharedPtr instantiate_next_executable()
+  virtual executor::AnyExecutable * instantiate_next_executable()
   {
-    return executor::AnyExecutable::SharedPtr(new executor::AnyExecutable);
+    return new executor::AnyExecutable;
   }
 
   virtual void * alloc(size_t size)

--- a/rclcpp/include/rclcpp/strategies/message_pool_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/message_pool_memory_strategy.hpp
@@ -25,7 +25,7 @@ namespace strategies
 namespace message_pool_memory_strategy
 {
 
-template<typename MessageT, size_t size,
+template<typename MessageT, size_t Size,
 typename std::enable_if<rosidl_generator_traits::has_fixed_size<MessageT>::value>::type * =
 nullptr>
 class MessagePoolMemoryStrategy
@@ -36,7 +36,7 @@ public:
   MessagePoolMemoryStrategy()
   : next_array_index_(0)
   {
-    for (size_t i = 0; i < size; ++i) {
+    for (size_t i = 0; i < Size; ++i) {
       pool_[i].msg_ptr_ = std::make_shared<MessageT>();
       pool_[i].used = false;
     }
@@ -45,7 +45,7 @@ public:
   std::shared_ptr<MessageT> borrow_message()
   {
     size_t current_index = next_array_index_;
-    next_array_index_ = (next_array_index_ + 1) % size;
+    next_array_index_ = (next_array_index_ + 1) % Size;
     if (pool_[current_index].used) {
       throw std::runtime_error("Tried to access message that was still in use! Abort.");
     }
@@ -58,7 +58,7 @@ public:
 
   void return_message(std::shared_ptr<MessageT> & msg)
   {
-    for (size_t i = 0; i < size; ++i) {
+    for (size_t i = 0; i < Size; ++i) {
       if (pool_[i].msg_ptr_ == msg) {
         pool_[i].used = false;
         return;
@@ -74,7 +74,7 @@ protected:
     bool used;
   };
 
-  std::array<PoolMember, size> pool_;
+  std::array<PoolMember, Size> pool_;
   size_t next_array_index_;
 
 };

--- a/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
@@ -54,22 +54,27 @@ public:
   {
     if (bounds_.pool_size_) {
       memory_pool_ = new void *[bounds_.pool_size_];
+      memset(memory_pool_, 0, bounds_.pool_size_ * sizeof(void *));
     }
 
     if (bounds_.max_subscriptions_) {
       subscription_pool_ = new void *[bounds_.max_subscriptions_];
+      memset(subscription_pool_, 0, bounds_.max_subscriptions_ * sizeof(void *));
     }
 
     if (bounds_.max_services_) {
       service_pool_ = new void *[bounds_.max_services_];
+      memset(service_pool_, 0, bounds_.max_services_ * sizeof(void *));
     }
 
     if (bounds_.max_clients_) {
       client_pool_ = new void *[bounds_.max_clients_];
+      memset(client_pool_, 0, bounds_.max_clients_ * sizeof(void *));
     }
 
     if (bounds_.max_guard_conditions_) {
       guard_condition_pool_ = new void *[bounds_.max_guard_conditions_];
+      memset(guard_condition_pool_, 0, bounds_.max_guard_conditions_ * sizeof(void *));
     }
 
     if (bounds_.max_executables_) {

--- a/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
@@ -154,6 +154,13 @@ public:
       throw std::runtime_error("Executable pool member was NULL");
     }
 
+    executable_pool_[prev_exec_seq_]->subscription.reset();
+    executable_pool_[prev_exec_seq_]->timer.reset();
+    executable_pool_[prev_exec_seq_]->service.reset();
+    executable_pool_[prev_exec_seq_]->client.reset();
+    executable_pool_[prev_exec_seq_]->callback_group.reset();
+    executable_pool_[prev_exec_seq_]->node.reset();
+
     return executable_pool_[prev_exec_seq_];
   }
 

--- a/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
@@ -49,42 +49,31 @@ class StaticMemoryStrategy : public memory_strategy::MemoryStrategy
 {
 public:
   StaticMemoryStrategy(ObjectPoolBounds bounds = ObjectPoolBounds())
-  : bounds_(bounds)
+  : bounds_(bounds), memory_pool_(nullptr), subscription_pool_(nullptr),
+    service_pool_(nullptr), guard_condition_pool_(nullptr), executable_pool_(nullptr)
   {
     if (bounds_.pool_size_) {
       memory_pool_ = new void *[bounds_.pool_size_];
-    } else {
-      memory_pool_ = 0;
     }
 
     if (bounds_.max_subscriptions_) {
       subscription_pool_ = new void *[bounds_.max_subscriptions_];
-    } else {
-      subscription_pool_ = 0;
     }
 
     if (bounds_.max_services_) {
       service_pool_ = new void *[bounds_.max_services_];
-    } else {
-      service_pool_ = 0;
     }
 
     if (bounds_.max_clients_) {
       client_pool_ = new void *[bounds_.max_clients_];
-    } else {
-      client_pool_ = 0;
     }
 
     if (bounds_.max_guard_conditions_) {
       guard_condition_pool_ = new void *[bounds_.max_guard_conditions_];
-    } else {
-      guard_condition_pool_ = 0;
     }
 
     if (bounds_.max_executables_) {
       executable_pool_ = new executor::AnyExecutable::SharedPtr[bounds_.max_executables_];
-    } else {
-      executable_pool_ = 0;
     }
 
     for (size_t i = 0; i < bounds_.max_executables_; ++i) {
@@ -158,16 +147,24 @@ public:
     (void)handles;
     switch (type) {
       case HandleType::subscription_handle:
-        memset(subscription_pool_, 0, bounds_.max_subscriptions_ * sizeof(void *));
+        if (bounds_.max_subscriptions_) {
+          memset(subscription_pool_, 0, bounds_.max_subscriptions_ * sizeof(void *));
+        }
         break;
       case HandleType::service_handle:
-        memset(service_pool_, 0, bounds_.max_services_ * sizeof(void *));
+        if (bounds_.max_services_) {
+          memset(service_pool_, 0, bounds_.max_services_ * sizeof(void *));
+        }
         break;
       case HandleType::client_handle:
-        memset(client_pool_, 0, bounds_.max_clients_ * sizeof(void *));
+        if (bounds_.max_clients_) {
+          memset(client_pool_, 0, bounds_.max_clients_ * sizeof(void *));
+        }
         break;
       case HandleType::guard_condition_handle:
-        memset(guard_condition_pool_, 0, bounds_.max_guard_conditions_ * sizeof(void *));
+        if (bounds_.max_guard_conditions_) {
+          memset(guard_condition_pool_, 0, bounds_.max_guard_conditions_ * sizeof(void *));
+        }
         break;
       default:
         throw std::runtime_error("Unrecognized enum, could not return handle memory.");

--- a/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
@@ -80,11 +80,21 @@ public:
 
   ~StaticMemoryStrategy()
   {
-    delete memory_pool_;
-    delete subscription_pool_;
-    delete service_pool_;
-    delete client_pool_;
-    delete guard_condition_pool_;
+    if (bounds_.pool_size_ > 0) {
+      delete memory_pool_;
+    }
+    if (bounds_.max_subscriptions_ > 0) {
+      delete subscription_pool_;
+    }
+    if (bounds_.max_services_ > 0) {
+      delete service_pool_;
+    }
+    if (bounds_.max_clients_ > 0) {
+      delete client_pool_;
+    }
+    if (bounds_.max_guard_conditions_ > 0) {
+      delete guard_condition_pool_;
+    }
   }
 
   void ** borrow_handles(HandleType type, size_t number_of_handles)

--- a/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
@@ -30,18 +30,53 @@ namespace static_memory_strategy
 struct ObjectPoolBounds
 {
 public:
-  size_t max_subscriptions_;
-  size_t max_services_;
-  size_t max_clients_;
-  size_t max_executables_;
-  size_t max_guard_conditions_;
-  size_t pool_size_;
+  size_t max_subscriptions;
+  size_t max_services;
+  size_t max_clients;
+  size_t max_executables;
+  size_t max_guard_conditions;
+  size_t pool_size;
 
-  ObjectPoolBounds(size_t subs = 10, size_t services = 10, size_t clients = 10,
-    size_t executables = 1, size_t guard_conditions = 2, size_t pool = 1024)
-  : max_subscriptions_(subs), max_services_(services), max_clients_(clients),
-    max_executables_(executables), max_guard_conditions_(guard_conditions), pool_size_(pool)
+  ObjectPoolBounds()
+  : max_subscriptions(10), max_services(10), max_clients(10),
+    max_executables(1), max_guard_conditions(2), pool_size(1024)
   {}
+
+  ObjectPoolBounds & set_max_subscriptions(size_t subscriptions)
+  {
+    max_subscriptions = subscriptions;
+    return *this;
+  }
+
+  ObjectPoolBounds & set_max_services(size_t services)
+  {
+    max_services = services;
+    return *this;
+  }
+
+  ObjectPoolBounds & set_max_clients(size_t clients)
+  {
+    max_clients = clients;
+    return *this;
+  }
+
+  ObjectPoolBounds & set_max_guard_conditions(size_t guard_conditions)
+  {
+    max_guard_conditions = guard_conditions;
+    return *this;
+  }
+
+  ObjectPoolBounds & set_max_executables(size_t executables)
+  {
+    max_executables = executables;
+    return *this;
+  }
+
+  ObjectPoolBounds & set_memory_pool_size(size_t pool)
+  {
+    pool_size = pool;
+    return *this;
+  }
 };
 
 
@@ -52,36 +87,36 @@ public:
   : bounds_(bounds), memory_pool_(nullptr), subscription_pool_(nullptr),
     service_pool_(nullptr), guard_condition_pool_(nullptr), executable_pool_(nullptr)
   {
-    if (bounds_.pool_size_) {
-      memory_pool_ = new void *[bounds_.pool_size_];
-      memset(memory_pool_, 0, bounds_.pool_size_ * sizeof(void *));
+    if (bounds_.pool_size) {
+      memory_pool_ = new void *[bounds_.pool_size];
+      memset(memory_pool_, 0, bounds_.pool_size * sizeof(void *));
     }
 
-    if (bounds_.max_subscriptions_) {
-      subscription_pool_ = new void *[bounds_.max_subscriptions_];
-      memset(subscription_pool_, 0, bounds_.max_subscriptions_ * sizeof(void *));
+    if (bounds_.max_subscriptions) {
+      subscription_pool_ = new void *[bounds_.max_subscriptions];
+      memset(subscription_pool_, 0, bounds_.max_subscriptions * sizeof(void *));
     }
 
-    if (bounds_.max_services_) {
-      service_pool_ = new void *[bounds_.max_services_];
-      memset(service_pool_, 0, bounds_.max_services_ * sizeof(void *));
+    if (bounds_.max_services) {
+      service_pool_ = new void *[bounds_.max_services];
+      memset(service_pool_, 0, bounds_.max_services * sizeof(void *));
     }
 
-    if (bounds_.max_clients_) {
-      client_pool_ = new void *[bounds_.max_clients_];
-      memset(client_pool_, 0, bounds_.max_clients_ * sizeof(void *));
+    if (bounds_.max_clients) {
+      client_pool_ = new void *[bounds_.max_clients];
+      memset(client_pool_, 0, bounds_.max_clients * sizeof(void *));
     }
 
-    if (bounds_.max_guard_conditions_) {
-      guard_condition_pool_ = new void *[bounds_.max_guard_conditions_];
-      memset(guard_condition_pool_, 0, bounds_.max_guard_conditions_ * sizeof(void *));
+    if (bounds_.max_guard_conditions) {
+      guard_condition_pool_ = new void *[bounds_.max_guard_conditions];
+      memset(guard_condition_pool_, 0, bounds_.max_guard_conditions * sizeof(void *));
     }
 
-    if (bounds_.max_executables_) {
-      executable_pool_ = new executor::AnyExecutable::SharedPtr[bounds_.max_executables_];
+    if (bounds_.max_executables) {
+      executable_pool_ = new executor::AnyExecutable::SharedPtr[bounds_.max_executables];
     }
 
-    for (size_t i = 0; i < bounds_.max_executables_; ++i) {
+    for (size_t i = 0; i < bounds_.max_executables; ++i) {
       executable_pool_[i] = std::make_shared<executor::AnyExecutable>();
     }
 
@@ -89,27 +124,27 @@ public:
     exec_seq_ = 0;
 
     // Reserve pool_size_ buckets in the memory map.
-    memory_map_.reserve(bounds_.pool_size_);
-    for (size_t i = 0; i < bounds_.pool_size_; ++i) {
+    memory_map_.reserve(bounds_.pool_size);
+    for (size_t i = 0; i < bounds_.pool_size; ++i) {
       memory_map_[memory_pool_[i]] = 0;
     }
   }
 
   ~StaticMemoryStrategy()
   {
-    if (bounds_.pool_size_) {
+    if (bounds_.pool_size) {
       delete[] memory_pool_;
     }
-    if (bounds_.max_subscriptions_) {
+    if (bounds_.max_subscriptions) {
       delete[] subscription_pool_;
     }
-    if (bounds_.max_services_) {
+    if (bounds_.max_services) {
       delete[] service_pool_;
     }
-    if (bounds_.max_clients_) {
+    if (bounds_.max_clients) {
       delete[] client_pool_;
     }
-    if (bounds_.max_guard_conditions_) {
+    if (bounds_.max_guard_conditions) {
       delete[] guard_condition_pool_;
     }
   }
@@ -118,25 +153,25 @@ public:
   {
     switch (type) {
       case HandleType::subscription_handle:
-        if (number_of_handles > bounds_.max_subscriptions_) {
+        if (number_of_handles > bounds_.max_subscriptions) {
           throw std::runtime_error("Requested size exceeded maximum subscriptions.");
         }
 
         return subscription_pool_;
       case HandleType::service_handle:
-        if (number_of_handles > bounds_.max_services_) {
+        if (number_of_handles > bounds_.max_services) {
           throw std::runtime_error("Requested size exceeded maximum services.");
         }
 
         return service_pool_;
       case HandleType::client_handle:
-        if (number_of_handles > bounds_.max_clients_) {
+        if (number_of_handles > bounds_.max_clients) {
           throw std::runtime_error("Requested size exceeded maximum clients.");
         }
 
         return client_pool_;
       case HandleType::guard_condition_handle:
-        if (number_of_handles > bounds_.max_guard_conditions_) {
+        if (number_of_handles > bounds_.max_guard_conditions) {
           throw std::runtime_error("Requested size exceeded maximum guard_conditions.");
         }
 
@@ -152,23 +187,23 @@ public:
     (void)handles;
     switch (type) {
       case HandleType::subscription_handle:
-        if (bounds_.max_subscriptions_) {
-          memset(subscription_pool_, 0, bounds_.max_subscriptions_ * sizeof(void *));
+        if (bounds_.max_subscriptions) {
+          memset(subscription_pool_, 0, bounds_.max_subscriptions * sizeof(void *));
         }
         break;
       case HandleType::service_handle:
-        if (bounds_.max_services_) {
-          memset(service_pool_, 0, bounds_.max_services_ * sizeof(void *));
+        if (bounds_.max_services) {
+          memset(service_pool_, 0, bounds_.max_services * sizeof(void *));
         }
         break;
       case HandleType::client_handle:
-        if (bounds_.max_clients_) {
-          memset(client_pool_, 0, bounds_.max_clients_ * sizeof(void *));
+        if (bounds_.max_clients) {
+          memset(client_pool_, 0, bounds_.max_clients * sizeof(void *));
         }
         break;
       case HandleType::guard_condition_handle:
-        if (bounds_.max_guard_conditions_) {
-          memset(guard_condition_pool_, 0, bounds_.max_guard_conditions_ * sizeof(void *));
+        if (bounds_.max_guard_conditions) {
+          memset(guard_condition_pool_, 0, bounds_.max_guard_conditions * sizeof(void *));
         }
         break;
       default:
@@ -178,7 +213,7 @@ public:
 
   executor::AnyExecutable::SharedPtr instantiate_next_executable()
   {
-    if (exec_seq_ >= bounds_.max_executables_) {
+    if (exec_seq_ >= bounds_.max_executables) {
       // wrap around
       exec_seq_ = 0;
     }
@@ -203,7 +238,7 @@ public:
   {
     // Extremely naive static allocation strategy
     // Keep track of block size at a given pointer
-    if (pool_seq_ + size > bounds_.pool_size_) {
+    if (pool_seq_ + size > bounds_.pool_size) {
       // Start at 0
       pool_seq_ = 0;
     }

--- a/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
@@ -27,22 +27,22 @@ namespace memory_strategies
 
 namespace static_memory_strategy
 {
-  struct ObjectPoolBounds
-  {
-  public:
-    size_t max_subscriptions_;
-    size_t max_services_;
-    size_t max_clients_;
-    size_t max_executables_;
-    size_t max_guard_conditions_;
-    size_t pool_size_;
+struct ObjectPoolBounds
+{
+public:
+  size_t max_subscriptions_;
+  size_t max_services_;
+  size_t max_clients_;
+  size_t max_executables_;
+  size_t max_guard_conditions_;
+  size_t pool_size_;
 
-    ObjectPoolBounds(size_t subs = 10, size_t services = 10, size_t clients = 10,
-      size_t executables = 1, size_t guard_conditions = 2, size_t pool = 1024)
-    : max_subscriptions_(subs), max_services_(services), max_clients_(clients),
-        max_executables_(executables), max_guard_conditions_(guard_conditions), pool_size_(pool)
-    {}
-  };
+  ObjectPoolBounds(size_t subs = 10, size_t services = 10, size_t clients = 10,
+    size_t executables = 1, size_t guard_conditions = 2, size_t pool = 1024)
+  : max_subscriptions_(subs), max_services_(services), max_clients_(clients),
+    max_executables_(executables), max_guard_conditions_(guard_conditions), pool_size_(pool)
+  {}
+};
 
 
 class StaticMemoryStrategy : public memory_strategy::MemoryStrategy

--- a/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
@@ -58,27 +58,27 @@ public:
     }
 
     if (bounds_.max_subscriptions_) {
-      subscriptions_pool_ = new void *[bounds_.max_subscriptions_];
+      subscription_pool_ = new void *[bounds_.max_subscriptions_];
     } else {
-      subscriptions_pool_ = 0;
+      subscription_pool_ = 0;
     }
 
     if (bounds_.max_services_) {
-      services_pool_ = new void *[bounds_.max_services_];
+      service_pool_ = new void *[bounds_.max_services_];
     } else {
-      services_pool_ = 0;
+      service_pool_ = 0;
     }
 
     if (bounds_.max_clients_) {
-      clients_pool_ = new void *[bounds_.max_clients_];
+      client_pool_ = new void *[bounds_.max_clients_];
     } else {
-      clients_pool_ = 0;
+      client_pool_ = 0;
     }
 
     if (bounds_.max_guard_conditions_) {
-      guard_conditions_pool_ = new void *[bounds_.max_guard_conditions_];
+      guard_condition_pool_ = new void *[bounds_.max_guard_conditions_];
     } else {
-      guard_conditions_pool_ = 0;
+      guard_condition_pool_ = 0;
     }
 
     if (bounds_.max_executables_) {

--- a/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
@@ -52,18 +52,23 @@ public:
   : bounds_(bounds)
   {
     memory_pool_ = static_cast<void **>(malloc(bounds_.pool_size_));
-    subscription_pool_ = static_cast<void **>(malloc(bounds_.max_subscriptions_));
-    service_pool_ = static_cast<void **>(malloc(bounds_.max_services_));
-    client_pool_ = static_cast<void **>(malloc(bounds_.max_clients_));
-    guard_condition_pool_ = static_cast<void **>(malloc(bounds_.max_guard_conditions_));
-    executable_pool_ = static_cast<executor::AnyExecutable *>(malloc(bounds_.max_executables_));
+    subscription_pool_ = static_cast<void **>(malloc(bounds_.max_subscriptions_*sizeof(void*)));
+    service_pool_ = static_cast<void **>(malloc(bounds_.max_services_*sizeof(void*)));
+    client_pool_ = static_cast<void **>(malloc(bounds_.max_clients_*sizeof(void*)));
+    guard_condition_pool_ = static_cast<void **>(malloc(bounds_.max_guard_conditions_*sizeof(void*)));
 
-    memset(memory_pool_, 0, bounds_.pool_size_);
-    memset(subscription_pool_, 0, bounds_.max_subscriptions_);
-    memset(service_pool_, 0, bounds_.max_services_);
-    memset(client_pool_, 0, bounds_.max_clients_);
-    memset(guard_condition_pool_, 0, bounds_.max_guard_conditions_);
-    memset(executable_pool_, 0, bounds_.max_executables_);
+    memset(memory_pool_, 0, bounds_.pool_size_*sizeof(void*));
+    memset(subscription_pool_, 0, bounds_.max_subscriptions_*sizeof(void*));
+    memset(service_pool_, 0, bounds_.max_services_*sizeof(void*));
+    memset(client_pool_, 0, bounds_.max_clients_*sizeof(void*));
+    memset(guard_condition_pool_, 0, bounds_.max_guard_conditions_*sizeof(void*));
+
+    executable_pool_ = static_cast<executor::AnyExecutable **>(malloc(bounds_.max_executables_));
+    for (size_t i = 0; i < bounds_.max_executables_; ++i)
+    {
+      executable_pool_[i] = new executor::AnyExecutable();
+    }
+
     pool_seq_ = 0;
     exec_seq_ = 0;
 
@@ -72,6 +77,22 @@ public:
     for (size_t i = 0; i < bounds_.pool_size_; ++i) {
       memory_map_[memory_pool_[i]] = 0;
     }
+  }
+
+  ~StaticMemoryStrategy()
+  {
+    std::free(memory_pool_);
+    std::free(subscription_pool_);
+    std::free(service_pool_);
+    std::free(client_pool_);
+    std::free(guard_condition_pool_);
+    for (size_t i = 0; i < bounds_.max_executables_; ++i)
+    {
+      delete executable_pool_[i];
+    }
+
+
+    std::free(executable_pool_);
   }
 
   void ** borrow_handles(HandleType type, size_t number_of_handles)
@@ -112,23 +133,23 @@ public:
     (void)handles;
     switch (type) {
       case HandleType::subscription_handle:
-        memset(subscription_pool_, 0, bounds_.max_subscriptions_);
+        memset(subscription_pool_, 0, bounds_.max_subscriptions_*sizeof(void*));
         break;
       case HandleType::service_handle:
-        memset(service_pool_, 0, bounds_.max_services_);
+        memset(service_pool_, 0, bounds_.max_services_*sizeof(void*));
         break;
       case HandleType::client_handle:
-        memset(client_pool_, 0, bounds_.max_clients_);
+        memset(client_pool_, 0, bounds_.max_clients_*sizeof(void*));
         break;
       case HandleType::guard_condition_handle:
-        memset(guard_condition_pool_, 0, bounds_.max_guard_conditions_);
+        memset(guard_condition_pool_, 0, bounds_.max_guard_conditions_*sizeof(void*));
         break;
       default:
         throw std::runtime_error("Unrecognized enum, could not return handle memory.");
     }
   }
 
-  executor::AnyExecutable::SharedPtr instantiate_next_executable()
+  executor::AnyExecutable* instantiate_next_executable()
   {
     if (exec_seq_ >= bounds_.max_executables_) {
       // wrap around
@@ -137,7 +158,14 @@ public:
     size_t prev_exec_seq_ = exec_seq_;
     ++exec_seq_;
 
-    return std::make_shared<executor::AnyExecutable>(executable_pool_[prev_exec_seq_]);
+    executable_pool_[prev_exec_seq_]->subscription.reset();
+    executable_pool_[prev_exec_seq_]->timer.reset();
+    executable_pool_[prev_exec_seq_]->service.reset();
+    executable_pool_[prev_exec_seq_]->client.reset();
+    executable_pool_[prev_exec_seq_]->callback_group.reset();
+    executable_pool_[prev_exec_seq_]->node.reset();
+
+    return executable_pool_[prev_exec_seq_];
   }
 
   void * alloc(size_t size)
@@ -151,7 +179,7 @@ public:
     void * ptr = memory_pool_[pool_seq_];
     if (memory_map_.count(ptr) == 0) {
       // We expect to have the state for all blocks pre-mapped into memory_map_
-      throw std::runtime_error("Unexpected pointer in rcl_malloc.");
+      throw std::runtime_error("Unexpected pointer in StaticMemoryStrategy::alloc.");
     }
     memory_map_[ptr] = size;
     size_t prev_pool_seq = pool_seq_;
@@ -163,7 +191,7 @@ public:
   {
     if (memory_map_.count(ptr) == 0) {
       // We expect to have the state for all blocks pre-mapped into memory_map_
-      throw std::runtime_error("Unexpected pointer in rcl_free.");
+      throw std::runtime_error("Unexpected pointer in StaticMemoryStrategy::free.");
     }
 
     memset(ptr, 0, memory_map_[ptr]);
@@ -177,7 +205,7 @@ private:
   void ** service_pool_;
   void ** client_pool_;
   void ** guard_condition_pool_;
-  executor::AnyExecutable * executable_pool_;
+  executor::AnyExecutable ** executable_pool_;
 
   size_t pool_seq_;
   size_t exec_seq_;

--- a/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
@@ -81,19 +81,19 @@ public:
   ~StaticMemoryStrategy()
   {
     if (bounds_.pool_size_ > 0) {
-      delete memory_pool_;
+      delete[] memory_pool_;
     }
     if (bounds_.max_subscriptions_ > 0) {
-      delete subscription_pool_;
+      delete[] subscription_pool_;
     }
     if (bounds_.max_services_ > 0) {
-      delete service_pool_;
+      delete[] service_pool_;
     }
     if (bounds_.max_clients_ > 0) {
-      delete client_pool_;
+      delete[] client_pool_;
     }
     if (bounds_.max_guard_conditions_ > 0) {
-      delete guard_condition_pool_;
+      delete[] guard_condition_pool_;
     }
   }
 

--- a/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
@@ -51,19 +51,42 @@ public:
   StaticMemoryStrategy(ObjectPoolBounds bounds = ObjectPoolBounds())
   : bounds_(bounds)
   {
-    memory_pool_ = new void *[bounds_.pool_size_];
-    subscription_pool_ = new void *[bounds_.max_subscriptions_];
-    service_pool_ = new void *[bounds_.max_services_];
-    client_pool_ = new void *[bounds_.max_clients_];
-    guard_condition_pool_ = new void *[bounds_.max_guard_conditions_];
+    if (bounds_.pool_size_) {
+      memory_pool_ = new void *[bounds_.pool_size_];
+    } else {
+      memory_pool_ = 0;
+    }
 
-    memset(memory_pool_, 0, bounds_.pool_size_ * sizeof(void *));
-    memset(subscription_pool_, 0, bounds_.max_subscriptions_ * sizeof(void *));
-    memset(service_pool_, 0, bounds_.max_services_ * sizeof(void *));
-    memset(client_pool_, 0, bounds_.max_clients_ * sizeof(void *));
-    memset(guard_condition_pool_, 0, bounds_.max_guard_conditions_ * sizeof(void *));
+    if (bounds_.max_subscriptions_) {
+      subscriptions_pool_ = new void *[bounds_.max_subscriptions_];
+    } else {
+      subscriptions_pool_ = 0;
+    }
 
-    executable_pool_ = new executor::AnyExecutable::SharedPtr[bounds_.max_executables_];
+    if (bounds_.max_services_) {
+      services_pool_ = new void *[bounds_.max_services_];
+    } else {
+      services_pool_ = 0;
+    }
+
+    if (bounds_.max_clients_) {
+      clients_pool_ = new void *[bounds_.max_clients_];
+    } else {
+      clients_pool_ = 0;
+    }
+
+    if (bounds_.max_guard_conditions_) {
+      guard_conditions_pool_ = new void *[bounds_.max_guard_conditions_];
+    } else {
+      guard_conditions_pool_ = 0;
+    }
+
+    if (bounds_.max_executables_) {
+      executable_pool_ = new executor::AnyExecutable::SharedPtr[bounds_.max_executables_];
+    } else {
+      executable_pool_ = 0;
+    }
+
     for (size_t i = 0; i < bounds_.max_executables_; ++i) {
       executable_pool_[i] = std::make_shared<executor::AnyExecutable>();
     }
@@ -80,19 +103,19 @@ public:
 
   ~StaticMemoryStrategy()
   {
-    if (bounds_.pool_size_ > 0) {
+    if (bounds_.pool_size_) {
       delete[] memory_pool_;
     }
-    if (bounds_.max_subscriptions_ > 0) {
+    if (bounds_.max_subscriptions_) {
       delete[] subscription_pool_;
     }
-    if (bounds_.max_services_ > 0) {
+    if (bounds_.max_services_) {
       delete[] service_pool_;
     }
-    if (bounds_.max_clients_ > 0) {
+    if (bounds_.max_clients_) {
       delete[] client_pool_;
     }
-    if (bounds_.max_guard_conditions_ > 0) {
+    if (bounds_.max_guard_conditions_) {
       delete[] guard_condition_pool_;
     }
   }

--- a/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/static_memory_strategy.hpp
@@ -80,11 +80,11 @@ public:
 
   ~StaticMemoryStrategy()
   {
-    std::free(memory_pool_);
-    std::free(subscription_pool_);
-    std::free(service_pool_);
-    std::free(client_pool_);
-    std::free(guard_condition_pool_);
+    delete memory_pool_;
+    delete subscription_pool_;
+    delete service_pool_;
+    delete client_pool_;
+    delete guard_condition_pool_;
   }
 
   void ** borrow_handles(HandleType type, size_t number_of_handles)

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -80,6 +80,7 @@ public:
 
   virtual std::shared_ptr<void> create_message() = 0;
   virtual void handle_message(std::shared_ptr<void> & message) = 0;
+  virtual void return_message(std::shared_ptr<void> & message) = 0;
 
 private:
   RCLCPP_DISABLE_COPY(SubscriptionBase);
@@ -128,6 +129,11 @@ public:
   {
     auto typed_message = std::static_pointer_cast<MessageT>(message);
     callback_(typed_message);
+  }
+
+  void return_message(std::shared_ptr<void> & message)
+  {
+    auto typed_message = std::static_pointer_cast<MessageT>(message);
     message_memory_strategy_->return_message(typed_message);
   }
 


### PR DESCRIPTION
there were some mistakes made in #81 that weren't caught because Jenkins doesn't test the `StaticMemoryStrategy`. This PR makes some improvements to that and the executor:

Revert omission of `guard_condition_handles` in `StaticMemoryStrategy`; we still need that for the interrupt guard condition.
Introduce a `Subscription::return_message` class to ensure that memory allocated or borrowed by `create_message` is always returned.
Consolidate `get_next_ready_executable` functions.
Store `AnyExecutable` pool in `StaticMemoryStrategy` as shared pointers.
Use `new` instead of `malloc` in `StaticMemoryStrategy`.