### PR TITLE
Add alternative callback signature to timer for accepting a Timer reference

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -171,11 +171,12 @@ public:
    * \param[in] callback User-defined callback function.
    * \param[in] group Callback group to execute this timer's callback in.
    */
+  template<typename CallbackType>
   RCLCPP_PUBLIC
-  rclcpp::timer::WallTimer::SharedPtr
+  typename rclcpp::timer::WallTimer<CallbackType>::SharedPtr
   create_wall_timer(
     std::chrono::nanoseconds period,
-    rclcpp::timer::CallbackType callback,
+    CallbackType && callback,
     rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr);
 
   /// Create a timer.

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -270,6 +270,28 @@ Node::create_subscription(
     allocator);
 }
 
+template<typename CallbackType>
+typename rclcpp::timer::WallTimer<CallbackType>::SharedPtr
+Node::create_wall_timer(
+  std::chrono::nanoseconds period,
+  CallbackType && callback,
+  rclcpp::callback_group::CallbackGroup::SharedPtr group)
+{
+  auto timer = rclcpp::timer::WallTimer<CallbackType>::make_shared(
+    period, std::forward<CallbackType>(callback));
+  if (group) {
+    if (!group_in_node(group)) {
+      // TODO(jacquelinekay): use custom exception
+      throw std::runtime_error("Cannot create timer, group not in node.");
+    }
+    group->add_timer(timer);
+  } else {
+    default_callback_group_->add_timer(timer);
+  }
+  number_of_timers_++;
+  return timer;
+}
+
 template<typename ServiceT>
 typename client::Client<ServiceT>::SharedPtr
 Node::create_client(

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -151,26 +151,6 @@ Node::group_in_node(rclcpp::callback_group::CallbackGroup::SharedPtr group)
   return group_belongs_to_this_node;
 }
 
-rclcpp::timer::WallTimer::SharedPtr
-Node::create_wall_timer(
-  std::chrono::nanoseconds period,
-  rclcpp::timer::CallbackType callback,
-  rclcpp::callback_group::CallbackGroup::SharedPtr group)
-{
-  auto timer = rclcpp::timer::WallTimer::make_shared(period, callback);
-  if (group) {
-    if (!group_in_node(group)) {
-      // TODO(jacquelinekay): use custom exception
-      throw std::runtime_error("Cannot create timer, group not in node.");
-    }
-    group->add_timer(timer);
-  } else {
-    default_callback_group_->add_timer(timer);
-  }
-  number_of_timers_++;
-  return timer;
-}
-
 // TODO(wjwwood): reenable this once I figure out why the demo doesn't build with it.
 // rclcpp::timer::WallTimer::SharedPtr
 // Node::create_wall_timer(

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -16,12 +16,10 @@
 
 #include <chrono>
 
-using rclcpp::timer::CallbackType;
 using rclcpp::timer::TimerBase;
 
-TimerBase::TimerBase(std::chrono::nanoseconds period, CallbackType callback)
+TimerBase::TimerBase(std::chrono::nanoseconds period)
 : period_(period),
-  callback_(callback),
   canceled_(false)
 {}
 
@@ -32,16 +30,4 @@ void
 TimerBase::cancel()
 {
   this->canceled_ = true;
-}
-
-void
-TimerBase::execute_callback() const
-{
-  callback_();
-}
-
-const CallbackType &
-TimerBase::get_callback() const
-{
-  return callback_;
 }


### PR DESCRIPTION
~~As discussed with @wjwwood offline. This PR changes the Timer callback signature to return a bool, which signals the Executor to cancel the timer if true.~~

Create an alternative callback signature to Timer that accepts a Timer object. This enables the user to implement timers that fire any number greater than 1 times by capturing a variable to keep track of the number of callbacks triggered and conditionally cancelling the timer. It could also allow the user to change the loop rate in the future.