### PR TITLE
Fixes for multithreaded execution

### DIFF
--- a/rclcpp/include/rclcpp/any_executable.hpp
+++ b/rclcpp/include/rclcpp/any_executable.hpp
@@ -48,9 +48,9 @@ struct AnyExecutable
   rclcpp::callback_group::CallbackGroup::SharedPtr get_callback_group() const;
   rclcpp::node::Node::SharedPtr get_node() const;
 
-  void set_subscription(const rclcpp::subscription::SubscriptionBase::SharedPtr subscription);
-  void set_subscription_intra_process(const rclcpp::subscription::SubscriptionBase::SharedPtr subscription);
-  void set_timer(const rclcpp::timer::TimerBase::SharedPtr timer);
+  void set_subscription(const rclcpp::subscription::SubscriptionBase::ConstSharedPtr subscription);
+  void set_subscription_intra_process(const rclcpp::subscription::SubscriptionBase::ConstSharedPtr subscription);
+  void set_timer(const rclcpp::timer::TimerBase::ConstSharedPtr timer);
   void set_service(const rclcpp::service::ServiceBase::SharedPtr service);
   void set_client(const rclcpp::client::ClientBase::SharedPtr client);
   // These are used to keep the scope on the containing items
@@ -59,9 +59,9 @@ struct AnyExecutable
 
 private:
   // Only one of the following pointers will be set.
-  rclcpp::subscription::SubscriptionBase::SharedPtr subscription_;
-  rclcpp::subscription::SubscriptionBase::SharedPtr subscription_intra_process_;
-  rclcpp::timer::TimerBase::SharedPtr timer_;
+  rclcpp::subscription::SubscriptionBase::ConstSharedPtr subscription_;
+  rclcpp::subscription::SubscriptionBase::ConstSharedPtr subscription_intra_process_;
+  rclcpp::timer::TimerBase::ConstSharedPtr timer_;
   rclcpp::service::ServiceBase::SharedPtr service_;
   rclcpp::client::ClientBase::SharedPtr client_;
   // These are used to keep the scope on the containing items

--- a/rclcpp/include/rclcpp/any_executable.hpp
+++ b/rclcpp/include/rclcpp/any_executable.hpp
@@ -39,9 +39,9 @@ struct AnyExecutable
 
   bool is_one_field_set() const;
 
-  rclcpp::subscription::SubscriptionBase::SharedPtr get_subscription() const;
-  rclcpp::subscription::SubscriptionBase::SharedPtr get_subscription_intra_process() const;
-  rclcpp::timer::TimerBase::SharedPtr get_timer() const;
+  rclcpp::subscription::SubscriptionBase::ConstSharedPtr get_subscription() const;
+  rclcpp::subscription::SubscriptionBase::ConstSharedPtr get_subscription_intra_process() const;
+  rclcpp::timer::TimerBase::ConstSharedPtr get_timer() const;
   rclcpp::service::ServiceBase::SharedPtr get_service() const;
   rclcpp::client::ClientBase::SharedPtr get_client() const;
   // These are used to keep the scope on the containing items

--- a/rclcpp/include/rclcpp/any_executable.hpp
+++ b/rclcpp/include/rclcpp/any_executable.hpp
@@ -16,6 +16,7 @@
 #define RCLCPP__ANY_EXECUTABLE_HPP_
 
 #include <memory>
+#include <mutex>
 
 #include "rclcpp/macros.hpp"
 #include "rclcpp/node.hpp"
@@ -36,15 +37,36 @@ struct AnyExecutable
   RCLCPP_PUBLIC
   virtual ~AnyExecutable();
 
-  // Only one of the following pointers will be set.
-  rclcpp::subscription::SubscriptionBase::SharedPtr subscription;
-  rclcpp::subscription::SubscriptionBase::SharedPtr subscription_intra_process;
-  rclcpp::timer::TimerBase::SharedPtr timer;
-  rclcpp::service::ServiceBase::SharedPtr service;
-  rclcpp::client::ClientBase::SharedPtr client;
+  bool is_one_field_set() const;
+
+  rclcpp::subscription::SubscriptionBase::SharedPtr get_subscription() const;
+  rclcpp::subscription::SubscriptionBase::SharedPtr get_subscription_intra_process() const;
+  rclcpp::timer::TimerBase::SharedPtr get_timer() const;
+  rclcpp::service::ServiceBase::SharedPtr get_service() const;
+  rclcpp::client::ClientBase::SharedPtr get_client() const;
   // These are used to keep the scope on the containing items
-  rclcpp::callback_group::CallbackGroup::SharedPtr callback_group;
-  rclcpp::node::Node::SharedPtr node;
+  rclcpp::callback_group::CallbackGroup::SharedPtr get_callback_group() const;
+  rclcpp::node::Node::SharedPtr get_node() const;
+
+  void set_subscription(const rclcpp::subscription::SubscriptionBase::SharedPtr subscription);
+  void set_subscription_intra_process(const rclcpp::subscription::SubscriptionBase::SharedPtr subscription);
+  void set_timer(const rclcpp::timer::TimerBase::SharedPtr timer);
+  void set_service(const rclcpp::service::ServiceBase::SharedPtr service);
+  void set_client(const rclcpp::client::ClientBase::SharedPtr client);
+  // These are used to keep the scope on the containing items
+  void set_callback_group(const rclcpp::callback_group::CallbackGroup::SharedPtr callback_group);
+  void set_node(const rclcpp::node::Node::SharedPtr node);
+
+private:
+  // Only one of the following pointers will be set.
+  rclcpp::subscription::SubscriptionBase::SharedPtr subscription_;
+  rclcpp::subscription::SubscriptionBase::SharedPtr subscription_intra_process_;
+  rclcpp::timer::TimerBase::SharedPtr timer_;
+  rclcpp::service::ServiceBase::SharedPtr service_;
+  rclcpp::client::ClientBase::SharedPtr client_;
+  // These are used to keep the scope on the containing items
+  rclcpp::callback_group::CallbackGroup::SharedPtr callback_group_;
+  rclcpp::node::Node::SharedPtr node_;
 };
 
 }  // namespace executor

