### PR TITLE
Topic names

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -102,7 +102,7 @@ public:
   get_name() const;
 
   /// Get the namespace of the node.
-  /** \return The namesoace of the node. */
+  /** \return The namespace of the node. */
   RCLCPP_PUBLIC
   const char *
   get_namespace() const;

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -101,6 +101,12 @@ public:
   const char *
   get_name() const;
 
+  /// Get the namespace of the node.
+  /** \return The namesoace of the node. */
+  RCLCPP_PUBLIC
+  const char *
+  get_namespace() const;
+
   /// Create and return a callback group.
   RCLCPP_PUBLIC
   rclcpp::callback_group::CallbackGroup::SharedPtr

--- a/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
@@ -52,6 +52,11 @@ public:
 
   RCLCPP_PUBLIC
   virtual
+  const char *
+  get_namespace() const;
+
+  RCLCPP_PUBLIC
+  virtual
   rclcpp::context::Context::SharedPtr
   get_context();
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
@@ -45,6 +45,13 @@ public:
   const char *
   get_name() const = 0;
 
+  /// Return the namespace of the node.
+  /** \return The namespace of the node. */
+  RCLCPP_PUBLIC
+  virtual
+  const char *
+  get_namespace() const = 0;
+
   /// Return the context of the node.
   /** \return SharedPtr to the node's context. */
   RCLCPP_PUBLIC

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -71,6 +71,12 @@ Node::get_name() const
   return node_base_->get_name();
 }
 
+const char *
+Node::get_namespace() const
+{
+  return node_base_->get_namespace();
+}
+
 rclcpp::callback_group::CallbackGroup::SharedPtr
 Node::create_callback_group(
   rclcpp::callback_group::CallbackGroupType group_type)

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -166,6 +166,12 @@ NodeBase::get_name() const
   return rcl_node_get_name(node_handle_.get());
 }
 
