### PR TITLE
declare dependency

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -14,6 +14,8 @@ if(AMENT_ENABLE_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
+  find_package(rmw REQUIRED)
+
   if(NOT WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
   endif()
@@ -23,7 +25,9 @@ if(AMENT_ENABLE_TESTING)
   ament_add_gtest(test_mapped_ring_buffer test/test_mapped_ring_buffer.cpp)
   ament_add_gtest(test_intra_process_manager test/test_intra_process_manager.cpp)
   if(TARGET test_intra_process_manager)
-    target_include_directories(test_intra_process_manager PUBLIC "${rcl_interfaces_INCLUDE_DIRS}")
+    target_include_directories(test_intra_process_manager PUBLIC
+      "${rcl_interfaces_INCLUDE_DIRS}"
+      "${rmw_INCLUDE_DIRS}")
   endif()
 endif()
 

--- a/rclcpp/package.xml
+++ b/rclcpp/package.xml
@@ -16,6 +16,7 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>rmw</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
It must be declared correctly in order to not break isolated builds.