### PR TITLE
add a new Node::get_parameter() with a default value

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -253,6 +253,13 @@ public:
   bool
   get_parameter(const std::string & name, ParameterT & parameter) const;
 
+  template<typename ParameterT>
+  bool
+  get_parameter(
+    const std::string & name,
+    ParameterT & parameter,
+    const ParameterT & default_value) const;
+
   RCLCPP_PUBLIC
   std::vector<rcl_interfaces::msg::ParameterDescriptor>
   describe_parameters(const std::vector<std::string> & names) const;

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -235,6 +235,12 @@ public:
   rcl_interfaces::msg::SetParametersResult
   set_parameters_atomically(const std::vector<rclcpp::parameter::ParameterVariant> & parameters);
 
+  template<typename ParameterT>
+  void
+  set_parameter_if_not_set(
+    const std::string & name,
+    const ParameterT & default_value);
+
   RCLCPP_PUBLIC
   std::vector<rclcpp::parameter::ParameterVariant>
   get_parameters(const std::vector<std::string> & names) const;

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -239,7 +239,7 @@ public:
   void
   set_parameter_if_not_set(
     const std::string & name,
-    const ParameterT & default_value);
+    const ParameterT & value);
 
   RCLCPP_PUBLIC
   std::vector<rclcpp::parameter::ParameterVariant>

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -255,10 +255,10 @@ public:
 
   template<typename ParameterT>
   bool
-  get_parameter(
+  get_parameter_or(
     const std::string & name,
     ParameterT & value,
-    const ParameterT & default_value) const;
+    const ParameterT & alternative_value) const;
 
   RCLCPP_PUBLIC
   std::vector<rcl_interfaces::msg::ParameterDescriptor>

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -257,7 +257,7 @@ public:
   bool
   get_parameter(
     const std::string & name,
-    ParameterT & parameter,
+    ParameterT & value,
     const ParameterT & default_value) const;
 
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -255,10 +255,29 @@ public:
     const std::string & name,
     rclcpp::parameter::ParameterVariant & parameter) const;
 
+  /// Assign the value of the parameter if set into the parameter argument.
+  /**
+   * If the parameter was not set, then the "parameter" argument is never assigned a value.
+   *
+   * \param[in] name The name of the parameter to get.
+   * \param[out] parameter The output where the value of the parameter should be assigned.
+   * \returns true if the parameter was set, false otherwise
+   */
   template<typename ParameterT>
   bool
   get_parameter(const std::string & name, ParameterT & parameter) const;
 
+  /// Get the parameter value, or the "alternative value" if not set, and assign it to "value".
+  /**
+   * If the parameter was not set, then the "value" argument is assigned
+   * the "alternative_value".
+   * In all cases, the parameter remains not set after this function is called.
+   *
+   * \param[in] name The name of the parameter to get.
+   * \param[out] value The output where the value of the parameter should be assigned.
+   * \param[in] alternative_value Value to be stored in output if the parameter was not set.
+   * \returns true if the parameter was set, false otherwise
+   */
   template<typename ParameterT>
   bool
   get_parameter_or(

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -222,12 +222,12 @@ template<typename ParameterT>
 bool
 Node::get_parameter(
   const std::string & name,
-  ParameterT & parameter,
+  ParameterT & value,
   const ParameterT & default_value) const
 {
-  bool got_parameter = get_parameter(name, parameter);
+  bool got_parameter = get_parameter(name, value);
   if (!got_parameter) {
-    parameter = default_value;
+    value = default_value;
   }
   return got_parameter;
 }

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -220,14 +220,14 @@ Node::get_parameter(const std::string & name, ParameterT & parameter) const
 
 template<typename ParameterT>
 bool
-Node::get_parameter(
+Node::get_parameter_or(
   const std::string & name,
   ParameterT & value,
-  const ParameterT & default_value) const
+  const ParameterT & alternative_value) const
 {
   bool got_parameter = get_parameter(name, value);
   if (!got_parameter) {
-    value = default_value;
+    value = alternative_value;
   }
   return got_parameter;
 }

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -211,12 +211,12 @@ template<typename ParameterT>
 void
 Node::set_parameter_if_not_set(
   const std::string & name,
-  const ParameterT & default_value)
+  const ParameterT & value)
 {
   rclcpp::parameter::ParameterVariant parameter_variant;
   if (!this->get_parameter(name, parameter_variant)) {
     this->set_parameters({
-          rclcpp::parameter::ParameterVariant(name, default_value),
+          rclcpp::parameter::ParameterVariant(name, value),
         });
   }
 }

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -218,6 +218,20 @@ Node::get_parameter(const std::string & name, ParameterT & parameter) const
   return result;
 }
 
+template<typename ParameterT>
+bool
+Node::get_parameter(
+  const std::string & name,
+  ParameterT & parameter,
+  const ParameterT & default_value) const
+{
+  bool got_parameter = get_parameter(name, parameter);
+  if (!got_parameter) {
+    parameter = default_value;
+  }
+  return got_parameter;
+}
+
 }  // namespace node
 }  // namespace rclcpp
 

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -208,6 +208,20 @@ Node::register_param_change_callback(CallbackT && callback)
 }
 
 template<typename ParameterT>
