### PR TITLE
Change behavior of timer on construction

### DIFF
--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -97,9 +97,8 @@ public:
   GenericTimer(std::chrono::nanoseconds period, CallbackType callback)
   : TimerBase(period, callback), loop_rate_(period)
   {
-    /* Subtracting the loop rate period ensures that the callback gets triggered
-       on the first call to check_and_trigger. */
-    last_triggered_time_ = Clock::now() - period;
+    /* Set last_triggered_time_ so that the timer fires at least one period after being created. */
+    last_triggered_time_ = Clock::now();
   }
 
   /// Default destructor.


### PR DESCRIPTION
Fixes ros2/system_tests#36

Based on the discussion in ros2/system_tests#66

Previously, timers would fire on the very first call to spin, no matter how much time passed between their construction and the call to spin.

This PR will change the behavior of timers so that the timer will fire one period after being created, or on the first call to spin IF that call happens after one period.