### PR TITLE
Use namespaces

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -30,6 +30,7 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/exceptions.cpp
   src/rclcpp/executor.cpp
   src/rclcpp/executors.cpp
+  src/rclcpp/expand_topic_or_service_name.cpp
   src/rclcpp/executors/multi_threaded_executor.cpp
   src/rclcpp/executors/single_threaded_executor.cpp
   src/rclcpp/graph_listener.cpp
@@ -92,6 +93,16 @@ if(BUILD_TESTING)
 
   find_package(rmw_implementation_cmake REQUIRED)
 
+  ament_add_gtest(test_expand_topic_or_service_name test/test_expand_topic_or_service_name.cpp)
+  if(TARGET test_expand_topic_or_service_name)
+    target_include_directories(test_expand_topic_or_service_name PUBLIC
+      ${rcl_interfaces_INCLUDE_DIRS}
+      ${rmw_INCLUDE_DIRS}
+      ${rosidl_generator_cpp_INCLUDE_DIRS}
+      ${rosidl_typesupport_cpp_INCLUDE_DIRS}
+    )
+    target_link_libraries(test_expand_topic_or_service_name ${PROJECT_NAME})
+  endif()
   ament_add_gtest(test_function_traits test/test_function_traits.cpp)
   if(TARGET test_function_traits)
     target_include_directories(test_function_traits PUBLIC

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -93,6 +93,16 @@ if(BUILD_TESTING)
 
   find_package(rmw_implementation_cmake REQUIRED)
 
+  ament_add_gtest(test_client test/test_client.cpp)
+  if(TARGET test_client)
+    target_include_directories(test_client PUBLIC
+      ${rcl_interfaces_INCLUDE_DIRS}
+      ${rmw_INCLUDE_DIRS}
+      ${rosidl_generator_cpp_INCLUDE_DIRS}
+      ${rosidl_typesupport_cpp_INCLUDE_DIRS}
+    )
+    target_link_libraries(test_client ${PROJECT_NAME})
+  endif()
   ament_add_gtest(test_expand_topic_or_service_name test/test_expand_topic_or_service_name.cpp)
   if(TARGET test_expand_topic_or_service_name)
     target_include_directories(test_expand_topic_or_service_name PUBLIC
@@ -132,6 +142,26 @@ if(BUILD_TESTING)
       ${rosidl_typesupport_cpp_INCLUDE_DIRS}
     )
   endif()
+  ament_add_gtest(test_node test/test_node.cpp)
+  if(TARGET test_node)
+    target_include_directories(test_node PUBLIC
+      ${rcl_interfaces_INCLUDE_DIRS}
+      ${rmw_INCLUDE_DIRS}
+      ${rosidl_generator_cpp_INCLUDE_DIRS}
+      ${rosidl_typesupport_cpp_INCLUDE_DIRS}
+    )
+    target_link_libraries(test_node ${PROJECT_NAME})
+  endif()
+  ament_add_gtest(test_publisher test/test_publisher.cpp)
+  if(TARGET test_publisher)
+    target_include_directories(test_publisher PUBLIC
+      ${rcl_interfaces_INCLUDE_DIRS}
+      ${rmw_INCLUDE_DIRS}
+      ${rosidl_generator_cpp_INCLUDE_DIRS}
+      ${rosidl_typesupport_cpp_INCLUDE_DIRS}
+    )
+    target_link_libraries(test_publisher ${PROJECT_NAME})
+  endif()
   ament_add_gtest(test_rate test/test_rate.cpp
     ENV RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation})
   if(TARGET test_rate)
@@ -144,6 +174,26 @@ if(BUILD_TESTING)
     target_link_libraries(test_rate
       ${PROJECT_NAME}
     )
