### PR TITLE
add helper methods for accessing params

### DIFF
--- a/rclcpp/include/rclcpp/parameter.hpp
+++ b/rclcpp/include/rclcpp/parameter.hpp
@@ -127,8 +127,8 @@ public:
   }
 
   template<ParameterType type>
-  typename std::enable_if<type == ParameterType::PARAMETER_BYTES,
-  const std::vector<uint8_t> &>::type
+  typename std::enable_if<
+    type == ParameterType::PARAMETER_BYTES, const std::vector<uint8_t> &>::type
   get_value() const
   {
     if (value_.type != rcl_interfaces::msg::ParameterType::PARAMETER_BYTES) {
@@ -141,8 +141,8 @@ public:
   // The following get_value() variants allow the use of primitive types
 
   template<typename type>
-  typename std::enable_if<std::is_integral<type>::value && !std::is_same<type, bool>::value,
-  int64_t>::type
+  typename std::enable_if<
+    std::is_integral<type>::value && !std::is_same<type, bool>::value, int64_t>::type
   get_value() const
   {
     return get_value<ParameterType::PARAMETER_INTEGER>();
@@ -170,8 +170,9 @@ public:
   }
 
   template<typename type>
-  typename std::enable_if<std::is_convertible<type, const std::vector<uint8_t> &>::value,
-  const std::vector<uint8_t> &>::type
+  typename std::enable_if<
+    std::is_convertible<
+      type, const std::vector<uint8_t> &>::value, const std::vector<uint8_t> &>::type
   get_value() const
   {
     return get_value<ParameterType::PARAMETER_BYTES>();

--- a/rclcpp/include/rclcpp/parameter.hpp
+++ b/rclcpp/include/rclcpp/parameter.hpp
@@ -80,6 +80,8 @@ public:
   rcl_interfaces::msg::ParameterValue
   get_parameter_value() const;
 
+  // The following get_value() variants require the use of ParameterType
+
   template<ParameterType type>
   typename std::enable_if<type == ParameterType::PARAMETER_INTEGER, int64_t>::type
   get_value() const
@@ -134,6 +136,45 @@ public:
       throw std::runtime_error("Invalid type");
     }
     return value_.bytes_value;
+  }
+
+  // The following get_value() variants allow the use of primitive types
+
+  template<typename type>
+  typename std::enable_if<std::is_integral<type>::value && !std::is_same<type, bool>::value,
+  int64_t>::type
+  get_value() const
+  {
+    return get_value<ParameterType::PARAMETER_INTEGER>();
+  }
+
+  template<typename type>
+  typename std::enable_if<std::is_floating_point<type>::value, double>::type
+  get_value() const
+  {
+    return get_value<ParameterType::PARAMETER_DOUBLE>();
+  }
+
+  template<typename type>
+  typename std::enable_if<std::is_convertible<type, std::string>::value, const std::string &>::type
+  get_value() const
+  {
+    return get_value<ParameterType::PARAMETER_STRING>();
+  }
+
+  template<typename type>
+  typename std::enable_if<std::is_same<type, bool>::value, bool>::type
+  get_value() const
+  {
+    return get_value<ParameterType::PARAMETER_BOOL>();
+  }
+
+  template<typename type>
+  typename std::enable_if<std::is_convertible<type, const std::vector<uint8_t> &>::value,
+  const std::vector<uint8_t> &>::type
+  get_value() const
+  {
+    return get_value<ParameterType::PARAMETER_BYTES>();
   }
 
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -48,7 +48,8 @@ public:
   RCLCPP_PUBLIC
   AsyncParametersClient(
     const rclcpp::node::Node::SharedPtr node,
-    const std::string & remote_node_name = "");
+    const std::string & remote_node_name = "",
+    const rmw_qos_profile_t & qos_profile = rmw_qos_profile_parameters);
 
   RCLCPP_PUBLIC
   std::shared_future<std::vector<rclcpp::parameter::ParameterVariant>>
@@ -119,12 +120,15 @@ public:
   RCLCPP_SMART_PTR_DEFINITIONS(SyncParametersClient);
 
   RCLCPP_PUBLIC
-  explicit SyncParametersClient(rclcpp::node::Node::SharedPtr node);
+  explicit SyncParametersClient(
+    rclcpp::node::Node::SharedPtr node,
+    const rmw_qos_profile_t & qos_profile = rmw_qos_profile_parameters);
 
   RCLCPP_PUBLIC
   SyncParametersClient(
     rclcpp::executor::Executor::SharedPtr executor,
-    rclcpp::node::Node::SharedPtr node);
+    rclcpp::node::Node::SharedPtr node,
+    const rmw_qos_profile_t & qos_profile = rmw_qos_profile_parameters);
 
   RCLCPP_PUBLIC
   std::vector<rclcpp::parameter::ParameterVariant>

