### PR TITLE
compare unsigned to unsigned

### DIFF
--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -37,14 +37,14 @@ TEST(TestTime, rate_basics) {
 
   Time system_now = rclcpp::Time::now<RCL_SYSTEM_TIME>();
   EXPECT_NE(0, system_now.sec);
-  EXPECT_NE(0, system_now.nanosec);
+  EXPECT_NE(0u, system_now.nanosec);
 
   Time steady_now = rclcpp::Time::now<RCL_STEADY_TIME>();
   EXPECT_NE(0, steady_now.sec);
-  EXPECT_NE(0, steady_now.nanosec);
+  EXPECT_NE(0u, steady_now.nanosec);
 
   // default
   Time default_now = rclcpp::Time::now();
   EXPECT_NE(0, default_now.sec);
-  EXPECT_NE(0, default_now.nanosec);
+  EXPECT_NE(0u, default_now.nanosec);
 }


### PR DESCRIPTION
I think this should fix the warning I've seen in some CI jobs (at least I think so, since I couldn't reproduce it, might be build type), e.g.: http://ci.ros2.org/job/ci_linux/2341/warnings22Result/