### PR TITLE
added remote node name to sync parameter client

### DIFF
--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -120,7 +120,8 @@ public:
 
   RCLCPP_PUBLIC
   SyncParametersClient(
-    rclcpp::node::Node::SharedPtr node);
+    rclcpp::node::Node::SharedPtr node,
+    const std::string & remote_node_name = "");
 
   RCLCPP_PUBLIC
   SyncParametersClient(

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -228,11 +228,11 @@ AsyncParametersClient::list_parameters(
 }
 
 SyncParametersClient::SyncParametersClient(
-  rclcpp::node::Node::SharedPtr node)
+  rclcpp::node::Node::SharedPtr node,const std::string & remote_node_name)
 : node_(node)
 {
   executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-  async_parameters_client_ = std::make_shared<AsyncParametersClient>(node);
+  async_parameters_client_ = std::make_shared<AsyncParametersClient>(node, remote_node_name);
 }
 
 SyncParametersClient::SyncParametersClient(


### PR DESCRIPTION
I added the remote node name to the constructor of the SyncParametersClient and passed it to the internal used AsyncParametersClient