### PR TITLE
Add mutex to protect vectors of pointers in callbackgroup

### DIFF
--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -16,6 +16,7 @@
 #define RCLCPP__CALLBACK_GROUP_HPP_
 
 #include <atomic>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -97,6 +98,8 @@ private:
   add_client(const rclcpp::client::ClientBase::SharedPtr client_ptr);
 
   CallbackGroupType type_;
+  // Mutex to protect the subsequent vectors of pointers.
+  mutable std::mutex mutex_;
   std::vector<rclcpp::subscription::SubscriptionBase::WeakPtr> subscription_ptrs_;
   std::vector<rclcpp::timer::TimerBase::WeakPtr> timer_ptrs_;
   std::vector<rclcpp::service::ServiceBase::SharedPtr> service_ptrs_;

--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -26,24 +26,28 @@ CallbackGroup::CallbackGroup(CallbackGroupType group_type)
 const std::vector<rclcpp::subscription::SubscriptionBase::WeakPtr> &
 CallbackGroup::get_subscription_ptrs() const
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   return subscription_ptrs_;
 }
 
 const std::vector<rclcpp::timer::TimerBase::WeakPtr> &
 CallbackGroup::get_timer_ptrs() const
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   return timer_ptrs_;
 }
 
 const std::vector<rclcpp::service::ServiceBase::SharedPtr> &
 CallbackGroup::get_service_ptrs() const
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   return service_ptrs_;
 }
 
 const std::vector<rclcpp::client::ClientBase::WeakPtr> &
 CallbackGroup::get_client_ptrs() const
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   return client_ptrs_;
 }
 
@@ -63,23 +67,27 @@ void
 CallbackGroup::add_subscription(
   const rclcpp::subscription::SubscriptionBase::SharedPtr subscription_ptr)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   subscription_ptrs_.push_back(subscription_ptr);
 }
 
 void
 CallbackGroup::add_timer(const rclcpp::timer::TimerBase::SharedPtr timer_ptr)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   timer_ptrs_.push_back(timer_ptr);
 }
 
 void
 CallbackGroup::add_service(const rclcpp::service::ServiceBase::SharedPtr service_ptr)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   service_ptrs_.push_back(service_ptr);
 }
 
 void
 CallbackGroup::add_client(const rclcpp::client::ClientBase::SharedPtr client_ptr)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   client_ptrs_.push_back(client_ptr);
 }


### PR DESCRIPTION
Test failures such as:

* http://ci.ros2.org/view/nightly/job/nightly_osx_repeated/339/testReport/%28root%29/projectroot/gtest_executor__rmw_fastrtps_cpp/
* http://ci.ros2.org/view/nightly/job/nightly_win_rel/105/testReport/%28root%29/projectroot/gtest_executor__rmw_opensplice_cpp/

can be traced to concurrent access to the various vectors of pointers in `CallbackGroup`. For example, if you have a single-threaded executor spinning a node and you call `create_wall_timer()` on that node from another thread, then you can be pushing the new timer onto `CallbackGroup::timer_ptrs_` while the executor is reading the same vector.

This PR adds a single mutex to protect all of the vectors. If we observe contention, we could consider making the protection more granular.

* Linux:
 * [![Build Status](http://ci.ros2.org/job/ci_linux/1409/badge/icon)](http://ci.ros2.org/job/ci_linux/1409/)
* OSX:
 * [![Build Status](http://ci.ros2.org/job/ci_osx/1093/badge/icon)](http://ci.ros2.org/job/ci_osx/1093/)
* Windows:
 * [![Build Status](http://ci.ros2.org/job/ci_windows/1417/badge/icon)](http://ci.ros2.org/job/ci_windows/1417/)