### PR TITLE
(dev) add simple sub/pub template

### DIFF
--- a/rclcpp/include/rclcpp/simple_publisher_node.hpp
+++ b/rclcpp/include/rclcpp/simple_publisher_node.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "rclcpp/node.hpp"
+#include "rclcpp/publisher.hpp"
+
+namespace rclcpp
+{
+namespace node
+{
+
+template<class MessageT>
+class SimplePublisherNode : public rclcpp::Node
+{
+public:
+  SimplePublisherNode( std::string node_name, std::string topic, size_t frequency ):
+    Node(std::move(node_name), true),
+    topic_(std::move(topic)),
+    frequency_(frequency)
+  {
+    pub_ = this->create_publisher<MessageT>(topic_, rmw_qos_profile_default);
+  }
+
+  virtual ~SimplePublisherNode( )
+  {
+  }
+
+  void run( )
+  {
+    auto callback = std::bind(&SimplePublisherNode::publish, this);
+    timer_ = this->create_wall_timer(std::chrono::milliseconds(1000/frequency_), callback);
+  }
+
+  void stop( )
+  {
+    timer_->cancel();
+  }
+
+  virtual void publish( ) = 0;
+
+protected:
+  std::string topic_;
+  size_t frequency_;
+
+  typename rclcpp::Publisher<MessageT>::SharedPtr pub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+};
+
+} // namespace node
+} // namespace rclcpp

--- a/rclcpp/include/rclcpp/simple_subscriber_node.hpp
+++ b/rclcpp/include/rclcpp/simple_subscriber_node.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "rclcpp/node.hpp"
+
+namespace rclcpp
+{
+namespace node
+{
+
+template<class MessageT>
+class SimpleSubscriberNode : public rclcpp::Node
+{
+public:
+  SimpleSubscriberNode( std::string node_name, std::string topic ):
+    Node(std::move(node_name), true),
+    topic_(std::move(topic))
+  {
+  }
+
+  void run( )
+  {
+    auto callback = std::bind(&SimpleSubscriberNode::callback, this, std::placeholders::_1);
+    sub_ = this->create_subscription<MessageT>(topic_, callback);
+    printf("Going to setup subscriber on topic %s\n", topic_.c_str());
+  }
+
+  virtual void callback( typename MessageT::UniquePtr msg ) = 0;
+
+protected:
+  std::string topic_;
+
+  typename rclcpp::Subscription<MessageT>::SharedPtr sub_;
+};
+
+} //namespace node
+} //namespace rclcpp


### PR DESCRIPTION
I added two simple templates for initializing a node with a single publisher or subscriber.
A node can easily be instantiated and added to the executor. The user only has to implement the constructor and the `publish` or `callback` function respectively. 

example publisher: https://github.com/Karsten1987/my_ros2_demos/blob/master/src/laser_publisher_node.hpp

example subscriber:
https://github.com/Karsten1987/my_ros2_demos/blob/master/src/laser_subscriber_node.hpp

If such an example would I make sense, I iterate more over it (test, style, etc.)

connects to https://github.com/ros2/examples/issues/129
