### PR TITLE
(dev) construct service from existing rcl_service_t

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -127,6 +127,31 @@ if(BUILD_TESTING)
     )
     target_link_libraries(test_find_weak_nodes ${PROJECT_NAME})
   endif()
+
+  get_default_rmw_implementation(default_rmw)
+  find_package(${default_rmw})
+  get_rmw_typesupport(typesupport_impls_cpp "${default_rmw}" LANGUAGE "cpp")
+  get_rmw_typesupport(typesupport_impls_c "${default_rmw}" LANGUAGE "c")
+  set(mock_msg_files
+    "test/mock_msgs/srv/Mock.srv")
+  rosidl_generate_interfaces(mock_msgs
+    ${mock_msg_files})
+
+  ament_add_gtest(test_externally_defined_services test/test_externally_defined_services.cpp)
+  if(TARGET test_externally_defined_services)
+    target_include_directories(test_externally_defined_services PUBLIC
+      ${rcl_INCLUDE_DIRS}
+    )
+    target_link_libraries(test_externally_defined_services ${PROJECT_NAME})
+    foreach(typesupport_impl_cpp ${typesupport_impls_cpp})
+      rosidl_target_interfaces(test_externally_defined_services
+        mock_msgs ${typesupport_impl_cpp})
+    endforeach()
+    foreach(typesupport_impl_c ${typesupport_impls_c})
+      rosidl_target_interfaces(test_externally_defined_services
+        mock_msgs ${typesupport_impl_c})
+    endforeach()
+  endif()
 endif()
 
 ament_package(

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -10,10 +10,8 @@ find_package(rmw_implementation REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
 find_package(rosidl_generator_cpp REQUIRED)
 
-if(NOT WIN32)
-  set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++11")
-endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++11")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -10,8 +10,11 @@ find_package(rmw_implementation REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
 find_package(rosidl_generator_cpp REQUIRED)
 
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++11")
+endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-std=c++11 -Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 include_directories(include)

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -129,7 +129,7 @@ if(BUILD_TESTING)
   endif()
 
   get_default_rmw_implementation(default_rmw)
-  find_package(${default_rmw})
+  find_package(${default_rmw} REQUIRED)
   get_rmw_typesupport(typesupport_impls_cpp "${default_rmw}" LANGUAGE "cpp")
   get_rmw_typesupport(typesupport_impls_c "${default_rmw}" LANGUAGE "c")
   set(mock_msg_files

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -135,7 +135,8 @@ if(BUILD_TESTING)
   set(mock_msg_files
     "test/mock_msgs/srv/Mock.srv")
   rosidl_generate_interfaces(mock_msgs
-    ${mock_msg_files})
+    ${mock_msg_files}
+    SKIP_INSTALL)
 
   ament_add_gtest(test_externally_defined_services test/test_externally_defined_services.cpp)
   if(TARGET test_externally_defined_services)

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -383,7 +383,7 @@ protected:
   RCLCPP_PUBLIC
   void
   add_service(const rclcpp::service::ServiceBase::SharedPtr service,
-      rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr);
+    rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr);
 
 private:
   RCLCPP_DISABLE_COPY(Node)

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -381,7 +381,7 @@ public:
 
   RCLCPP_PUBLIC
   void
-  add_service(const rclcpp::service::ServiceBase::SharedPtr service,
+  add_service(const rclcpp::service::ServiceBase::SharedPtr & service,
     rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr);
 
 private:

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -379,6 +379,12 @@ public:
 
   std::atomic_bool has_executor;
 
+protected:
+  RCLCPP_PUBLIC
+  void
+  add_service(const rclcpp::service::ServiceBase::SharedPtr service,
+      rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr);
+
 private:
   RCLCPP_DISABLE_COPY(Node)
 

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -381,7 +381,7 @@ public:
 
   RCLCPP_PUBLIC
   void
-  add_service(const rclcpp::service::ServiceBase::SharedPtr & service,
+  add_service(rclcpp::service::ServiceBase::SharedPtr service,
     rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr);
 
 private:

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -379,7 +379,6 @@ public:
 
   std::atomic_bool has_executor;
 
-protected:
   RCLCPP_PUBLIC
   void
   add_service(const rclcpp::service::ServiceBase::SharedPtr service,

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -344,21 +344,7 @@ Node::create_service(
     node_handle_,
     service_name, any_service_callback, service_options);
   auto serv_base_ptr = std::dynamic_pointer_cast<service::ServiceBase>(serv);
-  if (group) {
-    if (!group_in_node(group)) {
-      // TODO(jacquelinekay): use custom exception
-      throw std::runtime_error("Cannot create service, group not in node.");
-    }
-    group->add_service(serv_base_ptr);
-  } else {
-    default_callback_group_->add_service(serv_base_ptr);
-  }
-  number_of_services_++;
-  if (rcl_trigger_guard_condition(&notify_guard_condition_) != RCL_RET_OK) {
-    throw std::runtime_error(
-            std::string(
-              "Failed to notify waitset on service creation: ") + rmw_get_error_string());
-  }
+  add_service(serv_base_ptr, group);
   return serv;
 }
 

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -123,8 +123,8 @@ public:
     // TODO(Karsten1987): Can this go directly in RCL?
     if (service_handle->impl == NULL) {
       throw std::runtime_error(
-              std::string("rcl_service_t in constructor argument" +
-              "has to be initialized beforehand"));
+              std::string("rcl_service_t in constructor argument ") +
+              "has to be initialized beforehand");
     }
   }
 

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -126,11 +126,14 @@ public:
     any_callback_(any_callback)
   {
     // check if service handle was initialized
+    // TODO(karsten1987): Take this verification
+    // directly in rcl_*_t
     // see: https://github.com/ros2/rcl/issues/81
-    if (service_handle->impl == NULL) {
+    if (!service_handle->impl) {
+      // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
       throw std::runtime_error(
-              std::string("rcl_service_t in constructor argument ") +
-              "has to be initialized beforehand");
+        std::string("rcl_service_t in constructor argument must be initialized beforehand."));
+      // *INDENT-ON*
     }
     service_handle_ = service_handle;
     service_name_ = std::string(rcl_service_get_service_name(service_handle));

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -43,12 +43,12 @@ public:
 
   RCLCPP_PUBLIC
   ServiceBase(
-    rcl_node_t * node_handle,
+    std::shared_ptr<rcl_node_t> node_handle,
     const std::string & service_name);
 
   RCLCPP_PUBLIC
   explicit ServiceBase(
-    rcl_node_t * node_handle);
+    std::shared_ptr<rcl_node_t> node_handle);
 
   RCLCPP_PUBLIC
   virtual ~ServiceBase();
@@ -70,7 +70,7 @@ public:
 protected:
   RCLCPP_DISABLE_COPY(ServiceBase)
 
-  rcl_node_t * node_handle_;
+  std::shared_ptr<rcl_node_t> node_handle_;
 
   rcl_service_t * service_handle_ = nullptr;
   std::string service_name_;
@@ -100,7 +100,7 @@ public:
     const std::string & service_name,
     AnyServiceCallback<ServiceT> any_callback,
     rcl_service_options_t & service_options)