--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -154,7 +154,7 @@ public:
   }
 
   void dispatch(
-    std::shared_ptr<MessageT> message, const rmw_message_info_t & message_info)
+    std::shared_ptr<MessageT> message, const rmw_message_info_t & message_info) const
   {
     (void)message_info;
     if (shared_ptr_callback_) {
@@ -179,7 +179,7 @@ public:
   }
 
   void dispatch_intra_process(
-    MessageUniquePtr & message, const rmw_message_info_t & message_info)
+    MessageUniquePtr & message, const rmw_message_info_t & message_info) const
   {
     (void)message_info;
     if (shared_ptr_callback_) {

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -208,7 +208,7 @@ protected:
    */
   RCLCPP_PUBLIC
   void
-  execute_any_executable(const AnyExecutable::ConstSharedPtr any_exec);
+  execute_any_executable(const AnyExecutable::ConstSharedPtr & any_exec);
 
   RCLCPP_PUBLIC
   static void

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -208,7 +208,7 @@ protected:
    */
   RCLCPP_PUBLIC
   void
-  execute_any_executable(const AnyExecutable::ConstSharedPtr & any_exec);
+  execute_any_executable(const AnyExecutable::ConstSharedPtr any_exec);
 
   RCLCPP_PUBLIC
   static void

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 #include "rclcpp/any_executable.hpp"
@@ -207,21 +208,21 @@ protected:
    */
   RCLCPP_PUBLIC
   void
-  execute_any_executable(AnyExecutable::ConstSharedPtr any_exec) const;
+  execute_any_executable(const AnyExecutable::ConstSharedPtr any_exec);
 
   RCLCPP_PUBLIC
   static void
   execute_subscription(
-    rclcpp::subscription::SubscriptionBase::ConstSharedPtr subscription);
+    const rclcpp::subscription::SubscriptionBase::ConstSharedPtr subscription);
 
   RCLCPP_PUBLIC
   static void
   execute_intra_process_subscription(
-    rclcpp::subscription::SubscriptionBase::ConstSharedPtr subscription);
+    const rclcpp::subscription::SubscriptionBase::ConstSharedPtr subscription);
 
   RCLCPP_PUBLIC
   static void
-  execute_timer(rclcpp::timer::TimerBase::ConstSharedPtr timer);
+  execute_timer(const rclcpp::timer::TimerBase::ConstSharedPtr timer);
 
   RCLCPP_PUBLIC
   static void
@@ -244,7 +245,7 @@ protected:
   get_group_by_timer(rclcpp::timer::TimerBase::SharedPtr timer);
 
   RCLCPP_PUBLIC
-  void
+  bool
   get_next_timer(AnyExecutable::SharedPtr any_exec);
 
   RCLCPP_PUBLIC
@@ -263,7 +264,8 @@ protected:
   std::atomic_bool spinning;
 
   /// Guard condition for signaling the rmw layer to wake up for special events.
-  std::atomic<rmw_guard_condition_t *> interrupt_guard_condition_;
+  rmw_guard_condition_t * interrupt_guard_condition_;
+  std::mutex trigger_guard_condition_mutex_;
 
   /// The memory strategy: an interface for handling user-defined memory allocation strategies.
   memory_strategy::MemoryStrategy::SharedPtr memory_strategy_;

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -207,21 +207,21 @@ protected:
    */
   RCLCPP_PUBLIC
   void
-  execute_any_executable(AnyExecutable::SharedPtr any_exec);
+  execute_any_executable(AnyExecutable::ConstSharedPtr any_exec) const;
 
   RCLCPP_PUBLIC
   static void
   execute_subscription(
-    rclcpp::subscription::SubscriptionBase::SharedPtr subscription);
+    rclcpp::subscription::SubscriptionBase::ConstSharedPtr subscription);
 
   RCLCPP_PUBLIC
   static void
   execute_intra_process_subscription(
-    rclcpp::subscription::SubscriptionBase::SharedPtr subscription);
+    rclcpp::subscription::SubscriptionBase::ConstSharedPtr subscription);
 
   RCLCPP_PUBLIC
   static void
-  execute_timer(rclcpp::timer::TimerBase::SharedPtr timer);
+  execute_timer(rclcpp::timer::TimerBase::ConstSharedPtr timer);
 
   RCLCPP_PUBLIC
   static void
@@ -263,7 +263,7 @@ protected:
   std::atomic_bool spinning;
 
   /// Guard condition for signaling the rmw layer to wake up for special events.
-  rmw_guard_condition_t * interrupt_guard_condition_;
+  std::atomic<rmw_guard_condition_t *> interrupt_guard_condition_;
 
   /// The memory strategy: an interface for handling user-defined memory allocation strategies.
   memory_strategy::MemoryStrategy::SharedPtr memory_strategy_;

--- a/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
@@ -62,6 +62,7 @@ private:
   std::mutex wait_mutex_;
   size_t number_of_threads_;
   std::unordered_map<std::thread::id, size_t> thread_number_by_thread_id_;
+  std::vector<executor::AnyExecutable::SharedPtr> thread_executables;
 };
 
 }  // namespace multi_threaded_executor

--- a/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
@@ -62,7 +62,6 @@ private:
   std::mutex wait_mutex_;
   size_t number_of_threads_;
   std::unordered_map<std::thread::id, size_t> thread_number_by_thread_id_;
-  std::vector<executor::AnyExecutable::SharedPtr> thread_executables;
 };
 
 }  // namespace multi_threaded_executor

--- a/rclcpp/include/rclcpp/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager.hpp
@@ -333,7 +333,7 @@ public:
   /// Return true if the given rmw_gid_t matches any stored Publishers.
   RCLCPP_PUBLIC
   bool
-  matches_any_publishers(const rmw_gid_t * id) const;
+  matches_any_publishers(const rmw_gid_t * id);
 
 private:
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager.hpp
@@ -239,6 +239,7 @@ public:
     uint64_t intra_process_publisher_id,
     std::unique_ptr<MessageT, Deleter> & message)
   {
+    std::lock_guard<std::mutex> lock(mutex_);
     using MRBMessageAlloc = typename std::allocator_traits<Alloc>::template rebind_alloc<MessageT>;
     using TypedMRB = typename mapped_ring_buffer::MappedRingBuffer<MessageT, MRBMessageAlloc>;
     uint64_t message_seq = 0;
@@ -303,6 +304,7 @@ public:
     uint64_t requesting_subscriptions_intra_process_id,
     std::unique_ptr<MessageT, Deleter> & message)
   {
+    std::lock_guard<std::mutex> lock(mutex_);
     using MRBMessageAlloc = typename std::allocator_traits<Alloc>::template rebind_alloc<MessageT>;
     using TypedMRB = mapped_ring_buffer::MappedRingBuffer<MessageT, MRBMessageAlloc>;
     message = nullptr;
@@ -339,6 +341,7 @@ private:
   get_next_unique_id();
 
   IntraProcessManagerStateBase::SharedPtr state_;
+  std::mutex mutex_;
 };
 
 }  // namespace intra_process_manager

