### PR TITLE
Update spin error message to match function name

### DIFF
--- a/rclcpp/src/rclcpp/executors/single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/single_threaded_executor.cpp
@@ -26,7 +26,7 @@ void
 SingleThreadedExecutor::spin()
 {
   if (spinning.exchange(true)) {
-    throw std::runtime_error("spin_some() called while already spinning");
+    throw std::runtime_error("spin() called while already spinning");
   }
   RCLCPP_SCOPE_EXIT(this->spinning.store(false); );
   while (rclcpp::utilities::ok() && spinning.load()) {


### PR DESCRIPTION
tiny fixup I noticed while poking around