### PR TITLE
Remove declaration of friendship for Executor

### DIFF
--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -32,10 +32,6 @@ namespace node
 {
 class Node;
 } // namespace node
-namespace executor
-{
-class Executor;
-} // namespace executor
 
 namespace callback_group
 {
@@ -49,7 +45,6 @@ enum class CallbackGroupType
 class CallbackGroup
 {
   friend class rclcpp::node::Node;
-  friend class rclcpp::executor::Executor;
 
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(CallbackGroup);
@@ -57,6 +52,40 @@ public:
   CallbackGroup(CallbackGroupType group_type)
   : type_(group_type), can_be_taken_from_(true)
   {}
+
+  const std::vector<subscription::SubscriptionBase::WeakPtr> &
+  get_subscription_ptrs() const
+  {
+    return subscription_ptrs_;
+  }
+
+  const std::vector<timer::TimerBase::WeakPtr> &
+  get_timer_ptrs() const
+  {
+    return timer_ptrs_;
+  }
+
+  const std::vector<service::ServiceBase::SharedPtr> &
+  get_service_ptrs() const
+  {
+    return service_ptrs_;
+  }
+
+  const std::vector<client::ClientBase::SharedPtr> &
+  get_client_ptrs() const
+  {
+    return client_ptrs_;
+  }
+
+  std::atomic_bool & can_be_taken_from()
+  {
+    return can_be_taken_from_;
+  }
+
+  const CallbackGroupType & type() const
+  {
+    return type_;
+  }
 
 private:
   RCLCPP_DISABLE_COPY(CallbackGroup);

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -31,18 +31,11 @@
 namespace rclcpp
 {
 
-// Forward declaration for friend statement
-namespace executor
-{
-class Executor;
-} // namespace executor
-
 namespace client
 {
 
 class ClientBase
 {
-  friend class rclcpp::executor::Executor;
 
 public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(ClientBase);

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -47,18 +47,12 @@ struct rmw_node_t;
 namespace rclcpp
 {
 
-// Forward declaration for friend statement
-namespace executor
-{
-class Executor;
-} // namespace executor
 
 namespace node
 {
 /// Node is the single point of entry for creating publishers and subscribers.
 class Node
 {
-  friend class rclcpp::executor::Executor;
 
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(Node);
@@ -231,6 +225,8 @@ public:
   size_t count_publishers(const std::string & topic_name) const;
 
   size_t count_subscribers(const std::string & topic_name) const;
+
+  const CallbackGroupWeakPtrList & get_callback_groups() const;
 
 private:
   RCLCPP_DISABLE_COPY(Node);

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -643,4 +643,11 @@ Node::count_subscribers(const std::string & topic_name) const
   return count;
 }
 
+
+const Node::CallbackGroupWeakPtrList &
+Node::get_callback_groups() const
+{
+  return callback_groups_;
+}
+
 #endif /* RCLCPP_RCLCPP_NODE_IMPL_HPP_ */

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -30,18 +30,11 @@
 namespace rclcpp
 {
 
-// Forward declaration for friend statement
-namespace executor
-{
-class Executor;
-} // namespace executor
-
 namespace service
 {
 
 class ServiceBase
 {
-  friend class rclcpp::executor::Executor;
 
 public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(ServiceBase);

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -32,12 +32,6 @@
 namespace rclcpp
 {
 
-// Forward declaration is for friend statement in SubscriptionBase
-namespace executor
-{
-class Executor;
-} // namespace executor
-
 namespace node
 {
 class Node;
@@ -50,7 +44,6 @@ namespace subscription
 /// specializations of Subscription, among other things.
 class SubscriptionBase
 {
-  friend class rclcpp::executor::Executor;
 
 public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(SubscriptionBase);
@@ -102,6 +95,16 @@ public:
   const std::string & get_topic_name() const
   {
     return this->topic_name_;
+  }
+
+  const rmw_subscription_t * get_subscription_handle() const
+  {
+    return subscription_handle_;
+  }
+
+  const rmw_subscription_t * get_intra_process_subscription_handle() const
+  {
+    return intra_process_subscription_handle_;
   }
 
   /// Borrow a new message.

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -31,12 +31,6 @@
 namespace rclcpp
 {
 
-// Forward declaration is for friend statement in GenericTimer
-namespace executor
-{
-class Executor;
-} // namespace executor
-
 namespace timer
 {
 
@@ -44,7 +38,6 @@ using CallbackType = std::function<void()>;
 
 class TimerBase
 {
-  friend class rclcpp::executor::Executor;
 
 public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(TimerBase);
@@ -64,6 +57,16 @@ public:
   cancel()
   {
     this->canceled_ = true;
+  }
+
+  void execute_callback() const
+  {
+    callback_();
+  }
+
+  const CallbackType & get_callback() const
+  {
+    return callback_;
   }
 
   /// Check how long the timer has until its next scheduled callback.
@@ -95,7 +98,6 @@ protected:
 template<class Clock = std::chrono::high_resolution_clock>
 class GenericTimer : public TimerBase
 {
-  friend class rclcpp::executor::Executor;
 
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(GenericTimer);


### PR DESCRIPTION
This is to make adding allocator templates to stdlib structures in the executor easier.