--- a/rclcpp/include/rclcpp/intra_process_manager_state.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager_state.hpp
@@ -90,14 +90,12 @@ public:
   void
   add_subscription(uint64_t id, subscription::SubscriptionBase::SharedPtr subscription)
   {
-    subscriptions_[id] = subscription;
     subscription_ids_by_topic_[subscription->get_topic_name()].insert(id);
   }
 
   void
   remove_subscription(uint64_t intra_process_subscription_id)
   {
-    subscriptions_.erase(intra_process_subscription_id);
     for (auto & pair : subscription_ids_by_topic_) {
       pair.second.erase(intra_process_subscription_id);
     }
@@ -239,13 +237,8 @@ private:
   using RebindAlloc = typename std::allocator_traits<Allocator>::template rebind_alloc<T>;
 
   using AllocSet = std::set<uint64_t, std::less<uint64_t>, RebindAlloc<uint64_t>>;
-  using SubscriptionMap = std::unordered_map<uint64_t, subscription::SubscriptionBase::WeakPtr,
-      std::hash<uint64_t>, std::equal_to<uint64_t>,
-      RebindAlloc<std::pair<const uint64_t, subscription::SubscriptionBase::WeakPtr>>>;
   using IDTopicMap = std::map<std::string, AllocSet,
       std::less<std::string>, RebindAlloc<std::pair<std::string, AllocSet>>>;
-
-  SubscriptionMap subscriptions_;
 
   IDTopicMap subscription_ids_by_topic_;
 

--- a/rclcpp/include/rclcpp/intra_process_manager_state.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager_state.hpp
@@ -21,6 +21,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -102,6 +103,7 @@ public:
     // Iterate over all publisher infos and all stored subscription id's and
     // remove references to this subscription's id.
     for (auto & publisher_pair : publishers_) {
+      std::lock_guard<std::mutex> lock(publisher_pair.second.target_subscriptions_mutex_);
       for (auto & sub_pair : publisher_pair.second.target_subscriptions_by_message_sequence) {
         sub_pair.second.erase(intra_process_subscription_id);
       }
@@ -121,7 +123,10 @@ public:
     publishers_[id].sequence_number.store(0);
 
     publishers_[id].buffer = mrb;
-    publishers_[id].target_subscriptions_by_message_sequence.reserve(size);
+    {
+      std::lock_guard<std::mutex> lock(publishers_[id].target_subscriptions_mutex_);
+      publishers_[id].target_subscriptions_by_message_sequence.reserve(size);
+    }
   }
 
   void
@@ -136,6 +141,7 @@ public:
     uint64_t intra_process_publisher_id,
     uint64_t & message_seq)
   {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto it = publishers_.find(intra_process_publisher_id);
     if (it == publishers_.end()) {
       throw std::runtime_error("store_intra_process_message called with invalid publisher id");
@@ -150,6 +156,7 @@ public:
   void
   store_intra_process_message(uint64_t intra_process_publisher_id, uint64_t message_seq)
   {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto it = publishers_.find(intra_process_publisher_id);
     if (it == publishers_.end()) {
       throw std::runtime_error("store_intra_process_message called with invalid publisher id");
@@ -163,16 +170,19 @@ public:
     // Figure out what subscriptions should receive the message.
     auto & destined_subscriptions = subscription_ids_by_topic_[publisher->get_topic_name()];
     // Store the list for later comparison.
-    info.target_subscriptions_by_message_sequence[message_seq].clear();
-    std::copy(
-      destined_subscriptions.begin(), destined_subscriptions.end(),
-      // Memory allocation occurs in info.target_subscriptions_by_message_sequence[message_seq]
-      std::inserter(
-        info.target_subscriptions_by_message_sequence[message_seq],
-        // This ends up only being a hint to std::set, could also be .begin().
-        info.target_subscriptions_by_message_sequence[message_seq].end()
-      )
-    );
+    {
+      std::lock_guard<std::mutex> lock(info.target_subscriptions_mutex_);
+      info.target_subscriptions_by_message_sequence[message_seq].clear();
+      std::copy(
+        destined_subscriptions.begin(), destined_subscriptions.end(),
+        // Memory allocation occurs in info.target_subscriptions_by_message_sequence[message_seq]
+        std::inserter(
+          info.target_subscriptions_by_message_sequence[message_seq],
+          // This ends up only being a hint to std::set, could also be .begin().
+          info.target_subscriptions_by_message_sequence[message_seq].end()
+        )
+      );
+    }
   }
 
   mapped_ring_buffer::MappedRingBufferBase::SharedPtr
@@ -182,6 +192,7 @@ public:
     size_t & size
   )
   {
+    std::lock_guard<std::mutex> lock(mutex_);
     PublisherInfo * info;
     {
       auto it = publishers_.find(intra_process_publisher_id);
@@ -194,6 +205,7 @@ public:
     // Figure out how many subscriptions are left.
     AllocSet * target_subs;
     {
+      std::lock_guard<std::mutex> lock(info->target_subscriptions_mutex_);
       auto it = info->target_subscriptions_by_message_sequence.find(message_sequence_number);
       if (it == info->target_subscriptions_by_message_sequence.end()) {
         // Message is no longer being stored by this publisher.
@@ -256,6 +268,7 @@ private:
         std::hash<uint64_t>, std::equal_to<uint64_t>,
         RebindAlloc<std::pair<const uint64_t, AllocSet>>>;
     TargetSubscriptionsMap target_subscriptions_by_message_sequence;
+    std::mutex target_subscriptions_mutex_;
   };
 
   using PublisherMap = std::unordered_map<uint64_t, PublisherInfo,
@@ -263,6 +276,8 @@ private:
       RebindAlloc<std::pair<const uint64_t, PublisherInfo>>>;
 
   PublisherMap publishers_;
+
+  std::mutex mutex_;
 };
 
 RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/macros.hpp
+++ b/rclcpp/include/rclcpp/macros.hpp
@@ -47,7 +47,9 @@
   RCLCPP_WEAK_PTR_DEFINITIONS(__VA_ARGS__) \
   __RCLCPP_UNIQUE_PTR_ALIAS(__VA_ARGS__)
 
-#define __RCLCPP_SHARED_PTR_ALIAS(...) using SharedPtr = std::shared_ptr<__VA_ARGS__>;
+#define __RCLCPP_SHARED_PTR_ALIAS(...)\
+  using SharedPtr = std::shared_ptr<__VA_ARGS__>; \
+  using ConstSharedPtr = std::shared_ptr<const __VA_ARGS__>;
 
 #define __RCLCPP_MAKE_SHARED_DEFINITION(...) \
   template<typename ... Args> \

--- a/rclcpp/include/rclcpp/mapped_ring_buffer.hpp
+++ b/rclcpp/include/rclcpp/mapped_ring_buffer.hpp
@@ -19,6 +19,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 #include "rclcpp/allocator/allocator_common.hpp"
@@ -97,6 +98,7 @@ public:
   void
   get_copy_at_key(uint64_t key, ElemUniquePtr & value)
   {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto it = get_iterator_of_key(key);
     value = nullptr;
     if (it != elements_.end() && it->in_use) {
@@ -128,6 +130,7 @@ public:
   void
   get_ownership_at_key(uint64_t key, ElemUniquePtr & value)
   {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto it = get_iterator_of_key(key);
     value = nullptr;
     if (it != elements_.end() && it->in_use) {
@@ -155,6 +158,7 @@ public:
   void
   pop_at_key(uint64_t key, ElemUniquePtr & value)
   {
+    std::lock_guard<std::mutex> lock(mutex_);
     auto it = get_iterator_of_key(key);
     value = nullptr;
     if (it != elements_.end() && it->in_use) {
@@ -177,6 +181,7 @@ public:
   bool
   push_and_replace(uint64_t key, ElemUniquePtr & value)
   {
+    std::lock_guard<std::mutex> lock(mutex_);
     bool did_replace = elements_[head_].in_use;
     elements_[head_].key = key;
     elements_[head_].value.swap(value);
@@ -196,6 +201,7 @@ public:
   bool
   has_key(uint64_t key)
   {
+    std::lock_guard<std::mutex> lock(mutex_);
     return elements_.end() != get_iterator_of_key(key);
   }
 
@@ -225,6 +231,7 @@ private:
   std::vector<element, VectorAlloc> elements_;
   size_t head_;
   std::shared_ptr<ElemAlloc> allocator_;
+  std::mutex mutex_;
 };
 
 }  // namespace mapped_ring_buffer

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -59,15 +59,15 @@ public:
   // \return Shared pointer to the fresh executable.
   virtual rclcpp::executor::AnyExecutable::SharedPtr instantiate_next_executable() = 0;
 
-  virtual void
+  virtual bool
   get_next_subscription(rclcpp::executor::AnyExecutable::SharedPtr any_exec,
     const WeakNodeVector & weak_nodes) = 0;
 
-  virtual void
+  virtual bool
   get_next_service(rclcpp::executor::AnyExecutable::SharedPtr any_exec,
     const WeakNodeVector & weak_nodes) = 0;
 
-  virtual void
+  virtual bool
   get_next_client(rclcpp::executor::AnyExecutable::SharedPtr any_exec,
     const WeakNodeVector & weak_nodes) = 0;
 
@@ -87,7 +87,7 @@ public:
 
   static rclcpp::callback_group::CallbackGroup::SharedPtr
   get_group_by_subscription(
-    rclcpp::subscription::SubscriptionBase::SharedPtr subscription,
+    const rclcpp::subscription::SubscriptionBase::SharedPtr subscription,
     const WeakNodeVector & weak_nodes);
 
   static rclcpp::callback_group::CallbackGroup::SharedPtr

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -71,7 +71,7 @@ public:
   get_next_client(rclcpp::executor::AnyExecutable::SharedPtr any_exec,
     const WeakNodeVector & weak_nodes) = 0;
 
-  static rclcpp::subscription::SubscriptionBase::SharedPtr
+  static rclcpp::subscription::SubscriptionBase::ConstSharedPtr
   get_subscription_by_handle(void * subscriber_handle,
     const WeakNodeVector & weak_nodes);
 
@@ -87,7 +87,7 @@ public:
 
   static rclcpp::callback_group::CallbackGroup::SharedPtr
   get_group_by_subscription(
-    const rclcpp::subscription::SubscriptionBase::SharedPtr subscription,
+    const rclcpp::subscription::SubscriptionBase::ConstSharedPtr subscription,
     const WeakNodeVector & weak_nodes);
 
   static rclcpp::callback_group::CallbackGroup::SharedPtr

--- a/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
@@ -15,6 +15,7 @@
 #ifndef RCLCPP__STRATEGIES__ALLOCATOR_MEMORY_STRATEGY_HPP_
 #define RCLCPP__STRATEGIES__ALLOCATOR_MEMORY_STRATEGY_HPP_
 
+#include <cassert>
 #include <memory>
 #include <vector>
 
@@ -173,6 +174,7 @@ public:
   get_next_subscription(executor::AnyExecutable::SharedPtr any_exec,
     const WeakNodeVector & weak_nodes)
   {
+    assert(any_exec);
     auto it = subscriber_handles_.begin();
     while (it != subscriber_handles_.end()) {
       auto subscription = get_subscription_by_handle(*it, weak_nodes);

--- a/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
@@ -170,14 +170,13 @@ public:
     return std::allocate_shared<executor::AnyExecutable>(*executable_allocator_.get());
   }
 
-  virtual void
+  virtual bool
   get_next_subscription(executor::AnyExecutable::SharedPtr any_exec,
     const WeakNodeVector & weak_nodes)
   {
-    assert(any_exec);
     auto it = subscriber_handles_.begin();
     while (it != subscriber_handles_.end()) {
-      auto subscription = get_subscription_by_handle(*it, weak_nodes);
+      const subscription::SubscriptionBase::SharedPtr subscription = get_subscription_by_handle(*it, weak_nodes);
       if (subscription) {
         // Figure out if this is for intra-process or not.
         bool is_intra_process = false;
@@ -200,21 +199,22 @@ public:
         }
         // Otherwise it is safe to set and return the any_exec
         if (is_intra_process) {
-          any_exec->subscription_intra_process = subscription;
+          any_exec->set_subscription_intra_process(subscription);
         } else {
-          any_exec->subscription = subscription;
+          any_exec->set_subscription(subscription);
         }
-        any_exec->callback_group = group;
-        any_exec->node = get_node_by_group(group, weak_nodes);
+        any_exec->set_callback_group(group);
+        any_exec->set_node(get_node_by_group(group, weak_nodes));
         subscriber_handles_.erase(it);
-        return;
+        return true;
       }
       // Else, the subscription is no longer valid, remove it and continue
       subscriber_handles_.erase(it);
     }
+    return false;
   }
 
-  virtual void
+  virtual bool
   get_next_service(executor::AnyExecutable::SharedPtr any_exec,
     const WeakNodeVector & weak_nodes)
   {
@@ -237,18 +237,19 @@ public:
           continue;
         }
         // Otherwise it is safe to set and return the any_exec
-        any_exec->service = service;
-        any_exec->callback_group = group;
-        any_exec->node = get_node_by_group(group, weak_nodes);
+        any_exec->set_service(service);
+        any_exec->set_callback_group(group);
+        any_exec->set_node(get_node_by_group(group, weak_nodes));
         service_handles_.erase(it);
-        return;
+        return true;
       }
       // Else, the service is no longer valid, remove it and continue
       service_handles_.erase(it);
     }
+    return false;
   }
 
-  virtual void
+  virtual bool
   get_next_client(executor::AnyExecutable::SharedPtr any_exec, const WeakNodeVector & weak_nodes)
   {
     auto it = client_handles_.begin();
@@ -270,15 +271,16 @@ public:
           continue;
         }
         // Otherwise it is safe to set and return the any_exec
-        any_exec->client = client;
-        any_exec->callback_group = group;
-        any_exec->node = get_node_by_group(group, weak_nodes);
+        any_exec->set_client(client);
+        any_exec->set_callback_group(group);
+        any_exec->set_node(get_node_by_group(group, weak_nodes));
         client_handles_.erase(it);
-        return;
+        return true;
       }
       // Else, the service is no longer valid, remove it and continue
       client_handles_.erase(it);
     }
+    return false;
   }
 
 private:

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -82,23 +82,23 @@ public:
   /// Borrow a new message.
   // \return Shared pointer to the fresh message.
   virtual std::shared_ptr<void>
-  create_message() = 0;
+  create_message() const = 0;
   /// Check if we need to handle the message, and execute the callback if we do.
   /**
    * \param[in] message Shared pointer to the message to handle.
    * \param[in] message_info Metadata associated with this message.
    */
   virtual void
-  handle_message(std::shared_ptr<void> & message, const rmw_message_info_t & message_info) = 0;
+  handle_message(std::shared_ptr<void> & message, const rmw_message_info_t & message_info) const = 0;
 
   /// Return the message borrowed in create_message.
   // \param[in] Shared pointer to the returned message.
   virtual void
-  return_message(std::shared_ptr<void> & message) = 0;
+  return_message(std::shared_ptr<void> & message) const = 0;
   virtual void
   handle_intra_process_message(
     rcl_interfaces::msg::IntraProcessMessage & ipm,
-    const rmw_message_info_t & message_info) = 0;
+    const rmw_message_info_t & message_info) const = 0;
 
 protected:
   rmw_subscription_t * intra_process_subscription_handle_;
@@ -168,7 +168,7 @@ public:
   {
     message_memory_strategy_ = message_memory_strategy;
   }
-  std::shared_ptr<void> create_message()
+  std::shared_ptr<void> create_message() const
   {
     /* The default message memory strategy provides a dynamically allocated message on each call to
      * create_message, though alternative memory strategies that re-use a preallocated message may be
@@ -177,7 +177,7 @@ public:
     return message_memory_strategy_->borrow_message();
   }
 
-  void handle_message(std::shared_ptr<void> & message, const rmw_message_info_t & message_info)
+  void handle_message(std::shared_ptr<void> & message, const rmw_message_info_t & message_info) const
   {
     if (matches_any_intra_process_publishers_) {
       if (matches_any_intra_process_publishers_(&message_info.publisher_gid)) {
@@ -190,7 +190,7 @@ public:
     any_callback_.dispatch(typed_message, message_info);
   }
 
-  void return_message(std::shared_ptr<void> & message)
+  void return_message(std::shared_ptr<void> & message) const
   {
     auto typed_message = std::static_pointer_cast<MessageT>(message);
     message_memory_strategy_->return_message(typed_message);
@@ -198,7 +198,7 @@ public:
 
   void handle_intra_process_message(
     rcl_interfaces::msg::IntraProcessMessage & ipm,
-    const rmw_message_info_t & message_info)
+    const rmw_message_info_t & message_info) const
   {
     if (!get_intra_process_message_callback_) {
       // throw std::runtime_error(

--- a/rclcpp/src/rclcpp/any_executable.cpp
+++ b/rclcpp/src/rclcpp/any_executable.cpp
@@ -14,16 +14,18 @@
 
 #include "rclcpp/any_executable.hpp"
 
+#include <cassert>
+
 using rclcpp::executor::AnyExecutable;
 
-AnyExecutable::AnyExecutable()
-: subscription(nullptr),
-  subscription_intra_process(nullptr),
-  timer(nullptr),
-  service(nullptr),
-  client(nullptr),
-  callback_group(nullptr),
-  node(nullptr)
+AnyExecutable::AnyExecutable() :
+ subscription_(nullptr),
+ subscription_intra_process_(nullptr),
+ timer_(nullptr),
+ service_(nullptr),
+ client_(nullptr),
+ callback_group_(nullptr),
+ node_(nullptr)
 {}
 
 AnyExecutable::~AnyExecutable()
@@ -31,7 +33,93 @@ AnyExecutable::~AnyExecutable()
   // Make sure that discarded (taken but not executed) AnyExecutable's have
   // their callback groups reset. This can happen when an executor is canceled
   // between taking an AnyExecutable and executing it.
-  if (callback_group) {
-    callback_group->can_be_taken_from().store(true);
+  if (callback_group_) {
+    callback_group_->can_be_taken_from().store(true);
   }
+}
+
+bool AnyExecutable::is_one_field_set() const {
+  size_t fields_set = 0;
+  if (timer_) {
+    ++fields_set;
+  }
+  if (subscription_) {
+    ++fields_set;
+  }
+  if (subscription_intra_process_) {
+    ++fields_set;
+  }
+  if (service_) {
+    ++fields_set;
+  }
+  if (client_) {
+    ++fields_set;
+  }
+  return fields_set == 1;
+}
+
+rclcpp::subscription::SubscriptionBase::SharedPtr AnyExecutable::get_subscription() const {
+  return subscription_;
+}
+
+rclcpp::subscription::SubscriptionBase::SharedPtr
+AnyExecutable::get_subscription_intra_process() const {
+  return subscription_intra_process_;
+}
+
+rclcpp::timer::TimerBase::SharedPtr AnyExecutable::get_timer() const {
+  return timer_;
+}
+
+rclcpp::service::ServiceBase::SharedPtr AnyExecutable::get_service() const {
+  return service_;
+}
+
+rclcpp::client::ClientBase::SharedPtr AnyExecutable::get_client() const {
+  return client_;
+}
+
+rclcpp::callback_group::CallbackGroup::SharedPtr AnyExecutable::get_callback_group() const {
+  return callback_group_;
+}
+
+rclcpp::node::Node::SharedPtr AnyExecutable::get_node() const {
+  return node_;
+}
+
+void
+AnyExecutable::set_subscription(
+  const rclcpp::subscription::SubscriptionBase::SharedPtr subscription)
+{
+  subscription_ = subscription;
+}
+
+void
+AnyExecutable::set_subscription_intra_process(
+  const rclcpp::subscription::SubscriptionBase::SharedPtr subscription)
+{
+  subscription_intra_process_ = subscription;
+}
+
+void AnyExecutable::set_timer(const rclcpp::timer::TimerBase::SharedPtr timer) {
+  timer_ = timer;
+}
+
+void AnyExecutable::set_service(const rclcpp::service::ServiceBase::SharedPtr service) {
+  service_ = service;
+}
+
+void AnyExecutable::set_client(const rclcpp::client::ClientBase::SharedPtr client) {
+  client_ = client;
+}
+
+void
+AnyExecutable::set_callback_group(
+  const rclcpp::callback_group::CallbackGroup::SharedPtr callback_group)
+{
+  callback_group_ = callback_group;
+}
+
+void AnyExecutable::set_node(const rclcpp::node::Node::SharedPtr node) {
+  node_ = node;
 }

--- a/rclcpp/src/rclcpp/any_executable.cpp
+++ b/rclcpp/src/rclcpp/any_executable.cpp
@@ -42,10 +42,14 @@ bool AnyExecutable::is_one_field_set() const {
   std::atomic<size_t> fields_set(0);
   if (timer_) {
     fields_set.fetch_add(1, std::memory_order_relaxed);
-  }
+  }/* else {
+    assert(timer_.use_count() == 0);
+  }*/
   if (subscription_) {
     fields_set.fetch_add(1, std::memory_order_relaxed);
-  }
+  }/* else {
+    assert(subscription_.use_count() == 0);
+  }*/
   if (subscription_intra_process_) {
     fields_set.fetch_add(1, std::memory_order_relaxed);
   }
@@ -89,19 +93,19 @@ rclcpp::node::Node::SharedPtr AnyExecutable::get_node() const {
 
 void
 AnyExecutable::set_subscription(
-  const rclcpp::subscription::SubscriptionBase::SharedPtr subscription)
+  const rclcpp::subscription::SubscriptionBase::ConstSharedPtr subscription)
 {
   subscription_ = subscription;
 }
 
 void
 AnyExecutable::set_subscription_intra_process(
-  const rclcpp::subscription::SubscriptionBase::SharedPtr subscription)
+  const rclcpp::subscription::SubscriptionBase::ConstSharedPtr subscription)
 {
   subscription_intra_process_ = subscription;
 }
 
-void AnyExecutable::set_timer(const rclcpp::timer::TimerBase::SharedPtr timer) {
+void AnyExecutable::set_timer(const rclcpp::timer::TimerBase::ConstSharedPtr timer) {
   timer_ = timer;
 }
 

--- a/rclcpp/src/rclcpp/any_executable.cpp
+++ b/rclcpp/src/rclcpp/any_executable.cpp
@@ -39,35 +39,35 @@ AnyExecutable::~AnyExecutable()
 }
 
 bool AnyExecutable::is_one_field_set() const {
-  size_t fields_set = 0;
+  std::atomic<size_t> fields_set(0);
   if (timer_) {
-    ++fields_set;
+    fields_set.fetch_add(1, std::memory_order_relaxed);
   }
   if (subscription_) {
-    ++fields_set;
+    fields_set.fetch_add(1, std::memory_order_relaxed);
   }
   if (subscription_intra_process_) {
-    ++fields_set;
+    fields_set.fetch_add(1, std::memory_order_relaxed);
   }
   if (service_) {
-    ++fields_set;
+    fields_set.fetch_add(1, std::memory_order_relaxed);
   }
   if (client_) {
-    ++fields_set;
+    fields_set.fetch_add(1, std::memory_order_relaxed);
   }
-  return fields_set == 1;
+  return fields_set <= 1;
 }
 
-rclcpp::subscription::SubscriptionBase::SharedPtr AnyExecutable::get_subscription() const {
+rclcpp::subscription::SubscriptionBase::ConstSharedPtr AnyExecutable::get_subscription() const {
   return subscription_;
 }
 
-rclcpp::subscription::SubscriptionBase::SharedPtr
+rclcpp::subscription::SubscriptionBase::ConstSharedPtr
 AnyExecutable::get_subscription_intra_process() const {
   return subscription_intra_process_;
 }
 
-rclcpp::timer::TimerBase::SharedPtr AnyExecutable::get_timer() const {
+rclcpp::timer::TimerBase::ConstSharedPtr AnyExecutable::get_timer() const {
   return timer_;
 }
 

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -118,7 +118,7 @@ Executor::spin_some()
   }
   RCLCPP_SCOPE_EXIT(this->spinning.store(false); );
   AnyExecutable::SharedPtr any_exec;
-  while ((any_exec = get_next_executable(std::chrono::milliseconds::zero())) && spinning.load()) {
+  while ((any_exec = get_next_executable(std::chrono::milliseconds(0))) && spinning.load()) {
     execute_any_executable(any_exec);
   }
 }
@@ -160,10 +160,6 @@ void
 Executor::execute_any_executable(const AnyExecutable::ConstSharedPtr any_exec)
 {
   if (!any_exec || !spinning.load()) {
-    return;
-  }
-
-  if (any_exec->get_callback_group() && any_exec->get_callback_group()->can_be_taken_from().load()) {
     return;
   }
 

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -157,7 +157,7 @@ Executor::set_memory_strategy(rclcpp::memory_strategy::MemoryStrategy::SharedPtr
 }
 
 void
-Executor::execute_any_executable(const AnyExecutable::ConstSharedPtr any_exec)
+Executor::execute_any_executable(const AnyExecutable::ConstSharedPtr & any_exec)
 {
   if (!any_exec || !spinning.load()) {
     return;
@@ -185,6 +185,7 @@ Executor::execute_any_executable(const AnyExecutable::ConstSharedPtr any_exec)
       throw std::runtime_error(rmw_get_error_string_safe());
     }
   }
+  //assert(any_exec->is_one_field_set());
 }
 
 void
@@ -493,6 +494,8 @@ AnyExecutable::SharedPtr
 Executor::get_next_ready_executable()
 {
   auto any_exec = memory_strategy_->instantiate_next_executable();
+  assert(any_exec->is_one_field_set());
+
   // Check the timers to see if there are any that are ready, if so return
   if (get_next_timer(any_exec)) {
     return any_exec;

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -32,7 +32,6 @@ MultiThreadedExecutor::MultiThreadedExecutor(rclcpp::memory_strategy::MemoryStra
   if (number_of_threads_ == 0) {
     number_of_threads_ = 1;
   }
-  //thread_executables.resize(number_of_threads_, nullptr);
 }
 
 MultiThreadedExecutor::~MultiThreadedExecutor() {}
@@ -68,35 +67,25 @@ MultiThreadedExecutor::run(size_t this_thread_number)
 {
   thread_number_by_thread_id_[std::this_thread::get_id()] = this_thread_number;
   while (rclcpp::utilities::ok() && spinning.load()) {
-    executor::AnyExecutable::SharedPtr any_exec;
+    executor::AnyExecutable::SharedPtr any_exec = nullptr;
     {
       std::lock_guard<std::mutex> wait_lock(wait_mutex_);
       if (!rclcpp::utilities::ok() || !spinning.load()) {
         return;
       }
-      //printf("Create executable in thread %u\n", this_thread_number);
-      //fflush(stdout);
       any_exec = get_next_executable();
-      /*
       if (any_exec) {
         assert(any_exec->is_one_field_set());
       }
-      */
     }
 
     // Argh.
     execute_any_executable(any_exec);
-    //printf("Execute executable in thread %u\n", this_thread_number);
-    //fflush(stdout);
 
-      /*
     if (any_exec) {
       std::lock_guard<std::mutex> wait_lock(wait_mutex_);
-      if (any_exec) {
-        assert(any_exec->is_one_field_set());
-      }
+      assert(any_exec->is_one_field_set());
       any_exec.reset();
     }
-      */
   }
 }

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -82,10 +82,12 @@ MultiThreadedExecutor::run(size_t this_thread_number)
     // Argh.
     execute_any_executable(any_exec);
 
+    /*
     if (any_exec) {
       std::lock_guard<std::mutex> wait_lock(wait_mutex_);
       assert(any_exec->is_one_field_set());
       any_exec.reset();
     }
+    */
   }
 }

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -32,7 +32,7 @@ MultiThreadedExecutor::MultiThreadedExecutor(rclcpp::memory_strategy::MemoryStra
   if (number_of_threads_ == 0) {
     number_of_threads_ = 1;
   }
-  thread_executables.resize(number_of_threads_, nullptr);
+  //thread_executables.resize(number_of_threads_, nullptr);
 }
 
 MultiThreadedExecutor::~MultiThreadedExecutor() {}
@@ -74,9 +74,29 @@ MultiThreadedExecutor::run(size_t this_thread_number)
       if (!rclcpp::utilities::ok() || !spinning.load()) {
         return;
       }
-      thread_executables[this_thread_number] = get_next_executable();
+      //printf("Create executable in thread %u\n", this_thread_number);
+      //fflush(stdout);
+      any_exec = get_next_executable();
+      /*
+      if (any_exec) {
+        assert(any_exec->is_one_field_set());
+      }
+      */
     }
 
-    execute_any_executable(thread_executables[this_thread_number]);
+    // Argh.
+    execute_any_executable(any_exec);
+    //printf("Execute executable in thread %u\n", this_thread_number);
+    //fflush(stdout);
+
+      /*
+    if (any_exec) {
+      std::lock_guard<std::mutex> wait_lock(wait_mutex_);
+      if (any_exec) {
+        assert(any_exec->is_one_field_set());
+      }
+      any_exec.reset();
+    }
+      */
   }
 }

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -47,8 +47,7 @@ MultiThreadedExecutor::spin()
   std::vector<std::thread> threads;
   {
     std::lock_guard<std::mutex> wait_lock(wait_mutex_);
-    for(size_t i = 0; i < number_of_threads_; ++i) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    for (size_t i = 0; i < number_of_threads_; ++i) {
       auto func = std::bind(&MultiThreadedExecutor::run, this, i);
       threads.emplace_back(func);
     }
@@ -75,15 +74,9 @@ MultiThreadedExecutor::run(size_t this_thread_number)
       if (!rclcpp::utilities::ok() || !spinning.load()) {
         return;
       }
-      assert(this_thread_number < thread_executables.size());
       thread_executables[this_thread_number] = get_next_executable();
     }
 
     execute_any_executable(thread_executables[this_thread_number]);