+  endif()
+  ament_add_gtest(test_service test/test_service.cpp)
+  if(TARGET test_service)
+    target_include_directories(test_service PUBLIC
+      ${rcl_interfaces_INCLUDE_DIRS}
+      ${rmw_INCLUDE_DIRS}
+      ${rosidl_generator_cpp_INCLUDE_DIRS}
+      ${rosidl_typesupport_cpp_INCLUDE_DIRS}
+    )
+    target_link_libraries(test_service ${PROJECT_NAME})
+  endif()
+  ament_add_gtest(test_subscription test/test_subscription.cpp)
+  if(TARGET test_subscription)
+    target_include_directories(test_subscription PUBLIC
+      ${rcl_interfaces_INCLUDE_DIRS}
+      ${rmw_INCLUDE_DIRS}
+      ${rosidl_generator_cpp_INCLUDE_DIRS}
+      ${rosidl_typesupport_cpp_INCLUDE_DIRS}
+    )
+    target_link_libraries(test_subscription ${PROJECT_NAME})
   endif()
   ament_add_gtest(test_find_weak_nodes test/test_find_weak_nodes.cpp)
   if(TARGET test_find_weak_nodes)

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -227,7 +227,7 @@ public:
     int64_t sequence_number;
     rcl_ret_t ret = rcl_send_request(get_client_handle(), request.get(), &sequence_number);
     if (RCL_RET_OK != ret) {
-      rclcpp::exceptions::throw_from_rcl_error(ret);
+      rclcpp::exceptions::throw_from_rcl_error(ret, "failed to send request");
     }
 
     SharedPromise call_promise = std::make_shared<Promise>();

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -27,11 +27,13 @@
 #include "rcl/error_handling.h"
 #include "rcl/wait.h"
 
+#include "rclcpp/exceptions.hpp"
 #include "rclcpp/function_traits.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/node_interfaces/node_graph_interface.hpp"
 #include "rclcpp/type_support_decl.hpp"
 #include "rclcpp/utilities.hpp"
+#include "rclcpp/expand_topic_or_service_name.hpp"
 #include "rclcpp/visibility_control.hpp"
 
 #include "rmw/error_handling.h"
@@ -138,14 +140,24 @@ public:
     using rosidl_typesupport_cpp::get_service_type_support_handle;
     auto service_type_support_handle =
       get_service_type_support_handle<ServiceT>();
-    if (rcl_client_init(&client_handle_, this->get_rcl_node_handle(),
-      service_type_support_handle, service_name.c_str(), &client_options) != RCL_RET_OK)
-    {
-      // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
-      throw std::runtime_error(
-        std::string("could not create client: ") +
-        rcl_get_error_string_safe());
-      // *INDENT-ON*
+    rcl_ret_t ret = rcl_client_init(
+      &client_handle_,
+      this->get_rcl_node_handle(),
+      service_type_support_handle,
+      service_name.c_str(),
+      &client_options);
+    if (ret != RCL_RET_OK) {
+      if (ret == RCL_RET_SERVICE_NAME_INVALID) {
+        auto rcl_node_handle = this->get_rcl_node_handle();
+        // this will throw on any validation problem
+        rcl_reset_error();
+        expand_topic_or_service_name(
+          service_name,
+          rcl_node_get_name(rcl_node_handle),
+          rcl_node_get_namespace(rcl_node_handle),
+          true);
+      }
+      rclcpp::exceptions::throw_from_rcl_error(ret, "could not create client");
     }
   }
 
@@ -153,7 +165,8 @@ public:
   {
     if (rcl_client_fini(&client_handle_, this->get_rcl_node_handle()) != RCL_RET_OK) {
       fprintf(stderr,
-        "Error in destruction of rmw client handle: %s\n", rmw_get_error_string_safe());
+        "Error in destruction of rcl client handle: %s\n", rcl_get_error_string_safe());
+      rcl_reset_error();
     }
   }
 
