### PR TITLE
open Node/Publisher API for allowing inheritance

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -123,7 +123,8 @@ public:
    * \param[in] qos_history_depth The depth of the publisher message queue.
    * \return Shared pointer to the created publisher.
    */
-  template<typename MessageT, typename Alloc = std::allocator<void>, typename PublisherT = ::rclcpp::publisher::Publisher<MessageT, Alloc>>
+  template<typename MessageT, typename Alloc = std::allocator<void>,
+  typename PublisherT = ::rclcpp::publisher::Publisher<MessageT, Alloc>>
   std::shared_ptr<PublisherT>
   create_publisher(
     const std::string & topic_name, size_t qos_history_depth,
@@ -135,7 +136,8 @@ public:
    * \param[in] qos_profile The quality of service profile to pass on to the rmw implementation.
    * \return Shared pointer to the created publisher.
    */
-  template<typename MessageT, typename Alloc = std::allocator<void>, typename PublisherT = ::rclcpp::publisher::Publisher<MessageT, Alloc>>
+  template<typename MessageT, typename Alloc = std::allocator<void>,
+  typename PublisherT = ::rclcpp::publisher::Publisher<MessageT, Alloc>>
   std::shared_ptr<PublisherT>
   create_publisher(
     const std::string & topic_name,

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -123,8 +123,9 @@ public:
    * \param[in] qos_history_depth The depth of the publisher message queue.
    * \return Shared pointer to the created publisher.
    */
-  template<typename MessageT, typename Alloc = std::allocator<void>>
-  typename rclcpp::publisher::Publisher<MessageT, Alloc>::SharedPtr
+  template<typename MessageT, typename Alloc = std::allocator<void>,
+    template <class MessageT, class Alloc>  typename PublisherT = ::rclcpp::publisher::Publisher>
+  typename PublisherT<MessageT, Alloc>::SharedPtr
   create_publisher(
     const std::string & topic_name, size_t qos_history_depth,
     std::shared_ptr<Alloc> allocator = nullptr);
@@ -135,8 +136,9 @@ public:
    * \param[in] qos_profile The quality of service profile to pass on to the rmw implementation.
    * \return Shared pointer to the created publisher.
    */
-  template<typename MessageT, typename Alloc = std::allocator<void>>
-  typename rclcpp::publisher::Publisher<MessageT, Alloc>::SharedPtr
+  template<typename MessageT, typename Alloc = std::allocator<void>,
+    template <class MessageT, class Alloc>  typename PublisherT = ::rclcpp::publisher::Publisher>
+  typename PublisherT<MessageT, Alloc>::SharedPtr
   create_publisher(
     const std::string & topic_name,
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_default,

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -123,9 +123,8 @@ public:
    * \param[in] qos_history_depth The depth of the publisher message queue.
    * \return Shared pointer to the created publisher.
    */
-  template<typename MessageT, typename Alloc = std::allocator<void>,
-    template <class MessageT, class Alloc>  typename PublisherT = ::rclcpp::publisher::Publisher>
-  typename PublisherT<MessageT, Alloc>::SharedPtr
+  template<typename MessageT, typename Alloc = std::allocator<void>, typename PublisherT = ::rclcpp::publisher::Publisher<MessageT, Alloc>>
+  std::shared_ptr<PublisherT>
   create_publisher(
     const std::string & topic_name, size_t qos_history_depth,
     std::shared_ptr<Alloc> allocator = nullptr);
@@ -136,9 +135,8 @@ public:
    * \param[in] qos_profile The quality of service profile to pass on to the rmw implementation.
    * \return Shared pointer to the created publisher.
    */
-  template<typename MessageT, typename Alloc = std::allocator<void>,
-    template <class MessageT, class Alloc>  typename PublisherT = ::rclcpp::publisher::Publisher>
-  typename PublisherT<MessageT, Alloc>::SharedPtr
+  template<typename MessageT, typename Alloc = std::allocator<void>, typename PublisherT = ::rclcpp::publisher::Publisher<MessageT, Alloc>>
+  std::shared_ptr<PublisherT>
   create_publisher(
     const std::string & topic_name,
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_default,

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -123,8 +123,9 @@ public:
    * \param[in] qos_history_depth The depth of the publisher message queue.
    * \return Shared pointer to the created publisher.
    */
-  template<typename MessageT, typename Alloc = std::allocator<void>,
-  typename PublisherT = ::rclcpp::publisher::Publisher<MessageT, Alloc>>
+  template<
+    typename MessageT, typename Alloc = std::allocator<void>,
+    typename PublisherT = ::rclcpp::publisher::Publisher<MessageT, Alloc>>
   std::shared_ptr<PublisherT>
   create_publisher(
     const std::string & topic_name, size_t qos_history_depth,
@@ -136,8 +137,9 @@ public:
    * \param[in] qos_profile The quality of service profile to pass on to the rmw implementation.
    * \return Shared pointer to the created publisher.
    */
-  template<typename MessageT, typename Alloc = std::allocator<void>,
-  typename PublisherT = ::rclcpp::publisher::Publisher<MessageT, Alloc>>
+  template<
+    typename MessageT, typename Alloc = std::allocator<void>,
+    typename PublisherT = ::rclcpp::publisher::Publisher<MessageT, Alloc>>
   std::shared_ptr<PublisherT>
   create_publisher(
     const std::string & topic_name,

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -50,8 +50,9 @@ namespace rclcpp
 namespace node
 {
 
-template<typename MessageT, typename Alloc>
-typename rclcpp::publisher::Publisher<MessageT, Alloc>::SharedPtr
+template<typename MessageT, typename Alloc,
+  template <class MessageT, class Alloc>  typename PublisherT>
+typename PublisherT<MessageT, Alloc>::SharedPtr
 Node::create_publisher(
   const std::string & topic_name, size_t qos_history_depth,
   std::shared_ptr<Alloc> allocator)
@@ -61,11 +62,12 @@ Node::create_publisher(
   }
   rmw_qos_profile_t qos = rmw_qos_profile_default;
   qos.depth = qos_history_depth;
-  return this->create_publisher<MessageT, Alloc>(topic_name, qos, allocator);
+  return this->create_publisher<MessageT, Alloc, PublisherT>(topic_name, qos, allocator);
 }
 
-template<typename MessageT, typename Alloc>
-typename publisher::Publisher<MessageT, Alloc>::SharedPtr
+template<typename MessageT, typename Alloc,
+template <class MessageT, class Alloc> typename PublisherT>
+typename PublisherT<MessageT, Alloc>::SharedPtr
 Node::create_publisher(
   const std::string & topic_name, const rmw_qos_profile_t & qos_profile,
   std::shared_ptr<Alloc> allocator)
@@ -78,12 +80,12 @@ Node::create_publisher(
   publisher_options.qos = qos_profile;
 
   auto message_alloc =
-    std::make_shared<typename publisher::Publisher<MessageT, Alloc>::MessageAlloc>(
+    std::make_shared<typename PublisherT<MessageT, Alloc>::MessageAlloc>(
     *allocator.get());
   publisher_options.allocator = allocator::get_rcl_allocator<MessageT>(
     *message_alloc.get());
 
-  auto publisher = publisher::Publisher<MessageT, Alloc>::make_shared(
+  auto publisher = PublisherT<MessageT, Alloc>::make_shared(
     node_handle_, topic_name, publisher_options, message_alloc);
 
   if (use_intra_process_comms_) {

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -50,9 +50,8 @@ namespace rclcpp
 namespace node
 {
 
-template<typename MessageT, typename Alloc,
-  template <class MessageT, class Alloc>  typename PublisherT>
-typename PublisherT<MessageT, Alloc>::SharedPtr
+template<typename MessageT, typename Alloc, typename PublisherT>
+std::shared_ptr<PublisherT>
 Node::create_publisher(
   const std::string & topic_name, size_t qos_history_depth,
   std::shared_ptr<Alloc> allocator)
@@ -65,9 +64,8 @@ Node::create_publisher(
   return this->create_publisher<MessageT, Alloc, PublisherT>(topic_name, qos, allocator);
 }
 
-template<typename MessageT, typename Alloc,
-template <class MessageT, class Alloc> typename PublisherT>
-typename PublisherT<MessageT, Alloc>::SharedPtr
+template<typename MessageT, typename Alloc, typename PublisherT>
+std::shared_ptr<PublisherT>
 Node::create_publisher(
   const std::string & topic_name, const rmw_qos_profile_t & qos_profile,
   std::shared_ptr<Alloc> allocator)
@@ -80,12 +78,12 @@ Node::create_publisher(
   publisher_options.qos = qos_profile;
 
   auto message_alloc =
-    std::make_shared<typename PublisherT<MessageT, Alloc>::MessageAlloc>(
+    std::make_shared<typename PublisherT::MessageAlloc>(
     *allocator.get());
   publisher_options.allocator = allocator::get_rcl_allocator<MessageT>(
     *message_alloc.get());
 
-  auto publisher = PublisherT<MessageT, Alloc>::make_shared(
+  auto publisher = std::make_shared<PublisherT>(
     node_handle_, topic_name, publisher_options, message_alloc);
 
   if (use_intra_process_comms_) {

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -204,13 +204,12 @@ public:
     }
   }
 
-
   /// Send a message to the topic for this publisher.
   /**
    * This function is templated on the input message type, MessageT.
    * \param[in] msg A shared pointer to the message to send.
    */
-  void
+  virtual void
   publish(std::unique_ptr<MessageT, MessageDeleter> & msg)
   {
     this->do_inter_process_publish(msg.get());
@@ -242,7 +241,7 @@ public:
     }
   }
 
-  void
+  virtual void
   publish(const std::shared_ptr<MessageT> & msg)
   {
     // Avoid allocating when not using intra process.
@@ -261,7 +260,7 @@ public:
     return this->publish(unique_msg);
   }
 
-  void
+  virtual void
   publish(std::shared_ptr<const MessageT> msg)
   {
     // Avoid allocating when not using intra process.
@@ -280,7 +279,7 @@ public:
     return this->publish(unique_msg);
   }
 
-  void
+  virtual void
   publish(const MessageT & msg)
   {
     // Avoid allocating when not using intra process.


### PR DESCRIPTION
change:
- `Node::create_publisher` function has a new template parameter for publisher type (`rclcpp::publisher::Publisher` by default)
- all `publish` functions are virtual for being able to inherit from