### PR TITLE
Add any subscription callback types for shared_ptr<const T>

### DIFF
--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -207,12 +207,15 @@ public:
       any_callback_.shared_ptr_callback(typed_message);
     } else if (any_callback_.shared_ptr_with_info_callback) {
       any_callback_.shared_ptr_with_info_callback(typed_message, message_info);
+    } else if (any_callback_.const_shared_ptr_callback) {
+      any_callback_.const_shared_ptr_callback(typed_message);
+    } else if (any_callback_.const_shared_ptr_with_info_callback) {
+      any_callback_.const_shared_ptr_with_info_callback(typed_message, message_info);
     } else if (any_callback_.unique_ptr_callback) {
-      std::unique_ptr<MessageT> unique_msg(new MessageT(*typed_message));
-      any_callback_.unique_ptr_callback(unique_msg);
+      any_callback_.unique_ptr_callback(std::unique_ptr<MessageT>(new MessageT(*typed_message)));
     } else if (any_callback_.unique_ptr_with_info_callback) {
-      std::unique_ptr<MessageT> unique_msg(new MessageT(*typed_message));
-      any_callback_.unique_ptr_with_info_callback(unique_msg, message_info);
+      any_callback_.unique_ptr_with_info_callback(std::unique_ptr<MessageT>(new MessageT(*
+        typed_message)), message_info);
     } else {
       throw std::runtime_error("unexpected message without any callback set");
     }
@@ -253,10 +256,16 @@ public:
     } else if (any_callback_.shared_ptr_with_info_callback) {
       typename MessageT::SharedPtr shared_msg = std::move(msg);
       any_callback_.shared_ptr_with_info_callback(shared_msg, message_info);
+    } else if (any_callback_.const_shared_ptr_callback) {
+      typename MessageT::ConstSharedPtr const_shared_msg = std::move(msg);
+      any_callback_.const_shared_ptr_callback(const_shared_msg);
+    } else if (any_callback_.const_shared_ptr_with_info_callback) {
+      typename MessageT::ConstSharedPtr const_shared_msg = std::move(msg);
+      any_callback_.const_shared_ptr_with_info_callback(const_shared_msg, message_info);
     } else if (any_callback_.unique_ptr_callback) {
-      any_callback_.unique_ptr_callback(msg);
+      any_callback_.unique_ptr_callback(std::move(msg));
     } else if (any_callback_.unique_ptr_with_info_callback) {
-      any_callback_.unique_ptr_with_info_callback(msg, message_info);
+      any_callback_.unique_ptr_with_info_callback(std::move(msg), message_info);
     } else {
       throw std::runtime_error("unexpected message without any callback set");
     }


### PR DESCRIPTION
I noticed this was missing in #118. This should enable us to set up a subscription callback with `ConstSharedPtr`.