### PR TITLE
Add Executor::spin_some

### DIFF
--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -123,13 +123,17 @@ public:
   void spin_node_some(rclcpp::node::Node::SharedPtr & node)
   {
     this->add_node(node, false);
-    // non-blocking = true
+    spin_some();
+    this->remove_node(node, false);
+  }
+
+  virtual void spin_some()
+  {
     while (AnyExecutable::SharedPtr any_exec =
       get_next_executable(std::chrono::milliseconds::zero()))
     {
       execute_any_executable(any_exec);
     }
-    this->remove_node(node, false);
   }
 
   // Support dynamic switching of memory strategy


### PR DESCRIPTION
Add `spin_some`, which executes all available executors until none are available without blocking. Similar to `spin_node_some` but without the messy add/remove node logic.