### PR TITLE
use the param profile for param services

### DIFF
--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -48,7 +48,8 @@ public:
   RCLCPP_PUBLIC
   AsyncParametersClient(
     const rclcpp::node::Node::SharedPtr node,
-    const std::string & remote_node_name = "");
+    const std::string & remote_node_name = "",
+    const rmw_qos_profile_t & qos_profile = rmw_qos_profile_parameters);
 
   RCLCPP_PUBLIC
   std::shared_future<std::vector<rclcpp::parameter::ParameterVariant>>
@@ -119,12 +120,15 @@ public:
   RCLCPP_SMART_PTR_DEFINITIONS(SyncParametersClient);
 
   RCLCPP_PUBLIC
-  explicit SyncParametersClient(rclcpp::node::Node::SharedPtr node);
+  explicit SyncParametersClient(
+    rclcpp::node::Node::SharedPtr node,
+    const rmw_qos_profile_t & qos_profile = rmw_qos_profile_parameters);
 
   RCLCPP_PUBLIC
   SyncParametersClient(
     rclcpp::executor::Executor::SharedPtr executor,
-    rclcpp::node::Node::SharedPtr node);
+    rclcpp::node::Node::SharedPtr node,
+    const rmw_qos_profile_t & qos_profile = rmw_qos_profile_parameters);
 
   RCLCPP_PUBLIC
   std::vector<rclcpp::parameter::ParameterVariant>

--- a/rclcpp/include/rclcpp/parameter_service.hpp
+++ b/rclcpp/include/rclcpp/parameter_service.hpp
@@ -41,7 +41,9 @@ public:
   RCLCPP_SMART_PTR_DEFINITIONS(ParameterService);
 
   RCLCPP_PUBLIC
-  explicit ParameterService(const rclcpp::node::Node::SharedPtr node);
+  explicit ParameterService(
+    const rclcpp::node::Node::SharedPtr node,
+    const rmw_qos_profile_t & qos_profile = rmw_qos_profile_parameters);
 
 private:
   const rclcpp::node::Node::SharedPtr node_;

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -32,15 +32,15 @@ AsyncParametersClient::AsyncParametersClient(
     remote_node_name_ = node_->get_name();
   }
   get_parameters_client_ = node_->create_client<rcl_interfaces::srv::GetParameters>(
-    remote_node_name_ + "__get_parameters");
+    remote_node_name_ + "__get_parameters", rmw_qos_profile_parameters);
   get_parameter_types_client_ = node_->create_client<rcl_interfaces::srv::GetParameterTypes>(
-    remote_node_name_ + "__get_parameter_types");
+    remote_node_name_ + "__get_parameter_types", rmw_qos_profile_parameters);
   set_parameters_client_ = node_->create_client<rcl_interfaces::srv::SetParameters>(
-    remote_node_name_ + "__set_parameters");
+    remote_node_name_ + "__set_parameters", rmw_qos_profile_parameters);
   list_parameters_client_ = node_->create_client<rcl_interfaces::srv::ListParameters>(
-    remote_node_name_ + "__list_parameters");
+    remote_node_name_ + "__list_parameters", rmw_qos_profile_parameters);
   describe_parameters_client_ = node_->create_client<rcl_interfaces::srv::DescribeParameters>(
-    remote_node_name_ + "__describe_parameters");
+    remote_node_name_ + "__describe_parameters", rmw_qos_profile_parameters);
 }
 
 std::shared_future<std::vector<rclcpp::parameter::ParameterVariant>>

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -23,7 +23,8 @@ using rclcpp::parameter_client::SyncParametersClient;
 
 AsyncParametersClient::AsyncParametersClient(
   const rclcpp::node::Node::SharedPtr node,
-  const std::string & remote_node_name)
+  const std::string & remote_node_name,
+  const rmw_qos_profile_t & qos_profile)
 : node_(node)
 {
   if (remote_node_name != "") {
@@ -32,15 +33,15 @@ AsyncParametersClient::AsyncParametersClient(
     remote_node_name_ = node_->get_name();
   }
   get_parameters_client_ = node_->create_client<rcl_interfaces::srv::GetParameters>(
-    remote_node_name_ + "__get_parameters", rmw_qos_profile_parameters);
+    remote_node_name_ + "__get_parameters", qos_profile);
   get_parameter_types_client_ = node_->create_client<rcl_interfaces::srv::GetParameterTypes>(
-    remote_node_name_ + "__get_parameter_types", rmw_qos_profile_parameters);
+    remote_node_name_ + "__get_parameter_types", qos_profile);
   set_parameters_client_ = node_->create_client<rcl_interfaces::srv::SetParameters>(
-    remote_node_name_ + "__set_parameters", rmw_qos_profile_parameters);
+    remote_node_name_ + "__set_parameters", qos_profile);
   list_parameters_client_ = node_->create_client<rcl_interfaces::srv::ListParameters>(
-    remote_node_name_ + "__list_parameters", rmw_qos_profile_parameters);
+    remote_node_name_ + "__list_parameters", qos_profile);
   describe_parameters_client_ = node_->create_client<rcl_interfaces::srv::DescribeParameters>(
-    remote_node_name_ + "__describe_parameters", rmw_qos_profile_parameters);
+    remote_node_name_ + "__describe_parameters", qos_profile);
 }
 
 std::shared_future<std::vector<rclcpp::parameter::ParameterVariant>>
