### PR TITLE
Add const to do_inter_process_publish

### DIFF
--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -311,7 +311,7 @@ public:
 
 protected:
   void
-  do_inter_process_publish(MessageT * msg)
+  do_inter_process_publish(const MessageT * msg)
   {
     auto status = rmw_publish(publisher_handle_, msg);
     if (status != RMW_RET_OK) {


### PR DESCRIPTION
This wasn't necessary before because the function, not the publisher, was templated on the message type, and this function would specialize for a `const` type. The pattern now seems to be templating on the message type without const, and having specializations of publish based on the message passed to the Publisher. `rmw_publish` already takes the message as `const`, so I think requiring the message to be const in this function is an improvement.

http://ci.ros2.org/job/ros2_batch_ci_linux/434/
http://ci.ros2.org/job/ros2_batch_ci_osx/344/
http://ci.ros2.org/job/ros2_batch_ci_windows/486/