### PR TITLE
Add unit tests for rclcpp Rate objects

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -102,6 +102,17 @@ if(AMENT_ENABLE_TESTING)
       ${rosidl_generator_cpp_INCLUDE_DIRS}
     )
   endif()
+  ament_add_gtest(test_rate test/test_rate.cpp)
+  if(TARGET test_rate)
+    target_include_directories(test_rate PUBLIC
+      ${rcl_interfaces_INCLUDE_DIRS}
+      ${rmw_INCLUDE_DIRS}
+      ${rosidl_generator_cpp_INCLUDE_DIRS}
+    )
+    target_link_libraries(test_rate
+      ${PROJECT_NAME}${target_suffix}
+    )
+  endif()
 endif()
 
 ament_package(

--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -34,7 +34,7 @@ public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(RateBase);
 
   virtual bool sleep() = 0;
-  virtual bool is_steady() = 0;
+  virtual bool is_steady() const = 0;
   virtual void reset() = 0;
 };
 
@@ -89,7 +89,7 @@ public:
   }
 
   virtual bool
-  is_steady()
+  is_steady() const
   {
     return Clock::is_steady;
   }
@@ -109,7 +109,8 @@ private:
   RCLCPP_DISABLE_COPY(GenericRate);
 
   std::chrono::nanoseconds period_;
-  std::chrono::time_point<Clock> last_interval_;
+  using ClockDurationNano = std::chrono::duration<typename Clock::rep, std::nano>;
+  std::chrono::time_point<Clock, ClockDurationNano> last_interval_;
 };
 
 using Rate = GenericRate<std::chrono::system_clock>;

--- a/rclcpp/test/test_rate.cpp
+++ b/rclcpp/test/test_rate.cpp
@@ -24,61 +24,77 @@
 TEST(TestRate, rate_basics) {
   auto period = std::chrono::milliseconds(100);
   auto offset = std::chrono::milliseconds(50);
+  auto epsilon = std::chrono::milliseconds(1);
   double overrun_ratio = 1.5;
 
   auto start = std::chrono::system_clock::now();
   rclcpp::rate::Rate r(period);
   ASSERT_FALSE(r.is_steady());
-  r.sleep();
+  ASSERT_TRUE(r.sleep());
   auto one = std::chrono::system_clock::now();
   auto delta = one - start;
   ASSERT_TRUE(period < delta);
   ASSERT_TRUE(period * overrun_ratio > delta);
 
   rclcpp::utilities::sleep_for(offset);
-  r.sleep();
+  ASSERT_TRUE(r.sleep());
   auto two = std::chrono::system_clock::now();
   delta = two - one;
-  ASSERT_TRUE(period < delta);
+  ASSERT_TRUE(period < delta + epsilon);
   ASSERT_TRUE(period * overrun_ratio > delta);
 
   rclcpp::utilities::sleep_for(offset);
   auto two_offset = std::chrono::system_clock::now();
   r.reset();
-  r.sleep();
+  ASSERT_TRUE(r.sleep());
   auto three = std::chrono::system_clock::now();
   delta = three - two_offset;
   ASSERT_TRUE(period < delta);
   ASSERT_TRUE(period * overrun_ratio > delta);
+
+  rclcpp::utilities::sleep_for(offset + period);
+  auto four = std::chrono::system_clock::now();
+  ASSERT_FALSE(r.sleep());
+  auto five = std::chrono::system_clock::now();
+  delta = five - four;
+  ASSERT_TRUE(epsilon > delta);
 }
 
