### PR TITLE
Use variadic macros

### DIFF
--- a/rclcpp/include/rclcpp/macros.hpp
+++ b/rclcpp/include/rclcpp/macros.hpp
@@ -19,19 +19,19 @@
  *
  * Use in the private section of the class.
  */
-#define RCLCPP_DISABLE_COPY(Class) \
-  Class(const Class &) = delete; \
-  Class & operator=(const Class &) = delete;
+#define RCLCPP_DISABLE_COPY(...) \
+  __VA_ARGS__(const __VA_ARGS__ &) = delete; \
+  __VA_ARGS__ & operator=(const __VA_ARGS__ &) = delete;
 
 /* Defines aliases and static functions for using the Class with smart pointers.
  *
  * Use in the public section of the class.
  * Make sure to include <memory> in the header when using this.
  */
-#define RCLCPP_SMART_PTR_DEFINITIONS(Class) \
-  RCLCPP_SHARED_PTR_DEFINITIONS(Class) \
-  RCLCPP_WEAK_PTR_DEFINITIONS(Class) \
-  RCLCPP_UNIQUE_PTR_DEFINITIONS(Class)
+#define RCLCPP_SMART_PTR_DEFINITIONS(...) \
+  RCLCPP_SHARED_PTR_DEFINITIONS(__VA_ARGS__) \
+  RCLCPP_WEAK_PTR_DEFINITIONS(__VA_ARGS__) \
+  RCLCPP_UNIQUE_PTR_DEFINITIONS(__VA_ARGS__)
 
 /* Defines aliases and static functions for using the Class with smart pointers.
  *
@@ -42,44 +42,44 @@
  * Use in the public section of the class.
  * Make sure to include <memory> in the header when using this.
  */
-#define RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(Class) \
-  RCLCPP_SHARED_PTR_DEFINITIONS(Class) \
-  RCLCPP_WEAK_PTR_DEFINITIONS(Class) \
-  __RCLCPP_UNIQUE_PTR_ALIAS(Class)
+#define RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(...) \
+  RCLCPP_SHARED_PTR_DEFINITIONS(__VA_ARGS__) \
+  RCLCPP_WEAK_PTR_DEFINITIONS(__VA_ARGS__) \
+  __RCLCPP_UNIQUE_PTR_ALIAS(__VA_ARGS__)
 
-#define __RCLCPP_SHARED_PTR_ALIAS(Class) using SharedPtr = std::shared_ptr<Class>;
+#define __RCLCPP_SHARED_PTR_ALIAS(...) using SharedPtr = std::shared_ptr<__VA_ARGS__>;
 
-#define __RCLCPP_MAKE_SHARED_DEFINITION(Class) \
+#define __RCLCPP_MAKE_SHARED_DEFINITION(...) \
   template<typename ... Args> \
-  static std::shared_ptr<Class> \
+  static std::shared_ptr<__VA_ARGS__> \
   make_shared(Args && ... args) \
   { \
-    return std::make_shared<Class>(std::forward<Args>(args) ...); \
+    return std::make_shared<__VA_ARGS__>(std::forward<Args>(args) ...); \
   }
 
 /// Defines aliases and static functions for using the Class with shared_ptrs.
-#define RCLCPP_SHARED_PTR_DEFINITIONS(Class) \
-  __RCLCPP_SHARED_PTR_ALIAS(Class) \
-  __RCLCPP_MAKE_SHARED_DEFINITION(Class)
+#define RCLCPP_SHARED_PTR_DEFINITIONS(...) \
+  __RCLCPP_SHARED_PTR_ALIAS(__VA_ARGS__) \
+  __RCLCPP_MAKE_SHARED_DEFINITION(__VA_ARGS__)
 
-#define __RCLCPP_WEAK_PTR_ALIAS(Class) using WeakPtr = std::weak_ptr<Class>;
+#define __RCLCPP_WEAK_PTR_ALIAS(...) using WeakPtr = std::weak_ptr<__VA_ARGS__>;
 
 /// Defines aliases and static functions for using the Class with weak_ptrs.
-#define RCLCPP_WEAK_PTR_DEFINITIONS(Class) __RCLCPP_WEAK_PTR_ALIAS(Class)
+#define RCLCPP_WEAK_PTR_DEFINITIONS(...) __RCLCPP_WEAK_PTR_ALIAS(__VA_ARGS__)
 
-#define __RCLCPP_UNIQUE_PTR_ALIAS(Class) using UniquePtr = std::unique_ptr<Class>;
+#define __RCLCPP_UNIQUE_PTR_ALIAS(...) using UniquePtr = std::unique_ptr<__VA_ARGS__>;
 
-#define __RCLCPP_MAKE_UNIQUE_DEFINITION(Class) \
+#define __RCLCPP_MAKE_UNIQUE_DEFINITION(...) \
   template<typename ... Args> \
-  static std::unique_ptr<Class> \
+  static std::unique_ptr<__VA_ARGS__> \
   make_unique(Args && ... args) \
   { \
-    return std::unique_ptr<Class>(new Class(std::forward<Args>(args) ...)); \
+    return std::unique_ptr<__VA_ARGS__>(new __VA_ARGS__(std::forward<Args>(args) ...)); \
   }
 /// Defines aliases and static functions for using the Class with unique_ptrs.
-#define RCLCPP_UNIQUE_PTR_DEFINITIONS(Class) \
-  __RCLCPP_UNIQUE_PTR_ALIAS(Class) \
-  __RCLCPP_MAKE_UNIQUE_DEFINITION(Class)
+#define RCLCPP_UNIQUE_PTR_DEFINITIONS(...) \
+  __RCLCPP_UNIQUE_PTR_ALIAS(__VA_ARGS__) \
+  __RCLCPP_MAKE_UNIQUE_DEFINITION(__VA_ARGS__)
 
 #define RCLCPP_INFO(Args) std::cout << Args << std::endl;
 


### PR DESCRIPTION
While exposing the allocator template in rclcpp, I noticed our macro definitions have trouble when there are commas in a type (i.e. when there are multiple template arguments). I decided to change all the macro definitions to variadic macros, which will allow commas in the type names.