### PR TITLE
Replace shared pointers in AnyExecutable with raw pointers

### DIFF
--- a/rclcpp/include/rclcpp/any_executable.hpp
+++ b/rclcpp/include/rclcpp/any_executable.hpp
@@ -26,8 +26,22 @@ namespace rclcpp
 namespace executor
 {
 
-struct AnyExecutable
+struct AnyExecutableState
 {
+  // Only one of the following pointers will be set.
+  rclcpp::subscription::SubscriptionBase * subscription;
+  rclcpp::subscription::SubscriptionBase * subscription_intra_process;
+  rclcpp::timer::TimerBase * timer;
+  rclcpp::service::ServiceBase * service;
+  rclcpp::client::ClientBase * client;
+  // These are used to keep the scope on the containing items
+  rclcpp::callback_group::CallbackGroup * callback_group;
+  rclcpp::node::Node * node;
+};
+
+class AnyExecutable
+{
+public:
   RCLCPP_SMART_PTR_DEFINITIONS(AnyExecutable);
 
   RCLCPP_PUBLIC
@@ -36,15 +50,7 @@ struct AnyExecutable
   RCLCPP_PUBLIC
   virtual ~AnyExecutable();
 
-  // Only one of the following pointers will be set.
-  rclcpp::subscription::SubscriptionBase::SharedPtr subscription;
-  rclcpp::subscription::SubscriptionBase::SharedPtr subscription_intra_process;
-  rclcpp::timer::TimerBase::SharedPtr timer;
-  rclcpp::service::ServiceBase::SharedPtr service;
-  rclcpp::client::ClientBase::SharedPtr client;
-  // These are used to keep the scope on the containing items
-  rclcpp::callback_group::CallbackGroup::SharedPtr callback_group;
-  rclcpp::node::Node::SharedPtr node;
+  AnyExecutableState state;
 };
 
 }  // namespace executor

--- a/rclcpp/include/rclcpp/any_service_callback.hpp
+++ b/rclcpp/include/rclcpp/any_service_callback.hpp
@@ -85,7 +85,7 @@ public:
   void dispatch(
     std::shared_ptr<rmw_request_id_t> request_header,
     std::shared_ptr<typename ServiceT::Request> request,
-    std::shared_ptr<typename ServiceT::Response> response)
+    std::shared_ptr<typename ServiceT::Response> response) const
   {
     if (shared_ptr_callback_ != nullptr) {
       (void)request_header;

--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -154,7 +154,7 @@ public:
   }
 
   void dispatch(
-    std::shared_ptr<MessageT> message, const rmw_message_info_t & message_info)
+    std::shared_ptr<MessageT> message, const rmw_message_info_t & message_info) const
   {
     (void)message_info;
     if (shared_ptr_callback_) {
@@ -179,7 +179,7 @@ public:
   }
 
   void dispatch_intra_process(
-    MessageUniquePtr & message, const rmw_message_info_t & message_info)
+    MessageUniquePtr & message, const rmw_message_info_t & message_info) const
   {
     (void)message_info;
     if (shared_ptr_callback_) {

--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -69,9 +69,11 @@ public:
   const std::vector<rclcpp::client::ClientBase::SharedPtr> &
   get_client_ptrs() const;
 
+  /*
   RCLCPP_PUBLIC
   std::atomic_bool &
   can_be_taken_from();
+  */
 
   RCLCPP_PUBLIC
   const CallbackGroupType &
@@ -101,7 +103,8 @@ private:
   std::vector<rclcpp::timer::TimerBase::WeakPtr> timer_ptrs_;
   std::vector<rclcpp::service::ServiceBase::SharedPtr> service_ptrs_;
   std::vector<rclcpp::client::ClientBase::SharedPtr> client_ptrs_;
-  std::atomic_bool can_be_taken_from_;
+public:
+  std::atomic_bool can_be_taken_from;
 };
 
 }  // namespace callback_group

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -57,8 +57,8 @@ public:
   const rmw_client_t *
   get_client_handle() const;
 
