### PR TITLE
set signal_status to 0 in rclcpp::init

### DIFF
--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -127,6 +127,7 @@ rclcpp::utilities::init(int argc, char * argv[])
       error_string);
     // *INDENT-ON*
   }
+  ::g_signal_status = 0;
 }
 
 bool


### PR DESCRIPTION
`shutdown` should be the inverse function of `init`. This PR sets state that is set in `shutdown` back to what its starting value should be in `init`, to make the functions more symmetric.

Ideally, calling `init, shutdown, init` should have the same effect as calling `init` once.