### PR TITLE
CallbackGroup keeps now WeakPtrs to Services

### DIFF
--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -63,7 +63,7 @@ public:
   get_timer_ptrs() const;
 
   RCLCPP_PUBLIC
-  const std::vector<rclcpp::service::ServiceBase::SharedPtr> &
+  const std::vector<rclcpp::service::ServiceBase::WeakPtr> &
   get_service_ptrs() const;
 
   RCLCPP_PUBLIC
@@ -102,7 +102,7 @@ private:
   mutable std::mutex mutex_;
   std::vector<rclcpp::subscription::SubscriptionBase::WeakPtr> subscription_ptrs_;
   std::vector<rclcpp::timer::TimerBase::WeakPtr> timer_ptrs_;
-  std::vector<rclcpp::service::ServiceBase::SharedPtr> service_ptrs_;
+  std::vector<rclcpp::service::ServiceBase::WeakPtr> service_ptrs_;
   std::vector<rclcpp::client::ClientBase::WeakPtr> client_ptrs_;
   std::atomic_bool can_be_taken_from_;
 };

--- a/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
@@ -162,7 +162,8 @@ public:
             }
           }
         }
-        for (auto & service : group->get_service_ptrs()) {
+        for (auto & weak_service : group->get_service_ptrs()) {
+          auto service = weak_service.lock();
           if (service) {
             service_handles_.push_back(service->get_service_handle());
           }

--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -37,7 +37,7 @@ CallbackGroup::get_timer_ptrs() const
   return timer_ptrs_;
 }
 
-const std::vector<rclcpp::service::ServiceBase::SharedPtr> &
+const std::vector<rclcpp::service::ServiceBase::WeakPtr> &
 CallbackGroup::get_service_ptrs() const
 {
   std::lock_guard<std::mutex> lock(mutex_);

--- a/rclcpp/src/rclcpp/memory_strategy.cpp
+++ b/rclcpp/src/rclcpp/memory_strategy.cpp
@@ -60,8 +60,9 @@ MemoryStrategy::get_service_by_handle(const rcl_service_t * service_handle,
       if (!group) {
         continue;
       }
-      for (auto & service : group->get_service_ptrs()) {
-        if (service->get_service_handle() == service_handle) {
+      for (auto & weak_service : group->get_service_ptrs()) {
+        auto service = weak_service.lock();
+        if (service && service->get_service_handle() == service_handle) {
           return service;
         }
       }
@@ -158,8 +159,9 @@ MemoryStrategy::get_group_by_service(
       if (!group) {
         continue;
       }
-      for (auto & serv : group->get_service_ptrs()) {
-        if (serv == service) {
+      for (auto & weak_serv : group->get_service_ptrs()) {
+        auto serv = weak_serv.lock();
+        if (serv && serv == service) {
           return group;
         }
       }


### PR DESCRIPTION
It was not possible to shutdown a service when there
was a shared pointer preventing destructor from being called.