-  virtual std::shared_ptr<void> create_response() = 0;
-  virtual std::shared_ptr<void> create_request_header() = 0;
+  virtual std::shared_ptr<void> create_response() const = 0;
+  virtual std::shared_ptr<void> create_request_header() const = 0;
   virtual void handle_response(
     std::shared_ptr<void> & request_header, std::shared_ptr<void> & response) = 0;
 
@@ -99,12 +99,12 @@ public:
   : ClientBase(node_handle, client_handle, service_name)
   {}
 
-  std::shared_ptr<void> create_response()
+  std::shared_ptr<void> create_response() const
   {
     return std::shared_ptr<void>(new typename ServiceT::Response());
   }
 
-  std::shared_ptr<void> create_request_header()
+  std::shared_ptr<void> create_request_header() const
   {
     // TODO(wjwwood): This should probably use rmw_request_id's allocator.
     //                (since it is a C type)

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -207,29 +207,29 @@ protected:
    */
   RCLCPP_PUBLIC
   void
-  execute_any_executable(AnyExecutable::SharedPtr any_exec);
+  execute_any_executable(const AnyExecutable & any_exec) const;
 
   RCLCPP_PUBLIC
   static void
   execute_subscription(
-    rclcpp::subscription::SubscriptionBase::SharedPtr subscription);
+    const rclcpp::subscription::SubscriptionBase::SharedPtr subscription);
 
   RCLCPP_PUBLIC
   static void
   execute_intra_process_subscription(
-    rclcpp::subscription::SubscriptionBase::SharedPtr subscription);
+    const rclcpp::subscription::SubscriptionBase::SharedPtr subscription);
 
   RCLCPP_PUBLIC
   static void
-  execute_timer(rclcpp::timer::TimerBase::SharedPtr timer);
+  execute_timer(const rclcpp::timer::TimerBase::SharedPtr timer);
 
   RCLCPP_PUBLIC
   static void
-  execute_service(rclcpp::service::ServiceBase::SharedPtr service);
+  execute_service(const rclcpp::service::ServiceBase::SharedPtr service);
 
   RCLCPP_PUBLIC
   static void
-  execute_client(rclcpp::client::ClientBase::SharedPtr client);
+  execute_client(const rclcpp::client::ClientBase::SharedPtr client);
 
   RCLCPP_PUBLIC
   void

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -212,24 +212,24 @@ protected:
   RCLCPP_PUBLIC
   static void
   execute_subscription(
-    const rclcpp::subscription::SubscriptionBase::SharedPtr subscription);
+    const rclcpp::subscription::SubscriptionBase * subscription);
 
   RCLCPP_PUBLIC
   static void
   execute_intra_process_subscription(
-    const rclcpp::subscription::SubscriptionBase::SharedPtr subscription);
+    const rclcpp::subscription::SubscriptionBase * subscription);
 
   RCLCPP_PUBLIC
   static void
-  execute_timer(const rclcpp::timer::TimerBase::SharedPtr timer);
+  execute_timer(rclcpp::timer::TimerBase * timer);
 
   RCLCPP_PUBLIC
   static void
-  execute_service(const rclcpp::service::ServiceBase::SharedPtr service);
+  execute_service(rclcpp::service::ServiceBase * service);
 
   RCLCPP_PUBLIC
   static void
-  execute_client(const rclcpp::client::ClientBase::SharedPtr client);
+  execute_client(rclcpp::client::ClientBase * client);
 
   RCLCPP_PUBLIC
   void

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -48,17 +48,17 @@ public:
 
   RCLCPP_PUBLIC
   std::string
-  get_service_name();
+  get_service_name() const;
 
   RCLCPP_PUBLIC
   const rmw_service_t *
-  get_service_handle();
+  get_service_handle() const;
 
-  virtual std::shared_ptr<void> create_request() = 0;
-  virtual std::shared_ptr<void> create_request_header() = 0;
+  virtual std::shared_ptr<void> create_request() const = 0;
+  virtual std::shared_ptr<void> create_request_header() const = 0;
   virtual void handle_request(
     std::shared_ptr<void> request_header,
-    std::shared_ptr<void> request) = 0;
+    std::shared_ptr<void> request) const = 0;
 
 private:
   RCLCPP_DISABLE_COPY(ServiceBase);
