### PR TITLE
List all parameters

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -75,7 +75,7 @@ ament_export_include_directories(include)
 
 ament_export_libraries(${PROJECT_NAME})
 
-if(AMENT_ENABLE_TESTING)
+if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 
 project(rclcpp)
 
@@ -43,7 +43,7 @@ set(${PROJECT_NAME}_SRCS
 )
 
 macro(target)
-  if(NOT "${target_suffix} " STREQUAL " ")
+  if(NOT target_suffix STREQUAL "")
     get_rcl_information("${rmw_implementation}" "rcl${target_suffix}")
   endif()
   add_library(${PROJECT_NAME}${target_suffix} SHARED

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -105,7 +105,8 @@ if(BUILD_TESTING)
       ${rosidl_generator_cpp_INCLUDE_DIRS}
     )
   endif()
-  ament_add_gtest(test_rate test/test_rate.cpp)
+  ament_add_gtest(test_rate test/test_rate.cpp
+    ENV RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation})
   if(TARGET test_rate)
     target_include_directories(test_rate PUBLIC
       ${rcl_interfaces_INCLUDE_DIRS}

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(rclcpp)
 
 find_package(ament_cmake REQUIRED)
+find_package(rcl REQUIRED)
 find_package(rcl_interfaces REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rmw_implementation REQUIRED)
@@ -42,13 +43,14 @@ set(${PROJECT_NAME}_SRCS
 )
 
 macro(target)
+  if(NOT "${target_suffix} " STREQUAL " ")
+    get_rcl_information("${rmw_implementation}" "rcl${target_suffix}")
+  endif()
   add_library(${PROJECT_NAME}${target_suffix} SHARED
     ${${PROJECT_NAME}_SRCS})
   ament_target_dependencies(${PROJECT_NAME}${target_suffix}
-    "rcl_interfaces"
-    "rmw"
-    "rosidl_generator_cpp"
-    "${rmw_implementation}")
+    "rcl${target_suffix}"
+    "rosidl_generator_cpp")
 
   # Causes the visibility macros to use dllexport rather than dllimport,
   # which is appropriate when building the dll but not consuming it.
@@ -66,9 +68,7 @@ endmacro()
 call_for_each_rmw_implementation(target GENERATE_DEFAULT)
 
 ament_export_dependencies(ament_cmake)
-ament_export_dependencies(rcl_interfaces)
-ament_export_dependencies(rmw)
-ament_export_dependencies(rmw_implementation)
+ament_export_dependencies(rcl)
 ament_export_dependencies(rosidl_generator_cpp)
 
 ament_export_include_directories(include)
@@ -90,6 +90,7 @@ if(AMENT_ENABLE_TESTING)
   ament_add_gtest(test_mapped_ring_buffer test/test_mapped_ring_buffer.cpp)
   if(TARGET test_mapped_ring_buffer)
     target_include_directories(test_mapped_ring_buffer PUBLIC
+      ${rcl_INCLUDE_DIRS}
       ${rcl_interfaces_INCLUDE_DIRS}
       ${rmw_INCLUDE_DIRS}
       ${rosidl_generator_cpp_INCLUDE_DIRS}
@@ -98,6 +99,7 @@ if(AMENT_ENABLE_TESTING)
   ament_add_gtest(test_intra_process_manager test/test_intra_process_manager.cpp)
   if(TARGET test_intra_process_manager)
     target_include_directories(test_intra_process_manager PUBLIC
+      ${rcl_INCLUDE_DIRS}
       ${rcl_interfaces_INCLUDE_DIRS}
       ${rmw_INCLUDE_DIRS}
       ${rosidl_generator_cpp_INCLUDE_DIRS}

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -113,7 +113,7 @@ if(AMENT_ENABLE_TESTING)
       ${rosidl_generator_cpp_INCLUDE_DIRS}
     )
     target_link_libraries(test_rate
-      ${PROJECT_NAME}${target_suffix}
+      ${PROJECT_NAME}
     )
   endif()
 endif()

--- a/rclcpp/cmake/get_rclcpp_information.cmake
+++ b/rclcpp/cmake/get_rclcpp_information.cmake
@@ -28,6 +28,11 @@ macro(get_rclcpp_information rmw_implementation var_prefix)
   # so that the variables can be used by various functions / macros
   set(${var_prefix}_FOUND TRUE)
 
+  # Get rcl using the existing macro
+  if(NOT "${target_suffix} " STREQUAL " ")
+    get_rcl_information("${rmw_implementation}" "rcl${target_suffix}")
+  endif()
+
   # include directories
   normalize_path(${var_prefix}_INCLUDE_DIRS
     "${rclcpp_DIR}/../../../include")
@@ -63,8 +68,7 @@ macro(get_rclcpp_information rmw_implementation var_prefix)
   # dependencies
   set(_exported_dependencies
     "rcl_interfaces"
-    "rmw"
-    "${rmw_implementation}"
+    "rcl${target_suffix}"
     "rosidl_generator_cpp")
   set(${var_prefix}_DEFINITIONS)
   foreach(_dep ${_exported_dependencies})

--- a/rclcpp/cmake/get_rclcpp_information.cmake
+++ b/rclcpp/cmake/get_rclcpp_information.cmake
@@ -29,7 +29,7 @@ macro(get_rclcpp_information rmw_implementation var_prefix)
   set(${var_prefix}_FOUND TRUE)
 
   # Get rcl using the existing macro
-  if(NOT "${target_suffix} " STREQUAL " ")
+  if(NOT target_suffix STREQUAL "")
     get_rcl_information("${rmw_implementation}" "rcl${target_suffix}")
   endif()
 

--- a/rclcpp/include/rclcpp/allocator/allocator_common.hpp
+++ b/rclcpp/include/rclcpp/allocator/allocator_common.hpp
@@ -17,6 +17,8 @@
 
 #include <memory>
 
+#include "rcl/allocator.h"
+
 #include "rclcpp/allocator/allocator_deleter.hpp"
 
 namespace rclcpp
@@ -26,6 +28,64 @@ namespace allocator
 
 template<typename T, typename Alloc>
 using AllocRebind = typename std::allocator_traits<Alloc>::template rebind_traits<T>;
+
+template<typename Alloc>
+void * retyped_allocate(size_t size, void * untyped_allocator)
+{
+  auto typed_allocator = static_cast<Alloc *>(untyped_allocator);
+  if (!typed_allocator) {
+    throw std::runtime_error("Received incorrect allocator type");
+  }
+  return std::allocator_traits<Alloc>::allocate(*typed_allocator, size);
+}
+
+template<typename T, typename Alloc>
+void retyped_deallocate(void * untyped_pointer, void * untyped_allocator)
+{
+  auto typed_allocator = static_cast<Alloc *>(untyped_allocator);
+  if (!typed_allocator) {
+    throw std::runtime_error("Received incorrect allocator type");
+  }
+  auto typed_ptr = static_cast<T *>(untyped_pointer);
+  std::allocator_traits<Alloc>::deallocate(*typed_allocator, typed_ptr, 1);
+}
+
+template<typename T, typename Alloc>
+void * retyped_reallocate(void * untyped_pointer, size_t size, void * untyped_allocator)
+{
+  auto typed_allocator = static_cast<Alloc *>(untyped_allocator);
+  if (!typed_allocator) {
+    throw std::runtime_error("Received incorrect allocator type");
+  }
+  auto typed_ptr = static_cast<T *>(untyped_pointer);
+  std::allocator_traits<Alloc>::deallocate(*typed_allocator, typed_ptr, 1);
+  return std::allocator_traits<Alloc>::allocate(*typed_allocator, size);
+}
+
+
+// Convert a std::allocator_traits-formatted Allocator into an rcl allocator
+template<typename T, typename Alloc,
+typename std::enable_if<!std::is_same<Alloc, std::allocator<void>>::value>::type * = nullptr>
+rcl_allocator_t get_rcl_allocator(Alloc & allocator)
+{
+  rcl_allocator_t rcl_allocator = rcl_get_default_allocator();
+#ifndef _WIN32
+  rcl_allocator.allocate = &retyped_allocate<Alloc>;
+  rcl_allocator.deallocate = &retyped_deallocate<T, Alloc>;
+  rcl_allocator.reallocate = &retyped_reallocate<T, Alloc>;
+  rcl_allocator.state = &allocator;
+#endif
+  return rcl_allocator;
+}
+
+// TODO(jacquelinekay) Workaround for an incomplete implementation of std::allocator<void>
+template<typename T, typename Alloc,
+typename std::enable_if<std::is_same<Alloc, std::allocator<void>>::value>::type * = nullptr>
+rcl_allocator_t get_rcl_allocator(Alloc & allocator)
+{
+  (void)allocator;
+  return rcl_get_default_allocator();
+}
 
 }  // namespace allocator
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -16,6 +16,7 @@
 #define RCLCPP__CALLBACK_GROUP_HPP_
 
 #include <atomic>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -97,6 +98,8 @@ private:
   add_client(const rclcpp::client::ClientBase::SharedPtr client_ptr);
 
   CallbackGroupType type_;
