### PR TITLE
Rclcpp time

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.5)
 project(rclcpp)
 
 find_package(ament_cmake REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 find_package(rcl REQUIRED)
 find_package(rcl_interfaces REQUIRED)
 find_package(rmw REQUIRED)
@@ -17,7 +18,9 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -Wpedantic")
 endif()
 
-include_directories(include)
+include_directories(
+  include
+  ${builtin_interfaces_INCLUDE_DIRS})
 
 set(${PROJECT_NAME}_SRCS
   src/rclcpp/any_executable.cpp

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -82,7 +82,9 @@ ament_export_dependencies(rosidl_generator_cpp)
 ament_export_dependencies(rosidl_typesupport_c)
 ament_export_dependencies(rosidl_typesupport_cpp)
 
-ament_export_include_directories(include)
+ament_export_include_directories(
+  include
+  ${builtin_interfaces_INCLUDE_DIRS})
 
 ament_export_libraries(${PROJECT_NAME})
 
@@ -173,6 +175,15 @@ if(BUILD_TESTING)
       rosidl_target_interfaces(test_externally_defined_services
         mock_msgs ${typesupport_impl_c})
     endforeach()
+  endif()
+
+  ament_add_gtest(test_time test/test_time.cpp
+    APPEND_LIBRARY_DIRS "${append_library_dirs}")
+  if(TARGET test_time)
+    target_include_directories(test_time PUBLIC
+      ${rcl_INCLUDE_DIRS}
+    )
+    target_link_libraries(test_time ${PROJECT_NAME})
   endif()
 endif()
 

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -18,9 +18,7 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -Wpedantic")
 endif()
 
-include_directories(
-  include
-  ${builtin_interfaces_INCLUDE_DIRS})
+include_directories(include)
 
 set(${PROJECT_NAME}_SRCS
   src/rclcpp/any_executable.cpp
@@ -60,6 +58,7 @@ set(${PROJECT_NAME}_SRCS
 add_library(${PROJECT_NAME} SHARED
   ${${PROJECT_NAME}_SRCS})
 ament_target_dependencies(${PROJECT_NAME}
+  "builtin_interfaces"
   "rcl"
   "rosidl_generator_cpp"
   "rosidl_typesupport_cpp")
@@ -77,14 +76,13 @@ install(
 )
 
 ament_export_dependencies(ament_cmake)
+ament_export_dependencies(builtin_interfaces)
 ament_export_dependencies(rcl)
 ament_export_dependencies(rosidl_generator_cpp)
 ament_export_dependencies(rosidl_typesupport_c)
 ament_export_dependencies(rosidl_typesupport_cpp)
 
-ament_export_include_directories(
-  include
-  ${builtin_interfaces_INCLUDE_DIRS})
+ament_export_include_directories(include)
 
 ament_export_libraries(${PROJECT_NAME})
 
@@ -180,9 +178,8 @@ if(BUILD_TESTING)
   ament_add_gtest(test_time test/test_time.cpp
     APPEND_LIBRARY_DIRS "${append_library_dirs}")
   if(TARGET test_time)
-    target_include_directories(test_time PUBLIC
-      ${rcl_INCLUDE_DIRS}
-    )
+    ament_target_dependencies(test_time
+      "rcl")
     target_link_libraries(test_time ${PROJECT_NAME})
   endif()
 endif()

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -130,6 +130,7 @@
 #include "rclcpp/parameter_client.hpp"
 #include "rclcpp/parameter_service.hpp"
 #include "rclcpp/rate.hpp"
+#include "rclcpp/time.hpp"
 #include "rclcpp/utilities.hpp"
 #include "rclcpp/visibility_control.hpp"
 

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -114,6 +114,7 @@
  *   - rclcpp/function_traits.hpp
  *   - rclcpp/macros.hpp
  *   - rclcpp/scope_exit.hpp
+ *   - rclcpp/time.hpp
  *   - rclcpp/utilities.hpp
  *   - rclcpp/visibility_control.hpp
  */
@@ -130,7 +131,7 @@
 #include "rclcpp/parameter_client.hpp"
 #include "rclcpp/parameter_service.hpp"
 #include "rclcpp/rate.hpp"
-//#include "rclcpp/time.hpp"
+#include "rclcpp/time.hpp"
 #include "rclcpp/utilities.hpp"
 #include "rclcpp/visibility_control.hpp"
 

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -130,7 +130,7 @@
 #include "rclcpp/parameter_client.hpp"
 #include "rclcpp/parameter_service.hpp"
 #include "rclcpp/rate.hpp"
-#include "rclcpp/time.hpp"
+//#include "rclcpp/time.hpp"
 #include "rclcpp/utilities.hpp"
 #include "rclcpp/visibility_control.hpp"
 

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -1,0 +1,46 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__TIME_HPP_
+#define RCLCPP__TIME_HPP_
+
+#include <chrono>
+
+#include "builtin_interfaces/msg/time.hpp"
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+namespace time
+{
+
+template<class ClockT = std::chrono::high_resolution_clock>
+builtin_interfaces::msg::Time now()
+{
+  builtin_interfaces::msg::Time now;
+  now.sec = 0;
+  now.nanosec = 0;
+  auto now_nanosec = ClockT::now().time_since_epoch();
+  if (now_nanosec > std::chrono::nanoseconds(0)) {
+    now.sec = static_cast<builtin_interfaces::msg::Time::_sec_type>(
+      RCL_NS_TO_S(now_nanosec.count()));
+    now.nanosec = now_nanosec.count() % (1000 * 1000 * 1000);
+  }
+  return now;
+}
+
+}  // namespace time
+}  // namespace rclcpp
+
+#endif  // RCLCPP__TIME_HPP_

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -15,13 +15,11 @@
 #ifndef RCLCPP__TIME_HPP_
 #define RCLCPP__TIME_HPP_
 
-#include <chrono>
 #include <utility>
 
 #include "builtin_interfaces/msg/time.hpp"
 
 #include "rclcpp/exceptions.hpp"
-#include "rclcpp/visibility_control.hpp"
 
 namespace rclcpp
 {

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -55,7 +55,7 @@ public:
     }
     if (ret != RCL_RET_OK) {
       rclcpp::exceptions::throw_from_rcl_error(
-        ret, "Could not get current time: ", rcl_get_error_string_safe());
+        ret, "Could not get current time: ");
     }
 
     return Time(std::move(rcl_now));
@@ -64,8 +64,8 @@ public:
   operator builtin_interfaces::msg::Time() const
   {
     builtin_interfaces::msg::Time msg_time;
-    msg_time.sec = RCL_NS_TO_S(rcl_time_);
-    msg_time.nanosec = rcl_time_ % (1000 * 1000 * 1000);
+    msg_time.sec = static_cast<std::int32_t>(RCL_NS_TO_S(rcl_time_));
+    msg_time.nanosec = static_cast<std::uint32_t>(rcl_time_ % (1000 * 1000 * 1000));
     return msg_time;
   }
 };

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -28,16 +28,6 @@ namespace rclcpp
 
 class Time
 {
-  rcl_time_point_value_t rcl_time_;
-
-  Time(std::uint32_t sec, std::uint32_t nanosec)
-  : rcl_time_(RCL_S_TO_NS(sec) + nanosec)
-  {}
-
-  explicit Time(rcl_time_point_value_t && rcl_time)
-  : rcl_time_(std::forward<decltype(rcl_time)>(rcl_time))
-  {}
-
 public:
   template<rcl_time_source_type_t ClockT = RCL_SYSTEM_TIME>
   static Time
@@ -68,6 +58,17 @@ public:
     msg_time.nanosec = static_cast<std::uint32_t>(rcl_time_ % (1000 * 1000 * 1000));
     return msg_time;
   }
+
+private:
+  rcl_time_point_value_t rcl_time_;
+
+  Time(std::uint32_t sec, std::uint32_t nanosec)
+  : rcl_time_(RCL_S_TO_NS(sec) + nanosec)
+  {}
+
+  explicit Time(rcl_time_point_value_t && rcl_time)
+  : rcl_time_(std::forward<decltype(rcl_time)>(rcl_time))
+  {}
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -34,7 +34,7 @@ class Time
   : rcl_time_(RCL_S_TO_NS(sec) + nanosec)
   {}
 
-  Time(rcl_time_point_value_t && rcl_time)
+  explicit Time(rcl_time_point_value_t && rcl_time)
   : rcl_time_(std::forward<decltype(rcl_time)>(rcl_time))
   {}
 

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -19,6 +19,8 @@
 #include <utility>
 
 #include "builtin_interfaces/msg/time.hpp"
+
+#include "rclcpp/exceptions.hpp"
 #include "rclcpp/visibility_control.hpp"
 
 namespace rclcpp
@@ -44,8 +46,7 @@ public:
     rcl_time_point_value_t rcl_now = 0;
     rcl_ret_t ret = RCL_RET_ERROR;
     if (ClockT == RCL_ROS_TIME) {
-      // ret = rcl_ros_time_now(&rcl_now);
-      fprintf(stderr, "RCL_ROS_TIME is currently not implemented.\n");
+      throw std::runtime_error("RCL_ROS_TIME is currently not implemented.");
       ret = false;
     } else if (ClockT == RCL_SYSTEM_TIME) {
       ret = rcl_system_time_now(&rcl_now);
@@ -53,7 +54,8 @@ public:
       ret = rcl_steady_time_now(&rcl_now);
     }
     if (ret != RCL_RET_OK) {
-      fprintf(stderr, "Could not get current time: %s\n", rcl_get_error_string_safe());
+      rclcpp::exceptions::throw_from_rcl_error(
+        ret, "Could not get current time: ", rcl_get_error_string_safe());
     }
 
     return Time(std::move(rcl_now));

--- a/rclcpp/package.xml
+++ b/rclcpp/package.xml
@@ -11,10 +11,12 @@
 
   <build_export_depend>rmw</build_export_depend>
 
+  <build_depend>builtin_interfaces</build_depend>
   <build_depend>rcl_interfaces</build_depend>
   <build_depend>rosidl_generator_cpp</build_depend>
   <build_depend>rosidl_typesupport_c</build_depend>
   <build_depend>rosidl_typesupport_cpp</build_depend>
+  <build_export_depend>builtin_interfaces</build_export_depend>
   <build_export_depend>rcl_interfaces</build_export_depend>
   <build_export_depend>rosidl_generator_cpp</build_export_depend>
   <build_export_depend>rosidl_typesupport_c</build_export_depend>

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -32,9 +32,13 @@ protected:
 
 TEST(TestTime, rate_basics) {
   using builtin_interfaces::msg::Time;
-  Time ros_now = rclcpp::Time::now<RCL_ROS_TIME>();
-  EXPECT_EQ(0, ros_now.sec);
-  EXPECT_EQ(0, ros_now.nanosec);
+  try {
+    rclcpp::Time::now<RCL_ROS_TIME>();
+    FAIL();
+  } catch (const std::exception &) {
+    // test succeeded, ROStime not implemented yet
+    // TODO(karsten1987): Fix this test when ROStime is implemented
+  }
 
   Time system_now = rclcpp::Time::now<RCL_SYSTEM_TIME>();
   EXPECT_NE(0, system_now.sec);

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -1,0 +1,41 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "rcl/error_handling.h"
+#include "rcl/time.h"
+#include "rclcpp/time.hpp"
+
+TEST(TestRate, rate_basics) {
+  using builtin_interfaces::msg::Time;
+  Time ros_now = rclcpp::time::now<RCL_ROS_TIME>();
+  EXPECT_NE(0, ros_now.sec);
+  EXPECT_NE(0, ros_now.nanosec);
+
+  Time system_now = rclcpp::time::now<RCL_SYSTEM_TIME>();
+  EXPECT_NE(0, system_now.sec);
+  EXPECT_NE(0, system_now.nanosec);
+
+  Time steady_now = rclcpp::time::now<RCL_STEADY_TIME>();
+  EXPECT_NE(0, steady_now.sec);
+  EXPECT_NE(0, steady_now.nanosec);
+
+  // default
+  Time default_now = rclcpp::time::now();
+  EXPECT_NE(0, default_now.sec);
+  EXPECT_NE(0, default_now.nanosec);
+}

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -32,13 +32,7 @@ protected:
 
 TEST(TestTime, rate_basics) {
   using builtin_interfaces::msg::Time;
-  try {
-    rclcpp::Time::now<RCL_ROS_TIME>();
-    FAIL();
-  } catch (const std::exception &) {
-    // test succeeded, ROStime not implemented yet
-    // TODO(karsten1987): Fix this test when ROStime is implemented
-  }
+  EXPECT_ANY_THROW(rclcpp::Time::now<RCL_ROS_TIME>());
 
   Time system_now = rclcpp::Time::now<RCL_SYSTEM_TIME>();
   EXPECT_NE(0, system_now.sec);

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -32,6 +32,7 @@ protected:
 
 TEST(TestTime, rate_basics) {
   using builtin_interfaces::msg::Time;
+  // TODO(Karsten1987): Fix this test once ROS_TIME is implemented
   EXPECT_ANY_THROW(rclcpp::Time::now<RCL_ROS_TIME>());
 
   Time system_now = rclcpp::Time::now<RCL_SYSTEM_TIME>();

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 Open Source Robotics Foundation, Inc.
+// Copyright 2017 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,24 +18,34 @@
 
 #include "rcl/error_handling.h"
 #include "rcl/time.h"
+#include "rclcpp/rclcpp.hpp"
 #include "rclcpp/time.hpp"
 
-TEST(TestRate, rate_basics) {
-  using builtin_interfaces::msg::Time;
-  Time ros_now = rclcpp::time::now<RCL_ROS_TIME>();
-  EXPECT_NE(0, ros_now.sec);
-  EXPECT_NE(0, ros_now.nanosec);
+class TestTime : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+};
 
-  Time system_now = rclcpp::time::now<RCL_SYSTEM_TIME>();
+TEST(TestTime, rate_basics) {
+  using builtin_interfaces::msg::Time;
+  Time ros_now = rclcpp::Time::now<RCL_ROS_TIME>();
+  EXPECT_EQ(0, ros_now.sec);
+  EXPECT_EQ(0, ros_now.nanosec);
+
+  Time system_now = rclcpp::Time::now<RCL_SYSTEM_TIME>();
   EXPECT_NE(0, system_now.sec);
   EXPECT_NE(0, system_now.nanosec);
 
-  Time steady_now = rclcpp::time::now<RCL_STEADY_TIME>();
+  Time steady_now = rclcpp::Time::now<RCL_STEADY_TIME>();
   EXPECT_NE(0, steady_now.sec);
   EXPECT_NE(0, steady_now.nanosec);
 
   // default
-  Time default_now = rclcpp::time::now();
+  Time default_now = rclcpp::Time::now();
   EXPECT_NE(0, default_now.sec);
   EXPECT_NE(0, default_now.nanosec);
 }


### PR DESCRIPTION
connects to https://github.com/ros2/rclcpp/issues/310

prototype of `rclcpp::Time::now()`

For now it's mainly a convenience function, but may be object to further helper classes.
I introduced a new c++ class called Time, which by itself has a static member function `now` which returns basically a wrapper around `rcl_time_point_value_t`. In order to assign it to a message header, the same function can be called, but gets converter via the casting operator.

 