@@ -228,19 +229,21 @@ AsyncParametersClient::list_parameters(
 }
 
 SyncParametersClient::SyncParametersClient(
-  rclcpp::node::Node::SharedPtr node)
+  rclcpp::node::Node::SharedPtr node,
+  const rmw_qos_profile_t & qos_profile)
 : node_(node)
 {
   executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-  async_parameters_client_ = std::make_shared<AsyncParametersClient>(node);
+  async_parameters_client_ = std::make_shared<AsyncParametersClient>(node, "", qos_profile);
 }
 
 SyncParametersClient::SyncParametersClient(
   rclcpp::executor::Executor::SharedPtr executor,
-  rclcpp::node::Node::SharedPtr node)
+  rclcpp::node::Node::SharedPtr node,
+  const rmw_qos_profile_t & qos_profile)
 : executor_(executor), node_(node)
 {
-  async_parameters_client_ = std::make_shared<AsyncParametersClient>(node);
+  async_parameters_client_ = std::make_shared<AsyncParametersClient>(node, "", qos_profile);
 }
 
 std::vector<rclcpp::parameter::ParameterVariant>

--- a/rclcpp/src/rclcpp/parameter_service.cpp
+++ b/rclcpp/src/rclcpp/parameter_service.cpp
@@ -39,7 +39,8 @@ ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
       for (auto & pvariant : values) {
         response->values.push_back(pvariant.get_parameter_value());
       }
-    }
+    },
+    rmw_qos_profile_parameters
   );
 
   get_parameter_types_service_ = node_->create_service<rcl_interfaces::srv::GetParameterTypes>(
@@ -58,7 +59,8 @@ ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
       std::back_inserter(response->types), [](const uint8_t & type) {
         return static_cast<rclcpp::parameter::ParameterType>(type);
       });
-    }
+    },
+    rmw_qos_profile_parameters
   );
 
   set_parameters_service_ = node_->create_service<rcl_interfaces::srv::SetParameters>(
@@ -78,7 +80,8 @@ ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
       }
       auto results = node->set_parameters(pvariants);
       response->results = results;
-    }
+    },
+    rmw_qos_profile_parameters
   );
 
   set_parameters_atomically_service_ =
@@ -102,7 +105,8 @@ ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
       });
       auto result = node->set_parameters_atomically(pvariants);
       response->result = result;
-    }
+    },
+    rmw_qos_profile_parameters
   );
 
   describe_parameters_service_ = node_->create_service<rcl_interfaces::srv::DescribeParameters>(
@@ -118,7 +122,8 @@ ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
       }
       auto descriptors = node->describe_parameters(request->names);
       response->descriptors = descriptors;
-    }
+    },
+    rmw_qos_profile_parameters
   );
 
   list_parameters_service_ = node_->create_service<rcl_interfaces::srv::ListParameters>(
@@ -134,7 +139,8 @@ ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
       }
       auto result = node->list_parameters(request->prefixes, request->depth);
       response->result = result;
-    }
+    },
+    rmw_qos_profile_parameters
   );
   // *INDENT-ON*
 }

--- a/rclcpp/src/rclcpp/parameter_service.cpp
+++ b/rclcpp/src/rclcpp/parameter_service.cpp
@@ -19,7 +19,9 @@
 
 using rclcpp::parameter_service::ParameterService;
 
-ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
+ParameterService::ParameterService(
+  const rclcpp::node::Node::SharedPtr node,
+  const rmw_qos_profile_t & qos_profile)
 : node_(node)
 {
   std::weak_ptr<rclcpp::node::Node> captured_node = node_;
@@ -40,7 +42,7 @@ ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
         response->values.push_back(pvariant.get_parameter_value());
       }
     },
-    rmw_qos_profile_parameters
+    qos_profile
   );
 
   get_parameter_types_service_ = node_->create_service<rcl_interfaces::srv::GetParameterTypes>(
@@ -60,7 +62,7 @@ ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
         return static_cast<rclcpp::parameter::ParameterType>(type);
       });
     },
-    rmw_qos_profile_parameters
+    qos_profile
   );
 
   set_parameters_service_ = node_->create_service<rcl_interfaces::srv::SetParameters>(
@@ -81,7 +83,7 @@ ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
       auto results = node->set_parameters(pvariants);
       response->results = results;
     },
-    rmw_qos_profile_parameters
+    qos_profile
   );
 
   set_parameters_atomically_service_ =
@@ -106,7 +108,7 @@ ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
       auto result = node->set_parameters_atomically(pvariants);
       response->result = result;
     },
-    rmw_qos_profile_parameters
+    qos_profile
   );
 
   describe_parameters_service_ = node_->create_service<rcl_interfaces::srv::DescribeParameters>(
@@ -123,7 +125,7 @@ ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
       auto descriptors = node->describe_parameters(request->names);
       response->descriptors = descriptors;
     },
-    rmw_qos_profile_parameters
+    qos_profile
   );
 
   list_parameters_service_ = node_->create_service<rcl_interfaces::srv::ListParameters>(
@@ -140,7 +142,7 @@ ParameterService::ParameterService(const rclcpp::node::Node::SharedPtr node)
       auto result = node->list_parameters(request->prefixes, request->depth);
       response->result = result;
     },
-    rmw_qos_profile_parameters
+    qos_profile
   );
   // *INDENT-ON*
 }


### PR DESCRIPTION
We have a parameter qos profile (https://github.com/ros2/rmw/blob/master/rmw/include/rmw/qos_profiles.h#L33-L39), but we're not using it in the param service or client creation. This PR uses it.

A future extension to consider would be exposing the qos setting through the parameter service/client creation API, to allow the user to change it.

(This came up while working on eProsima/ROS-RMW-Fast-RTPS-cpp#46, wherein it was identified that the history depth was too shallow.)

- Linux:
  - [![Build Status](http://ci.ros2.org/job/ci_linux/1640//badge/icon)](http://ci.ros2.org/job/ci_linux/1640/) 
- OS X:
  - [![Build Status](http://ci.ros2.org/job/ci_osx/1229//badge/icon)](http://ci.ros2.org/job/ci_osx/1229/)