### PR TITLE
refactored the smart ptr class macros

### DIFF
--- a/rclcpp/include/rclcpp/any_executable.hpp
+++ b/rclcpp/include/rclcpp/any_executable.hpp
@@ -1,4 +1,4 @@
-// Copyright 2014 Open Source Robotics Foundation, Inc.
+// Copyright 2015 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,11 +27,11 @@ namespace executor
 
 struct AnyExecutable
 {
-  RCLCPP_MAKE_SHARED_DEFINITIONS(AnyExecutable);
+  RCLCPP_SMART_PTR_DEFINITIONS(AnyExecutable);
   AnyExecutable()
   : subscription(0), timer(0), callback_group(0), node(0)
   {}
-  // Either the subscription or the timer will be set, but not both
+  // Only one of the following pointers will be set.
   rclcpp::subscription::SubscriptionBase::SharedPtr subscription;
   rclcpp::timer::TimerBase::SharedPtr timer;
   rclcpp::service::ServiceBase::SharedPtr service;

--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -52,7 +52,7 @@ class CallbackGroup
   friend class rclcpp::executor::Executor;
 
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(CallbackGroup);
+  RCLCPP_SMART_PTR_DEFINITIONS(CallbackGroup);
 
   CallbackGroup(CallbackGroupType group_type)
   : type_(group_type), can_be_taken_from_(true)

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -45,7 +45,7 @@ class ClientBase
   friend class rclcpp::executor::Executor;
 
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(ClientBase);
+  RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(ClientBase);
 
   ClientBase(
     std::shared_ptr<rmw_node_t> node_handle,
@@ -99,7 +99,7 @@ public:
 
   typedef std::function<void (SharedFuture)> CallbackType;
 
-  RCLCPP_MAKE_SHARED_DEFINITIONS(Client);
+  RCLCPP_SMART_PTR_DEFINITIONS(Client);
 
   Client(
     std::shared_ptr<rmw_node_t> node_handle,

--- a/rclcpp/include/rclcpp/context.hpp
+++ b/rclcpp/include/rclcpp/context.hpp
@@ -28,7 +28,7 @@ namespace context
 class Context
 {
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(Context);
+  RCLCPP_SMART_PTR_DEFINITIONS(Context);
 
   Context() {}
 

--- a/rclcpp/include/rclcpp/contexts/default_context.hpp
+++ b/rclcpp/include/rclcpp/contexts/default_context.hpp
@@ -27,7 +27,7 @@ namespace default_context
 class DefaultContext : public rclcpp::context::Context
 {
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(DefaultContext);
+  RCLCPP_SMART_PTR_DEFINITIONS(DefaultContext);
 
   DefaultContext() {}
 

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -40,7 +40,7 @@ class Executor
   friend class memory_strategy::MemoryStrategy;
 
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(Executor);
+  RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(Executor);
 
   explicit Executor(memory_strategy::MemoryStrategy::SharedPtr ms =
     memory_strategy::create_default_strategy())

--- a/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
@@ -38,7 +38,7 @@ namespace multi_threaded_executor
 class MultiThreadedExecutor : public executor::Executor
 {
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(MultiThreadedExecutor);
+  RCLCPP_SMART_PTR_DEFINITIONS(MultiThreadedExecutor);
 
   MultiThreadedExecutor(memory_strategy::MemoryStrategy::SharedPtr ms =
     memory_strategy::create_default_strategy())

--- a/rclcpp/include/rclcpp/executors/single_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/single_threaded_executor.hpp
@@ -39,7 +39,7 @@ namespace single_threaded_executor
 class SingleThreadedExecutor : public executor::Executor
 {
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(SingleThreadedExecutor);
+  RCLCPP_SMART_PTR_DEFINITIONS(SingleThreadedExecutor);
 
   SingleThreadedExecutor(memory_strategy::MemoryStrategy::SharedPtr ms =
     memory_strategy::create_default_strategy())

--- a/rclcpp/include/rclcpp/macros.hpp
+++ b/rclcpp/include/rclcpp/macros.hpp
@@ -23,20 +23,63 @@
   Class(const Class &) = delete; \
   Class & operator=(const Class &) = delete;
 
-/* Defines a make_shared static function on the class using perfect forwarding.
+/* Defines aliases and static functions for using the Class with smart pointers.
  *
  * Use in the public section of the class.
  * Make sure to include <memory> in the header when using this.
  */
-#define RCLCPP_MAKE_SHARED_DEFINITIONS(Class) \
-  typedef std::shared_ptr<Class> SharedPtr; \
- \
+#define RCLCPP_SMART_PTR_DEFINITIONS(Class) \
+  RCLCPP_SHARED_PTR_DEFINITIONS(Class) \
+  RCLCPP_WEAK_PTR_DEFINITIONS(Class) \
+  RCLCPP_UNIQUE_PTR_DEFINITIONS(Class)
+
+/* Defines aliases and static functions for using the Class with smart pointers.
+ *
+ * Same as RCLCPP_SMART_PTR_DEFINITIONS expect it excludes the static
+ * Class::make_unique() method definition which does not work on classes which
+ * are not CopyConstructable.
+ *
+ * Use in the public section of the class.
+ * Make sure to include <memory> in the header when using this.
+ */
+#define RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(Class) \
+  RCLCPP_SHARED_PTR_DEFINITIONS(Class) \
+  RCLCPP_WEAK_PTR_DEFINITIONS(Class) \
+  __RCLCPP_UNIQUE_PTR_ALIAS(Class)
+
+#define __RCLCPP_SHARED_PTR_ALIAS(Class) using SharedPtr = std::shared_ptr<Class>;
+
+#define __RCLCPP_MAKE_SHARED_DEFINITION(Class) \
   template<typename ... Args> \
   static std::shared_ptr<Class> \
   make_shared(Args && ... args) \
   { \
     return std::make_shared<Class>(std::forward<Args>(args) ...); \
   }
+
+/// Defines aliases and static functions for using the Class with shared_ptrs.
+#define RCLCPP_SHARED_PTR_DEFINITIONS(Class) \
+  __RCLCPP_SHARED_PTR_ALIAS(Class) \
+  __RCLCPP_MAKE_SHARED_DEFINITION(Class)
+
+#define __RCLCPP_WEAK_PTR_ALIAS(Class) using WeakPtr = std::weak_ptr<Class>;
+
+/// Defines aliases and static functions for using the Class with weak_ptrs.
+#define RCLCPP_WEAK_PTR_DEFINITIONS(Class) __RCLCPP_WEAK_PTR_ALIAS(Class)
+
+#define __RCLCPP_UNIQUE_PTR_ALIAS(Class) using UniquePtr = std::unique_ptr<Class>;
+
+#define __RCLCPP_MAKE_UNIQUE_DEFINITION(Class) \
+  template<typename ... Args> \
+  static std::unique_ptr<Class> \
+  make_unique(Args && ... args) \
+  { \
+    return std::unique_ptr<Class>(new Class(std::forward<Args>(args) ...)); \
+  }
+/// Defines aliases and static functions for using the Class with unique_ptrs.
+#define RCLCPP_UNIQUE_PTR_DEFINITIONS(Class) \
+  __RCLCPP_UNIQUE_PTR_ALIAS(Class) \
+  __RCLCPP_MAKE_UNIQUE_DEFINITION(Class)
 
 #define RCLCPP_INFO(Args) std::cout << Args << std::endl;
 

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -36,7 +36,7 @@ class MemoryStrategy
   friend class executor::Executor;
 
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(MemoryStrategy);
+  RCLCPP_SMART_PTR_DEFINITIONS(MemoryStrategy);
   virtual void ** borrow_handles(HandleType type, size_t number_of_handles)
   {
     (void)type;

--- a/rclcpp/include/rclcpp/message_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/message_memory_strategy.hpp
@@ -29,7 +29,7 @@ class MessageMemoryStrategy
 {
 
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(MessageMemoryStrategy);
+  RCLCPP_SMART_PTR_DEFINITIONS(MessageMemoryStrategy);
 
   static SharedPtr create_default()
   {

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -100,7 +100,7 @@ class Node
   friend class rclcpp::executor::Executor;
 
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(Node);
+  RCLCPP_SMART_PTR_DEFINITIONS(Node);
 
   /* Create a node based on the node name. */
   Node(const std::string & node_name);

--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -44,7 +44,7 @@ class AsyncParametersClient
 {
 
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(AsyncParametersClient);
+  RCLCPP_SMART_PTR_DEFINITIONS(AsyncParametersClient);
 
   AsyncParametersClient(const rclcpp::node::Node::SharedPtr & node,
     const std::string & remote_node_name = "")
@@ -252,7 +252,7 @@ private:
 class SyncParametersClient
 {
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(SyncParametersClient);
+  RCLCPP_SMART_PTR_DEFINITIONS(SyncParametersClient);
 
   SyncParametersClient(
     rclcpp::node::Node::SharedPtr & node)

--- a/rclcpp/include/rclcpp/parameter_service.hpp
+++ b/rclcpp/include/rclcpp/parameter_service.hpp
@@ -41,7 +41,7 @@ class ParameterService
 {
 
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(ParameterService);
+  RCLCPP_SMART_PTR_DEFINITIONS(ParameterService);
 
   ParameterService(const rclcpp::node::Node::SharedPtr & node)
   : node_(node)

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -39,7 +39,7 @@ namespace publisher
 class Publisher
 {
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(Publisher);
+  RCLCPP_SMART_PTR_DEFINITIONS(Publisher);
 
   Publisher(std::shared_ptr<rmw_node_t> node_handle, rmw_publisher_t * publisher_handle)
   : node_handle_(node_handle), publisher_handle_(publisher_handle)

--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -30,7 +30,7 @@ namespace rate
 class RateBase
 {
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(RateBase);
+  RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(RateBase);
 
   virtual bool sleep() = 0;
   virtual bool is_steady() = 0;
@@ -45,7 +45,7 @@ template<class Clock = std::chrono::high_resolution_clock>
 class GenericRate : public RateBase
 {
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(GenericRate);
+  RCLCPP_SMART_PTR_DEFINITIONS(GenericRate);
 
   GenericRate(double rate)
   : GenericRate<Clock>(

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -44,7 +44,7 @@ class ServiceBase
   friend class rclcpp::executor::Executor;
 
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(ServiceBase);
+  RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(ServiceBase);
 
   ServiceBase(
     std::shared_ptr<rmw_node_t> node_handle,
@@ -105,7 +105,7 @@ public:
         const std::shared_ptr<rmw_request_id_t> &,
         const std::shared_ptr<typename ServiceT::Request> &,
         std::shared_ptr<typename ServiceT::Response> &)> CallbackWithHeaderType;
-  RCLCPP_MAKE_SHARED_DEFINITIONS(Service);
+  RCLCPP_SMART_PTR_DEFINITIONS(Service);
 
   Service(
     std::shared_ptr<rmw_node_t> node_handle,

--- a/rclcpp/include/rclcpp/strategies/message_pool_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/message_pool_memory_strategy.hpp
@@ -32,7 +32,7 @@ class MessagePoolMemoryStrategy
   : public message_memory_strategy::MessageMemoryStrategy<MessageT>
 {
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(MessagePoolMemoryStrategy);
+  RCLCPP_SMART_PTR_DEFINITIONS(MessagePoolMemoryStrategy);
   MessagePoolMemoryStrategy()
   : next_array_index_(0)
   {

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -44,8 +44,7 @@ class SubscriptionBase
   friend class rclcpp::executor::Executor;
 
 public:
-  typedef std::weak_ptr<SubscriptionBase> WeakPtr;
-  RCLCPP_MAKE_SHARED_DEFINITIONS(SubscriptionBase);
+  RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(SubscriptionBase);
 
   SubscriptionBase(
     std::shared_ptr<rmw_node_t> node_handle,
@@ -98,8 +97,7 @@ class Subscription : public SubscriptionBase
 {
 public:
   typedef std::function<void (const std::shared_ptr<MessageT> &)> CallbackType;
-  RCLCPP_MAKE_SHARED_DEFINITIONS(Subscription);
-  typedef std::weak_ptr<Subscription> WeakPtr;
+  RCLCPP_SMART_PTR_DEFINITIONS(Subscription);
 
   Subscription(
     std::shared_ptr<rmw_node_t> node_handle,

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -47,8 +47,7 @@ class TimerBase
   friend class rclcpp::executor::Executor;
 
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(TimerBase);
-  typedef std::weak_ptr<TimerBase> WeakPtr;
+  RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(TimerBase);
 
   TimerBase(std::chrono::nanoseconds period, CallbackType callback)
   : period_(period),
@@ -89,8 +88,7 @@ class GenericTimer : public TimerBase
   friend class rclcpp::executor::Executor;
 
 public:
-  RCLCPP_MAKE_SHARED_DEFINITIONS(GenericTimer);
-  typedef std::weak_ptr<GenericTimer> WeakPtr;
+  RCLCPP_SMART_PTR_DEFINITIONS(GenericTimer);
 
   GenericTimer(std::chrono::nanoseconds period, CallbackType callback)
   : TimerBase(period, callback), loop_rate_(period)


### PR DESCRIPTION
The macros are now more modular and there they include weak pointer and unique pointer definitions.

On classes which are not copy constructible we cannot make a `make_unique` definition, so there are two main entry point macros now, `RCLCPP_SMART_PTR_DEFINITIONS` and `RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE`. Where the latter is used on classes which are not copyable. I worked with @esteve to come up with an automatic solution to this using `enable_if` or something similar, but it doesn't seem to be possible with only one macro inside the class definition. So I made two macros instead. It will not compile if you use the wrong macro, so that should be ok.