### PR TITLE
fix error reporting for services

### DIFF
--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -291,11 +291,9 @@ Executor::execute_service(
     service->get_service_handle(),
     request_header.get(),
     request.get());
-  if (status != RCL_RET_SERVICE_TAKE_FAILED) {
-    if (status == RCL_RET_OK) {
-      service->handle_request(request_header, request);
-    }
-  } else {
+  if (status == RCL_RET_OK) {
+    service->handle_request(request_header, request);
+  } else if (status != RCL_RET_SERVICE_TAKE_FAILED) {
     fprintf(stderr,
       "[rclcpp::error] take request failed for server of service '%s': %s\n",
       service->get_service_name().c_str(), rcl_get_error_string_safe());
@@ -312,11 +310,9 @@ Executor::execute_client(
     client->get_client_handle(),
     request_header.get(),
     response.get());
-  if (status != RCL_RET_SERVICE_TAKE_FAILED) {
-    if (status == RCL_RET_OK) {
-      client->handle_response(request_header, response);
-    }
-  } else {
+  if (status == RCL_RET_OK) {
+    client->handle_response(request_header, response);
+  } else if (status != RCL_RET_SERVICE_TAKE_FAILED) {
     fprintf(stderr,
       "[rclcpp::error] take response failed for client of service '%s': %s\n",
       client->get_service_name().c_str(), rcl_get_error_string_safe());


### PR DESCRIPTION
Connect to #263.

The conditions for services were just wrong. They need to be the same as e.g. subscriptions, see https://github.com/ros2/rclcpp/blob/4c876d5966dfa220581cb2141d6d9a62e5c0c9a6/rclcpp/src/rclcpp/executor.cpp#L245-L252

[![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=1910)](http://ci.ros2.org/job/ci_linux/1910/) http://ci.ros2.org/job/ci_linux/1910/testReport/(root)/test_add_two_ints_server_add_two_ints_client__rmw_connext_cpp_/test_executable/