-
-    {
-      std::lock_guard<std::mutex> wait_lock(wait_mutex_);
-      thread_executables[this_thread_number] = nullptr;
-    }
   }
 }

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -32,7 +32,7 @@ MultiThreadedExecutor::MultiThreadedExecutor(rclcpp::memory_strategy::MemoryStra
   if (number_of_threads_ == 0) {
     number_of_threads_ = 1;
   }
-  thread_executables.resize(number_of_threads_);
+  thread_executables.resize(number_of_threads_, nullptr);
 }
 
 MultiThreadedExecutor::~MultiThreadedExecutor() {}
@@ -47,7 +47,6 @@ MultiThreadedExecutor::spin()
   std::vector<std::thread> threads;
   {
     std::lock_guard<std::mutex> wait_lock(wait_mutex_);
-    //for (size_t i = number_of_threads_-1; i >= 0; --i) {
     for(size_t i = 0; i < number_of_threads_; ++i) {
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
       auto func = std::bind(&MultiThreadedExecutor::run, this, i);

--- a/rclcpp/src/rclcpp/intra_process_manager.cpp
+++ b/rclcpp/src/rclcpp/intra_process_manager.cpp
@@ -51,8 +51,9 @@ IntraProcessManager::remove_publisher(uint64_t intra_process_publisher_id)
 }
 
 bool
-IntraProcessManager::matches_any_publishers(const rmw_gid_t * id) const
+IntraProcessManager::matches_any_publishers(const rmw_gid_t * id)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   return state_->matches_any_publishers(id);
 }
 