@@ -212,11 +225,9 @@ public:
   {
     std::lock_guard<std::mutex> lock(pending_requests_mutex_);
     int64_t sequence_number;
-    if (RCL_RET_OK != rcl_send_request(get_client_handle(), request.get(), &sequence_number)) {
-      // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
-      throw std::runtime_error(
-        std::string("failed to send request: ") + rcl_get_error_string_safe());
-      // *INDENT-ON*
+    rcl_ret_t ret = rcl_send_request(get_client_handle(), request.get(), &sequence_number);
+    if (RCL_RET_OK != ret) {
+      rclcpp::exceptions::throw_from_rcl_error(ret);
     }
 
     SharedPromise call_promise = std::make_shared<Promise>();

--- a/rclcpp/include/rclcpp/expand_topic_or_service_name.hpp
+++ b/rclcpp/include/rclcpp/expand_topic_or_service_name.hpp
@@ -1,0 +1,63 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__EXPAND_TOPIC_OR_SERVICE_NAME_HPP_
+#define RCLCPP__EXPAND_TOPIC_OR_SERVICE_NAME_HPP_
+
+#include <string>
+
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+
+/// Expand a topic or service name and throw if it is not valid.
+/**
+ * This function can be used to "just" validate a topic or service name too,
+ * since expanding the topic name is required to fully validate a name.
+ *
+ * If the name is invalid, then InvalidTopicNameError is thrown or
+ * InvalidServiceNameError if is_service is true.
+ *
+ * This function can take any form of a topic or service name, i.e. it does not
+ * have to be a fully qualified name.
+ * The node name and namespace are used to expand it if necessary while
+ * validating it.
+ *
+ * Expansion is done with rcl_expand_topic_name.
+ * The validation is doen with rcl_validate_topic_name and
+ * rmw_validate_full_topic_name, so details about failures can be found in the
+ * documentation for those functions.
+ *
+ * \param name the topic or service name to be validated
+ * \param node_name the name of the node associated with the name
+ * \param namespace_ the namespace of the node associated with the name
+ * \param is_service if true InvalidServiceNameError is thrown instead
+ * \returns expanded (and validated) topic name
+ * \throws InvalidTopicNameError if name is invalid and is_service is false
+ * \throws InvalidServiceNameError if name is invalid and is_service is true
+ * \throws std::bad_alloc if memory cannot be allocated
+ * \throws RCLError if an unexpect error occurs
+ */
+RCLCPP_PUBLIC
+std::string
+expand_topic_or_service_name(
+  const std::string & name,
+  const std::string & node_name,
+  const std::string & namespace_,
+  bool is_service = false);
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__EXPAND_TOPIC_OR_SERVICE_NAME_HPP_

--- a/rclcpp/include/rclcpp/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager.hpp
@@ -55,7 +55,7 @@ namespace intra_process_manager
  * When a publisher is created, it advertises on the topic the user provided,
  * as well as a "shadowing" topic of type rcl_interfaces/IntraProcessMessage.
  * For instance, if the user specified the topic '/namespace/chatter', then the
- * corresponding intra process topic might be '/namespace/chatter__intra'.
+ * corresponding intra process topic might be '/namespace/chatter/_intra'.
  * The publisher is also allocated an id which is unique among all publishers
  * and subscriptions in this process.
  * Additionally, when registered with this class a ring buffer is created and

--- a/rclcpp/src/rclcpp/expand_topic_or_service_name.cpp
+++ b/rclcpp/src/rclcpp/expand_topic_or_service_name.cpp
@@ -1,0 +1,196 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/expand_topic_or_service_name.hpp"
+
+#include <string>
+
+#include "rcl/expand_topic_name.h"
+#include "rcl/validate_topic_name.h"
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/scope_exit.hpp"
+#include "rcutils/types/string_map.h"
+#include "rmw/error_handling.h"
+#include "rmw/validate_namespace.h"
+#include "rmw/validate_node_name.h"
+#include "rmw/validate_full_topic_name.h"
+
+using rclcpp::exceptions::throw_from_rcl_error;
+
+std::string
+rclcpp::expand_topic_or_service_name(
+  const std::string & name,
+  const std::string & node_name,
+  const std::string & namespace_,
+  bool is_service)
+{
+  char * expanded_topic = nullptr;
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  rcutils_allocator_t rcutils_allocator = rcutils_get_default_allocator();
+  rcutils_string_map_t substitutions_map = rcutils_get_zero_initialized_string_map();
+
+  rcutils_ret_t rcutils_ret = rcutils_string_map_init(&substitutions_map, 0, rcutils_allocator);
+  if (rcutils_ret != RCUTILS_RET_OK) {
+    if (rcutils_ret == RCUTILS_RET_BAD_ALLOC) {
+      throw_from_rcl_error(RCL_RET_BAD_ALLOC, "", rcutils_get_error_state(), rcutils_reset_error);
+    } else {
+      throw_from_rcl_error(RCL_RET_ERROR, "", rcutils_get_error_state(), rcutils_reset_error);
+    }
+  }
+  rcl_ret_t ret = rcl_get_default_topic_name_substitutions(&substitutions_map);
+  if (ret != RCL_RET_OK) {
+    rcutils_error_state_t error_state;
+    if (rcutils_error_state_copy(rcl_get_error_state(), &error_state) != RCUTILS_RET_OK) {
+      throw std::bad_alloc();
+    }
+    auto error_state_scope_exit = rclcpp::make_scope_exit([&error_state]() {
+      rcutils_error_state_fini(&error_state);
+    });
+    // finalize the string map before throwing
+    rcutils_ret = rcutils_string_map_fini(&substitutions_map);
+    if (rcutils_ret != RCUTILS_RET_OK) {
+      fprintf(stderr,
+        "[rclcpp|" RCUTILS_STRINGIFY(__FILE__) ":" RCUTILS_STRINGIFY(__LINE__) "]: "
+        "failed to fini string_map (%d) during error handling: %s\n",
+        rcutils_ret,
+        rcutils_get_error_string_safe());
+      rcutils_reset_error();
+    }
+    throw_from_rcl_error(ret, "", &error_state);
+  }
+
+  ret = rcl_expand_topic_name(
+    name.c_str(),
+    node_name.c_str(),
+    namespace_.c_str(),
+    &substitutions_map,
+    allocator,
+    &expanded_topic);
+
+  std::string result;
+  if (ret == RCL_RET_OK) {
+    result = expanded_topic;
+    allocator.deallocate(expanded_topic, allocator.state);
+  }
+
+  rcutils_ret = rcutils_string_map_fini(&substitutions_map);
+  if (rcutils_ret != RCUTILS_RET_OK) {
+    throw_from_rcl_error(RCL_RET_ERROR, "", rcutils_get_error_state(), rcutils_reset_error);
+  }
+
+  // expansion failed
+  if (ret != RCL_RET_OK) {
+    // if invalid topic or unknown substitution
+    if (ret == RCL_RET_TOPIC_NAME_INVALID || ret == RCL_RET_UNKNOWN_SUBSTITUTION) {
+      rcl_reset_error();  // explicitly discard error from rcl_expand_topic_name()
+      int validation_result;
+      size_t invalid_index;
+      rcl_ret_t ret = rcl_validate_topic_name(name.c_str(), &validation_result, &invalid_index);
+      if (ret != RCL_RET_OK) {
+        throw_from_rcl_error(ret);
+      }
+
+      if (validation_result == RCL_TOPIC_NAME_VALID) {
+        throw std::runtime_error("topic name unexpectedly valid");
+      }
+      const char * validation_message = rcl_topic_name_validation_result_string(validation_result);
+      if (!validation_message) {
+        throw std::runtime_error("unable to get validation error message");
+      }
+      if (is_service) {
+        using rclcpp::exceptions::InvalidServiceNameError;
+        throw InvalidServiceNameError(name.c_str(), validation_message, invalid_index);
+      } else {
+        using rclcpp::exceptions::InvalidTopicNameError;
+        throw InvalidTopicNameError(name.c_str(), validation_message, invalid_index);
+      }
+      // if invalid node name
+    } else if (ret == RCL_RET_NODE_INVALID_NAME) {
+      rcl_reset_error();  // explicitly discard error from rcl_expand_topic_name()
+      int validation_result;
+      size_t invalid_index;
+      rmw_ret_t rmw_ret =
+        rmw_validate_node_name(node_name.c_str(), &validation_result, &invalid_index);
+      if (rmw_ret != RMW_RET_OK) {
+        if (rmw_ret == RMW_RET_INVALID_ARGUMENT) {
+          throw_from_rcl_error(
+            RCL_RET_INVALID_ARGUMENT, "failed to validate node name",
+            rmw_get_error_state(), rmw_reset_error);
+        }
+        throw_from_rcl_error(
+          RCL_RET_ERROR, "failed to validate node name",
+          rmw_get_error_state(), rmw_reset_error);
+      }
+      throw rclcpp::exceptions::InvalidNodeNameError(
+              node_name.c_str(),
+              rmw_node_name_validation_result_string(validation_result),
+              invalid_index);
+      // if invalid namespace
+    } else if (ret == RCL_RET_NODE_INVALID_NAMESPACE) {
+      rcl_reset_error();  // explicitly discard error from rcl_expand_topic_name()
+      int validation_result;
+      size_t invalid_index;
+      rmw_ret_t rmw_ret =
+        rmw_validate_namespace(namespace_.c_str(), &validation_result, &invalid_index);
+      if (rmw_ret != RMW_RET_OK) {
+        if (rmw_ret == RMW_RET_INVALID_ARGUMENT) {
+          throw_from_rcl_error(
+            RCL_RET_INVALID_ARGUMENT, "failed to validate namespace",
+            rmw_get_error_state(), rmw_reset_error);
+        }
+        throw_from_rcl_error(
+          RCL_RET_ERROR, "failed to validate namespace",
+          rmw_get_error_state(), rmw_reset_error);
+      }
+      throw rclcpp::exceptions::InvalidNamespaceError(
+              namespace_.c_str(),
+              rmw_namespace_validation_result_string(validation_result),
+              invalid_index);
+      // something else happened
+    } else {
+      throw_from_rcl_error(ret);
+    }
+  }
+
+  // expand succeeded, but full name validation may fail still
+  int validation_result;
+  size_t invalid_index;
+  rmw_ret_t rmw_ret =
+    rmw_validate_full_topic_name(result.c_str(), &validation_result, &invalid_index);
+  if (rmw_ret != RMW_RET_OK) {
+    if (rmw_ret == RMW_RET_INVALID_ARGUMENT) {
+      throw_from_rcl_error(
+        RCL_RET_INVALID_ARGUMENT, "failed to validate full topic name",
+        rmw_get_error_state(), rmw_reset_error);
+    }
+    throw_from_rcl_error(
+      RCL_RET_ERROR, "failed to validate full topic name",
+      rmw_get_error_state(), rmw_reset_error);
+  }
+  if (validation_result != RMW_TOPIC_VALID) {
+    if (is_service) {
+      throw rclcpp::exceptions::InvalidServiceNameError(
+              result.c_str(),
+              rmw_full_topic_name_validation_result_string(validation_result),
+              invalid_index);
+    } else {
+      throw rclcpp::exceptions::InvalidTopicNameError(
+              result.c_str(),
+              rmw_full_topic_name_validation_result_string(validation_result),
+              invalid_index);
+    }
+  }
+
+  return result;
+}

--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -51,3 +51,9 @@ ServiceBase::get_service_handle()
 {
   return service_handle_;
 }
+
+rcl_node_t *
+ServiceBase::get_rcl_node_handle() const
+{
+  return node_handle_.get();
+}

--- a/rclcpp/test/test_client.cpp
+++ b/rclcpp/test/test_client.cpp
@@ -1,0 +1,60 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include "rcl_interfaces/srv/list_parameters.hpp"
+
+class TestClient : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void SetUp()
+  {
+    node = std::make_shared<rclcpp::node::Node>("my_node", "/ns");
+  }
+
+  void TearDown()
+  {
+    node.reset();
+  }
+
+  rclcpp::node::Node::SharedPtr node;
+};
+
+/*
+   Testing client construction and destruction.
+ */
+TEST_F(TestClient, construction_and_destruction) {
+  using rcl_interfaces::srv::ListParameters;
+  {
+    auto client = node->create_client<ListParameters>("service");
+  }
+
+  {
+    ASSERT_THROW({
+      auto client = node->create_client<ListParameters>("invalid_service?");
+    }, rclcpp::exceptions::InvalidServiceNameError);
+  }
+}

--- a/rclcpp/test/test_expand_topic_or_service_name.cpp
+++ b/rclcpp/test/test_expand_topic_or_service_name.cpp
@@ -1,0 +1,74 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/expand_topic_or_service_name.hpp"
+
+/*
+   Testing expand_topic_or_service_name.
+ */
+TEST(TestExpandTopicOrServiceName, normal) {
+  using rclcpp::expand_topic_or_service_name;
+  {
+    ASSERT_EQ("/ns/chatter", expand_topic_or_service_name("chatter", "node", "/ns"));
+  }
+}
+
+/*
+   Testing exceptions of expand_topic_or_service_name.
+ */
+TEST(TestExpandTopicOrServiceName, exceptions) {
+  using rclcpp::expand_topic_or_service_name;
+  {
+    ASSERT_THROW({
+      expand_topic_or_service_name("chatter", "invalid_node?", "/ns");
+    }, rclcpp::exceptions::InvalidNodeNameError);
+  }
+
+  {
+    ASSERT_THROW({
+      expand_topic_or_service_name("chatter", "node", "/invalid_ns?");
+    }, rclcpp::exceptions::InvalidNamespaceError);
+  }
+
+  {
+    ASSERT_THROW({
+      expand_topic_or_service_name("chatter/42invalid", "node", "/ns");
+    }, rclcpp::exceptions::InvalidTopicNameError);
+  }
+
+  {
+    ASSERT_THROW({
+      // this one will only fail on the "full" topic name validation check
+      expand_topic_or_service_name("chatter/{ns}/invalid", "node", "/ns");
+    }, rclcpp::exceptions::InvalidTopicNameError);
+  }
+
+  {
+    ASSERT_THROW({
+      // is_service = true
+      expand_topic_or_service_name("chatter/42invalid", "node", "/ns", true);
+    }, rclcpp::exceptions::InvalidServiceNameError);
+  }
+
+  {
+    ASSERT_THROW({
+      // is_service = true
+      // this one will only fail on the "full" topic name validation check
+      expand_topic_or_service_name("chatter/{ns}/invalid", "node", "/ns", true);
+    }, rclcpp::exceptions::InvalidServiceNameError);
+  }
+}

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -1,0 +1,52 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+class TestNode : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+};
+
+/*
+   Testing node construction and destruction.
+ */
+TEST_F(TestNode, construction_and_destruction) {
+  {
+    auto node = std::make_shared<rclcpp::node::Node>("my_node", "/ns");
+  }
+
+  {
+    ASSERT_THROW({
+      auto node = std::make_shared<rclcpp::node::Node>("invalid_node?", "/ns");
+    }, rclcpp::exceptions::InvalidNodeNameError);
+  }
+
+  {
+    ASSERT_THROW({
+      auto node = std::make_shared<rclcpp::node::Node>("my_node", "/invalid_ns?");
+    }, rclcpp::exceptions::InvalidNamespaceError);
+  }
+}

