### PR TITLE
Added support for deducing the return type of a functor

### DIFF
--- a/rclcpp/include/rclcpp/function_traits.hpp
+++ b/rclcpp/include/rclcpp/function_traits.hpp
@@ -54,6 +54,8 @@ struct function_traits
 
   template<std::size_t N>
   using argument_type = typename std::tuple_element<N, arguments>::type;
+
+  using return_type = typename function_traits<decltype( & FunctionT::operator())>::return_type;
 };
 
 // Free functions
@@ -66,6 +68,8 @@ struct function_traits<ReturnTypeT(Args ...)>
 
   template<std::size_t N>
   using argument_type = typename std::tuple_element<N, arguments>::type;
+
+  using return_type = ReturnTypeT;
 };
 
 // Function pointers


### PR DESCRIPTION
This adds `return_type` as a member of the `function_traits` structure.