### PR TITLE
Deduce MessageT from the first argument of the callback

### DIFF
--- a/rclcpp/include/rclcpp/function_traits.hpp
+++ b/rclcpp/include/rclcpp/function_traits.hpp
@@ -25,6 +25,24 @@ namespace rclcpp
 namespace function_traits
 {
 
+template<typename MessageT>
+struct plain_message
+{
+  using type = MessageT;
+};
+
+template<typename MessageT>
+struct plain_message<std::shared_ptr<MessageT>> : plain_message<MessageT>
+{};
+
+template<typename MessageT>
+struct plain_message<const std::shared_ptr<MessageT>> : plain_message<MessageT>
+{};
+
+template<typename MessageT, typename Deleter>
+struct plain_message<std::unique_ptr<MessageT, Deleter>> : plain_message<MessageT>
+{};
+
 /* NOTE(esteve):
  * We support service callbacks that can optionally take the request id,
  * which should be possible with two overloaded create_service methods,

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -172,12 +172,38 @@ public:
      argument to msg_mem_strat, nullptr is a workaround.
    */
   template<
+    typename MessageT,
+    typename CallbackT,
+    typename Alloc = std::allocator<void>,
+    typename SubscriptionT = rclcpp::Subscription<MessageT, Alloc>,
+    typename DisableIfMessageTCallable = std::enable_if<
+      !rclcpp::function_traits::is_callable_t<MessageT>::value
+    >,
+    typename EnableIfCallbackTCallable = std::enable_if<
+      rclcpp::function_traits::is_callable_t<CallbackT>::value
+    >
+  >
+  std::shared_ptr<SubscriptionT>
+  create_subscription(
+    const std::string & topic_name,
+    CallbackT && callback,
+    const rmw_qos_profile_t & qos_profile = rmw_qos_profile_default,
+    rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr,
+    bool ignore_local_publications = false,
+    typename rclcpp::message_memory_strategy::MessageMemoryStrategy<MessageT, Alloc>::SharedPtr
+    msg_mem_strat = nullptr,
+    std::shared_ptr<Alloc> allocator = nullptr);
+
+  template<
     typename CallbackT,
     typename MessageT = typename rclcpp::function_traits::plain_message<
       typename rclcpp::function_traits::function_traits<CallbackT>::template argument_type<0>
     >::type,
     typename Alloc = std::allocator<void>,
-    typename SubscriptionT = rclcpp::Subscription<MessageT, Alloc>>
+    typename SubscriptionT = rclcpp::Subscription<MessageT, Alloc>,
+    typename EnableIfCallbackTCallable = std::enable_if<
+      rclcpp::function_traits::is_callable_t<CallbackT>::value
+    >
   >
   std::shared_ptr<SubscriptionT>
   create_subscription(
@@ -206,12 +232,38 @@ public:
      argument to msg_mem_strat, nullptr is a workaround.
    */
   template<
+    typename MessageT,
+    typename CallbackT,
+    typename Alloc = std::allocator<void>,
+    typename SubscriptionT = rclcpp::Subscription<MessageT, Alloc>,
+    typename DisableIfMessageTCallable = std::enable_if<
+      !rclcpp::function_traits::is_callable_t<MessageT>::value
+    >,
+    typename EnableIfCallbackTCallable = std::enable_if<
+      rclcpp::function_traits::is_callable_t<CallbackT>::value
+    >
+  >
+  std::shared_ptr<SubscriptionT>
+  create_subscription(
+    const std::string & topic_name,
+    size_t qos_history_depth,
+    CallbackT && callback,
+    rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr,
+    bool ignore_local_publications = false,
+    typename rclcpp::message_memory_strategy::MessageMemoryStrategy<MessageT, Alloc>::SharedPtr
+    msg_mem_strat = nullptr,
+    std::shared_ptr<Alloc> allocator = nullptr);
+
+  template<
     typename CallbackT,
     typename MessageT = typename rclcpp::function_traits::plain_message<
       typename rclcpp::function_traits::function_traits<CallbackT>::template argument_type<0>
     >::type,
     typename Alloc = std::allocator<void>,
-    typename SubscriptionT = rclcpp::Subscription<MessageT, Alloc>>
+    typename SubscriptionT = rclcpp::Subscription<MessageT, Alloc>,
+    typename EnableIfCallbackTCallable = std::enable_if<
+      rclcpp::function_traits::is_callable_t<CallbackT>::value
+    >
   >
   std::shared_ptr<SubscriptionT>
   create_subscription(

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -172,10 +172,13 @@ public:
      argument to msg_mem_strat, nullptr is a workaround.
    */
   template<
-    typename MessageT,
     typename CallbackT,
+    typename MessageT = typename rclcpp::function_traits::plain_message<
+      typename rclcpp::function_traits::function_traits<CallbackT>::template argument_type<0>
+    >::type,
     typename Alloc = std::allocator<void>,
     typename SubscriptionT = rclcpp::Subscription<MessageT, Alloc>>
+  >
   std::shared_ptr<SubscriptionT>
   create_subscription(
     const std::string & topic_name,
@@ -203,10 +206,13 @@ public:
      argument to msg_mem_strat, nullptr is a workaround.
    */
   template<
-    typename MessageT,
     typename CallbackT,
+    typename MessageT = typename rclcpp::function_traits::plain_message<
+      typename rclcpp::function_traits::function_traits<CallbackT>::template argument_type<0>
+    >::type,
     typename Alloc = std::allocator<void>,
     typename SubscriptionT = rclcpp::Subscription<MessageT, Alloc>>
+  >
   std::shared_ptr<SubscriptionT>
   create_subscription(
     const std::string & topic_name,

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -81,7 +81,14 @@ Node::create_publisher(
     allocator);
 }
 
-template<typename CallbackT, typename MessageT, typename Alloc, typename SubscriptionT>
+template<
+  typename MessageT,
+  typename CallbackT,
+  typename Alloc,
+  typename SubscriptionT,
+  typename DisableIfMessageTCallable,
+  typename EnableIfCallbackTCallable
+>
 std::shared_ptr<SubscriptionT>
 Node::create_subscription(
   const std::string & topic_name,
@@ -114,7 +121,42 @@ Node::create_subscription(
     allocator);
 }
 
-template<typename CallbackT, typename MessageT, typename Alloc, typename SubscriptionT>
+template<
+  typename CallbackT,
+  typename MessageT,
+  typename Alloc,
+  typename SubscriptionT,
+  typename EnableIfCallbackTCallable
+>
+std::shared_ptr<SubscriptionT>
+Node::create_subscription(
+  const std::string & topic_name,
+  CallbackT && callback,
+  const rmw_qos_profile_t & qos_profile,
+  rclcpp::callback_group::CallbackGroup::SharedPtr group,
+  bool ignore_local_publications,
+  typename rclcpp::message_memory_strategy::MessageMemoryStrategy<MessageT, Alloc>::SharedPtr
+  msg_mem_strat,
+  std::shared_ptr<Alloc> allocator)
+{
+  return this->create_subscription(
+    topic_name,
+    std::forward<CallbackT>(callback),
+    qos_profile,
+    group,
+    ignore_local_publications,
+    msg_mem_strat,
+    allocator);
+}
+
+template<
+  typename MessageT,
+  typename CallbackT,
+  typename Alloc,
+  typename SubscriptionT,
+  typename DisableIfMessageTCallable,
+  typename EnableIfCallbackTCallable
+>
 std::shared_ptr<SubscriptionT>
 Node::create_subscription(
   const std::string & topic_name,
@@ -128,10 +170,40 @@ Node::create_subscription(
 {
   rmw_qos_profile_t qos = rmw_qos_profile_default;
   qos.depth = qos_history_depth;
-  return this->create_subscription<CallbackT, MessageT, Alloc, SubscriptionT>(
+  return this->create_subscription<
+    MessageT, CallbackT, Alloc, SubscriptionT, DisableIfMessageTCallable, EnableIfCallbackTCallable
+  >(
     topic_name,
     std::forward<CallbackT>(callback),
     qos,
+    group,
+    ignore_local_publications,
+    msg_mem_strat,
+    allocator);
+}
+
+template<
+  typename CallbackT,
+  typename MessageT,
+  typename Alloc,
+  typename SubscriptionT,
+  typename EnableIfCallbackTCallable
+>
+std::shared_ptr<SubscriptionT>
+Node::create_subscription(
+  const std::string & topic_name,
+  size_t qos_history_depth,
+  CallbackT && callback,
+  rclcpp::callback_group::CallbackGroup::SharedPtr group,
+  bool ignore_local_publications,
+  typename rclcpp::message_memory_strategy::MessageMemoryStrategy<MessageT, Alloc>::SharedPtr
+  msg_mem_strat,
+  std::shared_ptr<Alloc> allocator)
+{
+  return this->create_subscription(
+    topic_name,
+    qos_history_depth,
+    std::forward<CallbackT>(callback),
     group,
     ignore_local_publications,
     msg_mem_strat,

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -81,7 +81,7 @@ Node::create_publisher(
     allocator);
 }
 
-template<typename MessageT, typename CallbackT, typename Alloc, typename SubscriptionT>
+template<typename CallbackT, typename MessageT, typename Alloc, typename SubscriptionT>
 std::shared_ptr<SubscriptionT>
 Node::create_subscription(
   const std::string & topic_name,
@@ -114,7 +114,7 @@ Node::create_subscription(
     allocator);
 }
 
-template<typename MessageT, typename CallbackT, typename Alloc, typename SubscriptionT>
+template<typename CallbackT, typename MessageT, typename Alloc, typename SubscriptionT>
 std::shared_ptr<SubscriptionT>
 Node::create_subscription(
   const std::string & topic_name,
@@ -128,7 +128,7 @@ Node::create_subscription(
 {
   rmw_qos_profile_t qos = rmw_qos_profile_default;
   qos.depth = qos_history_depth;
-  return this->create_subscription<MessageT, CallbackT, Alloc, SubscriptionT>(
+  return this->create_subscription<CallbackT, MessageT, Alloc, SubscriptionT>(
     topic_name,
     std::forward<CallbackT>(callback),
     qos,

--- a/rclcpp/test/test_function_traits.cpp
+++ b/rclcpp/test/test_function_traits.cpp
@@ -95,6 +95,8 @@ struct ObjectMember
   }
 };
 
+struct NotCallable {};
+
 template<
   typename FunctorT,
   std::size_t Arity = 0,
@@ -705,4 +707,94 @@ TEST(TestFunctionTraits, sfinae_match) {
   EXPECT_EQ(123.45, func_accept_callback_return_type(lambda_no_args_double));
 
   EXPECT_EQ("foo", func_accept_callback_return_type(lambda_no_args_string));
+}
+
+/*
+   Tests that funcion_traits detects that a functor is callabale.
+ */
+TEST(TestFunctionTraits, is_callable) {
+  // Test regular functions
+  static_assert(
+    rclcpp::function_traits::is_callable_t<decltype(func_no_args)>::value,
+    "Functor must be callable");
+
+  static_assert(
+    rclcpp::function_traits::is_callable_t<decltype(func_one_int)>::value,
+    "Functor must be callable");
+
+  static_assert(
+    rclcpp::function_traits::is_callable_t<decltype(func_two_ints)>::value,
+    "Functor must be callable");
+
+  static_assert(
+    rclcpp::function_traits::is_callable_t<decltype(func_one_int_one_char)>::value,
+    "Functor must be callable");
+
+  // Test lambdas
+  auto lambda_no_args = []() {
+      return 0;
+    };
+
+  auto lambda_one_int = [](int one) {
+      (void)one;
+      return 1;
+    };
+
+  auto lambda_two_ints = [](int one, int two) {
+      (void)one;
+      (void)two;
+      return 2;
+    };
+
+  auto lambda_one_int_one_char = [](int one, char two) {
+      (void)one;
+      (void)two;
+      return 3;
+    };
+
+  static_assert(
+    rclcpp::function_traits::is_callable_t<decltype(lambda_no_args)>::value,
+    "Functor must be callable");
+
+  static_assert(
+    rclcpp::function_traits::is_callable_t<decltype(lambda_one_int)>::value,
+    "Functor must be callable");
+
+  static_assert(
+    rclcpp::function_traits::is_callable_t<decltype(lambda_two_ints)>::value,
+    "Functor must be callable");
+
+  static_assert(
+    rclcpp::function_traits::is_callable_t<decltype(lambda_one_int_one_char)>::value,
+    "Functor must be callable");
+
+  // Test objects that have a call operator
+  static_assert(
+    rclcpp::function_traits::is_callable_t<FunctionObjectNoArgs>::value,
+    "Functor must be callable");
+
+  static_assert(
+    rclcpp::function_traits::is_callable_t<FunctionObjectOneInt>::value,
+    "Functor must be callable");
+
+  static_assert(
+    rclcpp::function_traits::is_callable_t<FunctionObjectTwoInts>::value,
+    "Functor must be callable");
+
+  static_assert(
+    rclcpp::function_traits::is_callable_t<FunctionObjectOneIntOneChar>::value,
+    "Functor must be callable");
+
+  // Test that types that don't have a call operator return false
+  static_assert(
+    !rclcpp::function_traits::is_callable_t<int>::value,
+    "Type is not callable");
+
+  static_assert(
+    !rclcpp::function_traits::is_callable_t<std::string>::value,
+    "Type is not callable");
+
+  static_assert(
+    !rclcpp::function_traits::is_callable_t<NotCallable>::value,
+    "Type is not callable");
 }


### PR DESCRIPTION
This PR removes the need to specify twice the type of a created subscription by deducing the message type from the callback.

This is a quick hack that came up from the discussion in https://discourse.ros.org/t/rfc-using-c-14/921/10