+const char *
+NodeBase::get_namespace() const
+{
+  return rcl_node_get_namespace(node_handle_.get());
+}
+
 rclcpp::context::Context::SharedPtr
 NodeBase::get_context()
 {

--- a/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
@@ -120,10 +120,16 @@ NodeGraph::get_node_names() const
 size_t
 NodeGraph::count_publishers(const std::string & topic_name) const
 {
+  auto rmw_node_handle = rcl_node_get_rmw_handle(node_base_->get_rcl_node_handle());
+  auto fqdn = rclcpp::expand_topic_or_service_name(
+      topic_name,
+      rmw_node_handle->name,
+      rmw_node_handle->namespace_,
+      false);  // false = not a service
+
   size_t count;
   // TODO(wjwwood): use the rcl equivalent methods
-  auto ret = rmw_count_publishers(rcl_node_get_rmw_handle(node_base_->get_rcl_node_handle()),
-      topic_name.c_str(), &count);
+  auto ret = rmw_count_publishers(rmw_node_handle, fqdn.c_str(), &count);
   if (ret != RMW_RET_OK) {
     // *INDENT-OFF*
     throw std::runtime_error(
@@ -136,10 +142,16 @@ NodeGraph::count_publishers(const std::string & topic_name) const
 size_t
 NodeGraph::count_subscribers(const std::string & topic_name) const
 {
+  auto rmw_node_handle = rcl_node_get_rmw_handle(node_base_->get_rcl_node_handle());
+  auto fqdn = rclcpp::expand_topic_or_service_name(
+      topic_name,
+      rmw_node_handle->name,
+      rmw_node_handle->namespace_,
+      false);  // false = not a service
+
   size_t count;
   // TODO(wjwwood): use the rcl equivalent methods
-  auto ret = rmw_count_subscribers(rcl_node_get_rmw_handle(node_base_->get_rcl_node_handle()),
-      topic_name.c_str(), &count);
+  auto ret = rmw_count_subscribers(rmw_node_handle, fqdn.c_str(), &count);
   if (ret != RMW_RET_OK) {
     // *INDENT-OFF*
     throw std::runtime_error(

--- a/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
@@ -122,10 +122,10 @@ NodeGraph::count_publishers(const std::string & topic_name) const
 {
   auto rmw_node_handle = rcl_node_get_rmw_handle(node_base_->get_rcl_node_handle());
   auto fqdn = rclcpp::expand_topic_or_service_name(
-      topic_name,
-      rmw_node_handle->name,
-      rmw_node_handle->namespace_,
-      false);  // false = not a service
+    topic_name,
+    rmw_node_handle->name,
+    rmw_node_handle->namespace_,
+    false);    // false = not a service
 
   size_t count;
   // TODO(wjwwood): use the rcl equivalent methods
@@ -144,10 +144,10 @@ NodeGraph::count_subscribers(const std::string & topic_name) const
 {
   auto rmw_node_handle = rcl_node_get_rmw_handle(node_base_->get_rcl_node_handle());
   auto fqdn = rclcpp::expand_topic_or_service_name(
-      topic_name,
-      rmw_node_handle->name,
-      rmw_node_handle->namespace_,
-      false);  // false = not a service
+    topic_name,
+    rmw_node_handle->name,
+    rmw_node_handle->namespace_,
+    false);    // false = not a service
 
   size_t count;
   // TODO(wjwwood): use the rcl equivalent methods

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -50,3 +50,26 @@ TEST_F(TestNode, construction_and_destruction) {
     }, rclcpp::exceptions::InvalidNamespaceError);
   }
 }
+
+TEST_F(TestNode, get_name_and_namespace) {
+  {
+    auto node = std::make_shared<rclcpp::node::Node>("my_node", "/ns");
+    EXPECT_STREQ("my_node", node->get_name());
+    EXPECT_STREQ("/ns", node->get_namespace());
+  }
+  {
+    auto node = std::make_shared<rclcpp::node::Node>("my_node", "ns");
+    EXPECT_STREQ("my_node", node->get_name());
+    EXPECT_STREQ("/ns", node->get_namespace());
+  }
+  {
+    auto node = std::make_shared<rclcpp::node::Node>("my_node", "/my/ns");
+    EXPECT_STREQ("my_node", node->get_name());
+    EXPECT_STREQ("/my/ns", node->get_namespace());
+  }
+  {
+    auto node = std::make_shared<rclcpp::node::Node>("my_node", "my/ns");
+    EXPECT_STREQ("my_node", node->get_name());
+    EXPECT_STREQ("/my/ns", node->get_namespace());
+  }
+}

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -102,6 +102,12 @@ public:
   const char *
   get_name() const;
 
+  /// Get the namespace of the node.
+  // \return The namespace of the node.
+  RCLCPP_LIFECYCLE_PUBLIC
+  const char *
+  get_namespace() const;
+
   /// Create and return a callback group.
   RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::callback_group::CallbackGroup::SharedPtr

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -89,6 +89,12 @@ LifecycleNode::get_name() const
   return node_base_->get_name();
 }
 
+const char *
+LifecycleNode::get_namespace() const
+{
+  return node_base_->get_namespace();
+}
+
 rclcpp::callback_group::CallbackGroup::SharedPtr
 LifecycleNode::create_callback_group(
   rclcpp::callback_group::CallbackGroupType group_type)

--- a/rclcpp_lifecycle/test/test_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_node.cpp
@@ -123,7 +123,8 @@ rcl_lifecycle_ret_t MoodyLifecycleNode<BadMood>::on_error(const rclcpp_lifecycle
 
 TEST_F(TestDefaultStateMachine, empty_initializer) {
   auto test_node = std::make_shared<EmptyLifecycleNode>("testnode");
-
+  EXPECT_STREQ("testnode", test_node->get_name());
+  EXPECT_STREQ("/", test_node->get_namespace());
   EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
 }
 


### PR DESCRIPTION
connects to ros2/rmw_fastrtps#114

will expand the topic name before asking `count_publisher` and `count_subscriber`. 
While doing, I noticed there is no cpp function for getting the node namespace, which is added in this PR as well. However, I am fine with removing that commit from this PR and open another one.