### PR TITLE
Add RCLCPP_PUBLIC to Context constructor

### DIFF
--- a/rclcpp/include/rclcpp/context.hpp
+++ b/rclcpp/include/rclcpp/context.hpp
@@ -37,6 +37,7 @@ class Context
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(Context);
 
+  RCLCPP_PUBLIC
   Context();
 
   template<typename SubContext, typename ... Args>


### PR DESCRIPTION
Potential fix for currently broken Windows build.

I use a local Context in the multithreaded test, to make sure the IntraProcessManager gets cleaned up between test cases.

The Context constructor does not use the RCLCPP_PUBLIC macro.

I believe we previously didn't test this constructor anywhere in user code.