### PR TITLE
always check if the service is available, even if the graph event wasn't triggered

### DIFF
--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -96,10 +96,9 @@ ClientBase::wait_for_service_nanoseconds(std::chrono::nanoseconds timeout)
       return false;
     }
     node_ptr->wait_for_graph_change(event, time_to_wait);
-    if (event->check_and_clear()) {
-      if (this->service_is_ready()) {
-        return true;
-      }
+    event->check_and_clear();  // reset the event
+    if (this->service_is_ready()) {  // check if the service is ready regardless
+      return true;
     }
     // server is not ready, loop if there is time left
     time_to_wait = timeout - (std::chrono::steady_clock::now() - start);

--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -97,7 +97,10 @@ ClientBase::wait_for_service_nanoseconds(std::chrono::nanoseconds timeout)
     }
     node_ptr->wait_for_graph_change(event, time_to_wait);
     event->check_and_clear();  // reset the event
-    if (this->service_is_ready()) {  // check if the service is ready regardless
+
+    // always check if the service is ready, even if the graph event wasn't triggered
+    // (see https://github.com/ros2/rmw_connext/issues/201)
+    if (this->service_is_ready()) {
       return true;
     }
     // server is not ready, loop if there is time left

--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -99,6 +99,7 @@ ClientBase::wait_for_service_nanoseconds(std::chrono::nanoseconds timeout)
     event->check_and_clear();  // reset the event
 
     // always check if the service is ready, even if the graph event wasn't triggered
+    // this is needed to avoid a race condition that is specific to the Connext RMW implementation
     // (see https://github.com/ros2/rmw_connext/issues/201)
     if (this->service_is_ready()) {
       return true;


### PR DESCRIPTION
This is needed to avoid the race condition that is specific to our Connext code, outlined in this issue:

https://github.com/ros2/rmw_connext/issues/201

Basically the assumption "we only need to check the service is available function after a graph event because the state can only change after the graph event is triggered" does not hold. As there is apparently a race between setting the graph event and the underlying state reflecting the full change.

Connects to ros2/rmw_connext#168