-  : ServiceBase(node_handle.get(), service_name), any_callback_(any_callback)
+  : ServiceBase(node_handle, service_name), any_callback_(any_callback)
   {
     using rosidl_generator_cpp::get_service_type_support_handle;
     auto service_type_support_handle = get_service_type_support_handle<ServiceT>();
@@ -119,7 +119,7 @@ public:
   }
 
   Service(
-    rcl_node_t * node_handle,
+    std::shared_ptr<rcl_node_t> node_handle,
     rcl_service_t * service_handle,
     AnyServiceCallback<ServiceT> any_callback)
   : ServiceBase(node_handle),
@@ -143,7 +143,7 @@ public:
   {
     // check if you have ownership of the handle
     if (owns_rcl_handle_) {
-      if (rcl_service_fini(service_handle_, node_handle_) != RCL_RET_OK) {
+      if (rcl_service_fini(service_handle_, node_handle_.get()) != RCL_RET_OK) {
         std::stringstream ss;
         ss << "Error in destruction of rcl service_handle_ handle: " <<
           rcl_get_error_string_safe() << '\n';

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -42,7 +42,10 @@ public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(ServiceBase)
 
   RCLCPP_PUBLIC
-  explicit ServiceBase(std::shared_ptr<rcl_node_t> node_handle);
+  explicit ServiceBase(rcl_node_t * node_handle);
+
+  RCLCPP_PUBLIC
+  explicit ServiceBase(rcl_service_t * service_handle);
 
   RCLCPP_PUBLIC
   virtual ~ServiceBase();
@@ -64,9 +67,9 @@ public:
 protected:
   RCLCPP_DISABLE_COPY(ServiceBase)
 
-  std::shared_ptr<rcl_node_t> node_handle_;
+  rcl_node_t * node_handle_;
 
-  rcl_service_t* service_handle_ = nullptr;
+  rcl_service_t * service_handle_ = nullptr;
 };
 
 using any_service_callback::AnyServiceCallback;
@@ -92,7 +95,7 @@ public:
     const std::string & service_name,
     AnyServiceCallback<ServiceT> any_callback,
     rcl_service_options_t & service_options)
-  : ServiceBase(node_handle), any_callback_(any_callback)
+  : ServiceBase(node_handle.get()), any_callback_(any_callback)
   {
     using rosidl_generator_cpp::get_service_type_support_handle;
     auto service_type_support_handle = get_service_type_support_handle<ServiceT>();
@@ -104,26 +107,24 @@ public:
         service_handle_, node_handle.get(), service_type_support_handle, service_name.c_str(),
         &service_options) != RCL_RET_OK)
     {
-      throw std::runtime_error(
-              std::string("could not create service: ") +
+      throw std::runtime_error(std::string("could not create service: ") +
               rcl_get_error_string_safe());
     }
   }
 
   Service(
-    std::shared_ptr<rcl_node_t> node_handle,
-    rcl_service_t* service_handle,
+    rcl_node_t * node_handle,
+    rcl_service_t * service_handle,
     AnyServiceCallback<ServiceT> any_callback)
   : ServiceBase(node_handle), defined_extern(true),
     any_callback_(any_callback)
   {
     // check if service handle was initialized
     // TODO(Karsten1987): Can this go directly in RCL?
-    if (service_handle->impl == NULL)
-    {
+    if (service_handle->impl == NULL) {
       throw std::runtime_error(
-          std::string("rcl_service_t in constructor argument \
-            has to be initialized beforehand"));
+              std::string("rcl_service_t in constructor argument" +
+              "has to be initialized beforehand"));
     }
   }
 
@@ -132,9 +133,8 @@ public:
   virtual ~Service()
   {
     // check if you have ownership of the handle
-    if (!defined_extern)
-    {
-      if (rcl_service_fini(service_handle_, node_handle_.get()) != RCL_RET_OK) {
+    if (!defined_extern) {
+      if (rcl_service_fini(service_handle_, node_handle_) != RCL_RET_OK) {
         std::stringstream ss;
         ss << "Error in destruction of rcl service_handle_ handle: " <<
           rcl_get_error_string_safe() << '\n';

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -101,6 +101,7 @@ public:
     auto service_type_support_handle = get_service_type_support_handle<ServiceT>();
 
     // rcl does the static memory allocation here
+    service_handle_ = new rcl_service_t;
     *service_handle_ = rcl_get_zero_initialized_service();
 
     if (rcl_service_init(

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -127,6 +127,7 @@ public:
               std::string("rcl_service_t in constructor argument ") +
               "has to be initialized beforehand");
     }
+    service_handle_ = service_handle;
   }
 
   Service() = delete;

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -546,9 +546,13 @@ Node::count_graph_users()
 
 // PROTECTED IMPLEMENTATION
 void
-Node::add_service(const rclcpp::service::ServiceBase::SharedPtr serv_base_ptr,
+Node::add_service(const rclcpp::service::ServiceBase::SharedPtr & serv_base_ptr,
   rclcpp::callback_group::CallbackGroup::SharedPtr group)
 {
+  if (!serv_base_ptr) {
+    throw std::runtime_error("Cannot add empty service to group");
+  }
+
   if (group) {
     if (!group_in_node(group)) {
       // TODO(jacquelinekay): use custom exception

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -542,3 +542,26 @@ Node::count_graph_users()
 {
   return graph_users_count_.load();
 }
+
+
+// PROTECTED IMPLEMENTATION
+void
+Node::add_service(const rclcpp::service::ServiceBase::SharedPtr serv_base_ptr,
+    rclcpp::callback_group::CallbackGroup::SharedPtr group)
+{
+  if (group) {
+    if (!group_in_node(group)) {
+      // TODO(jacquelinekay): use custom exception
+      throw std::runtime_error("Cannot create service, group not in node.");
+    }
+    group->add_service(serv_base_ptr);
+  } else {
+    default_callback_group_->add_service(serv_base_ptr);
+  }
+  number_of_services_++;
+  if (rcl_trigger_guard_condition(&notify_guard_condition_) != RCL_RET_OK) {
+    throw std::runtime_error(
+            std::string(
+              "Failed to notify waitset on service creation: ") + rmw_get_error_string());
+  }
+}

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -547,7 +547,7 @@ Node::count_graph_users()
 // PROTECTED IMPLEMENTATION
 void
 Node::add_service(const rclcpp::service::ServiceBase::SharedPtr serv_base_ptr,
-    rclcpp::callback_group::CallbackGroup::SharedPtr group)
+  rclcpp::callback_group::CallbackGroup::SharedPtr group)
 {
   if (group) {
     if (!group_in_node(group)) {

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -546,7 +546,7 @@ Node::count_graph_users()
 
 // PROTECTED IMPLEMENTATION
 void
-Node::add_service(const rclcpp::service::ServiceBase::SharedPtr & serv_base_ptr,
+Node::add_service(rclcpp::service::ServiceBase::SharedPtr serv_base_ptr,
   rclcpp::callback_group::CallbackGroup::SharedPtr group)
 {
   if (!serv_base_ptr) {

--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -27,6 +27,12 @@
 
 using rclcpp::service::ServiceBase;
 
+ServiceBase::ServiceBase(
+  rcl_node_t * node_handle,
+  const std::string & service_name)
+: node_handle_(node_handle), service_name_(service_name)
+{}
+
 ServiceBase::ServiceBase(rcl_node_t * node_handle)
 : node_handle_(node_handle)
 {}
@@ -37,7 +43,7 @@ ServiceBase::~ServiceBase()
 std::string
 ServiceBase::get_service_name()
 {
-  return rcl_service_get_service_name(service_handle_);
+  return this->service_name_;
 }
 
 const rcl_service_t *

--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -28,12 +28,12 @@
 using rclcpp::service::ServiceBase;
 
 ServiceBase::ServiceBase(
-  rcl_node_t * node_handle,
+  std::shared_ptr<rcl_node_t> node_handle,
   const std::string & service_name)
 : node_handle_(node_handle), service_name_(service_name)
 {}
 
-ServiceBase::ServiceBase(rcl_node_t * node_handle)
+ServiceBase::ServiceBase(std::shared_ptr<rcl_node_t> node_handle)
 : node_handle_(node_handle)
 {}
 

--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -27,7 +27,7 @@
 
 using rclcpp::service::ServiceBase;
 
-ServiceBase::ServiceBase(std::shared_ptr<rcl_node_t> node_handle)
+ServiceBase::ServiceBase(rcl_node_t * node_handle)
 : node_handle_(node_handle)
 {}
 

--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -27,10 +27,8 @@
 
 using rclcpp::service::ServiceBase;
 
-ServiceBase::ServiceBase(
-  std::shared_ptr<rcl_node_t> node_handle,
-  const std::string service_name)
-: node_handle_(node_handle), service_name_(service_name)
+ServiceBase::ServiceBase(std::shared_ptr<rcl_node_t> node_handle)
+: node_handle_(node_handle)
 {}
 
 ServiceBase::~ServiceBase()
@@ -39,11 +37,11 @@ ServiceBase::~ServiceBase()
 std::string
 ServiceBase::get_service_name()
 {
-  return this->service_name_;
+  return rcl_service_get_service_name(service_handle_);
 }
 
 const rcl_service_t *
 ServiceBase::get_service_handle()
 {
-  return &service_handle_;
+  return service_handle_;
 }

--- a/rclcpp/test/mock_msgs/srv/Mock.srv
+++ b/rclcpp/test/mock_msgs/srv/Mock.srv
@@ -1,0 +1,3 @@
+bool request
+---
+bool response

--- a/rclcpp/test/test_externally_defined_services.cpp
+++ b/rclcpp/test/test_externally_defined_services.cpp
@@ -45,9 +45,9 @@ TEST_F(TestExternallyDefinedServices, default_behavior) {
   auto node_handle = rclcpp::node::Node::make_shared("base_node");
 
   try {
-  auto srv = node_handle->create_service<rclcpp::srv::Mock>("test",
-      callback);
-  } catch (const std::exception& e) {
+    auto srv = node_handle->create_service<rclcpp::srv::Mock>("test",
+        callback);
+  } catch (const std::exception & e) {
     FAIL();
     return;
   }

--- a/rclcpp/test/test_externally_defined_services.cpp
+++ b/rclcpp/test/test_externally_defined_services.cpp
@@ -1,0 +1,119 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "rclcpp/node.hpp"
+#include "rclcpp/any_service_callback.hpp"
+#include "rclcpp/service.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include "rcl/service.h"
+
+#include "rclcpp/srv/mock.hpp"
+#include "rclcpp/srv/mock.h"
+
+class TestExternallyDefinedServices : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+};
+
+void
+callback(const std::shared_ptr<rclcpp::srv::Mock::Request> /*req*/,
+    std::shared_ptr<rclcpp::srv::Mock::Response> /*resp*/);
+
+TEST_F(TestExternallyDefinedServices, extern_defined_uninitialized) {
+  auto node_handle = rclcpp::node::Node::make_shared("base_node");
+
+  // mock for externally defined service
+  rcl_service_t service_handle = rcl_get_zero_initialized_service();
+
+  rclcpp::any_service_callback::AnyServiceCallback<rclcpp::srv::Mock> cb;
+
+  // don't initialize the service
+  // expect fail
+  try
+  {
+    rclcpp::service::Service<rclcpp::srv::Mock>(node_handle->get_shared_node_handle(), &service_handle, cb);
+  } catch(const std::runtime_error & e){
+    SUCCEED();
+    return;
+  }
+
+  FAIL();
+}
+
+TEST_F(TestExternallyDefinedServices, extern_defined_initialized) {
+  auto node_handle = rclcpp::node::Node::make_shared("base_node");
+
+  // mock for externally defined service
+  rcl_service_t service_handle = rcl_get_zero_initialized_service();
+  rcl_service_options_t service_options = rcl_service_get_default_options();
+  const rosidl_service_type_support_t * ts = ROSIDL_GET_TYPE_SUPPORT(
+      rclcpp, srv, Mock);
+  if (rcl_service_init(&service_handle, node_handle->get_rcl_node_handle(),
+      ts, "base_node_service", &service_options) != RCL_RET_OK)
+  {
+    FAIL();
+    return;
+  }
+  rclcpp::any_service_callback::AnyServiceCallback<rclcpp::srv::Mock> cb;
+  // don't initialize the service
+  // expect fail
+  try
+  {
+    rclcpp::service::Service<rclcpp::srv::Mock>(node_handle->get_shared_node_handle(), &service_handle, cb);
+  } catch(const std::runtime_error & e){
+    FAIL();
+    return;
+  }
+
+  SUCCEED();
+}
+
+TEST_F(TestExternallyDefinedServices, extern_defined_destructor) {
+  auto node_handle = rclcpp::node::Node::make_shared("base_node");
+
+  // mock for externally defined service
+  rcl_service_t service_handle = rcl_get_zero_initialized_service();
+  rcl_service_options_t service_options = rcl_service_get_default_options();
+  const rosidl_service_type_support_t * ts = ROSIDL_GET_TYPE_SUPPORT(
+      rclcpp, srv, Mock);
+  if (rcl_service_init(&service_handle, node_handle->get_rcl_node_handle(),
+      ts, "base_node_service", &service_options) != RCL_RET_OK)
+  {
+    FAIL();
+    return;
+  }
+  rclcpp::any_service_callback::AnyServiceCallback<rclcpp::srv::Mock> cb;
+
+  {
+  rclcpp::service::Service<rclcpp::srv::Mock>(node_handle->get_shared_node_handle(), &service_handle, cb);
+  }
+
+  if (service_handle.impl == NULL)
+  {
+    FAIL();
+    return;
+  }
+  SUCCEED();
+}
+
+

--- a/rclcpp/test/test_externally_defined_services.cpp
+++ b/rclcpp/test/test_externally_defined_services.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include <string>
+#include <memory>
 
 #include "rclcpp/node.hpp"
 #include "rclcpp/any_service_callback.hpp"
@@ -36,8 +37,8 @@ protected:
 };
 
 void
-callback(const std::shared_ptr<rclcpp::srv::Mock::Request> /*req*/,
-    std::shared_ptr<rclcpp::srv::Mock::Response> /*resp*/);
+callback(const std::shared_ptr<rclcpp::srv::Mock::Request>/*req*/,
+  std::shared_ptr<rclcpp::srv::Mock::Response>/*resp*/);
 
 TEST_F(TestExternallyDefinedServices, extern_defined_uninitialized) {
   auto node_handle = rclcpp::node::Node::make_shared("base_node");
@@ -49,10 +50,10 @@ TEST_F(TestExternallyDefinedServices, extern_defined_uninitialized) {
 
   // don't initialize the service
   // expect fail
-  try
-  {
-    rclcpp::service::Service<rclcpp::srv::Mock>(node_handle->get_shared_node_handle(), &service_handle, cb);
-  } catch(const std::runtime_error & e){
+  try {
+    rclcpp::service::Service<rclcpp::srv::Mock>(node_handle->get_rcl_node_handle(),
+      &service_handle, cb);
+  } catch (const std::runtime_error & e) {
     SUCCEED();
     return;
   }
@@ -67,9 +68,9 @@ TEST_F(TestExternallyDefinedServices, extern_defined_initialized) {
   rcl_service_t service_handle = rcl_get_zero_initialized_service();
   rcl_service_options_t service_options = rcl_service_get_default_options();
   const rosidl_service_type_support_t * ts = ROSIDL_GET_TYPE_SUPPORT(
-      rclcpp, srv, Mock);
+    rclcpp, srv, Mock);
   if (rcl_service_init(&service_handle, node_handle->get_rcl_node_handle(),
-      ts, "base_node_service", &service_options) != RCL_RET_OK)
+    ts, "base_node_service", &service_options) != RCL_RET_OK)
   {
     FAIL();
     return;
@@ -77,10 +78,10 @@ TEST_F(TestExternallyDefinedServices, extern_defined_initialized) {
   rclcpp::any_service_callback::AnyServiceCallback<rclcpp::srv::Mock> cb;
   // don't initialize the service
   // expect fail
-  try
-  {
-    rclcpp::service::Service<rclcpp::srv::Mock>(node_handle->get_shared_node_handle(), &service_handle, cb);
-  } catch(const std::runtime_error & e){
+  try {
+    rclcpp::service::Service<rclcpp::srv::Mock>(node_handle->get_rcl_node_handle(),
+      &service_handle, cb);
+  } catch (const std::runtime_error & e) {
     FAIL();
     return;
   }
@@ -95,9 +96,9 @@ TEST_F(TestExternallyDefinedServices, extern_defined_destructor) {
   rcl_service_t service_handle = rcl_get_zero_initialized_service();
   rcl_service_options_t service_options = rcl_service_get_default_options();
   const rosidl_service_type_support_t * ts = ROSIDL_GET_TYPE_SUPPORT(
-      rclcpp, srv, Mock);
+    rclcpp, srv, Mock);
   if (rcl_service_init(&service_handle, node_handle->get_rcl_node_handle(),
-      ts, "base_node_service", &service_options) != RCL_RET_OK)
+    ts, "base_node_service", &service_options) != RCL_RET_OK)
   {
     FAIL();
     return;
@@ -105,15 +106,13 @@ TEST_F(TestExternallyDefinedServices, extern_defined_destructor) {
   rclcpp::any_service_callback::AnyServiceCallback<rclcpp::srv::Mock> cb;
 
   {
-  rclcpp::service::Service<rclcpp::srv::Mock>(node_handle->get_shared_node_handle(), &service_handle, cb);
+    rclcpp::service::Service<rclcpp::srv::Mock>(node_handle->get_rcl_node_handle(),
+      &service_handle, cb);
   }
 
-  if (service_handle.impl == NULL)
-  {
+  if (service_handle.impl == NULL) {
     FAIL();
     return;
   }
   SUCCEED();
 }
-
-

--- a/rclcpp/test/test_externally_defined_services.cpp
+++ b/rclcpp/test/test_externally_defined_services.cpp
@@ -90,9 +90,9 @@ TEST_F(TestExternallyDefinedServices, extern_defined_initialized) {
     FAIL();
     return;
   }
+
   rclcpp::any_service_callback::AnyServiceCallback<rclcpp::srv::Mock> cb;
-  // don't initialize the service
-  // expect fail
+
   try {
     rclcpp::service::Service<rclcpp::srv::Mock>(node_handle->get_rcl_node_handle(),
       &service_handle, cb);
@@ -121,8 +121,10 @@ TEST_F(TestExternallyDefinedServices, extern_defined_destructor) {
   rclcpp::any_service_callback::AnyServiceCallback<rclcpp::srv::Mock> cb;
 
   {
-    rclcpp::service::Service<rclcpp::srv::Mock>(node_handle->get_rcl_node_handle(),
+    // Call constructor
+    rclcpp::service::Service<rclcpp::srv::Mock> srv_cpp(node_handle->get_rcl_node_handle(),
       &service_handle, cb);
+    // Call destructor
   }
 
   if (service_handle.impl == NULL) {

--- a/rclcpp/test/test_externally_defined_services.cpp
+++ b/rclcpp/test/test_externally_defined_services.cpp
@@ -47,7 +47,7 @@ TEST_F(TestExternallyDefinedServices, default_behavior) {
   try {
     auto srv = node_handle->create_service<rclcpp::srv::Mock>("test",
         callback);
-  } catch (const std::exception & e) {
+  } catch (const std::exception &) {
     FAIL();
     return;
   }
@@ -68,7 +68,7 @@ TEST_F(TestExternallyDefinedServices, extern_defined_uninitialized) {
   try {
     rclcpp::service::Service<rclcpp::srv::Mock>(node_handle->get_shared_node_handle(),
       &service_handle, cb);
-  } catch (const std::runtime_error & e) {
+  } catch (const std::runtime_error &) {
     SUCCEED();
     return;
   }
@@ -96,7 +96,7 @@ TEST_F(TestExternallyDefinedServices, extern_defined_initialized) {
   try {
     rclcpp::service::Service<rclcpp::srv::Mock>(node_handle->get_shared_node_handle(),
       &service_handle, cb);
-  } catch (const std::runtime_error & e) {
+  } catch (const std::runtime_error &) {
     FAIL();
     return;
   }

--- a/rclcpp/test/test_externally_defined_services.cpp
+++ b/rclcpp/test/test_externally_defined_services.cpp
@@ -38,7 +38,22 @@ protected:
 
 void
 callback(const std::shared_ptr<rclcpp::srv::Mock::Request>/*req*/,
-  std::shared_ptr<rclcpp::srv::Mock::Response>/*resp*/);
+  std::shared_ptr<rclcpp::srv::Mock::Response>/*resp*/)
+{}
+
+TEST_F(TestExternallyDefinedServices, default_behavior) {
+  auto node_handle = rclcpp::node::Node::make_shared("base_node");
+
+  try {
+  auto srv = node_handle->create_service<rclcpp::srv::Mock>("test",
+      callback);
+  } catch (const std::exception& e) {
+    FAIL();
+    return;
+  }
+  SUCCEED();
+}
+
 
 TEST_F(TestExternallyDefinedServices, extern_defined_uninitialized) {
   auto node_handle = rclcpp::node::Node::make_shared("base_node");

--- a/rclcpp/test/test_externally_defined_services.cpp
+++ b/rclcpp/test/test_externally_defined_services.cpp
@@ -127,7 +127,7 @@ TEST_F(TestExternallyDefinedServices, extern_defined_destructor) {
     // Call destructor
   }
 
-  if (service_handle.impl == NULL) {
+  if (!service_handle.impl) {
     FAIL();
     return;
   }

--- a/rclcpp/test/test_externally_defined_services.cpp
+++ b/rclcpp/test/test_externally_defined_services.cpp
@@ -66,7 +66,7 @@ TEST_F(TestExternallyDefinedServices, extern_defined_uninitialized) {
   // don't initialize the service
   // expect fail
   try {
-    rclcpp::service::Service<rclcpp::srv::Mock>(node_handle->get_rcl_node_handle(),
+    rclcpp::service::Service<rclcpp::srv::Mock>(node_handle->get_shared_node_handle(),
       &service_handle, cb);
   } catch (const std::runtime_error & e) {
     SUCCEED();
@@ -94,7 +94,7 @@ TEST_F(TestExternallyDefinedServices, extern_defined_initialized) {
   rclcpp::any_service_callback::AnyServiceCallback<rclcpp::srv::Mock> cb;
 
   try {
-    rclcpp::service::Service<rclcpp::srv::Mock>(node_handle->get_rcl_node_handle(),
+    rclcpp::service::Service<rclcpp::srv::Mock>(node_handle->get_shared_node_handle(),
       &service_handle, cb);
   } catch (const std::runtime_error & e) {
     FAIL();
@@ -122,7 +122,7 @@ TEST_F(TestExternallyDefinedServices, extern_defined_destructor) {
 
   {
     // Call constructor
-    rclcpp::service::Service<rclcpp::srv::Mock> srv_cpp(node_handle->get_rcl_node_handle(),
+    rclcpp::service::Service<rclcpp::srv::Mock> srv_cpp(node_handle->get_shared_node_handle(),
       &service_handle, cb);
     // Call destructor
   }


### PR DESCRIPTION
this PR enables a wrapping around a rcl_service_t which is externally initialized. The goal here is to instantiate a service on the rcl level and still be able to add it into a rclcpp executor. 

On the flipside, I have to have a boolean flag stating whether we own ownership over this service or not. This becomes important when trying to destroy the service. 