### PR TITLE
fix the return type of create_subscription

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -152,7 +152,7 @@ public:
     typename CallbackT,
     typename Alloc = std::allocator<void>,
     typename SubscriptionT = rclcpp::subscription::Subscription<MessageT, Alloc>>
-  typename rclcpp::subscription::Subscription<MessageT, Alloc>::SharedPtr
+  std::shared_ptr<SubscriptionT>
   create_subscription(
     const std::string & topic_name,
     CallbackT && callback,
@@ -182,7 +182,7 @@ public:
     typename CallbackT,
     typename Alloc = std::allocator<void>,
     typename SubscriptionT = rclcpp::subscription::Subscription<MessageT, Alloc>>
-  typename rclcpp::subscription::Subscription<MessageT, Alloc>::SharedPtr
+  std::shared_ptr<SubscriptionT>
   create_subscription(
     const std::string & topic_name,
     size_t qos_history_depth,

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -84,7 +84,7 @@ Node::create_publisher(
 }
 
 template<typename MessageT, typename CallbackT, typename Alloc, typename SubscriptionT>
-typename rclcpp::subscription::Subscription<MessageT, Alloc>::SharedPtr
+std::shared_ptr<SubscriptionT>
 Node::create_subscription(
   const std::string & topic_name,
   CallbackT && callback,
@@ -117,7 +117,7 @@ Node::create_subscription(
 }
 
 template<typename MessageT, typename CallbackT, typename Alloc, typename SubscriptionT>
-typename rclcpp::subscription::Subscription<MessageT, Alloc>::SharedPtr
+std::shared_ptr<SubscriptionT>
 Node::create_subscription(
   const std::string & topic_name,
   size_t qos_history_depth,


### PR DESCRIPTION
Follow up to #277, thanks to @Karsten1987 for pointing it out.

CI:

- Linux:
  - [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2030)](http://ci.ros2.org/job/ci_linux/2030/)
- OS X:
  - [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1559)](http://ci.ros2.org/job/ci_osx/1559/)
- Windows:
  - [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2017)](http://ci.ros2.org/job/ci_windows/2017/)