### PR TITLE
throw on second call of register_param_change_callback

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -226,5 +226,9 @@ NodeParameters::list_parameters(const std::vector<std::string> & prefixes, uint6
 void
 NodeParameters::register_param_change_callback(ParametersCallbackFunction callback)
 {
+  if (parameters_callback_) {
+    fprintf(stderr, "Warning: param_change_callback already registered, "
+      "overwriting previous callback\n");
+  }
   parameters_callback_ = callback;
 }


### PR DESCRIPTION
We should throw instead of silently overwriting the old callback