### PR TITLE
Only enable Timer if clock type is steady

### DIFF
--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -84,10 +84,11 @@ using TimerCallbackType = std::function<void(TimerBase &)>;
 /// Generic timer templated on the clock type. Periodically executes a user-specified callback.
 template<
   typename FunctorT,
-  class Clock = std::chrono::high_resolution_clock,
+  class Clock,
   typename std::enable_if<
-    rclcpp::function_traits::same_arguments<FunctorT, VoidCallbackType>::value ||
-    rclcpp::function_traits::same_arguments<FunctorT, TimerCallbackType>::value
+    (rclcpp::function_traits::same_arguments<FunctorT, VoidCallbackType>::value ||
+    rclcpp::function_traits::same_arguments<FunctorT, TimerCallbackType>::value) &&
+    Clock::is_steady
   >::type * = nullptr
 >
 class GenericTimer : public TimerBase


### PR DESCRIPTION
rcl currently does not expose the clock type for timers; it assumes a steady clock.

Additionally, in our current implementation of rclcpp, specializing the GenericTimer type with a non-steady clock type results in undefined behavior.

Exposing the clock type for rcl and adding logic to handle non-monotonic timers will take a little more forethought and design (to be done when @tfoote continues pushing on ROS time features). In the meantime, this pull request disables the GenericTimer specialization if the Clock type is not steady (luckily `std::chrono` provides a constant boolean for Clock types for this kind of thing).

@wjwwood, we discussed this change but I'm now unsure how to write a test for this because I've disabled the specialization at compile time, let me know if you have any ideas.