### PR TITLE
Remove reference so that lambdas are supported

### DIFF
--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -341,7 +341,7 @@ public:
 
   template<typename FunctorT>
   typename rclcpp::subscription::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr
-  on_parameter_event(FunctorT & callback)
+  on_parameter_event(FunctorT callback)
   {
     return async_parameters_client_->on_parameter_event(callback);
   }


### PR DESCRIPTION
This removes a reference, lambdas can't be passed otherwise.