--- a/rclcpp/test/test_publisher.cpp
+++ b/rclcpp/test/test_publisher.cpp
@@ -1,0 +1,60 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include "rcl_interfaces/msg/intra_process_message.hpp"
+
+class TestPublisher : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void SetUp()
+  {
+    node = std::make_shared<rclcpp::node::Node>("my_node", "/ns");
+  }
+
+  void TearDown()
+  {
+    node.reset();
+  }
+
+  rclcpp::node::Node::SharedPtr node;
+};
+
+/*
+   Testing publisher construction and destruction.
+ */
+TEST_F(TestPublisher, construction_and_destruction) {
+  using rcl_interfaces::msg::IntraProcessMessage;
+  {
+    auto publisher = node->create_publisher<IntraProcessMessage>("topic");
+  }
+
+  {
+    ASSERT_THROW({
+      auto publisher = node->create_publisher<IntraProcessMessage>("invalid_topic?");
+    }, rclcpp::exceptions::InvalidTopicNameError);
+  }
+}

--- a/rclcpp/test/test_service.cpp
+++ b/rclcpp/test/test_service.cpp
@@ -1,0 +1,63 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include "rcl_interfaces/srv/list_parameters.hpp"
+
+class TestService : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void SetUp()
+  {
+    node = std::make_shared<rclcpp::node::Node>("my_node", "/ns");
+  }
+
+  void TearDown()
+  {
+    node.reset();
+  }
+
+  rclcpp::node::Node::SharedPtr node;
+};
+
+/*
+   Testing service construction and destruction.
+ */
+TEST_F(TestService, construction_and_destruction) {
+  using rcl_interfaces::srv::ListParameters;
+  auto callback =
+    [](const ListParameters::Request::SharedPtr, ListParameters::Response::SharedPtr) {
+    };
+  {
+    auto service = node->create_service<ListParameters>("service", callback);
+  }
+
+  {
+    ASSERT_THROW({
+      auto service = node->create_service<ListParameters>("invalid_service?", callback);
+    }, rclcpp::exceptions::InvalidServiceNameError);
+  }
+}

