### PR TITLE
Pass weak pointer to callback

### DIFF
--- a/rclcpp/include/rclcpp/parameter_service.hpp
+++ b/rclcpp/include/rclcpp/parameter_service.hpp
@@ -46,12 +46,17 @@ public:
   ParameterService(const rclcpp::node::Node::SharedPtr node)
   : node_(node)
   {
+    std::weak_ptr<rclcpp::node::Node> captured_node = node_;
     get_parameters_service_ = node_->create_service<rcl_interfaces::srv::GetParameters>(
-      node_->get_name() + "__get_parameters", [node](
+      node_->get_name() + "__get_parameters", [captured_node](
         const std::shared_ptr<rmw_request_id_t>,
         const std::shared_ptr<rcl_interfaces::srv::GetParameters::Request> request,
         std::shared_ptr<rcl_interfaces::srv::GetParameters::Response> response)
         {
+          auto node = captured_node.lock();
+          if (!node) {
+            return;
+          }
           auto values = node->get_parameters(request->names);
           for (auto & pvariant : values) {
             response->values.push_back(pvariant.get_parameter_value());
@@ -60,11 +65,15 @@ public:
       );
 
     get_parameter_types_service_ = node_->create_service<rcl_interfaces::srv::GetParameterTypes>(
-      node_->get_name() + "__get_parameter_types", [node](
+      node_->get_name() + "__get_parameter_types", [captured_node](
         const std::shared_ptr<rmw_request_id_t>,
         const std::shared_ptr<rcl_interfaces::srv::GetParameterTypes::Request> request,
         std::shared_ptr<rcl_interfaces::srv::GetParameterTypes::Response> response)
         {
+          auto node = captured_node.lock();
+          if (!node) {
+            return;
+          }
           auto types = node->get_parameter_types(request->names);
           std::transform(types.cbegin(), types.cend(),
           std::back_inserter(response->types), [](const uint8_t & type) {
@@ -74,11 +83,15 @@ public:
       );
 
     set_parameters_service_ = node_->create_service<rcl_interfaces::srv::SetParameters>(
-      node_->get_name() + "__set_parameters", [node](
+      node_->get_name() + "__set_parameters", [captured_node](
         const std::shared_ptr<rmw_request_id_t>,
         const std::shared_ptr<rcl_interfaces::srv::SetParameters::Request> request,
         std::shared_ptr<rcl_interfaces::srv::SetParameters::Response> response)
         {
+          auto node = captured_node.lock();
+          if (!node) {
+            return;
+          }
           std::vector<rclcpp::parameter::ParameterVariant> pvariants;
           for (auto & p : request->parameters) {
             pvariants.push_back(rclcpp::parameter::ParameterVariant::from_parameter(p));
@@ -90,11 +103,15 @@ public:
 
     set_parameters_atomically_service_ =
       node_->create_service<rcl_interfaces::srv::SetParametersAtomically>(
-      node_->get_name() + "__set_parameters_atomically", [node](
+      node_->get_name() + "__set_parameters_atomically", [captured_node](
         const std::shared_ptr<rmw_request_id_t>,
         const std::shared_ptr<rcl_interfaces::srv::SetParametersAtomically::Request> request,
         std::shared_ptr<rcl_interfaces::srv::SetParametersAtomically::Response> response)
         {
+          auto node = captured_node.lock();
+          if (!node) {
+            return;
+          }
           std::vector<rclcpp::parameter::ParameterVariant> pvariants;
           std::transform(request->parameters.cbegin(), request->parameters.cend(),
           std::back_inserter(pvariants),
@@ -108,22 +125,30 @@ public:
       );
 
     describe_parameters_service_ = node_->create_service<rcl_interfaces::srv::DescribeParameters>(
-      node_->get_name() + "__describe_parameters", [node](
+      node_->get_name() + "__describe_parameters", [captured_node](
         const std::shared_ptr<rmw_request_id_t>,
         const std::shared_ptr<rcl_interfaces::srv::DescribeParameters::Request> request,
         std::shared_ptr<rcl_interfaces::srv::DescribeParameters::Response> response)
         {
+          auto node = captured_node.lock();
+          if (!node) {
+            return;
+          }
           auto descriptors = node->describe_parameters(request->names);
           response->descriptors = descriptors;
         }
       );
 
     list_parameters_service_ = node_->create_service<rcl_interfaces::srv::ListParameters>(
-      node_->get_name() + "__list_parameters", [node](
+      node_->get_name() + "__list_parameters", [captured_node](
         const std::shared_ptr<rmw_request_id_t>,
         const std::shared_ptr<rcl_interfaces::srv::ListParameters::Request> request,
         std::shared_ptr<rcl_interfaces::srv::ListParameters::Response> response)
         {
+          auto node = captured_node.lock();
+          if (!node) {
+            return;
+          }
           auto result = node->list_parameters(request->prefixes, request->depth);
           response->result = result;
         }


### PR DESCRIPTION
Pass a weak pointer instead of a shared pointer to avoid circular references.