### PR TITLE
Unify create_subscription API

### DIFF
--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -114,35 +114,28 @@ struct AnySubscriptionCallback
   {
     const_shared_ptr_with_info_callback = callback;
   }
-/*
-  template<typename CallbackT,
+
+  template<
+    typename CallbackT,
     typename std::enable_if<
-      function_traits<CallbackT>::arity == 1
-    >::type * = nullptr,
-    typename std::enable_if<
-      std::is_same<
-        typename function_traits<CallbackT>::template argument_type<0>,
+      rclcpp::check_argument_types<
+        CallbackT,
         typename std::unique_ptr<MessageT>
       >::value
     >::type * = nullptr
   >
   void set(CallbackT callback)
   {
-    static_assert(std::is_same<
-        typename function_traits<CallbackT>::template argument_type<0>,
-        typename std::unique_ptr<MessageT>
-      >::value, "Not a unique pointer");
     unique_ptr_callback = callback;
   }
 
-  template<typename CallbackT,
+  template<
+    typename CallbackT,
     typename std::enable_if<
-      function_traits<CallbackT>::arity == 2
-    >::type * = nullptr,
-    typename std::enable_if<
-      std::is_same<
-        typename function_traits<CallbackT>::template argument_type<0>,
-        typename std::unique_ptr<MessageT>
+      rclcpp::check_argument_types<
+        CallbackT,
+        typename std::unique_ptr<MessageT>,
+        const rmw_message_info_t &
       >::value
     >::type * = nullptr
   >
@@ -150,7 +143,6 @@ struct AnySubscriptionCallback
   {
     unique_ptr_with_info_callback = callback;
   }
-  */
 };
 
 } /* namespace any_subscription_callback */

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -164,17 +164,6 @@ public:
     typename rclcpp::message_memory_strategy::MessageMemoryStrategy<MessageT>::SharedPtr
     msg_mem_strat = nullptr);
 
