### PR TITLE
fix wrong link library for test_rate gtest

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -113,7 +113,7 @@ if(AMENT_ENABLE_TESTING)
       ${rosidl_generator_cpp_INCLUDE_DIRS}
     )
     target_link_libraries(test_rate
-      ${PROJECT_NAME}${target_suffix}
+      ${PROJECT_NAME}
     )
   endif()
 endif()


### PR DESCRIPTION
See https://github.com/ros2/rclcpp/pull/182/files#r61188395

Without this fix it failed for me similar to ros2/rcl#52 when using the evaluation version of Connext (x64Linux3gcc4.8.2).