--- a/rclcpp/test/test_subscription.cpp
+++ b/rclcpp/test/test_subscription.cpp
@@ -1,0 +1,63 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include "rcl_interfaces/msg/intra_process_message.hpp"
+
+class TestSubscription : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void SetUp()
+  {
+    node = std::make_shared<rclcpp::node::Node>("my_node", "/ns");
+  }
+
+  void TearDown()
+  {
+    node.reset();
+  }
+
+  rclcpp::node::Node::SharedPtr node;
+};
+
+/*
+   Testing subscription construction and destruction.
+ */
+TEST_F(TestSubscription, construction_and_destruction) {
+  using rcl_interfaces::msg::IntraProcessMessage;
+  auto callback = [](const IntraProcessMessage::SharedPtr msg) {
+      (void)msg;
+    };
+  {
+    auto sub = node->create_subscription<IntraProcessMessage>("topic", callback);
+  }
+
+  {
+    ASSERT_THROW({
+      auto sub = node->create_subscription<IntraProcessMessage>("invalid_topic?", callback);
+    }, rclcpp::exceptions::InvalidTopicNameError);
+  }
+}


### PR DESCRIPTION
Connects to ros2/rcl#137

Examples of it in use:

```
% talker -t /foo/3bar
libc++abi.dylib: terminating with uncaught exception of type rclcpp::exceptions::InvalidTopicNameError: Invalid topic name: topic name token must not start with a number:
  '/foo/3bar'
        ^

[1]    82558 abort      talker -t /foo/3bar
```

