### PR TITLE
move vectors instantiated in wait_for_work to MemoryStrategy

### DIFF
--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -97,6 +97,10 @@ public:
   {
     return std::free(ptr);
   }
+
+  std::vector<rclcpp::subscription::SubscriptionBase::SharedPtr> subs;
+  std::vector<rclcpp::service::ServiceBase::SharedPtr> services;
+  std::vector<rclcpp::client::ClientBase::SharedPtr> clients;
 };
 
 

--- a/rclcpp/include/rclcpp/strategies/heap_pool_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/heap_pool_memory_strategy.hpp
@@ -171,6 +171,10 @@ public:
     for (size_t i = 0; i < bounds_.pool_size; ++i) {
       memory_map_[memory_pool_[i]] = 0;
     }
+
+    subs.reserve(bounds_.max_subscriptions);
+    clients.reserve(bounds_.max_clients);
+    services.reserve(bounds_.max_services);
   }
 
   /// Default destructor. Free all allocated memory.

--- a/rclcpp/include/rclcpp/strategies/stack_pool_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/stack_pool_memory_strategy.hpp
@@ -76,6 +76,9 @@ public:
     for (size_t i = 0; i < PoolSize; ++i) {
       memory_map_[memory_pool_[i]] = 0;
     }
+    subs.reserve(MaxSubscriptions);
+    clients.reserve(MaxClients);
+    services.reserve(MaxServices);
   }
 
   void ** borrow_handles(HandleType type, size_t number_of_handles)


### PR DESCRIPTION
This was done in my attempt to reduce pagefaults in Executor::spin. Several vectors that were being instantiated on the stack in Executor::spin have been moved into the MemoryStrategy, so that they can be preallocated (with `vector::reserve`) on construction.