--- a/rclcpp/src/rclcpp/memory_strategy.cpp
+++ b/rclcpp/src/rclcpp/memory_strategy.cpp
@@ -16,22 +16,22 @@
 
 using rclcpp::memory_strategy::MemoryStrategy;
 
-rclcpp::subscription::SubscriptionBase::SharedPtr
+rclcpp::subscription::SubscriptionBase::ConstSharedPtr
 MemoryStrategy::get_subscription_by_handle(
   void * subscriber_handle, const WeakNodeVector & weak_nodes)
 {
   for (auto & weak_node : weak_nodes) {
-    auto node = weak_node.lock();
+    const auto node = weak_node.lock();
     if (!node) {
       continue;
     }
     for (auto & weak_group : node->get_callback_groups()) {
-      auto group = weak_group.lock();
+      const auto group = weak_group.lock();
       if (!group) {
         continue;
       }
       for (auto & weak_subscription : group->get_subscription_ptrs()) {
-        auto subscription = weak_subscription.lock();
+        const auto subscription = weak_subscription.lock();
         if (subscription) {
           if (subscription->get_subscription_handle()->data == subscriber_handle) {
             return subscription;
@@ -102,12 +102,12 @@ MemoryStrategy::get_node_by_group(rclcpp::callback_group::CallbackGroup::SharedP
     return nullptr;
   }
   for (auto & weak_node : weak_nodes) {
-    auto node = weak_node.lock();
+    const auto node = weak_node.lock();
     if (!node) {
       continue;
     }
     for (auto & weak_group : node->get_callback_groups()) {
-      auto callback_group = weak_group.lock();
+      const auto callback_group = weak_group.lock();
       if (callback_group == group) {
         return node;
       }
@@ -118,16 +118,16 @@ MemoryStrategy::get_node_by_group(rclcpp::callback_group::CallbackGroup::SharedP
 
 rclcpp::callback_group::CallbackGroup::SharedPtr
 MemoryStrategy::get_group_by_subscription(
-  const rclcpp::subscription::SubscriptionBase::SharedPtr subscription,
+  const rclcpp::subscription::SubscriptionBase::ConstSharedPtr subscription,
   const WeakNodeVector & weak_nodes)
 {
   for (auto & weak_node : weak_nodes) {
-    auto node = weak_node.lock();
+    const auto node = weak_node.lock();
     if (!node) {
       continue;
     }
     for (auto & weak_group : node->get_callback_groups()) {
-      auto group = weak_group.lock();
+      const auto group = weak_group.lock();
       if (!group) {
         continue;
       }

--- a/rclcpp/src/rclcpp/memory_strategy.cpp
+++ b/rclcpp/src/rclcpp/memory_strategy.cpp
@@ -118,7 +118,7 @@ MemoryStrategy::get_node_by_group(rclcpp::callback_group::CallbackGroup::SharedP
 
 rclcpp::callback_group::CallbackGroup::SharedPtr
 MemoryStrategy::get_group_by_subscription(
-  rclcpp::subscription::SubscriptionBase::SharedPtr subscription,
+  const rclcpp::subscription::SubscriptionBase::SharedPtr subscription,
   const WeakNodeVector & weak_nodes)
 {
   for (auto & weak_node : weak_nodes) {
@@ -132,7 +132,7 @@ MemoryStrategy::get_group_by_subscription(
         continue;
       }
       for (auto & weak_sub : group->get_subscription_ptrs()) {
-        auto sub = weak_sub.lock();
+        const rclcpp::subscription::SubscriptionBase::SharedPtr sub = weak_sub.lock();
         if (sub == subscription) {
           return group;
         }


### PR DESCRIPTION
Connects to ros2/ros2#92

Known issues:

to reproduce:

./build/test_rclcpp/gtest_multithreaded__rmw_opensplice_cpp --gtest_filter=*publisher_intra_process --gtest_repeat=-1

Issues only seem to occur in Opensplice in the intra process test cases, and much more frequently in the multi_access_publisher_intra_process case.

- AnyExecutable occasionally gets garbage in a few of its shared_ptr fields.

```
timer: {_M_ptr = 0x106cbf8, _M_refcount = {_M_pi = 0x106cbe0}}, <No data fields>}
subscription: {_M_ptr = 0x0, _M_refcount = {_M_pi = 0x2}}, <No data fields>}
subscription_intra_process: {_M_ptr = 0x100003b31, _M_refcount = {_M_pi = 0x0}}
```

It looks to me like:
timer is a valid shared_ptr. The pointer value changes between runs but it always looks like a valid shared_ptr.
subscription is a null pointer with a refcount of 2 (not good). These values stay the same in every occurrence of the bug.
subscription_intra_process is an invalid pointer (value evaluates to 2^32+15153 in decimal) with no ref count. The ref count is always 0, the pointer value changes between runs (but it's always over 2^32 aka 0x100000000).

Timer is not always set, sometimes the error occurs when the any_executable already has null ptr fields and it's trying to set `subscription`. However, it segfaults because it sees that `subscription` has a non-zero refcount and tries to release already null memory.

- Random deadlock.
- Random segfaults due to ownership issues of an rmw_guard_condition (probably have to extend locking of the interrupt_guard_condition in Executor).