-TEST(TestRate, wallrate_basics) {
+TEST(TestRate, wall_rate_basics) {
   auto period = std::chrono::milliseconds(100);
   auto offset = std::chrono::milliseconds(50);
+  auto epsilon = std::chrono::milliseconds(1);
   double overrun_ratio = 1.5;
 
   auto start = std::chrono::system_clock::now();
   rclcpp::rate::WallRate r(period);
   ASSERT_TRUE(r.is_steady());
-  r.sleep();
+  ASSERT_TRUE(r.sleep());
   auto one = std::chrono::system_clock::now();
   auto delta = one - start;
   ASSERT_TRUE(period < delta);
   ASSERT_TRUE(period * overrun_ratio > delta);
 
   rclcpp::utilities::sleep_for(offset);
-  r.sleep();
+  ASSERT_TRUE(r.sleep());
   auto two = std::chrono::system_clock::now();
   delta = two - one;
-  ASSERT_TRUE(period < delta);
+  ASSERT_TRUE(period < delta + epsilon);
   ASSERT_TRUE(period * overrun_ratio > delta);
 
   rclcpp::utilities::sleep_for(offset);
   auto two_offset = std::chrono::system_clock::now();
   r.reset();
-  r.sleep();
+  ASSERT_TRUE(r.sleep());
   auto three = std::chrono::system_clock::now();
   delta = three - two_offset;
   ASSERT_TRUE(period < delta);
   ASSERT_TRUE(period * overrun_ratio > delta);
+
+  rclcpp::utilities::sleep_for(offset + period);
+  auto four = std::chrono::system_clock::now();
+  ASSERT_FALSE(r.sleep());
+  auto five = std::chrono::system_clock::now();
+  delta = five - four;
+  ASSERT_TRUE(epsilon > delta);
 }

--- a/rclcpp/test/test_rate.cpp
+++ b/rclcpp/test/test_rate.cpp
@@ -22,8 +22,8 @@
    Tests that funcion_traits calculates arity of several functors.
  */
 TEST(TestRate, rate_basics) {
-  auto period = std::chrono::milliseconds(10);
-  auto delta = std::chrono::milliseconds(1);
+  auto period = std::chrono::milliseconds(100);
+  auto delta = std::chrono::milliseconds(10);
 
   auto start = std::chrono::system_clock::now();
   rclcpp::rate::Rate r(period);
@@ -45,12 +45,12 @@ TEST(TestRate, rate_basics) {
   r.sleep();
   auto three = std::chrono::system_clock::now();
   ASSERT_TRUE(period + 3 * delta < three - two);
-  ASSERT_TRUE(period + 5 * delta > three - two);
+  ASSERT_TRUE(period + 7 * delta > three - two);
 }
 
 TEST(TestRate, wallrate_basics) {
-  auto period = std::chrono::milliseconds(10);
-  auto delta = std::chrono::milliseconds(1);
+  auto period = std::chrono::milliseconds(100);
+  auto delta = std::chrono::milliseconds(10);
 
   auto start = std::chrono::system_clock::now();
   rclcpp::rate::WallRate r(period);
@@ -72,5 +72,5 @@ TEST(TestRate, wallrate_basics) {
   r.sleep();
   auto three = std::chrono::system_clock::now();
   ASSERT_TRUE(period + 3 * delta < three - two);
-  ASSERT_TRUE(period + 5 * delta > three - two);
+  ASSERT_TRUE(period + 7 * delta > three - two);
 }

--- a/rclcpp/test/test_rate.cpp
+++ b/rclcpp/test/test_rate.cpp
@@ -23,54 +23,62 @@
  */
 TEST(TestRate, rate_basics) {
   auto period = std::chrono::milliseconds(100);
-  auto delta = std::chrono::milliseconds(10);
+  auto offset = std::chrono::milliseconds(50);
+  double overrun_ratio = 1.5;
 
   auto start = std::chrono::system_clock::now();
   rclcpp::rate::Rate r(period);
   ASSERT_FALSE(r.is_steady());
   r.sleep();
   auto one = std::chrono::system_clock::now();
-  ASSERT_TRUE(period - delta < one - start);
-  ASSERT_TRUE(period + delta > one - start);
+  auto delta = one - start;
+  ASSERT_TRUE(period < delta);
+  ASSERT_TRUE(period * overrun_ratio > delta);
 
-  rclcpp::utilities::sleep_for(delta * 4);
+  rclcpp::utilities::sleep_for(offset);
   r.sleep();
   auto two = std::chrono::system_clock::now();
+  delta = two - one;
+  ASSERT_TRUE(period < delta);
+  ASSERT_TRUE(period * overrun_ratio > delta);
 
-  ASSERT_TRUE(period - delta < two - one);
-  ASSERT_TRUE(period + delta > two - one);
-
-  rclcpp::utilities::sleep_for(delta * 4);
+  rclcpp::utilities::sleep_for(offset);
+  auto two_offset = std::chrono::system_clock::now();
   r.reset();
   r.sleep();
   auto three = std::chrono::system_clock::now();
-  ASSERT_TRUE(period + 3 * delta < three - two);
-  ASSERT_TRUE(period + 7 * delta > three - two);
+  delta = three - two_offset;
+  ASSERT_TRUE(period < delta);
+  ASSERT_TRUE(period * overrun_ratio > delta);
 }
 
 TEST(TestRate, wallrate_basics) {
   auto period = std::chrono::milliseconds(100);
-  auto delta = std::chrono::milliseconds(10);
+  auto offset = std::chrono::milliseconds(50);
+  double overrun_ratio = 1.5;
 
   auto start = std::chrono::system_clock::now();
   rclcpp::rate::WallRate r(period);
   ASSERT_TRUE(r.is_steady());
   r.sleep();
   auto one = std::chrono::system_clock::now();
-  ASSERT_TRUE(period - delta < one - start);
-  ASSERT_TRUE(period + delta > one - start);
+  auto delta = one - start;
+  ASSERT_TRUE(period < delta);
+  ASSERT_TRUE(period * overrun_ratio > delta);
 
-  rclcpp::utilities::sleep_for(delta * 4);
+  rclcpp::utilities::sleep_for(offset);
   r.sleep();
   auto two = std::chrono::system_clock::now();
+  delta = two - one;
+  ASSERT_TRUE(period < delta);
+  ASSERT_TRUE(period * overrun_ratio > delta);
 
-  ASSERT_TRUE(period - delta < two - one);
-  ASSERT_TRUE(period + delta > two - one);
-
-  rclcpp::utilities::sleep_for(delta * 4);
+  rclcpp::utilities::sleep_for(offset);
+  auto two_offset = std::chrono::system_clock::now();
   r.reset();
   r.sleep();
   auto three = std::chrono::system_clock::now();
-  ASSERT_TRUE(period + 3 * delta < three - two);
-  ASSERT_TRUE(period + 7 * delta > three - two);
+  delta = three - two_offset;
+  ASSERT_TRUE(period < delta);
+  ASSERT_TRUE(period * overrun_ratio > delta);
 }

--- a/rclcpp/test/test_rate.cpp
+++ b/rclcpp/test/test_rate.cpp
@@ -19,7 +19,7 @@
 #include "rclcpp/rate.hpp"
 
 /*
-   Tests that funcion_traits calculates arity of several functors.
+   Basic tests for the Rate and WallRate clases.
  */
 TEST(TestRate, rate_basics) {
   auto period = std::chrono::milliseconds(100);

--- a/rclcpp/test/test_rate.cpp
+++ b/rclcpp/test/test_rate.cpp
@@ -1,0 +1,76 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "rclcpp/rate.hpp"
+
+/*
+   Tests that funcion_traits calculates arity of several functors.
+ */
+TEST(TestRate, rate_basics) {
+  auto period = std::chrono::milliseconds(10);
+  auto delta = std::chrono::milliseconds(1);
+
+  auto start = std::chrono::system_clock::now();
+  rclcpp::rate::Rate r(period);
+  ASSERT_FALSE(r.is_steady());
+  r.sleep();
+  auto one = std::chrono::system_clock::now();
+  ASSERT_TRUE(period - delta < one - start);
+  ASSERT_TRUE(period + delta > one - start);
+
+  rclcpp::utilities::sleep_for(delta * 4);
+  r.sleep();
+  auto two = std::chrono::system_clock::now();
+
+  ASSERT_TRUE(period - delta < two - one);
+  ASSERT_TRUE(period + delta > two - one);
+
+  rclcpp::utilities::sleep_for(delta * 4);
+  r.reset();
+  r.sleep();
+  auto three = std::chrono::system_clock::now();
+  ASSERT_TRUE(period + 3 * delta < three - two);
+  ASSERT_TRUE(period + 5 * delta > three - two);
+}
+
+TEST(TestRate, wallrate_basics) {
+  auto period = std::chrono::milliseconds(10);
+  auto delta = std::chrono::milliseconds(1);
+
+  auto start = std::chrono::system_clock::now();
+  rclcpp::rate::WallRate r(period);
+  ASSERT_TRUE(r.is_steady());
+  r.sleep();
+  auto one = std::chrono::system_clock::now();
+  ASSERT_TRUE(period - delta < one - start);
+  ASSERT_TRUE(period + delta > one - start);
+
+  rclcpp::utilities::sleep_for(delta * 4);
+  r.sleep();
+  auto two = std::chrono::system_clock::now();
+
+  ASSERT_TRUE(period - delta < two - one);
+  ASSERT_TRUE(period + delta > two - one);
+
+  rclcpp::utilities::sleep_for(delta * 4);
+  r.reset();
+  r.sleep();
+  auto three = std::chrono::system_clock::now();
+  ASSERT_TRUE(period + 3 * delta < three - two);
+  ASSERT_TRUE(period + 5 * delta > three - two);
+}


### PR DESCRIPTION
Connects to #181 

First adding unit tests for coverage. Next debug problem. 

The problem from 181 is reproduced in these unit tests: 

CI: http://ci.ros2.org/job/ci_osx/602/

```
08:42:55 In file included from /Users/osrf/jenkins/workspace/ci_osx/ws/src/ros2/rclcpp/rclcpp/test/test_rate.cpp:19:
08:42:55 /Users/osrf/jenkins/workspace/ci_osx/ws/src/ros2/rclcpp/rclcpp/include/rclcpp/rate.hpp:74:20: error: no viable overloaded '+='
08:42:55     last_interval_ += period_;
08:42:55     ~~~~~~~~~~~~~~ ^  ~~~~~~~
08:42:55 /Users/osrf/jenkins/workspace/ci_osx/ws/src/ros2/rclcpp/rclcpp/test/test_rate.cpp:32:5: note: in instantiation of member function 'rclcpp::rate::GenericRate<std::__1::chrono::system_clock>::sleep' requested here
08:42:55   r.sleep();
08:42:55     ^
08:42:55 /Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/chrono:782:79: note: candidate function not viable: no known conversion from 'duration<[...], ratio<[...], 1000000000>>' to 'const duration<[...], ratio<[...], 1000000>>' for 1st argument
08:42:55     __attribute__ ((__visibility__("hidden"), __always_inline__)) time_point& operator+=(const duration& __d) {__d_ += __d; return *this;}
08:42:55                                                                               ^
08:42:55 In file included from /Users/osrf/jenkins/workspace/ci_osx/ws/src/ros2/rclcpp/rclcpp/test/test_rate.cpp:19:
08:42:55 /Users/osrf/jenkins/workspace/ci_osx/ws/src/ros2/rclcpp/rclcpp/include/rclcpp/rate.hpp:81:24: error: no viable overloaded '='
08:42:55         last_interval_ = now + period_;
08:42:55         ~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~
08:42:55 /Users/osrf/jenkins/workspace/ci_osx/ws/src/ros2/rclcpp/rclcpp/test/test_rate.cpp:32:5: note: in instantiation of member function 'rclcpp::rate::GenericRate<std::__1::chrono::system_clock>::sleep' requested here
08:42:55   r.sleep();
08:42:55     ^
08:42:55 /Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/chrono:750:56: note: candidate function (the implicit copy assignment operator) not viable: no known conversion from 'time_point<[...], duration<[...], ratio<[...], 1000000000>>>' to 'const time_point<[...], duration<[...], ratio<[...], 1000000>>>' for 1st argument
08:42:55 class __attribute__ ((__type_visibility__("default"))) time_point
08:42:55                                                        ^
08:42:55 /Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/chrono:750:56: note: candidate function (the implicit move assignment operator) not viable: no known conversion from 'time_point<[...], duration<[...], ratio<[...], 1000000000>>>' to 'time_point<[...], duration<[...], ratio<[...], 1000000>>>' for 1st argument
08:42:55 class __attribute__ ((__type_visibility__("default"))) time_point
```