+  // Mutex to protect the subsequent vectors of pointers.
+  mutable std::mutex mutex_;
   std::vector<rclcpp::subscription::SubscriptionBase::WeakPtr> subscription_ptrs_;
   std::vector<rclcpp::timer::TimerBase::WeakPtr> timer_ptrs_;
   std::vector<rclcpp::service::ServiceBase::SharedPtr> service_ptrs_;

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -108,7 +108,7 @@ public:
     if (rcl_client_init(&client_handle_, this->node_handle_.get(),
       service_type_support_handle, service_name.c_str(), &client_options) != RCL_RET_OK)
     {
-      // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+      // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
       throw std::runtime_error(
         std::string("could not create client: ") +
         rcl_get_error_string_safe());
@@ -175,7 +175,7 @@ public:
     std::lock_guard<std::mutex> lock(pending_requests_mutex_);
     int64_t sequence_number;
     if (RCL_RET_OK != rcl_send_request(get_client_handle(), request.get(), &sequence_number)) {
-      // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+      // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
       throw std::runtime_error(
         std::string("failed to send request: ") + rcl_get_error_string_safe());
       // *INDENT-ON*

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -51,7 +51,7 @@ public:
     const std::string & service_name);
 
   RCLCPP_PUBLIC
-  ~ClientBase();
+  virtual ~ClientBase();
 
   RCLCPP_PUBLIC
   const std::string &

--- a/rclcpp/include/rclcpp/context.hpp
+++ b/rclcpp/include/rclcpp/context.hpp
@@ -51,7 +51,7 @@ public:
     auto it = sub_contexts_.find(type_i);
     if (it == sub_contexts_.end()) {
       // It doesn't exist yet, make it
-      // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+      // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
       sub_context = std::shared_ptr<SubContext>(
         new SubContext(std::forward<Args>(args) ...),
         [] (SubContext * sub_context_ptr) {

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -306,8 +306,6 @@ protected:
   /// Spinning state, used to prevent multi threaded calls to spin and to cancel blocking spins.
   std::atomic_bool spinning;
 
-  rmw_guard_conditions_t fixed_guard_conditions_;
-
   /// Guard condition for signaling the rmw layer to wake up for special events.
   rmw_guard_condition_t * interrupt_guard_condition_;
 
@@ -321,7 +319,6 @@ private:
   RCLCPP_DISABLE_COPY(Executor);
 
   std::vector<std::weak_ptr<rclcpp::node::Node>> weak_nodes_;
-  std::array<void *, 2> guard_cond_handles_;
 };
 
 }  // namespace executor

--- a/rclcpp/include/rclcpp/mapped_ring_buffer.hpp
+++ b/rclcpp/include/rclcpp/mapped_ring_buffer.hpp
@@ -220,7 +220,7 @@ private:
   typename std::vector<element, VectorAlloc>::iterator
   get_iterator_of_key(uint64_t key)
   {
-    // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+    // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
     auto it = std::find_if(elements_.begin(), elements_.end(), [key](element & e) -> bool {
       return e.key == key && e.in_use;
     });

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -18,6 +18,9 @@
 #include <memory>
 #include <vector>
 
+#include "rcl/allocator.h"
+#include "rcl/wait.h"
+
 #include "rclcpp/any_executable.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/node.hpp"
@@ -40,31 +43,25 @@ public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(MemoryStrategy);
   using WeakNodeVector = std::vector<std::weak_ptr<rclcpp::node::Node>>;
 
-  // return the new number of subscribers
-  virtual size_t fill_subscriber_handles(void ** & ptr) = 0;
-
-  // return the new number of services
-  virtual size_t fill_service_handles(void ** & ptr) = 0;
-
-  // return the new number of clients
-  virtual size_t fill_client_handles(void ** & ptr) = 0;
-
-  // return the new number of guard_conditions
-  virtual size_t fill_guard_condition_handles(void ** & ptr) = 0;
-
-  virtual void clear_active_entities() = 0;
-
-  virtual void clear_handles() = 0;
-  virtual void remove_null_handles() = 0;
   virtual bool collect_entities(const WeakNodeVector & weak_nodes) = 0;
+
+  virtual size_t number_of_ready_subscriptions() const = 0;
+  virtual size_t number_of_ready_services() const = 0;
+  virtual size_t number_of_ready_clients() const = 0;
+  virtual size_t number_of_ready_timers() const = 0;
+  virtual size_t number_of_guard_conditions() const = 0;
+
+  virtual bool add_handles_to_waitset(rcl_wait_set_t * wait_set) = 0;
+  virtual void clear_handles() = 0;
+  virtual void remove_null_handles(rcl_wait_set_t * wait_set) = 0;
 
   /// Provide a newly initialized AnyExecutable object.
   // \return Shared pointer to the fresh executable.
   virtual rclcpp::executor::AnyExecutable::SharedPtr instantiate_next_executable() = 0;
 
-  virtual void add_guard_condition(const rmw_guard_condition_t * guard_condition) = 0;
+  virtual void add_guard_condition(const rcl_guard_condition_t * guard_condition) = 0;
 
-  virtual void remove_guard_condition(const rmw_guard_condition_t * guard_condition) = 0;
+  virtual void remove_guard_condition(const rcl_guard_condition_t * guard_condition) = 0;
 
   virtual void
   get_next_subscription(rclcpp::executor::AnyExecutable::SharedPtr any_exec,
@@ -78,15 +75,18 @@ public:
   get_next_client(rclcpp::executor::AnyExecutable::SharedPtr any_exec,
     const WeakNodeVector & weak_nodes) = 0;
 
+  virtual rcl_allocator_t
+  get_allocator() = 0;
+
   static rclcpp::subscription::SubscriptionBase::SharedPtr
-  get_subscription_by_handle(void * subscriber_handle,
+  get_subscription_by_handle(const rcl_subscription_t * subscriber_handle,
     const WeakNodeVector & weak_nodes);
 
   static rclcpp::service::ServiceBase::SharedPtr
-  get_service_by_handle(void * service_handle, const WeakNodeVector & weak_nodes);
+  get_service_by_handle(const rcl_service_t * service_handle, const WeakNodeVector & weak_nodes);
 
   static rclcpp::client::ClientBase::SharedPtr
-  get_client_by_handle(void * client_handle, const WeakNodeVector & weak_nodes);
+  get_client_by_handle(const rcl_client_t * client_handle, const WeakNodeVector & weak_nodes);
 
   static rclcpp::node::Node::SharedPtr
   get_node_by_group(rclcpp::callback_group::CallbackGroup::SharedPtr group,

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -49,6 +49,9 @@ public:
   // return the new number of clients
   virtual size_t fill_client_handles(void ** & ptr) = 0;
 
+  // return the new number of guard_conditions
+  virtual size_t fill_guard_condition_handles(void ** & ptr) = 0;
+
   virtual void clear_active_entities() = 0;
 
   virtual void clear_handles() = 0;
@@ -58,6 +61,10 @@ public:
   /// Provide a newly initialized AnyExecutable object.
   // \return Shared pointer to the fresh executable.
   virtual rclcpp::executor::AnyExecutable::SharedPtr instantiate_next_executable() = 0;
+
+  virtual void add_guard_condition(const rmw_guard_condition_t * guard_condition) = 0;
+
+  virtual void remove_guard_condition(const rmw_guard_condition_t * guard_condition) = 0;
 
   virtual void
   get_next_subscription(rclcpp::executor::AnyExecutable::SharedPtr any_exec,

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -77,6 +77,9 @@ public:
     const std::string & node_name, rclcpp::context::Context::SharedPtr context,
     bool use_intra_process_comms = false);
 
+  RCLCPP_PUBLIC
+  ~Node();
+
   /// Get the name of the node.
   // \return The name of the node.
   RCLCPP_PUBLIC
@@ -252,6 +255,9 @@ public:
   const CallbackGroupWeakPtrList &
   get_callback_groups() const;
 
+  RCLCPP_PUBLIC
+  rmw_guard_condition_t * get_notify_guard_condition() const;
+
   std::atomic_bool has_executor;
 
 private:
@@ -278,6 +284,9 @@ private:
   bool use_intra_process_comms_;
 
   mutable std::mutex mutex_;
+
+  /// Guard condition for notifying the Executor of changes to this node.
+  rmw_guard_condition_t * notify_guard_condition_;
 
   std::map<std::string, rclcpp::parameter::ParameterVariant> parameters_;
 

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -22,6 +22,9 @@
 #include <tuple>
 #include <vector>
 
+#include "rcl/error_handling.h"
+#include "rcl/node.h"
+
 #include "rcl_interfaces/msg/list_parameters_result.hpp"
 #include "rcl_interfaces/msg/parameter_descriptor.hpp"
 #include "rcl_interfaces/msg/parameter_event.hpp"
@@ -39,11 +42,10 @@
 #include "rclcpp/timer.hpp"
 #include "rclcpp/visibility_control.hpp"
 
-// Forward declaration of ROS middleware class
-namespace rmw
+namespace rcl
 {
-struct rmw_node_t;
-}  // namespace rmw
+struct rcl_node_t;
+}  // namespace rcl
 
 namespace rclcpp
 {
@@ -256,7 +258,7 @@ public:
   get_callback_groups() const;
 
   RCLCPP_PUBLIC
-  rmw_guard_condition_t * get_notify_guard_condition() const;
+  const rcl_guard_condition_t * get_notify_guard_condition() const;
 
   std::atomic_bool has_executor;
 
@@ -269,7 +271,7 @@ private:
 
   std::string name_;
 
-  std::shared_ptr<rmw_node_t> node_handle_;
+  std::shared_ptr<rcl_node_t> node_handle_;
 
   rclcpp::context::Context::SharedPtr context_;
 
@@ -286,7 +288,7 @@ private:
   mutable std::mutex mutex_;
 
   /// Guard condition for notifying the Executor of changes to this node.
-  rmw_guard_condition_t * notify_guard_condition_;
+  rcl_guard_condition_t notify_guard_condition_ = rcl_get_zero_initialized_guard_condition();
 
   std::map<std::string, rclcpp::parameter::ParameterVariant> parameters_;
 

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -80,7 +80,7 @@ public:
     bool use_intra_process_comms = false);
 
   RCLCPP_PUBLIC
-  ~Node();
+  virtual ~Node();
 
   /// Get the name of the node.
   // \return The name of the node.

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -134,6 +134,11 @@ Node::create_publisher(
       shared_publish_callback,
       intra_process_publisher_handle);
   }
+  if (rmw_trigger_guard_condition(notify_guard_condition_) != RMW_RET_OK) {
+    throw std::runtime_error(
+            std::string(
+              "Failed to notify waitset on publisher creation: ") + rmw_get_error_string());
+  }
   return publisher;
 }
 
@@ -243,6 +248,11 @@ Node::create_subscription(
     default_callback_group_->add_subscription(sub_base_ptr);
   }
   number_of_subscriptions_++;
+  if (rmw_trigger_guard_condition(notify_guard_condition_) != RMW_RET_OK) {
+    throw std::runtime_error(
+            std::string(
+              "Failed to notify waitset on subscription creation: ") + rmw_get_error_string());
+  }
   return sub;
 }
 
@@ -289,6 +299,11 @@ Node::create_wall_timer(
     default_callback_group_->add_timer(timer);
   }
   number_of_timers_++;
+  if (rmw_trigger_guard_condition(notify_guard_condition_) != RMW_RET_OK) {
+    throw std::runtime_error(
+            std::string(
+              "Failed to notify waitset on timer creation: ") + rmw_get_error_string());
+  }
   return timer;
 }
 
@@ -333,6 +348,11 @@ Node::create_client(
   }
   number_of_clients_++;
 
+  if (rmw_trigger_guard_condition(notify_guard_condition_) != RMW_RET_OK) {
+    throw std::runtime_error(
+            std::string(
+              "Failed to notify waitset on client creation: ") + rmw_get_error_string());
+  }
   return cli;
 }
 