-  template<typename MessageT>
-  typename rclcpp::subscription::Subscription<MessageT>::SharedPtr
-  create_subscription_with_unique_ptr_callback(
-    const std::string & topic_name,
-    const rmw_qos_profile_t & qos_profile,
-    typename rclcpp::subscription::AnySubscriptionCallback<MessageT>::UniquePtrCallback callback,
-    rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr,
-    bool ignore_local_publications = false,
-    typename rclcpp::message_memory_strategy::MessageMemoryStrategy<MessageT>::SharedPtr
-    msg_mem_strat = nullptr);
-
   /// Create a timer.
   /**
    * \param[in] period Time interval between triggers of the callback.

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -117,31 +117,6 @@ public:
   /// Create and return a Subscription.
   /**
    * \param[in] topic_name The topic to subscribe on.
-   * \param[in] qos_history_depth The depth of the subscription's incoming message queue.
-   * \param[in] callback The user-defined callback function.
-   * \param[in] group The callback group for this subscription. NULL for no callback group.
-   * \param[in] ignore_local_publications True to ignore local publications.
-   * \param[in] msg_mem_strat The message memory strategy to use for allocating messages.
-   * \return Shared pointer to the created subscription.
-   */
-  /* TODO(jacquelinekay):
-     Windows build breaks when static member function passed as default
-     argument to msg_mem_strat, nullptr is a workaround.
-   */
-  template<typename MessageT, typename CallbackT>
-  typename rclcpp::subscription::Subscription<MessageT>::SharedPtr
-  create_subscription(
-    const std::string & topic_name,
-    size_t qos_history_depth,
-    CallbackT callback,
-    rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr,
-    bool ignore_local_publications = false,
-    typename rclcpp::message_memory_strategy::MessageMemoryStrategy<MessageT>::SharedPtr
-    msg_mem_strat = nullptr);
-
-  /// Create and return a Subscription.
-  /**
-   * \param[in] topic_name The topic to subscribe on.
    * \param[in] qos_profile The quality of service profile to pass on to the rmw implementation.
    * \param[in] callback The user-defined callback function.
    * \param[in] group The callback group for this subscription. NULL for no callback group.
@@ -158,6 +133,31 @@ public:
   create_subscription(
     const std::string & topic_name,
     const rmw_qos_profile_t & qos_profile,
+    CallbackT callback,
+    rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr,
+    bool ignore_local_publications = false,
+    typename rclcpp::message_memory_strategy::MessageMemoryStrategy<MessageT>::SharedPtr
+    msg_mem_strat = nullptr);
+
+  /// Create and return a Subscription.
+  /**
+   * \param[in] topic_name The topic to subscribe on.
+   * \param[in] qos_history_depth The depth of the subscription's incoming message queue.
+   * \param[in] callback The user-defined callback function.
+   * \param[in] group The callback group for this subscription. NULL for no callback group.
+   * \param[in] ignore_local_publications True to ignore local publications.
+   * \param[in] msg_mem_strat The message memory strategy to use for allocating messages.
+   * \return Shared pointer to the created subscription.
+   */
+  /* TODO(jacquelinekay):
+     Windows build breaks when static member function passed as default
+     argument to msg_mem_strat, nullptr is a workaround.
+   */
+  template<typename MessageT, typename CallbackT>
+  typename rclcpp::subscription::Subscription<MessageT>::SharedPtr
+  create_subscription(
+    const std::string & topic_name,
+    size_t qos_history_depth,
     CallbackT callback,
     rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr,
     bool ignore_local_publications = false,
@@ -261,16 +261,6 @@ private:
   std::map<std::string, rclcpp::parameter::ParameterVariant> parameters_;
 
   publisher::Publisher<rcl_interfaces::msg::ParameterEvent>::SharedPtr events_publisher_;
-
-  template<typename MessageT>
-  typename subscription::Subscription<MessageT>::SharedPtr
-  create_subscription_internal(
-    const std::string & topic_name,
-    const rmw_qos_profile_t & qos_profile,
-    rclcpp::subscription::AnySubscriptionCallback<MessageT> callback,
-    rclcpp::callback_group::CallbackGroup::SharedPtr group,
-    bool ignore_local_publications,
-    typename message_memory_strategy::MessageMemoryStrategy<MessageT>::SharedPtr msg_mem_strat);
 
   template<
     typename ServiceT,

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -216,14 +216,12 @@ Node::create_subscription(
   typename rclcpp::message_memory_strategy::MessageMemoryStrategy<MessageT>::SharedPtr
   msg_mem_strat)
 {
-  rclcpp::subscription::AnySubscriptionCallback<MessageT> any_subscription_callback;
-  any_subscription_callback.set(callback);
   rmw_qos_profile_t qos = rmw_qos_profile_default;
   qos.depth = qos_history_depth;
-  return this->create_subscription_internal(
+  return this->create_subscription(
     topic_name,
     qos,
-    any_subscription_callback,
+    callback,
     group,
     ignore_local_publications,
     msg_mem_strat);
@@ -242,25 +240,7 @@ Node::create_subscription(
 {
   rclcpp::subscription::AnySubscriptionCallback<MessageT> any_subscription_callback;
   any_subscription_callback.set(callback);
-  return this->create_subscription_internal(
-    topic_name,
-    qos_profile,
-    any_subscription_callback,
-    group,
-    ignore_local_publications,
-    msg_mem_strat);
-}
 
-template<typename MessageT>
-typename subscription::Subscription<MessageT>::SharedPtr
-Node::create_subscription_internal(
-  const std::string & topic_name,
-  const rmw_qos_profile_t & qos_profile,
-  rclcpp::subscription::AnySubscriptionCallback<MessageT> callback,
-  rclcpp::callback_group::CallbackGroup::SharedPtr group,
-  bool ignore_local_publications,
-  typename message_memory_strategy::MessageMemoryStrategy<MessageT>::SharedPtr msg_mem_strat)
-{
   using rosidl_generator_cpp::get_message_type_support_handle;
 
   if (!msg_mem_strat) {
@@ -286,7 +266,7 @@ Node::create_subscription_internal(
     subscriber_handle,
     topic_name,
     ignore_local_publications,
-    callback,
+    any_subscription_callback,
     msg_mem_strat);
   auto sub_base_ptr = std::dynamic_pointer_cast<SubscriptionBase>(sub);
   // Setup intra process.

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -252,28 +252,6 @@ Node::create_subscription(
 }
 
 template<typename MessageT>
-typename rclcpp::subscription::Subscription<MessageT>::SharedPtr
-Node::create_subscription_with_unique_ptr_callback(
-  const std::string & topic_name,
-  const rmw_qos_profile_t & qos_profile,
-  typename rclcpp::subscription::AnySubscriptionCallback<MessageT>::UniquePtrCallback callback,
-  rclcpp::callback_group::CallbackGroup::SharedPtr group,
-  bool ignore_local_publications,
-  typename rclcpp::message_memory_strategy::MessageMemoryStrategy<MessageT>::SharedPtr
-  msg_mem_strat)
-{
-  rclcpp::subscription::AnySubscriptionCallback<MessageT> any_subscription_callback;
-  any_subscription_callback.unique_ptr_callback = callback;
-  return this->create_subscription_internal(
-    topic_name,
-    qos_profile,
-    any_subscription_callback,
-    group,
-    ignore_local_publications,
-    msg_mem_strat);
-}
-
-template<typename MessageT>
 typename subscription::Subscription<MessageT>::SharedPtr
 Node::create_subscription_internal(
   const std::string & topic_name,

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -209,28 +209,6 @@ template<typename MessageT, typename CallbackT>
 typename rclcpp::subscription::Subscription<MessageT>::SharedPtr
 Node::create_subscription(
   const std::string & topic_name,
-  size_t qos_history_depth,
-  CallbackT callback,
-  rclcpp::callback_group::CallbackGroup::SharedPtr group,
-  bool ignore_local_publications,
-  typename rclcpp::message_memory_strategy::MessageMemoryStrategy<MessageT>::SharedPtr
-  msg_mem_strat)
-{
-  rmw_qos_profile_t qos = rmw_qos_profile_default;
-  qos.depth = qos_history_depth;
-  return this->create_subscription(
-    topic_name,
-    qos,
-    callback,
-    group,
-    ignore_local_publications,
-    msg_mem_strat);
-}
-
-template<typename MessageT, typename CallbackT>
-typename rclcpp::subscription::Subscription<MessageT>::SharedPtr
-Node::create_subscription(
-  const std::string & topic_name,
   const rmw_qos_profile_t & qos_profile,
   CallbackT callback,
   rclcpp::callback_group::CallbackGroup::SharedPtr group,
@@ -326,6 +304,28 @@ Node::create_subscription(
   }
   number_of_subscriptions_++;
   return sub;
+}
+
+template<typename MessageT, typename CallbackT>
+typename rclcpp::subscription::Subscription<MessageT>::SharedPtr
+Node::create_subscription(
+  const std::string & topic_name,
+  size_t qos_history_depth,
+  CallbackT callback,
+  rclcpp::callback_group::CallbackGroup::SharedPtr group,
+  bool ignore_local_publications,
+  typename rclcpp::message_memory_strategy::MessageMemoryStrategy<MessageT>::SharedPtr
+  msg_mem_strat)
+{
+  rmw_qos_profile_t qos = rmw_qos_profile_default;
+  qos.depth = qos_history_depth;
+  return this->create_subscription<MessageT, CallbackT>(
+    topic_name,
+    qos,
+    callback,
+    group,
+    ignore_local_publications,
+    msg_mem_strat);
 }
 
 rclcpp::timer::WallTimer::SharedPtr


### PR DESCRIPTION
This PR removes `create_subscription_with_unique_ptr_callback` and delegates the logic of storing `std::unique_ptr` to `AnySubscriptionCallback`, unifying the `create_subscription` API

Depends on #130 