### PR TITLE
refactor executor::cancel to use a spinning state

### DIFF
--- a/rclcpp/include/rclcpp/any_executable.hpp
+++ b/rclcpp/include/rclcpp/any_executable.hpp
@@ -33,6 +33,9 @@ struct AnyExecutable
   RCLCPP_PUBLIC
   AnyExecutable();
 
+  RCLCPP_PUBLIC
+  virtual ~AnyExecutable();
+
   // Only one of the following pointers will be set.
   rclcpp::subscription::SubscriptionBase::SharedPtr subscription;
   rclcpp::subscription::SubscriptionBase::SharedPtr subscription_intra_process;

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -180,9 +180,8 @@ public:
     return FutureReturnCode::INTERRUPTED;
   }
 
-  /// Stop everything
-  /**
-   */
+  /// Cancels any running spin* function, causing it to return.
+  /* This function can be called asynchonously from any thread. */
   RCLCPP_PUBLIC
   void
   cancel();
@@ -260,8 +259,8 @@ protected:
   AnyExecutable::SharedPtr
   get_next_executable(std::chrono::nanoseconds timeout = std::chrono::nanoseconds(-1));
 
-  /// For cancelling execution mid-spin.
-  std::atomic_bool canceled;
+  /// Spinning state, used to prevent multi threaded calls to spin and to cancel blocking spins.
+  std::atomic_bool spinning;
 
   /// Guard condition for signaling the rmw layer to wake up for special events.
   rmw_guard_condition_t * interrupt_guard_condition_;

--- a/rclcpp/src/rclcpp/any_executable.cpp
+++ b/rclcpp/src/rclcpp/any_executable.cpp
@@ -25,3 +25,13 @@ AnyExecutable::AnyExecutable()
   callback_group(nullptr),
   node(nullptr)
 {}
+
+AnyExecutable::~AnyExecutable()
+{
+  // Make sure that discarded (taken but not executed) AnyExecutable's have
+  // their callback groups reset. This can happen when an executor is canceled
+  // between taking an AnyExecutable and executing it.
+  if (callback_group) {
+    callback_group->can_be_taken_from().store(true);
+  }
+}

--- a/rclcpp/src/rclcpp/executors/single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/single_threaded_executor.cpp
@@ -26,9 +26,12 @@ SingleThreadedExecutor::~SingleThreadedExecutor() {}
 void
 SingleThreadedExecutor::spin()
 {
-  canceled = false;
-  while (rclcpp::utilities::ok() && !canceled) {
+  if (spinning.exchange(true)) {
+    throw std::runtime_error("spin_some() called while already spinning");
+  }
+  while (rclcpp::utilities::ok() && spinning.load()) {
     auto any_exec = get_next_executable();
     execute_any_executable(any_exec);
   }
+  spinning.store(false);
 }


### PR DESCRIPTION
@jacquelinekay as we discussed off-line.