--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -135,6 +135,38 @@ public:
   get_parameters(const std::vector<std::string> & parameter_names);
 
   RCLCPP_PUBLIC
+  bool
+  has_parameter(const std::string & parameter_name);
+
+  template<typename T>
+  T
+  get_parameter(const std::string & parameter_name, const T & default_value)
+  {
+    std::vector<std::string> names;
+    names.push_back(parameter_name);
+    auto vars = get_parameters(names);
+    if ((vars.size() == 0) || (vars[0].get_type() == rclcpp::parameter::PARAMETER_NOT_SET)) {
+      return default_value;
+    } else {
+      return vars[0].get_value<T>();
+    }
+  }
+
+  template<typename T>
+  T
+  get_parameter(const std::string & parameter_name)
+  {
+    std::vector<std::string> names;
+    names.push_back(parameter_name);
+    auto vars = get_parameters(names);
+    if ((vars.size() == 0) || (vars[0].get_type() == rclcpp::parameter::PARAMETER_NOT_SET)) {
+      throw std::runtime_error("Parameter not set");
+    } else {
+      return vars[0].get_value<T>();
+    }
+  }
+
+  RCLCPP_PUBLIC
   std::vector<rclcpp::parameter::ParameterType>
   get_parameter_types(const std::vector<std::string> & parameter_names);
 

--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -148,7 +148,7 @@ public:
     if ((vars.size() == 0) || (vars[0].get_type() == rclcpp::parameter::PARAMETER_NOT_SET)) {
       return default_value;
     } else {
-      return vars[0].get_value<T>();
+      return static_cast<T>(vars[0].get_value<T>());
     }
   }
 
@@ -162,7 +162,7 @@ public:
     if ((vars.size() == 0) || (vars[0].get_type() == rclcpp::parameter::PARAMETER_NOT_SET)) {
       throw std::runtime_error("Parameter not set");
     } else {
-      return vars[0].get_value<T>();
+      return static_cast<T>(vars[0].get_value<T>());
     }
   }
 

--- a/rclcpp/include/rclcpp/parameter_service.hpp
+++ b/rclcpp/include/rclcpp/parameter_service.hpp
@@ -41,7 +41,9 @@ public:
   RCLCPP_SMART_PTR_DEFINITIONS(ParameterService);
 
   RCLCPP_PUBLIC
-  explicit ParameterService(const rclcpp::node::Node::SharedPtr node);
+  explicit ParameterService(
+    const rclcpp::node::Node::SharedPtr node,
+    const rmw_qos_profile_t & qos_profile = rmw_qos_profile_parameters);
 
 private:
   const rclcpp::node::Node::SharedPtr node_;

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -264,8 +264,8 @@ SyncParametersClient::has_parameter(const std::string & parameter_name)
 {
   std::vector<std::string> names;
   names.push_back(parameter_name);
-  auto vars = get_parameters(names);
-  return vars.size() > 0;
+  auto vars = list_parameters(names, 1);
+  return vars.names.size() > 0;
 }
 
 std::vector<rclcpp::parameter::ParameterType>

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -23,7 +23,8 @@ using rclcpp::parameter_client::SyncParametersClient;
 
 AsyncParametersClient::AsyncParametersClient(
   const rclcpp::node::Node::SharedPtr node,
-  const std::string & remote_node_name)
+  const std::string & remote_node_name,
+  const rmw_qos_profile_t & qos_profile)
 : node_(node)
 {
   if (remote_node_name != "") {
@@ -32,15 +33,15 @@ AsyncParametersClient::AsyncParametersClient(
     remote_node_name_ = node_->get_name();
   }
   get_parameters_client_ = node_->create_client<rcl_interfaces::srv::GetParameters>(
-    remote_node_name_ + "__get_parameters");
+    remote_node_name_ + "__get_parameters", qos_profile);
   get_parameter_types_client_ = node_->create_client<rcl_interfaces::srv::GetParameterTypes>(
-    remote_node_name_ + "__get_parameter_types");
+    remote_node_name_ + "__get_parameter_types", qos_profile);
   set_parameters_client_ = node_->create_client<rcl_interfaces::srv::SetParameters>(
-    remote_node_name_ + "__set_parameters");
+    remote_node_name_ + "__set_parameters", qos_profile);
   list_parameters_client_ = node_->create_client<rcl_interfaces::srv::ListParameters>(
-    remote_node_name_ + "__list_parameters");
+    remote_node_name_ + "__list_parameters", qos_profile);
   describe_parameters_client_ = node_->create_client<rcl_interfaces::srv::DescribeParameters>(
-    remote_node_name_ + "__describe_parameters");
+    remote_node_name_ + "__describe_parameters", qos_profile);
 }
 
 std::shared_future<std::vector<rclcpp::parameter::ParameterVariant>>
