### PR TITLE
check intra-process subscription handle before dereference

### DIFF
--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -491,7 +491,9 @@ protected:
             if (subscription->subscription_handle_->data == subscriber_handle) {
               return subscription;
             }
-            if (subscription->intra_process_subscription_handle_->data == subscriber_handle) {
+            if (subscription->intra_process_subscription_handle_ &&
+              subscription->intra_process_subscription_handle_->data == subscriber_handle)
+            {
               return subscription;
             }
           }


### PR DESCRIPTION
This was causing a segfault in the realtime demo, which does not use intra-process messaging.