"full" topic name check (post expansion check):

```
% talker -t /foo/{ns}/bar
libc++abi.dylib: terminating with uncaught exception of type rclcpp::exceptions::InvalidTopicNameError: Invalid topic name: topic name must not contain repeated '/':
  '/foo///bar'
        ^

[1]    82579 abort      talker -t /foo/{ns}/bar
```

Services:

```
% add_two_ints_client -s foo/3bar
libc++abi.dylib: terminating with uncaught exception of type rclcpp::exceptions::InvalidServiceNameError: Invalid service name: topic name token must not start with a number:
  'foo/3bar'
       ^

[1]    82599 abort      add_two_ints_client -s foo/3bar
```

```
% add_two_ints_client -s foo/3bar
libc++abi.dylib: terminating with uncaught exception of type rclcpp::exceptions::InvalidServiceNameError: Invalid service name: topic name token must not start with a number:
  'foo/3bar'
       ^

[1]    82599 abort      add_two_ints_client -s foo/3bar
```

Node name (locally modified):

```
% talker
libc++abi.dylib: terminating with uncaught exception of type rclcpp::exceptions::InvalidNodeNameError: Invalid node name: node name must not contain characters other than alphanumerics or '_':
  'invalid_talker?'
                 ^

[1]    83140 abort      talker
```

Namespace (locally modified):

```
% talker
libc++abi.dylib: terminating with uncaught exception of type rclcpp::exceptions::InvalidNamespaceError: Invalid namespace: namespace must not contain characters other than alphanumerics, '_', or '/':
  '/invalid_ns?'
              ^

[1]    83509 abort      talker
```