### PR TITLE
Give a different signal guard condition for each waitset

### DIFF
--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -52,7 +52,7 @@ shutdown();
 /// Get a handle to the rmw guard condition that manages the signal handler.
 RCLCPP_PUBLIC
 rcl_guard_condition_t *
-get_global_sigint_guard_condition();
+get_global_sigint_guard_condition(void*);
 
 /// Use the global condition variable to block for the specified amount of time.
 /**

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -20,6 +20,7 @@
 #include "rclcpp/visibility_control.hpp"
 
 #include "rcl/guard_condition.h"
+#include "rcl/wait.h"
 
 #include "rmw/macros.h"
 #include "rmw/rmw.h"
@@ -50,9 +51,20 @@ void
 shutdown();
 
 /// Get a handle to the rmw guard condition that manages the signal handler.
+/**
+ * The first time that this function is called for a given waitset a new guard
+ * condition will be created and returned; thereafter the same guard condition
+ * will be returned for the same waitset. This mechanism is designed to ensure
+ * that the same guard condition is not reused across waitsets (e.g., when
+ * using multiple executors in the same process). Can throw an exception if
+ * initialization of the guard condition fails.
+ * \param[waitset] waitset Pointer to the rcl_wait_set_t that will be using the
+ * resulting guard condition.
+ * \return Pointer to the guard condition.
+ */
 RCLCPP_PUBLIC
 rcl_guard_condition_t *
-get_global_sigint_guard_condition(void*);
+get_sigint_guard_condition(rcl_wait_set_t * waitset);
 
 /// Use the global condition variable to block for the specified amount of time.
 /**

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -56,7 +56,7 @@ shutdown();
  * condition will be created and returned; thereafter the same guard condition
  * will be returned for the same waitset. This mechanism is designed to ensure
  * that the same guard condition is not reused across waitsets (e.g., when
- * using multiple executors in the same process). Can throw an exception if
+ * using multiple executors in the same process). Will throw an exception if
  * initialization of the guard condition fails.
  * \param[waitset] waitset Pointer to the rcl_wait_set_t that will be using the
  * resulting guard condition.
@@ -65,6 +65,19 @@ shutdown();
 RCLCPP_PUBLIC
 rcl_guard_condition_t *
 get_sigint_guard_condition(rcl_wait_set_t * waitset);
+
+/// Release the previously allocated guard condition that manages the signal handler
+/**
+ * If you previously called get_sigint_guard_condition() for a given waitset
+ * to get a sigint guard condition, then you should call release_sigint_guard_condition()
+ * when you're done, to free that condition.  Will throw an exception if
+ * get_sigint_guard_condition() wasn't previously called for the given waitset.
+ * \param[waitset] waitset Pointer to the rcl_wait_set_t that was using the
+ * resulting guard condition.
+ */
+RCLCPP_PUBLIC
+void
+release_sigint_guard_condition(rcl_wait_set_t * waitset);
 
 /// Use the global condition variable to block for the specified amount of time.
 /**

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -66,7 +66,7 @@ RCLCPP_PUBLIC
 rcl_guard_condition_t *
 get_sigint_guard_condition(rcl_wait_set_t * waitset);
 
-/// Release the previously allocated guard condition that manages the signal handler
+/// Release the previously allocated guard condition that manages the signal handler.
 /**
  * If you previously called get_sigint_guard_condition() for a given waitset
  * to get a sigint guard condition, then you should call release_sigint_guard_condition()

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -77,6 +77,8 @@ Executor::~Executor()
     fprintf(stderr,
       "[rclcpp::error] failed to destroy guard condition: %s\n", rcl_get_error_string_safe());
   }
+  // Release the sigint guard condition
+  rclcpp::utilities::release_sigint_guard_condition(&waitset_);
 }
 
 void

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -46,7 +46,7 @@ Executor::Executor(const ExecutorArgs & args)
   // and one for the executor's guard cond (interrupt_guard_condition_)
 
   // Put the global ctrl-c guard condition in
-  memory_strategy_->add_guard_condition(rclcpp::utilities::get_global_sigint_guard_condition(&waitset_));
+  memory_strategy_->add_guard_condition(rclcpp::utilities::get_sigint_guard_condition(&waitset_));
 
   // Put the executor's guard condition in
   memory_strategy_->add_guard_condition(&interrupt_guard_condition_);

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -46,7 +46,7 @@ Executor::Executor(const ExecutorArgs & args)
   // and one for the executor's guard cond (interrupt_guard_condition_)
 
   // Put the global ctrl-c guard condition in
-  memory_strategy_->add_guard_condition(rclcpp::utilities::get_global_sigint_guard_condition());
+  memory_strategy_->add_guard_condition(rclcpp::utilities::get_global_sigint_guard_condition(&waitset_));
 
   // Put the executor's guard condition in
   memory_strategy_->add_guard_condition(&interrupt_guard_condition_);

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -77,7 +77,8 @@ Executor::~Executor()
     fprintf(stderr,
       "[rclcpp::error] failed to destroy guard condition: %s\n", rcl_get_error_string_safe());
   }
-  // Release the sigint guard condition
+  // Remove and release the sigint guard condition
+  memory_strategy_->remove_guard_condition(rclcpp::utilities::get_sigint_guard_condition(&waitset_));
   rclcpp::utilities::release_sigint_guard_condition(&waitset_);
 }
 

--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -201,16 +201,15 @@ rclcpp::utilities::release_sigint_guard_condition(rcl_wait_set_t * waitset)
   auto kv = g_sigint_guard_cond_handles.find(waitset);
   if (kv != g_sigint_guard_cond_handles.end()) {
     if (rcl_guard_condition_fini(&kv->second) != RCL_RET_OK) {
-      fprintf(stderr,
-        "[rclcpp::error] failed to destroy sigint guard condition: %s\n",
+      throw std::runtime_error(std::string(
+        "Failed to destroy sigint guard condition: ") +
         rcl_get_error_string_safe());
     }
     g_sigint_guard_cond_handles.erase(kv);
   } else {
     // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
     throw std::runtime_error(std::string(
-      "Tried to release sigint guard condition for nonexistent waitset: %s") +
-      rcl_get_error_string_safe());
+      "Tried to release sigint guard condition for nonexistent waitset"));
     // *INDENT-ON*
   }
 }


### PR DESCRIPTION
Fix #225 by returning a different guard condition for each waitset, to avoid having one condition reused across waitsets.

@wjwwood, this isn't the implementation that you suggested, but I found it to be the most straightforward way to fix the problem. What do you think?

(I'll run CI after I get consensus on the implementation.)