@@ -97,19 +97,19 @@ public:
 
   Service() = delete;
 
-  std::shared_ptr<void> create_request()
+  std::shared_ptr<void> create_request() const
   {
     return std::shared_ptr<void>(new typename ServiceT::Request());
   }
 
-  std::shared_ptr<void> create_request_header()
+  std::shared_ptr<void> create_request_header() const
   {
     // TODO(wjwwood): This should probably use rmw_request_id's allocator.
     //                (since it is a C type)
     return std::shared_ptr<void>(new rmw_request_id_t);
   }
 
-  void handle_request(std::shared_ptr<void> request_header, std::shared_ptr<void> request)
+  void handle_request(std::shared_ptr<void> request_header, std::shared_ptr<void> request) const
   {
     auto typed_request = std::static_pointer_cast<typename ServiceT::Request>(request);
     auto typed_request_header = std::static_pointer_cast<rmw_request_id_t>(request_header);
@@ -120,7 +120,7 @@ public:
 
   void send_response(
     std::shared_ptr<rmw_request_id_t> req_id,
-    std::shared_ptr<typename ServiceT::Response> response)
+    std::shared_ptr<typename ServiceT::Response> response) const
   {
     rmw_ret_t status = rmw_send_response(get_service_handle(), req_id.get(), response.get());
     if (status != RMW_RET_OK) {

--- a/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
@@ -137,7 +137,7 @@ public:
       }
       for (auto & weak_group : node->get_callback_groups()) {
         auto group = weak_group.lock();
-        if (!group || !group->can_be_taken_from().load()) {
+        if (!group || !group->can_be_taken_from.load()) {
           continue;
         }
         for (auto & weak_subscription : group->get_subscription_ptrs()) {
@@ -190,7 +190,7 @@ public:
           subscriber_handles_.erase(it);
           continue;
         }
-        if (!group->can_be_taken_from().load()) {
+        if (!group->can_be_taken_from.load()) {
           // Group is mutually exclusive and is being used, so skip it for now
           // Leave it to be checked next time, but continue searching
           ++it;
@@ -228,7 +228,7 @@ public:
           service_handles_.erase(it);
           continue;
         }
-        if (!group->can_be_taken_from().load()) {
+        if (!group->can_be_taken_from.load()) {
           // Group is mutually exclusive and is being used, so skip it for now
           // Leave it to be checked next time, but continue searching
           ++it;
@@ -261,7 +261,7 @@ public:
           client_handles_.erase(it);
           continue;
         }
-        if (!group->can_be_taken_from().load()) {
+        if (!group->can_be_taken_from.load()) {
           // Group is mutually exclusive and is being used, so skip it for now
           // Leave it to be checked next time, but continue searching
           ++it;

--- a/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
@@ -198,12 +198,12 @@ public:
         }
         // Otherwise it is safe to set and return the any_exec
         if (is_intra_process) {
-          any_exec->subscription_intra_process = subscription;
+          any_exec->state.subscription_intra_process = subscription.get();
         } else {
-          any_exec->subscription = subscription;
+          any_exec->state.subscription = subscription.get();
         }
-        any_exec->callback_group = group;
-        any_exec->node = get_node_by_group(group, weak_nodes);
+        any_exec->state.callback_group = group.get();
+        any_exec->state.node = get_node_by_group(group, weak_nodes).get();
         subscriber_handles_.erase(it);
         return;
       }
@@ -235,9 +235,9 @@ public:
           continue;
         }
         // Otherwise it is safe to set and return the any_exec
-        any_exec->service = service;
-        any_exec->callback_group = group;
-        any_exec->node = get_node_by_group(group, weak_nodes);
+        any_exec->state.service = service.get();
+        any_exec->state.callback_group = group.get();
+        any_exec->state.node = get_node_by_group(group, weak_nodes).get();
         service_handles_.erase(it);
         return;
       }
@@ -268,9 +268,9 @@ public:
           continue;
         }
         // Otherwise it is safe to set and return the any_exec
-        any_exec->client = client;
-        any_exec->callback_group = group;
-        any_exec->node = get_node_by_group(group, weak_nodes);
+        any_exec->state.client = client.get();
+        any_exec->state.callback_group = group.get();
+        any_exec->state.node = get_node_by_group(group, weak_nodes).get();
         client_handles_.erase(it);
         return;
       }

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -82,23 +82,24 @@ public:
   /// Borrow a new message.
   // \return Shared pointer to the fresh message.
   virtual std::shared_ptr<void>
-  create_message() = 0;
+  create_message() const = 0;
   /// Check if we need to handle the message, and execute the callback if we do.
   /**
    * \param[in] message Shared pointer to the message to handle.
    * \param[in] message_info Metadata associated with this message.
    */
   virtual void
-  handle_message(std::shared_ptr<void> & message, const rmw_message_info_t & message_info) = 0;
+  handle_message(std::shared_ptr<void> & message, const rmw_message_info_t & message_info) const = 0;
 
   /// Return the message borrowed in create_message.
   // \param[in] Shared pointer to the returned message.
   virtual void
-  return_message(std::shared_ptr<void> & message) = 0;
+  return_message(std::shared_ptr<void> & message) const = 0;
+
   virtual void
   handle_intra_process_message(
     rcl_interfaces::msg::IntraProcessMessage & ipm,
-    const rmw_message_info_t & message_info) = 0;
+    const rmw_message_info_t & message_info) const = 0;
 
 protected:
   rmw_subscription_t * intra_process_subscription_handle_;