@@ -228,19 +229,21 @@ AsyncParametersClient::list_parameters(
 }
 
 SyncParametersClient::SyncParametersClient(
-  rclcpp::node::Node::SharedPtr node)
+  rclcpp::node::Node::SharedPtr node,
+  const rmw_qos_profile_t & qos_profile)
 : node_(node)
 {
   executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-  async_parameters_client_ = std::make_shared<AsyncParametersClient>(node);
+  async_parameters_client_ = std::make_shared<AsyncParametersClient>(node, "", qos_profile);
 }
 
 SyncParametersClient::SyncParametersClient(
   rclcpp::executor::Executor::SharedPtr executor,
-  rclcpp::node::Node::SharedPtr node)
+  rclcpp::node::Node::SharedPtr node,
+  const rmw_qos_profile_t & qos_profile)
 : executor_(executor), node_(node)
 {
-  async_parameters_client_ = std::make_shared<AsyncParametersClient>(node);
+  async_parameters_client_ = std::make_shared<AsyncParametersClient>(node, "", qos_profile);
 }
 
 std::vector<rclcpp::parameter::ParameterVariant>

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -259,6 +259,15 @@ SyncParametersClient::get_parameters(const std::vector<std::string> & parameter_
   return std::vector<rclcpp::parameter::ParameterVariant>();
 }
 
+bool
+SyncParametersClient::has_parameter(const std::string & parameter_name)
+{
+  std::vector<std::string> names;
+  names.push_back(parameter_name);
+  auto vars = get_parameters(names);
+  return vars.size() > 0;
+}
+
 std::vector<rclcpp::parameter::ParameterType>
 SyncParametersClient::get_parameter_types(const std::vector<std::string> & parameter_names)
 {

--- a/rclcpp/src/rclcpp/parameter_service.cpp
+++ b/rclcpp/src/rclcpp/parameter_service.cpp
@@ -19,7 +19,9 @@
 
 using rclcpp::parameter_service::ParameterService;
 
-ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
+ParameterService::ParameterService(
+  const rclcpp::node::Node::SharedPtr node,
+  const rmw_qos_profile_t & qos_profile)
 : node_(node)
 {
   std::weak_ptr<rclcpp::node::Node> captured_node = node_;
@@ -39,7 +41,8 @@ ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
       for (auto & pvariant : values) {
         response->values.push_back(pvariant.get_parameter_value());
       }
-    }
+    },
+    qos_profile
   );
 
   get_parameter_types_service_ = node_->create_service<rcl_interfaces::srv::GetParameterTypes>(
@@ -58,7 +61,8 @@ ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
       std::back_inserter(response->types), [](const uint8_t & type) {
         return static_cast<rclcpp::parameter::ParameterType>(type);
       });
-    }
+    },
+    qos_profile
   );
 
   set_parameters_service_ = node_->create_service<rcl_interfaces::srv::SetParameters>(
@@ -78,7 +82,8 @@ ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
       }
       auto results = node->set_parameters(pvariants);
       response->results = results;
-    }
+    },
+    qos_profile
   );
 
   set_parameters_atomically_service_ =
@@ -102,7 +107,8 @@ ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
       });
       auto result = node->set_parameters_atomically(pvariants);
       response->result = result;
-    }
+    },
+    qos_profile
   );
 
   describe_parameters_service_ = node_->create_service<rcl_interfaces::srv::DescribeParameters>(
@@ -118,7 +124,8 @@ ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
       }
       auto descriptors = node->describe_parameters(request->names);
       response->descriptors = descriptors;
-    }
+    },
+    qos_profile
   );
 
   list_parameters_service_ = node_->create_service<rcl_interfaces::srv::ListParameters>(
@@ -134,7 +141,8 @@ ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
       }
       auto result = node->list_parameters(request->prefixes, request->depth);
       response->result = result;
-    }
+    },
+    qos_profile
   );
   // *INDENT-ON*
 }


### PR DESCRIPTION
Add features that are handy when working with params:

* Check for existence of param: `bool exists = client.has_parameter("foo")`
* Get value of one param: `double bar = client.get_parameter<double>("foo")` (throws if the param isn't set)
* Get value of one param, with default: `double bar = client.get_parameter("foo", 4.2)` (returns 4.2 if the param isn't set)

Tests are in ros2/system_tests#149.

- Linux:
  - [![Build Status](http://ci.ros2.org/job/ci_linux/1622//badge/icon)](http://ci.ros2.org/job/ci_linux/1622/) 
- OS X:
  - [![Build Status](http://ci.ros2.org/job/ci_osx/1221//badge/icon)](http://ci.ros2.org/job/ci_osx/1221/)