### PR TITLE
Add template parameter to publisher

### DIFF
--- a/rclcpp/include/rclcpp/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager.hpp
@@ -190,7 +190,8 @@ public:
    */
   template<typename MessageT>
   uint64_t
-  add_publisher(publisher::Publisher::SharedPtr publisher, size_t buffer_size = 0)
+  add_publisher(typename publisher::Publisher<MessageT>::SharedPtr publisher,
+    size_t buffer_size = 0)
   {
     auto id = IntraProcessManager::get_next_unique_id();
     publishers_[id].publisher = publisher;
@@ -419,7 +420,7 @@ private:
 
     PublisherInfo() = default;
 
-    publisher::Publisher::WeakPtr publisher;
+    publisher::PublisherBase::WeakPtr publisher;
     std::atomic<uint64_t> sequence_number;
     mapped_ring_buffer::MappedRingBufferBase::SharedPtr buffer;
     std::unordered_map<uint64_t, std::set<uint64_t>> target_subscriptions_by_message_sequence;

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -99,7 +99,7 @@ public:
    * \return Shared pointer to the created publisher.
    */
   template<typename MessageT>
-  rclcpp::publisher::Publisher::SharedPtr
+  typename rclcpp::publisher::Publisher<MessageT>::SharedPtr
   create_publisher(
     const std::string & topic_name, const rmw_qos_profile_t & qos_profile);
 
@@ -235,7 +235,7 @@ private:
 
   std::map<std::string, rclcpp::parameter::ParameterVariant> parameters_;
 
-  publisher::Publisher::SharedPtr events_publisher_;
+  publisher::Publisher<rcl_interfaces::msg::ParameterEvent>::SharedPtr events_publisher_;
 
   template<typename MessageT>
   typename subscription::Subscription<MessageT>::SharedPtr

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -114,7 +114,7 @@ Node::create_callback_group(
 }
 
 template<typename MessageT>
-publisher::Publisher::SharedPtr
+typename publisher::Publisher<MessageT>::SharedPtr
 Node::create_publisher(
   const std::string & topic_name, const rmw_qos_profile_t & qos_profile)
 {
@@ -130,7 +130,7 @@ Node::create_publisher(
     // *INDENT-ON*
   }
 
-  auto publisher = publisher::Publisher::make_shared(
+  auto publisher = publisher::Publisher<MessageT>::make_shared(
     node_handle_, publisher_handle, topic_name, qos_profile.depth);
 
   if (use_intra_process_comms_) {

--- a/rclcpp/test/test_intra_process_manager.cpp
+++ b/rclcpp/test/test_intra_process_manager.cpp
@@ -27,12 +27,12 @@ namespace publisher
 namespace mock
 {
 
-class Publisher
+class PublisherBase
 {
 public:
-  RCLCPP_SMART_PTR_DEFINITIONS(Publisher);
+  RCLCPP_SMART_PTR_DEFINITIONS(PublisherBase);
 
-  Publisher()
+  PublisherBase()
   : mock_topic_name(""), mock_queue_size(0) {}
 
   const std::string & get_topic_name() const
@@ -53,6 +53,13 @@ public:
 
   std::string mock_topic_name;
   size_t mock_queue_size;
+};
+
+template<typename T>
+class Publisher : public PublisherBase
+{
+public:
+  RCLCPP_SMART_PTR_DEFINITIONS(Publisher<T>);
 };
 
 }
@@ -96,10 +103,12 @@ public:
 #define RCLCPP_RCLCPP_SUBSCRIPTION_HPP_
 // Force ipm to use our mock publisher class.
 #define Publisher mock::Publisher
+#define PublisherBase mock::PublisherBase
 #define SubscriptionBase mock::SubscriptionBase
 #include <rclcpp/intra_process_manager.hpp>
 #undef SubscriptionBase
 #undef Publisher
+#undef PublisherBase
 
 #include <rcl_interfaces/msg/intra_process_message.hpp>
 
@@ -116,11 +125,13 @@ public:
 TEST(TestIntraProcessManager, nominal) {
   rclcpp::intra_process_manager::IntraProcessManager ipm;
 
-  auto p1 = std::make_shared<rclcpp::publisher::mock::Publisher>();
+  auto p1 =
+    std::make_shared<rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>>();
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 2;
 
-  auto p2 = std::make_shared<rclcpp::publisher::mock::Publisher>();
+  auto p2 =
+    std::make_shared<rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>>();
   p2->mock_topic_name = "nominal2";
   p2->mock_queue_size = 10;
 
@@ -201,7 +212,8 @@ TEST(TestIntraProcessManager, nominal) {
 TEST(TestIntraProcessManager, remove_publisher_before_trying_to_take) {
   rclcpp::intra_process_manager::IntraProcessManager ipm;
 
-  auto p1 = std::make_shared<rclcpp::publisher::mock::Publisher>();
+  auto p1 =
+    std::make_shared<rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>>();
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 10;
 
@@ -240,7 +252,8 @@ TEST(TestIntraProcessManager, remove_publisher_before_trying_to_take) {
 TEST(TestIntraProcessManager, removed_subscription_affects_take) {
   rclcpp::intra_process_manager::IntraProcessManager ipm;
 
-  auto p1 = std::make_shared<rclcpp::publisher::mock::Publisher>();
+  auto p1 =
+    std::make_shared<rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>>();
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 10;
 
@@ -308,7 +321,8 @@ TEST(TestIntraProcessManager, removed_subscription_affects_take) {
 TEST(TestIntraProcessManager, multiple_subscriptions_one_publisher) {
   rclcpp::intra_process_manager::IntraProcessManager ipm;
 
-  auto p1 = std::make_shared<rclcpp::publisher::mock::Publisher>();
+  auto p1 =
+    std::make_shared<rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>>();
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 10;
 
@@ -377,15 +391,18 @@ TEST(TestIntraProcessManager, multiple_subscriptions_one_publisher) {
 TEST(TestIntraProcessManager, multiple_publishers_one_subscription) {
   rclcpp::intra_process_manager::IntraProcessManager ipm;
 
-  auto p1 = std::make_shared<rclcpp::publisher::mock::Publisher>();
+  auto p1 =
+    std::make_shared<rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>>();
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 10;
 
-  auto p2 = std::make_shared<rclcpp::publisher::mock::Publisher>();
+  auto p2 =
+    std::make_shared<rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>>();
   p2->mock_topic_name = "nominal1";
   p2->mock_queue_size = 10;
 
-  auto p3 = std::make_shared<rclcpp::publisher::mock::Publisher>();
+  auto p3 =
+    std::make_shared<rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>>();
   p3->mock_topic_name = "nominal1";
   p3->mock_queue_size = 10;
 
@@ -468,15 +485,18 @@ TEST(TestIntraProcessManager, multiple_publishers_one_subscription) {
 TEST(TestIntraProcessManager, multiple_publishers_multiple_subscription) {
   rclcpp::intra_process_manager::IntraProcessManager ipm;
 
-  auto p1 = std::make_shared<rclcpp::publisher::mock::Publisher>();
+  auto p1 =
+    std::make_shared<rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>>();
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 10;
 
-  auto p2 = std::make_shared<rclcpp::publisher::mock::Publisher>();
+  auto p2 =
+    std::make_shared<rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>>();
   p2->mock_topic_name = "nominal1";
   p2->mock_queue_size = 10;
 
-  auto p3 = std::make_shared<rclcpp::publisher::mock::Publisher>();
+  auto p3 =
+    std::make_shared<rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>>();
   p3->mock_topic_name = "nominal1";
   p3->mock_queue_size = 10;
 
@@ -626,7 +646,8 @@ TEST(TestIntraProcessManager, multiple_publishers_multiple_subscription) {
 TEST(TestIntraProcessManager, ring_buffer_displacement) {
   rclcpp::intra_process_manager::IntraProcessManager ipm;
 
-  auto p1 = std::make_shared<rclcpp::publisher::mock::Publisher>();
+  auto p1 =
+    std::make_shared<rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>>();
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 2;
 
@@ -694,7 +715,8 @@ TEST(TestIntraProcessManager, ring_buffer_displacement) {
 TEST(TestIntraProcessManager, subscription_creation_race_condition) {
   rclcpp::intra_process_manager::IntraProcessManager ipm;
 
-  auto p1 = std::make_shared<rclcpp::publisher::mock::Publisher>();
+  auto p1 =
+    std::make_shared<rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>>();
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 2;
 
@@ -740,7 +762,8 @@ TEST(TestIntraProcessManager, publisher_out_of_scope_take) {
   uint64_t p1_id;
   uint64_t p1_m1_id;
   {
-    auto p1 = std::make_shared<rclcpp::publisher::mock::Publisher>();
+    auto p1 =
+      std::make_shared<rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>>();
     p1->mock_topic_name = "nominal1";
     p1->mock_queue_size = 2;
 
@@ -777,7 +800,8 @@ TEST(TestIntraProcessManager, publisher_out_of_scope_store) {
 
   uint64_t p1_id;
   {
-    auto p1 = std::make_shared<rclcpp::publisher::mock::Publisher>();
+    auto p1 =
+      std::make_shared<rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>>();
     p1->mock_topic_name = "nominal1";
     p1->mock_queue_size = 2;
 


### PR DESCRIPTION
This changes the Publisher to be templated on its message type.

This came up while I was designing the allocator template interface. If the Allocator is the only template argument to the Publisher, and there is a default argument to the Allocator, then the default Publisher must be instantiated with brackets (ugly). It's a bit safer to associate a Publisher with a message type at compile time (especially since publishers are created with a message type in mind). Additionally, separate the templated and non-templated parts of Publisher puts more parts of rclcpp into the shared library (when it gets separate) and less in the headers.