### PR TITLE
Implement std::to_string for Android

### DIFF
--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -26,6 +26,22 @@
 #include "rmw/macros.h"
 #include "rmw/rmw.h"
 
+#ifdef ANDROID
+#include <string>
+#include <sstream>
+
+namespace std
+{
+template<typename T>
+std::string to_string(T value)
+{
+  std::ostringstream os;
+  os << value;
+  return os.str();
+}
+}
+#endif
+
 namespace rclcpp
 {
 namespace utilities

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -21,6 +21,7 @@
 
 #include "rclcpp/executor.hpp"
 #include "rclcpp/scope_exit.hpp"
+#include "rclcpp/utilities.hpp"
 
 #include "rcl_interfaces/msg/intra_process_message.hpp"
 

--- a/rclcpp/src/rclcpp/parameter.cpp
+++ b/rclcpp/src/rclcpp/parameter.cpp
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "rclcpp/parameter.hpp"
-
 #include <ostream>
 #include <sstream>
 #include <string>
 #include <vector>
+
+#include "rclcpp/parameter.hpp"
+#include "rclcpp/utilities.hpp"
 
 using rclcpp::parameter::ParameterType;
 using rclcpp::parameter::ParameterVariant;

--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -126,7 +126,7 @@ rclcpp::utilities::init(int argc, char * argv[])
     // NOLINTNEXTLINE(runtime/arrays)
     char error_string[error_length];
 #ifndef _WIN32
-#ifdef _GNU_SOURCE
+#if (defined(_GNU_SOURCE) && !defined(ANDROID))
     char * msg = strerror_r(errno, error_string, error_length);
     if (msg != error_string) {
       strncpy(error_string, msg, error_length);


### PR DESCRIPTION
This PR implements `std::to_string` for Android, which does not exist on the NDK.

Also, `bionic`, the C library for Android uses the standard signature for `strerror_r`, not the GNU extension, despite `GNU_SOURCE` being defined.

I don't know if `utilities.hpp` is the best place to put `std::to_string`, so I'm open to suggestions.