### PR TITLE
Fix flaky subscription and spinning test

### DIFF
--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <chrono>
 #include <cstdlib>
 #include <iostream>
 #include <list>
@@ -42,7 +43,13 @@ namespace executor
  * INTERRUPTED: The future is not complete, spinning was interrupted by Ctrl-C or another error.
  * TIMEOUT: Spinning timed out.
  */
-enum FutureReturnCode {SUCCESS, INTERRUPTED, TIMEOUT};
+enum class FutureReturnCode {SUCCESS, INTERRUPTED, TIMEOUT};
+
+std::ostream &
+operator << (std::ostream & os, const FutureReturnCode & future_return_code);
+
+std::string
+to_string(const FutureReturnCode & future_return_code);
 
 ///
 /**

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <type_traits>
+
 #include "rclcpp/executor.hpp"
 #include "rclcpp/scope_exit.hpp"
 
@@ -20,6 +22,7 @@
 using rclcpp::executor::AnyExecutable;
 using rclcpp::executor::Executor;
 using rclcpp::executor::ExecutorArgs;
+using rclcpp::executor::FutureReturnCode;
 
 Executor::Executor(const ExecutorArgs & args)
 : spinning(false),
@@ -568,4 +571,26 @@ Executor::get_next_executable(std::chrono::nanoseconds timeout)
     }
   }
   return any_exec;
+}
+
+std::ostream &
+rclcpp::executor::operator << (std::ostream & os, const FutureReturnCode & future_return_code)
+{
+  return os << to_string(future_return_code);
+}
+
+std::string
+rclcpp::executor::to_string(const FutureReturnCode & future_return_code)
+{
+  using enum_type = std::underlying_type<FutureReturnCode>::type;
+  using std::string;
+  using std::to_string;
+  switch (future_return_code) {
+    case FutureReturnCode::SUCCESS:
+      return string("SUCCESS (" + to_string(static_cast<enum_type>(future_return_code)) + ")");
+    case FutureReturnCode::INTERRUPTED:
+      return string("INTERRUPTED (" + to_string(static_cast<enum_type>(future_return_code)) + ")");
+    case FutureReturnCode::TIMEOUT:
+      return string("TIMEOUT (" + to_string(static_cast<enum_type>(future_return_code)) + ")");
+  }
 }

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
 #include <type_traits>
 
 #include "rclcpp/executor.hpp"
@@ -574,7 +575,7 @@ Executor::get_next_executable(std::chrono::nanoseconds timeout)
 }
 
 std::ostream &
-rclcpp::executor::operator << (std::ostream & os, const FutureReturnCode & future_return_code)
+rclcpp::executor::operator<<(std::ostream & os, const FutureReturnCode & future_return_code)
 {
   return os << to_string(future_return_code);
 }
@@ -583,14 +584,18 @@ std::string
 rclcpp::executor::to_string(const FutureReturnCode & future_return_code)
 {
   using enum_type = std::underlying_type<FutureReturnCode>::type;
-  using std::string;
-  using std::to_string;
+  std::string prefix = "Unknown enum value (";
+  std::string ret_as_string = std::to_string(static_cast<enum_type>(future_return_code));
   switch (future_return_code) {
     case FutureReturnCode::SUCCESS:
-      return string("SUCCESS (" + to_string(static_cast<enum_type>(future_return_code)) + ")");
+      prefix = "SUCCESS (";
+      break;
     case FutureReturnCode::INTERRUPTED:
-      return string("INTERRUPTED (" + to_string(static_cast<enum_type>(future_return_code)) + ")");
+      prefix = "INTERRUPTED (";
+      break;
     case FutureReturnCode::TIMEOUT:
-      return string("TIMEOUT (" + to_string(static_cast<enum_type>(future_return_code)) + ")");
+      prefix = "TIMEOUT (";
+      break;
   }
+  return prefix + ret_as_string + ")";
 }


### PR DESCRIPTION
This pr does two things, first it adds a way to print out a meaningful string for a given FutureReturnCode (which I needed when debugging). You can now get an output like this:

```
/Users/william/ros2_ws/src/ros2/system_tests/test_rclcpp/test/test_subscription.cpp:80: Failure
Value of: future_ret
  Actual: INTERRUPTED (1)
Expected: FutureReturnCode::SUCCESS
Which is: SUCCESS (0)
```

Second it refactors the `executor.spin_until_future_complete` which was, imo, not working correctly before and which I needed when addressing some flaky-ness of one of the tests in `test_rclcpp`. Before this patch, I believe it would pass the full `timeout` value to `spin_once` even if it had spent some time spinning a previous time through the while loop. The changes to fix up the test (and use these changes) is forthcoming.

Connects to ros2/system_tests#108