### PR TITLE
Use move semantics to store callback and perfect forwarding to pass it down to GenericTimer

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -175,7 +175,7 @@ public:
   typename rclcpp::timer::WallTimer<CallbackType>::SharedPtr
   create_wall_timer(
     std::chrono::nanoseconds period,
-    CallbackType && callback,
+    CallbackType callback,
     rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr);
 
   /// Create a timer.

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -274,11 +274,11 @@ template<typename CallbackType>
 typename rclcpp::timer::WallTimer<CallbackType>::SharedPtr
 Node::create_wall_timer(
   std::chrono::nanoseconds period,
-  CallbackType && callback,
+  CallbackType callback,
   rclcpp::callback_group::CallbackGroup::SharedPtr group)
 {
   auto timer = rclcpp::timer::WallTimer<CallbackType>::make_shared(
-    period, std::forward<CallbackType>(callback));
+    period, std::move(callback));
   if (group) {
     if (!group_in_node(group)) {
       // TODO(jacquelinekay): use custom exception

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -101,7 +101,7 @@ public:
    * \param[in] callback User-specified callback function.
    */
   GenericTimer(std::chrono::nanoseconds period, FunctorT && callback)
-  : TimerBase(period), callback_(callback), loop_rate_(period)
+  : TimerBase(period), callback_(std::forward<FunctorT>(callback)), loop_rate_(period)
   {
     /* Set last_triggered_time_ so that the timer fires at least one period after being created. */
     last_triggered_time_ = Clock::now();


### PR DESCRIPTION
Use move semantics to store callback and perfect forwarding to pass it down to GenericTimer