+void
+Node::set_parameter_if_not_set(
+  const std::string & name,
+  const ParameterT & default_value)
+{
+  rclcpp::parameter::ParameterVariant parameter_variant;
+  if (!this->get_parameter(name, parameter_variant)) {
+    this->set_parameters({
+      rclcpp::parameter::ParameterVariant(name, default_value),
+    });
+  }
+}
+
+template<typename ParameterT>
 bool
 Node::get_parameter(const std::string & name, ParameterT & value) const
 {

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -216,8 +216,8 @@ Node::set_parameter_if_not_set(
   rclcpp::parameter::ParameterVariant parameter_variant;
   if (!this->get_parameter(name, parameter_variant)) {
     this->set_parameters({
-      rclcpp::parameter::ParameterVariant(name, default_value),
-    });
+          rclcpp::parameter::ParameterVariant(name, default_value),
+        });
   }
 }
 

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -209,11 +209,13 @@ Node::register_param_change_callback(CallbackT && callback)
 
 template<typename ParameterT>
 bool
-Node::get_parameter(const std::string & name, ParameterT & parameter) const
+Node::get_parameter(const std::string & name, ParameterT & value) const
 {
-  rclcpp::parameter::ParameterVariant parameter_variant(name, parameter);
+  rclcpp::parameter::ParameterVariant parameter_variant;
   bool result = get_parameter(name, parameter_variant);
-  parameter = parameter_variant.get_value<ParameterT>();
+  if (result) {
+    value = parameter_variant.get_value<ParameterT>();
+  }
 
   return result;
 }

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -83,11 +83,18 @@ NodeParameters::set_parameters_atomically(
   for (auto p : parameters) {
     if (parameters_.find(p.get_name()) == parameters_.end()) {
       if (p.get_type() != rclcpp::parameter::ParameterType::PARAMETER_NOT_SET) {
+        // case: parameter not set before, and input is something other than "NOT_SET"
         parameter_event->new_parameters.push_back(p.to_parameter());
       }
     } else if (p.get_type() != rclcpp::parameter::ParameterType::PARAMETER_NOT_SET) {
+      // case: parameter was set before, and input is something other than "NOT_SET"
       parameter_event->changed_parameters.push_back(p.to_parameter());
     } else {
+      // case: parameter was set before, and input is "NOT_SET"
+      // therefore we will "unset" the previous set parameter
+      // it is not necessary to erase the parameter from parameters_
+      // because the new value for this key (p.get_name()) will be a
+      // ParameterVariant with type "NOT_SET"
       parameter_event->deleted_parameters.push_back(p.to_parameter());
     }
     tmp_map[p.get_name()] = p;

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -91,7 +91,7 @@ NodeParameters::set_parameters_atomically(
       parameter_event->changed_parameters.push_back(p.to_parameter());
     } else {
       // case: parameter was set before, and input is "NOT_SET"
-      // therefore we will "unset" the previous set parameter
+      // therefore we will "unset" the previously set parameter
       // it is not necessary to erase the parameter from parameters_
       // because the new value for this key (p.get_name()) will be a
       // ParameterVariant with type "NOT_SET"


### PR DESCRIPTION
I ran into needing something like this when converting `map_server`. And I think it's useful, but I'm not sure about a few details.

First, If the parameter is not set, so it be set to the default value or not? Put another way:

```c++
int foo;
ASSERT_FALSE(node->get_parameter("foo", foo, 42));  // this is the new signature
bool result = node->get_parameter("foo", foo);  // Should result be true or false?
```

---

This new API is meant to replicate ROS 1's API (http://docs.ros.org/kinetic/api/roscpp/html/classros_1_1NodeHandle.html#a05941572641a453fd416c6603b91d39f):

```c++
// ROS 1
std::string frame_id;
node_handle.param("frame_id", frame_id, std::string("map"));
```

This is what it would look like with this pr:

```c++
// ROS 2
std::string frame_id;
node->get_parameter("frame_id", frame_id, std::string("map"));
```

---

Separately, we could choose to support the other API provided by ROS 1 which is similar but it returns `T` (http://docs.ros.org/kinetic/api/roscpp/html/classros_1_1NodeHandle.html#aa9b23d4206216ed13b5833fb1a090f1a):

```c++
// ROS 1 alternative
std::string frame_id = node_handle.param("frame_id", std::string("map"));
```

We could do this, but it begins to get a little confusing when you have one signature that takes `T &, const T &` and another that takes just `const T &`. The `const` should prevent you from getting into strange situations, but it might be the case that having fewer options would be better.

---

Finally, the Google style guide says you should pass `T *` rather than `T &` when you intend to modify the variable because it is easier to see what's going on from the calling code. In this case, I think that might be worth following. I consider this snippet from the `map_server` to be clearer with the rule applied:

```c++
// ROS 1 with pass by reference
private_nh.param("negate", negate, 0);
private_nh.param("occupied_thresh", occ_th, 0.65);
private_nh.param("free_thresh", free_th, 0.196);
```

Versus:

```c++
// ROS 1 with pass by pointer
private_nh.param("negate", &negate, 0);
private_nh.param("occupied_thresh", &occ_th, 0.65);
private_nh.param("free_thresh", &free_th, 0.196);
```

Novice users will probably lament that they have to add a `&` and they don't know why, but I think that it is easier to infer what is happening here if you know C++ well enough.

---

Anyways, I'd appreciate anyone who's interested in giving some feedback on this.