@@ -168,7 +169,7 @@ public:
   {
     message_memory_strategy_ = message_memory_strategy;
   }
-  std::shared_ptr<void> create_message()
+  std::shared_ptr<void> create_message() const
   {
     /* The default message memory strategy provides a dynamically allocated message on each call to
      * create_message, though alternative memory strategies that re-use a preallocated message may be
@@ -177,7 +178,7 @@ public:
     return message_memory_strategy_->borrow_message();
   }
 
-  void handle_message(std::shared_ptr<void> & message, const rmw_message_info_t & message_info)
+  void handle_message(std::shared_ptr<void> & message, const rmw_message_info_t & message_info) const
   {
     if (matches_any_intra_process_publishers_) {
       if (matches_any_intra_process_publishers_(&message_info.publisher_gid)) {
@@ -190,7 +191,7 @@ public:
     any_callback_.dispatch(typed_message, message_info);
   }
 
-  void return_message(std::shared_ptr<void> & message)
+  void return_message(std::shared_ptr<void> & message) const
   {
     auto typed_message = std::static_pointer_cast<MessageT>(message);
     message_memory_strategy_->return_message(typed_message);
@@ -198,7 +199,7 @@ public:
 
   void handle_intra_process_message(
     rcl_interfaces::msg::IntraProcessMessage & ipm,
-    const rmw_message_info_t & message_info)
+    const rmw_message_info_t & message_info) const
   {
     if (!get_intra_process_message_callback_) {
       // throw std::runtime_error(

--- a/rclcpp/src/rclcpp/any_executable.cpp
+++ b/rclcpp/src/rclcpp/any_executable.cpp
@@ -32,6 +32,6 @@ AnyExecutable::~AnyExecutable()
   // their callback groups reset. This can happen when an executor is canceled
   // between taking an AnyExecutable and executing it.
   if (callback_group) {
-    callback_group->can_be_taken_from().store(true);
+    callback_group->can_be_taken_from.store(true);
   }
 }

--- a/rclcpp/src/rclcpp/any_executable.cpp
+++ b/rclcpp/src/rclcpp/any_executable.cpp
@@ -17,21 +17,22 @@
 using rclcpp::executor::AnyExecutable;
 
 AnyExecutable::AnyExecutable()
-: subscription(nullptr),
-  subscription_intra_process(nullptr),
-  timer(nullptr),
-  service(nullptr),
-  client(nullptr),
-  callback_group(nullptr),
-  node(nullptr)
-{}
+{
+  state.subscription = nullptr;
+  state.subscription_intra_process = nullptr;
+  state.timer = nullptr;
+  state.service = nullptr;
+  state.client = nullptr;
+  state.callback_group = nullptr;
+  state.node = nullptr;
+}
 
 AnyExecutable::~AnyExecutable()
 {
   // Make sure that discarded (taken but not executed) AnyExecutable's have
   // their callback groups reset. This can happen when an executor is canceled
   // between taking an AnyExecutable and executing it.
-  if (callback_group) {
-    callback_group->can_be_taken_from.store(true);
+  if (state.callback_group) {
+    state.callback_group->can_be_taken_from.store(true);
   }
 }

--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -20,7 +20,7 @@ using rclcpp::callback_group::CallbackGroup;
 using rclcpp::callback_group::CallbackGroupType;
 
 CallbackGroup::CallbackGroup(CallbackGroupType group_type)
-: type_(group_type), can_be_taken_from_(true)
+: type_(group_type), can_be_taken_from(true)
 {}
 
 const std::vector<rclcpp::subscription::SubscriptionBase::WeakPtr> &
@@ -47,11 +47,13 @@ CallbackGroup::get_client_ptrs() const
   return client_ptrs_;
 }
 
+/*
 std::atomic_bool &
 CallbackGroup::can_be_taken_from()
 {
   return can_be_taken_from_;
 }
+*/
 
 const CallbackGroupType &
 CallbackGroup::type() const

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -157,23 +157,24 @@ Executor::execute_any_executable(const AnyExecutable & any_exec) const
   if (!spinning.load()) {
     return;
   }
-  if (any_exec.timer) {
-    execute_timer(any_exec.timer);
+  if (any_exec.state.timer) {
+    execute_timer(any_exec.state.timer);
   }
-  if (any_exec.subscription) {
-    execute_subscription(any_exec.subscription);
+  if (any_exec.state.subscription) {
+    execute_subscription(any_exec.state.subscription);
   }
-  if (any_exec.subscription_intra_process) {
-    execute_intra_process_subscription(any_exec.subscription_intra_process);
+  if (any_exec.state.subscription_intra_process) {
+    execute_intra_process_subscription(any_exec.state.subscription_intra_process);
   }
-  if (any_exec.service) {
-    execute_service(any_exec.service);
+  if (any_exec.state.service) {
+    execute_service(any_exec.state.service);
   }
-  if (any_exec.client) {
-    execute_client(any_exec.client);
+  if (any_exec.state.client) {
+    execute_client(any_exec.state.client);
   }
   // Reset the callback_group, regardless of type
-  any_exec.callback_group->can_be_taken_from.store(true);
+  if (any_exec.state.callback_group)
+    any_exec.state.callback_group->can_be_taken_from.store(true);
   // Wake the wait, because it may need to be recalculated or work that
   // was previously blocked is now available.
   rmw_ret_t status = rmw_trigger_guard_condition(interrupt_guard_condition_);
@@ -184,7 +185,7 @@ Executor::execute_any_executable(const AnyExecutable & any_exec) const
 
 void
 Executor::execute_subscription(
-  const rclcpp::subscription::SubscriptionBase::SharedPtr subscription)
+  const rclcpp::subscription::SubscriptionBase * subscription)
 {
   std::shared_ptr<void> message = subscription->create_message();
   bool taken = false;
@@ -207,7 +208,7 @@ Executor::execute_subscription(
 
 void
 Executor::execute_intra_process_subscription(
-  const rclcpp::subscription::SubscriptionBase::SharedPtr subscription)
+  const rclcpp::subscription::SubscriptionBase * subscription)
 {
   rcl_interfaces::msg::IntraProcessMessage ipm;
   bool taken = false;
@@ -231,14 +232,14 @@ Executor::execute_intra_process_subscription(
 
 void
 Executor::execute_timer(
-  const rclcpp::timer::TimerBase::SharedPtr timer)
+  rclcpp::timer::TimerBase * timer)
 {
   timer->execute_callback();
 }
 
 void
 Executor::execute_service(
-  const rclcpp::service::ServiceBase::SharedPtr service)
+  rclcpp::service::ServiceBase * service)
 {
   std::shared_ptr<void> request_header = service->create_request_header();
   std::shared_ptr<void> request = service->create_request();
@@ -261,7 +262,7 @@ Executor::execute_service(
 
 void
 Executor::execute_client(
-  const rclcpp::client::ClientBase::SharedPtr client)
+  rclcpp::client::ClientBase * client)
 {
   std::shared_ptr<void> request_header = client->create_request_header();
   std::shared_ptr<void> response = client->create_response();
@@ -442,8 +443,8 @@ Executor::get_next_timer(AnyExecutable::SharedPtr any_exec)
       for (auto & timer_ref : group->get_timer_ptrs()) {
         auto timer = timer_ref.lock();
         if (timer && timer->check_and_trigger()) {
-          any_exec->timer = timer;
-          any_exec->callback_group = group;
+          any_exec->state.timer = timer.get();
+          any_exec->state.callback_group = group.get();
           node = get_node_by_group(group);
           return;
         }
@@ -489,22 +490,22 @@ Executor::get_next_ready_executable()
   auto any_exec = memory_strategy_->instantiate_next_executable();
   // Check the timers to see if there are any that are ready, if so return
   get_next_timer(any_exec);
-  if (any_exec->timer) {
+  if (any_exec->state.timer) {
     return any_exec;
   }
   // Check the subscriptions to see if there are any that are ready
   memory_strategy_->get_next_subscription(any_exec, weak_nodes_);
-  if (any_exec->subscription || any_exec->subscription_intra_process) {
+  if (any_exec->state.subscription || any_exec->state.subscription_intra_process) {
     return any_exec;
   }
   // Check the services to see if there are any that are ready
   memory_strategy_->get_next_service(any_exec, weak_nodes_);
-  if (any_exec->service) {
+  if (any_exec->state.service) {
     return any_exec;
   }
   // Check the clients to see if there are any that are ready
   memory_strategy_->get_next_client(any_exec, weak_nodes_);
-  if (any_exec->client) {
+  if (any_exec->state.client) {
     return any_exec;
   }
   // If there is no ready executable, return a null ptr
@@ -532,15 +533,15 @@ Executor::get_next_executable(std::chrono::nanoseconds timeout)
   if (any_exec) {
     // If it is valid, check to see if the group is mutually exclusive or
     // not, then mark it accordingly
-    if (any_exec->callback_group && any_exec->callback_group->type() == \
+    if (any_exec->state.callback_group && any_exec->state.callback_group->type() == \
       callback_group::CallbackGroupType::MutuallyExclusive)
     {
       // It should not have been taken otherwise
-      assert(any_exec->callback_group->can_be_taken_from.load());
+      assert(any_exec->state.callback_group->can_be_taken_from.load());
       // Set to false to indicate something is being run from this group
       // This is reset to true either when the any_exec is executed or when the
       // any_exec is destructued
-      any_exec->callback_group->can_be_taken_from.store(false);
+      any_exec->state.callback_group->can_be_taken_from.store(false);
     }
   }
   return any_exec;

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -75,6 +75,6 @@ MultiThreadedExecutor::run(size_t this_thread_number)
       }
       any_exec = get_next_executable();
     }
-    execute_any_executable(any_exec);
+    execute_any_executable(*any_exec.get());
   }
 }

--- a/rclcpp/src/rclcpp/executors/single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/single_threaded_executor.cpp
@@ -33,6 +33,6 @@ SingleThreadedExecutor::spin()
   RCLCPP_SCOPE_EXIT(this->spinning.store(false); );
   while (rclcpp::utilities::ok() && spinning.load()) {
     auto any_exec = get_next_executable();
-    execute_any_executable(any_exec);
+    execute_any_executable(*any_exec.get());
   }
 }

--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -47,13 +47,13 @@ ServiceBase::~ServiceBase()
 }
 
 std::string
-ServiceBase::get_service_name()
+ServiceBase::get_service_name() const
 {
   return this->service_name_;
 }
 
 const rmw_service_t *
-ServiceBase::get_service_handle()
+ServiceBase::get_service_handle() const
 {
   return this->service_handle_;
 }


### PR DESCRIPTION
In progress.

Potential fix for the weird pointer corruption bugs in ros2/system_tests#72 (still testing).

I broke AnyExecutable into a State class so that I can use a pure POD type for the lock-free queue in LockFreeExecutor. I can revert this part of the PR and create the class in LockFreeExecutor if need be.