### PR TITLE
Remove a constructor that we can't test.

### DIFF
--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -62,10 +62,6 @@ public:
 private:
   rcl_time_point_value_t rcl_time_;
 
-  Time(std::uint32_t sec, std::uint32_t nanosec)
-  : rcl_time_(RCL_S_TO_NS(sec) + nanosec)
-  {}
-
   explicit Time(rcl_time_point_value_t && rcl_time)
   : rcl_time_(std::forward<decltype(rcl_time)>(rcl_time))
   {}


### PR DESCRIPTION
There are currently no paths that lead to it, and it has
a bug anyway; if a large enough value is passed into sec,
then we will overflow sec on the multiply.  Just remove it
since we can't reach the code anyway.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2772)](http://ci.ros2.org/job/ci_linux/2772/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=305)](http://ci.ros2.org/job/ci_linux-aarch64/305/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2246)](http://ci.ros2.org/job/ci_osx/2246/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2913)](http://ci.ros2.org/job/ci_windows/2913/)