### PR TITLE
Virtual destructors (fixes ros1bridge build)

### DIFF
--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -51,7 +51,7 @@ public:
     const std::string & service_name);
 
   RCLCPP_PUBLIC
-  ~ClientBase();
+  virtual ~ClientBase();
 
   RCLCPP_PUBLIC
   const std::string &

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -80,7 +80,7 @@ public:
     bool use_intra_process_comms = false);
 
   RCLCPP_PUBLIC
-  ~Node();
+  virtual ~Node();
 
   /// Get the name of the node.
   // \return The name of the node.

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -67,7 +67,7 @@ public:
     size_t queue_size);
 
   RCLCPP_PUBLIC
-  ~PublisherBase();
+  virtual ~PublisherBase();
 
   /// Get the topic that this publisher publishes on.
   // \return The topic name.

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -47,7 +47,7 @@ public:
     const std::string service_name);
 
   RCLCPP_PUBLIC
-  ~ServiceBase();
+  virtual ~ServiceBase();
 
   RCLCPP_PUBLIC
   std::string


### PR DESCRIPTION
In #207 I broke the packaging job by messing with the virtual destructor of `PublisherBase`. This caused the ros1bridge to fail because of a dynamic_cast from PublisherBase to Publisher.

Packaging test:
http://ci.ros2.org/view/packaging/job/packaging_linux/226/

Normal CI:
http://ci.ros2.org/job/ci_linux/1219/
http://ci.ros2.org/job/ci_osx/984/
http://ci.ros2.org/job/ci_windows/1266/