### PR TITLE
Remove redundant vector initializations in allocator_memory_strategy

### DIFF
--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -52,7 +52,7 @@ public:
   virtual void clear_active_entities() = 0;
 
   virtual void clear_handles() = 0;
-  virtual void revalidate_handles() = 0;
+  virtual void remove_null_handles() = 0;
   virtual bool collect_entities(const WeakNodeVector & weak_nodes) = 0;
 
   /// Provide a newly initialized AnyExecutable object.

--- a/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
@@ -108,35 +108,22 @@ public:
     client_handles_.clear();
   }
 
-  void revalidate_handles()
+  void remove_null_handles()
   {
-    {
-      VectorRebind<void *> temp;
-      for (auto & subscriber_handle : subscriber_handles_) {
-        if (subscriber_handle) {
-          temp.push_back(subscriber_handle);
-        }
-      }
-      subscriber_handles_.swap(temp);
-    }
-    {
-      VectorRebind<void *> temp;
-      for (auto & service_handle : service_handles_) {
-        if (service_handle) {
-          temp.push_back(service_handle);
-        }
-      }
-      service_handles_.swap(temp);
-    }
-    {
-      VectorRebind<void *> temp;
-      for (auto & client_handle : client_handles_) {
-        if (client_handle) {
-          temp.push_back(client_handle);
-        }
-      }
-      client_handles_.swap(temp);
-    }
+    subscriber_handles_.erase(
+      std::remove(subscriber_handles_.begin(), subscriber_handles_.end(), nullptr),
+      subscriber_handles_.end()
+    );
+
+    service_handles_.erase(
+      std::remove(service_handles_.begin(), service_handles_.end(), nullptr),
+      service_handles_.end()
+    );
+
+    client_handles_.erase(
+      std::remove(client_handles_.begin(), client_handles_.end(), nullptr),
+      client_handles_.end()
+    );
   }
 
   bool collect_entities(const WeakNodeVector & weak_nodes)

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -379,7 +379,7 @@ Executor::wait_for_work(std::chrono::nanoseconds timeout)
     return;
   }
 
-  memory_strategy_->revalidate_handles();
+  memory_strategy_->remove_null_handles();
 }
 
 rclcpp::node::Node::SharedPtr


### PR DESCRIPTION
this is a very messy piece of code that I wanted to rework. It's particularly important because instantiating a vector instantiates a new allocator, which is really bad if your allocator constructor is, say, not RT-safe.