### PR TITLE
account for spurious wake ups from std::condition_variable::wait_for

### DIFF
--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -45,7 +45,7 @@ rmw_guard_condition_t * g_sigint_guard_cond_handle = \
   rmw_create_guard_condition();
 /// Condition variable for timed sleep (see sleep_for).
 std::condition_variable g_interrupt_condition_variable;
-std::atomic<bool> g_is_interrupted = false;
+std::atomic<bool> g_is_interrupted(false);
 /// Mutex for protecting the global condition variable.
 std::mutex g_interrupt_mutex;
 


### PR DESCRIPTION
On Windows this issue is most prenounced, but apparently it is possible on all platforms that `std::condition_variable::wait_for` can be spuriously interrupted and return `std::cv_status::no_timeout` even when not notified.

This logic attempts to deal with this by adding an additional bool to indicate when the system has been interrupted either by ctrl-c or `rclcpp::shutdown` and will recurse if the specified duration has not yet been exceeded.