### PR TITLE
comply with stricter cpplint rules

### DIFF
--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <stdexcept>
 #include <type_traits>
+#include <utility>
 
 #include "rclcpp/allocator/allocator_common.hpp"
 #include "rclcpp/function_traits.hpp"

--- a/rclcpp/include/rclcpp/context.hpp
+++ b/rclcpp/include/rclcpp/context.hpp
@@ -21,6 +21,7 @@
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>
+#include <utility>
 
 #include "rclcpp/macros.hpp"
 #include "rclcpp/visibility_control.hpp"

--- a/rclcpp/include/rclcpp/macros.hpp
+++ b/rclcpp/include/rclcpp/macros.hpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+#include <utility>
+
 #ifndef RCLCPP__MACROS_HPP_
 #define RCLCPP__MACROS_HPP_
 

--- a/rclcpp/include/rclcpp/mapped_ring_buffer.hpp
+++ b/rclcpp/include/rclcpp/mapped_ring_buffer.hpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <utility>
 #include <vector>
 
 #include "rclcpp/allocator/allocator_common.hpp"

--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -16,6 +16,7 @@
 #define RCLCPP__PARAMETER_CLIENT_HPP_
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "rcl_interfaces/msg/parameter.hpp"

--- a/rclcpp/include/rclcpp/strategies/message_pool_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/message_pool_memory_strategy.hpp
@@ -15,6 +15,8 @@
 #ifndef RCLCPP__STRATEGIES__MESSAGE_POOL_MEMORY_STRATEGY_HPP_
 #define RCLCPP__STRATEGIES__MESSAGE_POOL_MEMORY_STRATEGY_HPP_
 
+#include <memory>
+
 #include "rclcpp/macros.hpp"
 #include "rclcpp/message_memory_strategy.hpp"
 #include "rclcpp/visibility_control.hpp"

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <thread>
 #include <type_traits>
+#include <utility>
 
 #include "rclcpp/function_traits.hpp"
 #include "rclcpp/macros.hpp"

--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -16,6 +16,7 @@
 
 #include <chrono>
 #include <cstdio>
+#include <memory>
 #include <string>
 
 #include "rcl/graph.h"

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <memory>
 #include <string>
 #include <type_traits>
 

--- a/rclcpp/src/rclcpp/graph_listener.cpp
+++ b/rclcpp/src/rclcpp/graph_listener.cpp
@@ -16,6 +16,7 @@
 
 #include <cstdio>
 #include <exception>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/rclcpp/src/rclcpp/memory_strategies.cpp
+++ b/rclcpp/src/rclcpp/memory_strategies.cpp
@@ -14,6 +14,8 @@
 
 #include "rclcpp/memory_strategies.hpp"
 
+#include <memory>
+
 #include "rclcpp/strategies/allocator_memory_strategy.hpp"
 
 using rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy;

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <limits>
 #include <map>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -15,6 +15,7 @@
 #include "rclcpp/parameter_client.hpp"
 
 #include <algorithm>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/rclcpp/src/rclcpp/parameter_service.cpp
+++ b/rclcpp/src/rclcpp/parameter_service.cpp
@@ -15,6 +15,7 @@
 #include "rclcpp/parameter_service.hpp"
 
 #include <algorithm>
+#include <memory>
 #include <vector>
 
 using rclcpp::parameter_service::ParameterService;

--- a/rclcpp/src/rclcpp/subscription.cpp
+++ b/rclcpp/src/rclcpp/subscription.cpp
@@ -15,6 +15,7 @@
 #include "rclcpp/subscription.hpp"
 
 #include <cstdio>
+#include <memory>
 #include <string>
 
 #include "rmw/error_handling.h"

--- a/rclcpp/test/test_mapped_ring_buffer.cpp
+++ b/rclcpp/test/test_mapped_ring_buffer.cpp
@@ -17,6 +17,8 @@
 #define RCLCPP_BUILDING_LIBRARY 1  // Prevent including unavailable symbols
 #include <rclcpp/mapped_ring_buffer.hpp>
 
+#include <memory>
+
 /*
    Tests get_copy and pop on an empty mrb.
  */


### PR DESCRIPTION
Update style to pass new cpplint check (ament/ament_lint#59).

http://ci.ros2.org/job/ci_linux/1763/