### PR TITLE
dependency order

### DIFF
--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -29,9 +29,9 @@ macro(targets)
     src/transition.cpp
   )
   ament_target_dependencies(rclcpp_lifecycle${target_suffix}
-    "rclcpp${target_suffix}"
+    "lifecycle_msgs"
     "rcl_lifecycle${target_suffix}"
-    "lifecycle_msgs")
+    "rclcpp${target_suffix}")
 
   # Causes the visibility macros to use dllexport rather than dllimport,
   # which is appropriate when building the dll but not consuming it.


### PR DESCRIPTION
now that the typesupport refactor is done (https://github.com/ros2/ros2/issues/253#issuecomment-270202324) we can reorder dependencies properly

see https://github.com/ros2/demos/pull/104 for CI