@@ -374,6 +394,11 @@ Node::create_service(
     default_callback_group_->add_service(serv_base_ptr);
   }
   number_of_services_++;
+  if (rmw_trigger_guard_condition(notify_guard_condition_) != RMW_RET_OK) {
+    throw std::runtime_error(
+            std::string(
+              "Failed to notify waitset on service creation: ") + rmw_get_error_string());
+  }
   return serv;
 }
 

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -67,7 +67,7 @@ public:
     size_t queue_size);
 
   RCLCPP_PUBLIC
-  ~PublisherBase();
+  virtual ~PublisherBase();
 
   /// Get the topic that this publisher publishes on.
   // \return The topic name.

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -180,7 +180,7 @@ public:
               std::string("failed to get rmw handle: ") + rcl_get_error_string_safe());
     }
     if (rmw_get_gid_for_publisher(publisher_rmw_handle, &rmw_gid_) != RMW_RET_OK) {
-      // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+      // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
       throw std::runtime_error(
         std::string("failed to get publisher gid: ") + rmw_get_error_string_safe());
       // *INDENT-ON*
@@ -231,7 +231,7 @@ public:
       ipm.message_sequence = message_seq;
       auto status = rcl_publish(&intra_process_publisher_handle_, &ipm);
       if (status != RCL_RET_OK) {
-        // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+        // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
         throw std::runtime_error(
           std::string("failed to publish intra process message: ") + rcl_get_error_string_safe());
         // *INDENT-ON*
@@ -306,7 +306,7 @@ protected:
   {
     auto status = rcl_publish(&publisher_handle_, msg);
     if (status != RCL_RET_OK) {
-      // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+      // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
       throw std::runtime_error(
         std::string("failed to publish message: ") + rcl_get_error_string_safe());
       // *INDENT-ON*

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -150,7 +150,7 @@ public:
     rcl_ret_t status = rcl_send_response(get_service_handle(), req_id.get(), response.get());
 
     if (status != RCL_RET_OK) {
-      // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+      // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
       throw std::runtime_error(
         std::string("failed to send response: ") + rcl_get_error_string_safe());
       // *INDENT-ON*

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -55,9 +55,9 @@ public:
   get_service_handle();
 
   virtual std::shared_ptr<void> create_request() = 0;
-  virtual std::shared_ptr<void> create_request_header() = 0;
+  virtual std::shared_ptr<rmw_request_id_t> create_request_header() = 0;
   virtual void handle_request(
-    std::shared_ptr<void> request_header,
+    std::shared_ptr<rmw_request_id_t> request_header,
     std::shared_ptr<void> request) = 0;
 
 private:
@@ -102,20 +102,20 @@ public:
     return std::shared_ptr<void>(new typename ServiceT::Request());
   }
 
-  std::shared_ptr<void> create_request_header()
+  std::shared_ptr<rmw_request_id_t> create_request_header()
   {
     // TODO(wjwwood): This should probably use rmw_request_id's allocator.
     //                (since it is a C type)
-    return std::shared_ptr<void>(new rmw_request_id_t);
+    return std::shared_ptr<rmw_request_id_t>(new rmw_request_id_t);
   }
 
-  void handle_request(std::shared_ptr<void> request_header, std::shared_ptr<void> request)
+  void handle_request(std::shared_ptr<rmw_request_id_t> request_header,
+    std::shared_ptr<void> request)
   {
     auto typed_request = std::static_pointer_cast<typename ServiceT::Request>(request);
-    auto typed_request_header = std::static_pointer_cast<rmw_request_id_t>(request_header);
     auto response = std::shared_ptr<typename ServiceT::Response>(new typename ServiceT::Response);
-    any_callback_.dispatch(typed_request_header, typed_request, response);
-    send_response(typed_request_header, response);
+    any_callback_.dispatch(request_header, typed_request, response);
+    send_response(request_header, response);
   }
 
   void send_response(

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -47,7 +47,7 @@ public:
     const std::string service_name);
 
   RCLCPP_PUBLIC
-  ~ServiceBase();
+  virtual ~ServiceBase();
 
   RCLCPP_PUBLIC
   std::string

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -251,7 +251,7 @@ private:
         (get_topic_name() + "__intra").c_str(),
         &intra_process_options) != RCL_RET_OK)
     {
-      // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+      // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
       throw std::runtime_error(
         std::string("could not create intra process subscription: ") + rcl_get_error_string_safe());
       // *INDENT-ON*

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -84,10 +84,11 @@ using TimerCallbackType = std::function<void(TimerBase &)>;
 /// Generic timer templated on the clock type. Periodically executes a user-specified callback.
 template<
   typename FunctorT,
-  class Clock = std::chrono::high_resolution_clock,
+  class Clock,
   typename std::enable_if<
-    rclcpp::function_traits::same_arguments<FunctorT, VoidCallbackType>::value ||
-    rclcpp::function_traits::same_arguments<FunctorT, TimerCallbackType>::value
+    (rclcpp::function_traits::same_arguments<FunctorT, VoidCallbackType>::value ||
+    rclcpp::function_traits::same_arguments<FunctorT, TimerCallbackType>::value) &&
+    Clock::is_steady
   >::type * = nullptr
 >
 class GenericTimer : public TimerBase

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -18,6 +18,9 @@
 #include <chrono>
 
 #include "rclcpp/visibility_control.hpp"
+
+#include "rcl/guard_condition.h"
+
 #include "rmw/macros.h"
 #include "rmw/rmw.h"
 
@@ -48,7 +51,7 @@ shutdown();
 
 /// Get a handle to the rmw guard condition that manages the signal handler.
 RCLCPP_PUBLIC
-rmw_guard_condition_t *
+rcl_guard_condition_t *
 get_global_sigint_guard_condition();
 
 /// Use the global condition variable to block for the specified amount of time.

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -20,6 +20,7 @@
 #include "rclcpp/visibility_control.hpp"
 
 #include "rcl/guard_condition.h"
+#include "rcl/wait.h"
 
 #include "rmw/macros.h"
 #include "rmw/rmw.h"
@@ -50,9 +51,33 @@ void
 shutdown();
 
 /// Get a handle to the rmw guard condition that manages the signal handler.
+/**
+ * The first time that this function is called for a given waitset a new guard
+ * condition will be created and returned; thereafter the same guard condition
+ * will be returned for the same waitset. This mechanism is designed to ensure
+ * that the same guard condition is not reused across waitsets (e.g., when
+ * using multiple executors in the same process). Will throw an exception if
+ * initialization of the guard condition fails.
+ * \param[waitset] waitset Pointer to the rcl_wait_set_t that will be using the
+ * resulting guard condition.
+ * \return Pointer to the guard condition.
+ */
 RCLCPP_PUBLIC
 rcl_guard_condition_t *
-get_global_sigint_guard_condition();
+get_sigint_guard_condition(rcl_wait_set_t * waitset);
+
+/// Release the previously allocated guard condition that manages the signal handler.
+/**
+ * If you previously called get_sigint_guard_condition() for a given waitset
+ * to get a sigint guard condition, then you should call release_sigint_guard_condition()
+ * when you're done, to free that condition.  Will throw an exception if
+ * get_sigint_guard_condition() wasn't previously called for the given waitset.
+ * \param[waitset] waitset Pointer to the rcl_wait_set_t that was using the
+ * resulting guard condition.
+ */
+RCLCPP_PUBLIC
+void
+release_sigint_guard_condition(rcl_wait_set_t * waitset);
 
 /// Use the global condition variable to block for the specified amount of time.
 /**

--- a/rclcpp/package.xml
+++ b/rclcpp/package.xml
@@ -16,6 +16,7 @@
   <build_export_depend>rcl_interfaces</build_export_depend>
   <build_export_depend>rosidl_generator_cpp</build_export_depend>
 
+  <depend>rcl</depend>
   <depend>rmw_implementation</depend>
 
   <exec_depend>ament_cmake</exec_depend>

--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -26,24 +26,28 @@ CallbackGroup::CallbackGroup(CallbackGroupType group_type)
 const std::vector<rclcpp::subscription::SubscriptionBase::WeakPtr> &
 CallbackGroup::get_subscription_ptrs() const
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   return subscription_ptrs_;
 }
 
 const std::vector<rclcpp::timer::TimerBase::WeakPtr> &
 CallbackGroup::get_timer_ptrs() const
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   return timer_ptrs_;
 }
 
 const std::vector<rclcpp::service::ServiceBase::SharedPtr> &
 CallbackGroup::get_service_ptrs() const
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   return service_ptrs_;
 }
 
 const std::vector<rclcpp::client::ClientBase::WeakPtr> &
 CallbackGroup::get_client_ptrs() const
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   return client_ptrs_;
 }
 
@@ -63,23 +67,27 @@ void
 CallbackGroup::add_subscription(
   const rclcpp::subscription::SubscriptionBase::SharedPtr subscription_ptr)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   subscription_ptrs_.push_back(subscription_ptr);
 }
 
 void
 CallbackGroup::add_timer(const rclcpp::timer::TimerBase::SharedPtr timer_ptr)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   timer_ptrs_.push_back(timer_ptr);
 }
 
 void
 CallbackGroup::add_service(const rclcpp::service::ServiceBase::SharedPtr service_ptr)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   service_ptrs_.push_back(service_ptr);
 }
 
 void
 CallbackGroup::add_client(const rclcpp::client::ClientBase::SharedPtr client_ptr)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   client_ptrs_.push_back(client_ptr);
 }

--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -22,20 +22,13 @@
 using rclcpp::client::ClientBase;
 
 ClientBase::ClientBase(
-  std::shared_ptr<rmw_node_t> node_handle,
-  rmw_client_t * client_handle,
+  std::shared_ptr<rcl_node_t> node_handle,
   const std::string & service_name)
-: node_handle_(node_handle), client_handle_(client_handle), service_name_(service_name)
+: node_handle_(node_handle), service_name_(service_name)
 {}
 
 ClientBase::~ClientBase()
 {
-  if (client_handle_) {
-    if (rmw_destroy_client(client_handle_) != RMW_RET_OK) {
-      fprintf(stderr,
-        "Error in destruction of rmw client handle: %s\n", rmw_get_error_string_safe());
-    }
-  }
 }
 
 const std::string &
@@ -44,8 +37,8 @@ ClientBase::get_service_name() const
   return this->service_name_;
 }
 
-const rmw_client_t *
+const rcl_client_t *
 ClientBase::get_client_handle() const
 {
-  return this->client_handle_;
+  return &client_handle_;
 }

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
+#include <type_traits>
+
 #include "rclcpp/executor.hpp"
 #include "rclcpp/scope_exit.hpp"
 
@@ -20,6 +23,7 @@
 using rclcpp::executor::AnyExecutable;
 using rclcpp::executor::Executor;
 using rclcpp::executor::ExecutorArgs;
+using rclcpp::executor::FutureReturnCode;
 
 Executor::Executor(const ExecutorArgs & args)
 : spinning(false),
@@ -568,4 +572,30 @@ Executor::get_next_executable(std::chrono::nanoseconds timeout)
     }
   }
   return any_exec;
+}
+
+std::ostream &
+rclcpp::executor::operator<<(std::ostream & os, const FutureReturnCode & future_return_code)
+{
+  return os << to_string(future_return_code);
+}
+
+std::string
+rclcpp::executor::to_string(const FutureReturnCode & future_return_code)
+{
+  using enum_type = std::underlying_type<FutureReturnCode>::type;
+  std::string prefix = "Unknown enum value (";
+  std::string ret_as_string = std::to_string(static_cast<enum_type>(future_return_code));
+  switch (future_return_code) {
+    case FutureReturnCode::SUCCESS:
+      prefix = "SUCCESS (";
+      break;
+    case FutureReturnCode::INTERRUPTED:
+      prefix = "INTERRUPTED (";
+      break;
+    case FutureReturnCode::TIMEOUT:
+      prefix = "TIMEOUT (";
+      break;
+  }
+  return prefix + ret_as_string + ")";
 }

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -78,7 +78,8 @@ Executor::~Executor()
       "[rclcpp::error] failed to destroy guard condition: %s\n", rcl_get_error_string_safe());
   }
   // Remove and release the sigint guard condition
-  memory_strategy_->remove_guard_condition(rclcpp::utilities::get_sigint_guard_condition(&waitset_));
+  memory_strategy_->remove_guard_condition(
+    rclcpp::utilities::get_sigint_guard_condition(&waitset_));
   rclcpp::utilities::release_sigint_guard_condition(&waitset_);
 }
 

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -287,7 +287,7 @@ void
 Executor::execute_service(
   rclcpp::service::ServiceBase::SharedPtr service)
 {
-  std::shared_ptr<void> request_header = service->create_request_header();
+  auto request_header = service->create_request_header();
   std::shared_ptr<void> request = service->create_request();
   bool taken = false;
   rmw_ret_t status = rmw_take_request(
@@ -310,7 +310,7 @@ void
 Executor::execute_client(
   rclcpp::client::ClientBase::SharedPtr client)
 {
-  std::shared_ptr<void> request_header = client->create_request_header();
+  auto request_header = client->create_request_header();
   std::shared_ptr<void> response = client->create_response();
   bool taken = false;
   rmw_ret_t status = rmw_take_response(

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -112,7 +112,7 @@ Executor::remove_node(rclcpp::node::Node::SharedPtr node_ptr, bool notify)
   weak_nodes_.erase(
     std::remove_if(
       weak_nodes_.begin(), weak_nodes_.end(),
-      // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+      // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
       [&](std::weak_ptr<rclcpp::node::Node> & i)
       {
         bool matched = (i.lock() == node_ptr);
@@ -329,7 +329,7 @@ Executor::wait_for_work(std::chrono::nanoseconds timeout)
     weak_nodes_.erase(
       remove_if(
         weak_nodes_.begin(), weak_nodes_.end(),
-        // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+        // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
         [](std::weak_ptr<rclcpp::node::Node> i)
         {
           return i.expired();

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -46,7 +46,7 @@ Executor::Executor(const ExecutorArgs & args)
   // and one for the executor's guard cond (interrupt_guard_condition_)
 
   // Put the global ctrl-c guard condition in
-  memory_strategy_->add_guard_condition(rclcpp::utilities::get_global_sigint_guard_condition());
+  memory_strategy_->add_guard_condition(rclcpp::utilities::get_sigint_guard_condition(&waitset_));
 
   // Put the executor's guard condition in
   memory_strategy_->add_guard_condition(&interrupt_guard_condition_);
@@ -77,6 +77,9 @@ Executor::~Executor()
     fprintf(stderr,
       "[rclcpp::error] failed to destroy guard condition: %s\n", rcl_get_error_string_safe());
   }
+  // Remove and release the sigint guard condition
+  memory_strategy_->remove_guard_condition(rclcpp::utilities::get_sigint_guard_condition(&waitset_));
+  rclcpp::utilities::release_sigint_guard_condition(&waitset_);
 }
 
 void

--- a/rclcpp/src/rclcpp/intra_process_manager.cpp
+++ b/rclcpp/src/rclcpp/intra_process_manager.cpp
@@ -69,7 +69,7 @@ IntraProcessManager::get_next_unique_id()
     // So around 585 million years. Even at 1 GHz, it would take 585 years.
     // I think it's safe to avoid trying to handle overflow.
     // If we roll over then it's most likely a bug.
-    // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+    // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
     throw std::overflow_error(
       "exhausted the unique id's for publishers and subscribers in this process "
       "(congratulations your computer is either extremely fast or extremely old)");

--- a/rclcpp/src/rclcpp/memory_strategy.cpp
+++ b/rclcpp/src/rclcpp/memory_strategy.cpp
@@ -18,7 +18,7 @@ using rclcpp::memory_strategy::MemoryStrategy;
 
 rclcpp::subscription::SubscriptionBase::SharedPtr
 MemoryStrategy::get_subscription_by_handle(
-  void * subscriber_handle, const WeakNodeVector & weak_nodes)
+  const rcl_subscription_t * subscriber_handle, const WeakNodeVector & weak_nodes)
 {
   for (auto & weak_node : weak_nodes) {
     auto node = weak_node.lock();
@@ -33,12 +33,10 @@ MemoryStrategy::get_subscription_by_handle(
       for (auto & weak_subscription : group->get_subscription_ptrs()) {
         auto subscription = weak_subscription.lock();
         if (subscription) {
-          if (subscription->get_subscription_handle()->data == subscriber_handle) {
+          if (subscription->get_subscription_handle() == subscriber_handle) {
             return subscription;
           }
-          if (subscription->get_intra_process_subscription_handle() &&
-            subscription->get_intra_process_subscription_handle()->data == subscriber_handle)
-          {
+          if (subscription->get_intra_process_subscription_handle() == subscriber_handle) {
             return subscription;
           }
         }
@@ -49,7 +47,8 @@ MemoryStrategy::get_subscription_by_handle(
 }
 
 rclcpp::service::ServiceBase::SharedPtr
-MemoryStrategy::get_service_by_handle(void * service_handle, const WeakNodeVector & weak_nodes)
+MemoryStrategy::get_service_by_handle(const rcl_service_t * service_handle,
+  const WeakNodeVector & weak_nodes)
 {
   for (auto & weak_node : weak_nodes) {
     auto node = weak_node.lock();
@@ -62,7 +61,7 @@ MemoryStrategy::get_service_by_handle(void * service_handle, const WeakNodeVecto
         continue;
       }
       for (auto & service : group->get_service_ptrs()) {
-        if (service->get_service_handle()->data == service_handle) {
+        if (service->get_service_handle() == service_handle) {
           return service;
         }
       }
@@ -72,7 +71,8 @@ MemoryStrategy::get_service_by_handle(void * service_handle, const WeakNodeVecto
 }
 
 rclcpp::client::ClientBase::SharedPtr
-MemoryStrategy::get_client_by_handle(void * client_handle, const WeakNodeVector & weak_nodes)
+MemoryStrategy::get_client_by_handle(const rcl_client_t * client_handle,
+  const WeakNodeVector & weak_nodes)
 {
   for (auto & weak_node : weak_nodes) {
     auto node = weak_node.lock();
@@ -86,7 +86,7 @@ MemoryStrategy::get_client_by_handle(void * client_handle, const WeakNodeVector 
       }
       for (auto & weak_client : group->get_client_ptrs()) {
         auto client = weak_client.lock();
-        if (client && client->get_client_handle()->data == client_handle) {
+        if (client && client->get_client_handle() == client_handle) {
           return client;
         }
       }

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -272,7 +272,7 @@ Node::list_parameters(
   // TODO(esteve): define parameter separator, use "." for now
   for (auto & kv : parameters_) {
     if ((prefixes.size() == 0) ||
-        (std::any_of(prefixes.cbegin(), prefixes.cend(), [&kv, &depth](const std::string & prefix) {
+      (std::any_of(prefixes.cbegin(), prefixes.cend(), [&kv, &depth](const std::string & prefix) {
       if (kv.first == prefix) {
         return true;
       } else if (kv.first.find(prefix + ".") == 0) {

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -271,7 +271,9 @@ Node::list_parameters(
 
   // TODO(esteve): define parameter separator, use "." for now
   for (auto & kv : parameters_) {
-    if ((prefixes.size() == 0) ||
+    if (((prefixes.size() == 0) &&
+      ((depth == 0) ||
+      (static_cast<uint64_t>(std::count(kv.first.begin(), kv.first.end(), '.')) < depth))) ||
       (std::any_of(prefixes.cbegin(), prefixes.cend(), [&kv, &depth](const std::string & prefix) {
       if (kv.first == prefix) {
         return true;
@@ -279,7 +281,8 @@ Node::list_parameters(
         size_t length = prefix.length();
         std::string substr = kv.first.substr(length);
         // Cast as unsigned integer to avoid warning
-        return static_cast<uint64_t>(std::count(substr.begin(), substr.end(), '.')) < depth;
+        return (depth == 0) ||
+        (static_cast<uint64_t>(std::count(substr.begin(), substr.end(), '.')) < depth);
       }
       return false;
     })))

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -271,7 +271,8 @@ Node::list_parameters(
 
   // TODO(esteve): define parameter separator, use "." for now
   for (auto & kv : parameters_) {
-    if (std::any_of(prefixes.cbegin(), prefixes.cend(), [&kv, &depth](const std::string & prefix) {
+    if ((prefixes.size() == 0) ||
+        (std::any_of(prefixes.cbegin(), prefixes.cend(), [&kv, &depth](const std::string & prefix) {
       if (kv.first == prefix) {
         return true;
       } else if (kv.first.find(prefix + ".") == 0) {
@@ -281,7 +282,7 @@ Node::list_parameters(
         return static_cast<uint64_t>(std::count(substr.begin(), substr.end(), '.')) < depth;
       }
       return false;
-    }))
+    })))
     {
       result.names.push_back(kv.first);
       size_t last_separator = kv.first.find_last_of('.');

--- a/rclcpp/src/rclcpp/parameter.cpp
+++ b/rclcpp/src/rclcpp/parameter.cpp
@@ -105,7 +105,7 @@ ParameterVariant::get_type_name() const
     case rclcpp::parameter::ParameterType::PARAMETER_NOT_SET:
       return "not set";
     default:
-      // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+      // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
       throw std::runtime_error(
         "Unexpected type from ParameterVariant: " + std::to_string(get_type()));
       // *INDENT-ON*
@@ -172,7 +172,7 @@ ParameterVariant::from_parameter(const rcl_interfaces::msg::Parameter & paramete
       throw std::runtime_error("Type from ParameterValue is not set");
     default:
       // TODO(wjwwood): use custom exception
-      // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+      // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
       throw std::runtime_error(
         "Unexpected type from ParameterVariant: " + std::to_string(parameter.value.type));
       // *INDENT-ON*
@@ -218,7 +218,7 @@ ParameterVariant::value_to_string() const
     case rclcpp::parameter::ParameterType::PARAMETER_NOT_SET:
       return "not set";
     default:
-      // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+      // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
       throw std::runtime_error(
         "Unexpected type from ParameterVariant: " + std::to_string(get_type()));
       // *INDENT-ON*

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -57,7 +57,7 @@ AsyncParametersClient::get_parameters(
   auto request = std::make_shared<rcl_interfaces::srv::GetParameters::Request>();
   request->names = names;
 
-  // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+  // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
   get_parameters_client_->async_send_request(
     request,
     [request, promise_result, future_result, &callback](
@@ -100,7 +100,7 @@ AsyncParametersClient::get_parameter_types(
   auto request = std::make_shared<rcl_interfaces::srv::GetParameterTypes::Request>();
   request->names = names;
 
-  // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+  // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
   get_parameter_types_client_->async_send_request(
     request,
     [promise_result, future_result, &callback](
@@ -135,7 +135,7 @@ AsyncParametersClient::set_parameters(
 
   auto request = std::make_shared<rcl_interfaces::srv::SetParameters::Request>();
 
-  // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+  // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
   std::transform(parameters.begin(), parameters.end(), std::back_inserter(request->parameters),
     [](rclcpp::parameter::ParameterVariant p) {
       return p.to_parameter();
@@ -171,7 +171,7 @@ AsyncParametersClient::set_parameters_atomically(
 
   auto request = std::make_shared<rcl_interfaces::srv::SetParametersAtomically::Request>();
 
-  // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+  // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
   std::transform(parameters.begin(), parameters.end(), std::back_inserter(request->parameters),
     [](rclcpp::parameter::ParameterVariant p) {
       return p.to_parameter();
@@ -210,7 +210,7 @@ AsyncParametersClient::list_parameters(
   request->prefixes = prefixes;
   request->depth = depth;
 
-  // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+  // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
   list_parameters_client_->async_send_request(
     request,
     [promise_result, future_result, &callback](

--- a/rclcpp/src/rclcpp/parameter_service.cpp
+++ b/rclcpp/src/rclcpp/parameter_service.cpp
@@ -23,7 +23,7 @@ ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
 : node_(node)
 {
   std::weak_ptr<rclcpp::node::Node> captured_node = node_;
-  // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+  // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
   get_parameters_service_ = node_->create_service<rcl_interfaces::srv::GetParameters>(
     node_->get_name() + "__get_parameters",
     [captured_node](

--- a/rclcpp/src/rclcpp/publisher.cpp
+++ b/rclcpp/src/rclcpp/publisher.cpp
@@ -33,42 +33,17 @@
 using rclcpp::publisher::PublisherBase;
 
 PublisherBase::PublisherBase(
-  std::shared_ptr<rmw_node_t> node_handle,
-  rmw_publisher_t * publisher_handle,
+  std::shared_ptr<rcl_node_t> node_handle,
   std::string topic,
   size_t queue_size)
-: node_handle_(node_handle), publisher_handle_(publisher_handle),
-  intra_process_publisher_handle_(nullptr),
+: node_handle_(node_handle),
   topic_(topic), queue_size_(queue_size),
   intra_process_publisher_id_(0), store_intra_process_message_(nullptr)
 {
-  // Life time of this object is tied to the publisher handle.
-  if (rmw_get_gid_for_publisher(publisher_handle_, &rmw_gid_) != RMW_RET_OK) {
-    // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
-    throw std::runtime_error(
-      std::string("failed to get publisher gid: ") + rmw_get_error_string_safe());
-    // *INDENT-ON*
-  }
 }
 
 PublisherBase::~PublisherBase()
 {
-  if (intra_process_publisher_handle_) {
-    if (rmw_destroy_publisher(node_handle_.get(), intra_process_publisher_handle_)) {
-      fprintf(
-        stderr,
-        "Error in destruction of intra process rmw publisher handle: %s\n",
-        rmw_get_error_string_safe());
-    }
-  }
-  if (publisher_handle_) {
-    if (rmw_destroy_publisher(node_handle_.get(), publisher_handle_) != RMW_RET_OK) {
-      fprintf(
-        stderr,
-        "Error in destruction of rmw publisher handle: %s\n",
-        rmw_get_error_string_safe());
-    }
-  }
 }
 
 const std::string &
@@ -124,13 +99,29 @@ void
 PublisherBase::setup_intra_process(
   uint64_t intra_process_publisher_id,
   StoreMessageCallbackT callback,
-  rmw_publisher_t * intra_process_publisher_handle)
+  const rcl_publisher_options_t & intra_process_options)
 {
+  if (rcl_publisher_init(
+      &intra_process_publisher_handle_, node_handle_.get(),
+      rclcpp::type_support::get_intra_process_message_msg_type_support(),
+      (topic_ + "__intra").c_str(), &intra_process_options) != RCL_RET_OK)
+  {
+    throw std::runtime_error(
+            std::string("could not create intra process publisher: ") +
+            rcl_get_error_string_safe());
+  }
+
   intra_process_publisher_id_ = intra_process_publisher_id;
   store_intra_process_message_ = callback;
-  intra_process_publisher_handle_ = intra_process_publisher_handle;
   // Life time of this object is tied to the publisher handle.
-  auto ret = rmw_get_gid_for_publisher(intra_process_publisher_handle_, &intra_process_rmw_gid_);
+  rmw_publisher_t * publisher_rmw_handle = rcl_publisher_get_rmw_handle(
+    &intra_process_publisher_handle_);
+  if (publisher_rmw_handle == nullptr) {
+    throw std::runtime_error(std::string(
+              "Failed to get rmw publisher handle") + rcl_get_error_string_safe());
+  }
+  auto ret = rmw_get_gid_for_publisher(
+    publisher_rmw_handle, &intra_process_rmw_gid_);
   if (ret != RMW_RET_OK) {
     // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
     throw std::runtime_error(

--- a/rclcpp/src/rclcpp/publisher.cpp
+++ b/rclcpp/src/rclcpp/publisher.cpp
@@ -123,7 +123,7 @@ PublisherBase::setup_intra_process(
   auto ret = rmw_get_gid_for_publisher(
     publisher_rmw_handle, &intra_process_rmw_gid_);
   if (ret != RMW_RET_OK) {
-    // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+    // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
     throw std::runtime_error(
       std::string("failed to create intra process publisher gid: ") +
       rmw_get_error_string_safe());

--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -28,23 +28,13 @@
 using rclcpp::service::ServiceBase;
 
 ServiceBase::ServiceBase(
-  std::shared_ptr<rmw_node_t> node_handle,
-  rmw_service_t * service_handle,
+  std::shared_ptr<rcl_node_t> node_handle,
   const std::string service_name)
-: node_handle_(node_handle), service_handle_(service_handle), service_name_(service_name)
+: node_handle_(node_handle), service_name_(service_name)
 {}
 
 ServiceBase::~ServiceBase()
-{
-  if (service_handle_) {
-    if (rmw_destroy_service(service_handle_) != RMW_RET_OK) {
-      std::stringstream ss;
-      ss << "Error in destruction of rmw service_handle_ handle: " <<
-        rmw_get_error_string_safe() << '\n';
-      (std::cerr << ss.str()).flush();
-    }
-  }
-}
+{}
 
 std::string
 ServiceBase::get_service_name()
@@ -52,8 +42,8 @@ ServiceBase::get_service_name()
   return this->service_name_;
 }
 
-const rmw_service_t *
+const rcl_service_t *
 ServiceBase::get_service_handle()
 {
-  return this->service_handle_;
+  return &service_handle_;
 }

--- a/rclcpp/src/rclcpp/subscription.cpp
+++ b/rclcpp/src/rclcpp/subscription.cpp
@@ -24,13 +24,10 @@
 using rclcpp::subscription::SubscriptionBase;
 
 SubscriptionBase::SubscriptionBase(
-  std::shared_ptr<rmw_node_t> node_handle,
-  rmw_subscription_t * subscription_handle,
+  std::shared_ptr<rcl_node_t> node_handle,
   const std::string & topic_name,
   bool ignore_local_publications)
-: intra_process_subscription_handle_(nullptr),
-  node_handle_(node_handle),
-  subscription_handle_(subscription_handle),
+:   node_handle_(node_handle),
   topic_name_(topic_name),
   ignore_local_publications_(ignore_local_publications)
 {
@@ -40,22 +37,19 @@ SubscriptionBase::SubscriptionBase(
 
 SubscriptionBase::~SubscriptionBase()
 {
-  if (subscription_handle_) {
-    if (rmw_destroy_subscription(node_handle_.get(), subscription_handle_) != RMW_RET_OK) {
-      std::stringstream ss;
-      ss << "Error in destruction of rmw subscription handle: " <<
-        rmw_get_error_string_safe() << '\n';
-      (std::cerr << ss.str()).flush();
-    }
+  if (rcl_subscription_fini(&subscription_handle_, node_handle_.get()) != RCL_RET_OK) {
+    std::stringstream ss;
+    ss << "Error in destruction of rcl subscription handle: " <<
+      rcl_get_error_string_safe() << '\n';
+    (std::cerr << ss.str()).flush();
   }
-  if (intra_process_subscription_handle_) {
-    auto ret = rmw_destroy_subscription(node_handle_.get(), intra_process_subscription_handle_);
-    if (ret != RMW_RET_OK) {
-      std::stringstream ss;
-      ss << "Error in destruction of rmw intra process subscription handle: " <<
-        rmw_get_error_string_safe() << '\n';
-      (std::cerr << ss.str()).flush();
-    }
+  if (rcl_subscription_fini(
+      &intra_process_subscription_handle_, node_handle_.get()) != RCL_RET_OK)
+  {
+    std::stringstream ss;
+    ss << "Error in destruction of rmw intra process subscription handle: " <<
+      rcl_get_error_string_safe() << '\n';
+    (std::cerr << ss.str()).flush();
   }
 }
 
@@ -65,14 +59,14 @@ SubscriptionBase::get_topic_name() const
   return this->topic_name_;
 }
 
-const rmw_subscription_t *
+const rcl_subscription_t *
 SubscriptionBase::get_subscription_handle() const
 {
-  return subscription_handle_;
+  return &subscription_handle_;
 }
 
-const rmw_subscription_t *
+const rcl_subscription_t *
 SubscriptionBase::get_intra_process_subscription_handle() const
 {
-  return intra_process_subscription_handle_;
+  return &intra_process_subscription_handle_;
 }

--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -201,9 +201,11 @@ rclcpp::utilities::release_sigint_guard_condition(rcl_wait_set_t * waitset)
   auto kv = g_sigint_guard_cond_handles.find(waitset);
   if (kv != g_sigint_guard_cond_handles.end()) {
     if (rcl_guard_condition_fini(&kv->second) != RCL_RET_OK) {
+      // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
       throw std::runtime_error(std::string(
         "Failed to destroy sigint guard condition: ") +
         rcl_get_error_string_safe());
+      // *INDENT-ON*
     }
     g_sigint_guard_cond_handles.erase(kv);
   } else {

--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -22,6 +22,9 @@
 #include <mutex>
 #include <string>
 
+#include "rcl/error_handling.h"
+#include "rcl/rcl.h"
+
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"
 
@@ -33,7 +36,8 @@
 /// Represent the status of the global interrupt signal.
 static volatile sig_atomic_t g_signal_status = 0;
 /// Guard condition for interrupting the rmw implementation when the global interrupt signal fired.
-static rmw_guard_condition_t * g_sigint_guard_cond_handle = rmw_create_guard_condition();
+static rcl_guard_condition_t g_sigint_guard_cond_handle =
+  rcl_get_zero_initialized_guard_condition();
 /// Condition variable for timed sleep (see sleep_for).
 static std::condition_variable g_interrupt_condition_variable;
 static std::atomic<bool> g_is_interrupted(false);
@@ -77,10 +81,10 @@ signal_handler(int signal_value)
   }
 #endif
   g_signal_status = signal_value;
-  rmw_ret_t status = rmw_trigger_guard_condition(g_sigint_guard_cond_handle);
-  if (status != RMW_RET_OK) {
+  rcl_ret_t status = rcl_trigger_guard_condition(&g_sigint_guard_cond_handle);
+  if (status != RCL_RET_OK) {
     fprintf(stderr,
-      "[rclcpp::error] failed to trigger guard condition: %s\n", rmw_get_error_string_safe());
+      "[rclcpp::error] failed to trigger guard condition: %s\n", rcl_get_error_string_safe());
   }
   g_is_interrupted.store(true);
   g_interrupt_condition_variable.notify_all();
@@ -89,14 +93,11 @@ signal_handler(int signal_value)
 void
 rclcpp::utilities::init(int argc, char * argv[])
 {
-  (void)argc;
-  (void)argv;
   g_is_interrupted.store(false);
-  rmw_ret_t status = rmw_init();
-  if (status != RMW_RET_OK) {
+  if (rcl_init(argc, argv, rcl_get_default_allocator()) != RCL_RET_OK) {
     // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
     throw std::runtime_error(
-      std::string("failed to initialize rmw implementation: ") + rmw_get_error_string_safe());
+      std::string("failed to initialize rmw implementation: ") + rcl_get_error_string_safe());
     // *INDENT-ON*
   }
 #ifdef HAS_SIGACTION
@@ -138,6 +139,11 @@ rclcpp::utilities::init(int argc, char * argv[])
       error_string);
     // *INDENT-ON*
   }
+  rcl_guard_condition_options_t options = rcl_guard_condition_get_default_options();
+  if (rcl_guard_condition_init(&g_sigint_guard_cond_handle, options) != RCL_RET_OK) {
+    throw std::runtime_error(std::string(
+              "Couldn't initialize guard condition: ") + rcl_get_error_string_safe());
+  }
 }
 
 bool
@@ -150,8 +156,7 @@ void
 rclcpp::utilities::shutdown()
 {
   g_signal_status = SIGINT;
-  rmw_ret_t status = rmw_trigger_guard_condition(g_sigint_guard_cond_handle);
-  if (status != RMW_RET_OK) {
+  if (rcl_trigger_guard_condition(&g_sigint_guard_cond_handle) != RCL_RET_OK) {
     fprintf(stderr,
       "[rclcpp::error] failed to trigger guard condition: %s\n", rmw_get_error_string_safe());
   }
@@ -159,10 +164,10 @@ rclcpp::utilities::shutdown()
   g_interrupt_condition_variable.notify_all();
 }
 
-rmw_guard_condition_t *
+rcl_guard_condition_t *
 rclcpp::utilities::get_global_sigint_guard_condition()
 {
-  return ::g_sigint_guard_cond_handle;
+  return &::g_sigint_guard_cond_handle;
 }
 
 bool

--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -95,7 +95,7 @@ rclcpp::utilities::init(int argc, char * argv[])
 {
   g_is_interrupted.store(false);
   if (rcl_init(argc, argv, rcl_get_default_allocator()) != RCL_RET_OK) {
-    // *INDENT-OFF* (prevent uncrustify from making unecessary indents here)
+    // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
     throw std::runtime_error(
       std::string("failed to initialize rmw implementation: ") + rcl_get_error_string_safe());
     // *INDENT-ON*


### PR DESCRIPTION
Connects to ros2/rclcpp#196 and ros2/system_tests#107.

Add the ability to retrieve the list of all parameters by passing an empty list of prefixes. In that case, the depth argument is ignored. This is one way to do it; other ideas for calling semantics to get the desired behavior?