### PR TITLE
fix allocator type

### DIFF
--- a/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
@@ -254,7 +254,7 @@ private:
       std::hash<uint64_t>, std::equal_to<uint64_t>,
       RebindAlloc<std::pair<const uint64_t, subscription::SubscriptionBase::WeakPtr>>>;
   using IDTopicMap = std::map<std::string, AllocSet,
-      std::less<std::string>, RebindAlloc<std::pair<std::string, AllocSet>>>;
+      std::less<std::string>, RebindAlloc<std::pair<const std::string, AllocSet>>>;
 
   SubscriptionMap subscriptions_;
 


### PR DESCRIPTION
Otherwise this code fails the stricter static assertion added in libc++ 3.9.

```
In file included from /Users/osrf/jenkins/workspace/ci_osx/ws/src/ros2/rclcpp/rclcpp/include/rclcpp/intra_process_manager_impl.hpp:22:
/usr/local/Cellar/llvm/3.9.0/bin/../include/c++/v1/map:820:5: error: static_assert failed "Allocator::value_type must be same type as value_type"
static_assert((is_same<typename allocator_type::value_type, value_type>::value),
```