### PR TITLE
Only use _dupenv_s if it's defined

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -48,6 +48,9 @@ macro(target)
   endif()
   add_library(${PROJECT_NAME}${target_suffix} SHARED
     ${${PROJECT_NAME}_SRCS})
+  if("${CMAKE_SYSTEM_NAME} " STREQUAL "WindowsPhone " OR "${CMAKE_SYSTEM_NAME} " STREQUAL "WindowsStore ")
+    set_property(TARGET ${PROJECT_NAME}${target_suffix} PROPERTY VS_WINRT_COMPONENT 1)
+  endif()
   ament_target_dependencies(${PROJECT_NAME}${target_suffix}
     "rcl${target_suffix}"
     "rosidl_generator_cpp")

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -54,8 +54,10 @@ Node::Node(
 #ifndef _WIN32
   ros_domain_id = getenv(env_var);
 #else
+#ifndef __cplusplus_winrt
   size_t ros_domain_id_size;
   _dupenv_s(&ros_domain_id, &ros_domain_id_size, env_var);
+#endif
 #endif
   if (ros_domain_id) {
     uint32_t number = strtoul(ros_domain_id, NULL, 0);


### PR DESCRIPTION
This enables building on UWP, which does not implement `_dupenv_s`:

https://msdn.microsoft.com/en-us/library/windows/apps/jj606124.aspx
