### PR TITLE
expose error handling for state changes

### DIFF
--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -373,7 +373,15 @@ public:
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
+  trigger_transition(const Transition & transition, rcl_ret_t & error);
+
+  RCLCPP_LIFECYCLE_PUBLIC
+  const State &
   trigger_transition(uint8_t transition_id);
+
+  RCLCPP_LIFECYCLE_PUBLIC
+  const State &
+  trigger_transition(uint8_t transition_id, rcl_lifecycle_ret_t & error);
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
@@ -381,7 +389,15 @@ public:
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
+  configure(rcl_lifecycle_ret_t & error);
+
+  RCLCPP_LIFECYCLE_PUBLIC
+  const State &
   cleanup();
+
+  RCLCPP_LIFECYCLE_PUBLIC
+  const State &
+  cleanup(rcl_lifecycle_ret_t & error);
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
@@ -389,11 +405,23 @@ public:
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
+  activate(rcl_lifecycle_ret_t & error);
+
+  RCLCPP_LIFECYCLE_PUBLIC
+  const State &
   deactivate();
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
+  deactivate(rcl_lifecycle_ret_t & error);
+
+  RCLCPP_LIFECYCLE_PUBLIC
+  const State &
   shutdown();
+
+  RCLCPP_LIFECYCLE_PUBLIC
+  const State &
+  shutdown(rcl_lifecycle_ret_t & error);
 
   RCLCPP_LIFECYCLE_PUBLIC
   bool

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -373,7 +373,7 @@ public:
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
-  trigger_transition(const Transition & transition, rcl_ret_t & error);
+  trigger_transition(const Transition & transition, rcl_lifecycle_ret_t & cb_return_code);
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
@@ -381,7 +381,7 @@ public:
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
-  trigger_transition(uint8_t transition_id, rcl_lifecycle_ret_t & error);
+  trigger_transition(uint8_t transition_id, rcl_lifecycle_ret_t & cb_return_code);
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
@@ -389,7 +389,7 @@ public:
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
-  configure(rcl_lifecycle_ret_t & error);
+  configure(rcl_lifecycle_ret_t & cb_return_code);
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
@@ -397,7 +397,7 @@ public:
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
-  cleanup(rcl_lifecycle_ret_t & error);
+  cleanup(rcl_lifecycle_ret_t & cb_return_code);
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
@@ -405,7 +405,7 @@ public:
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
-  activate(rcl_lifecycle_ret_t & error);
+  activate(rcl_lifecycle_ret_t & cb_return_code);
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
@@ -413,7 +413,7 @@ public:
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
-  deactivate(rcl_lifecycle_ret_t & error);
+  deactivate(rcl_lifecycle_ret_t & cb_return_code);
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
@@ -421,7 +421,7 @@ public:
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
-  shutdown(rcl_lifecycle_ret_t & error);
+  shutdown(rcl_lifecycle_ret_t & cb_return_code);
 
   RCLCPP_LIFECYCLE_PUBLIC
   bool

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -306,9 +306,21 @@ LifecycleNode::trigger_transition(const Transition & transition)
 }
 
 const State &
+LifecycleNode::trigger_transition(const Transition & transition, rcl_ret_t & error)
+{
+  return trigger_transition(transition.id(), error);
+}
+
+const State &
 LifecycleNode::trigger_transition(uint8_t transition_id)
 {
   return impl_->trigger_transition(transition_id);
+}
+
+const State &
+LifecycleNode::trigger_transition(uint8_t transition_id, rcl_ret_t & error)
+{
+  return impl_->trigger_transition(transition_id, error);
 }
 
 const State &
@@ -319,10 +331,24 @@ LifecycleNode::configure()
 }
 
 const State &
+LifecycleNode::configure(rcl_lifecycle_ret_t & error)
+{
+  return impl_->trigger_transition(
+    lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE, error);
+}
+
+const State &
 LifecycleNode::cleanup()
 {
   return impl_->trigger_transition(
     lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP);
+}
+
+const State &
+LifecycleNode::cleanup(rcl_lifecycle_ret_t & error)
+{
+  return impl_->trigger_transition(
+    lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP, error);
 }
 
 const State &
@@ -333,6 +359,13 @@ LifecycleNode::activate()
 }
 
 const State &
+LifecycleNode::activate(rcl_lifecycle_ret_t & error)
+{
+  return impl_->trigger_transition(
+    lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE, error);
+}
+
+const State &
 LifecycleNode::deactivate()
 {
   return impl_->trigger_transition(
@@ -340,10 +373,24 @@ LifecycleNode::deactivate()
 }
 
 const State &
+LifecycleNode::deactivate(rcl_lifecycle_ret_t & error)
+{
+  return impl_->trigger_transition(
+    lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE, error);
+}
+
+const State &
 LifecycleNode::shutdown()
 {
   return impl_->trigger_transition(
     lifecycle_msgs::msg::Transition::TRANSITION_SHUTDOWN);
+}
+
+const State &
+LifecycleNode::shutdown(rcl_lifecycle_ret_t & error)
+{
+  return impl_->trigger_transition(
+    lifecycle_msgs::msg::Transition::TRANSITION_SHUTDOWN, error);
 }
 
 void

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -306,9 +306,10 @@ LifecycleNode::trigger_transition(const Transition & transition)
 }
 
 const State &
-LifecycleNode::trigger_transition(const Transition & transition, rcl_ret_t & error)
+LifecycleNode::trigger_transition(
+  const Transition & transition, rcl_lifecycle_ret_t & cb_return_code)
 {
-  return trigger_transition(transition.id(), error);
+  return trigger_transition(transition.id(), cb_return_code);
 }
 
 const State &
@@ -318,9 +319,10 @@ LifecycleNode::trigger_transition(uint8_t transition_id)
 }
 
 const State &
-LifecycleNode::trigger_transition(uint8_t transition_id, rcl_ret_t & error)
+LifecycleNode::trigger_transition(
+  uint8_t transition_id, rcl_lifecycle_ret_t & cb_return_code)
 {
-  return impl_->trigger_transition(transition_id, error);
+  return impl_->trigger_transition(transition_id, cb_return_code);
 }
 
 const State &
@@ -331,10 +333,10 @@ LifecycleNode::configure()
 }
 
 const State &
-LifecycleNode::configure(rcl_lifecycle_ret_t & error)
+LifecycleNode::configure(rcl_lifecycle_ret_t & cb_return_code)
 {
   return impl_->trigger_transition(
-    lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE, error);
+    lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE, cb_return_code);
 }
 
 const State &
@@ -345,10 +347,10 @@ LifecycleNode::cleanup()
 }
 
 const State &
-LifecycleNode::cleanup(rcl_lifecycle_ret_t & error)
+LifecycleNode::cleanup(rcl_lifecycle_ret_t & cb_return_code)
 {
   return impl_->trigger_transition(
-    lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP, error);
+    lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP, cb_return_code);
 }
 
 const State &
@@ -359,10 +361,10 @@ LifecycleNode::activate()
 }
 
 const State &
-LifecycleNode::activate(rcl_lifecycle_ret_t & error)
+LifecycleNode::activate(rcl_lifecycle_ret_t & cb_return_code)
 {
   return impl_->trigger_transition(
-    lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE, error);
+    lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE, cb_return_code);
 }
 
 const State &
@@ -373,10 +375,10 @@ LifecycleNode::deactivate()
 }
 
 const State &
-LifecycleNode::deactivate(rcl_lifecycle_ret_t & error)
+LifecycleNode::deactivate(rcl_lifecycle_ret_t & cb_return_code)
 {
   return impl_->trigger_transition(
-    lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE, error);
+    lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE, cb_return_code);
 }
 
 const State &
@@ -387,10 +389,10 @@ LifecycleNode::shutdown()
 }
 
 const State &
-LifecycleNode::shutdown(rcl_lifecycle_ret_t & error)
+LifecycleNode::shutdown(rcl_lifecycle_ret_t & cb_return_code)
 {
   return impl_->trigger_transition(
-    lifecycle_msgs::msg::Transition::TRANSITION_SHUTDOWN, error);
+    lifecycle_msgs::msg::Transition::TRANSITION_SHUTDOWN, cb_return_code);
 }
 
 void

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -40,6 +40,8 @@
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/node_interfaces/node_services_interface.hpp"
 
+#include "rcutils/logging_macros.h"
+
 namespace rclcpp_lifecycle
 {
 
@@ -179,7 +181,8 @@ public:
       throw std::runtime_error(
               "Can't get state. State machine is not initialized.");
     }
-    resp->success = change_state(req->transition.id);
+    auto ret = change_state(req->transition.id);
+    resp->success = (ret == RCL_RET_OK) ? true : false;
   }
 
   void
@@ -226,7 +229,6 @@ public:
     if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
       throw std::runtime_error(
               "Can't get available transitions. State machine is not initialized.");
-      return;
     }
 
     for (uint8_t i = 0; i < state_machine_.transition_map.transitions_size; ++i) {
@@ -273,13 +275,13 @@ public:
     return transitions;
   }
 
-  bool
+  rcl_ret_t
   change_state(std::uint8_t lifecycle_transition)
   {
     if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
-      fprintf(stderr, "%s:%d, Unable to change state for state machine for %s: %s \n",
-        __FILE__, __LINE__, node_base_interface_->get_name(), rcl_get_error_string_safe());
-      return false;
+      RCUTILS_LOG_ERROR("Unable to change state for state machine for %s: %s",
+        node_base_interface_->get_name(), rcl_get_error_string_safe())
+      return RCL_RET_ERROR;
     }
 
     // keep the initial state to pass to a transition callback
@@ -287,10 +289,9 @@ public:
 
     uint8_t transition_id = lifecycle_transition;
     if (rcl_lifecycle_trigger_transition(&state_machine_, transition_id, true) != RCL_RET_OK) {
-      fprintf(stderr, "%s:%d, Unable to start transition %u from current state %s: %s\n",
-        __FILE__, __LINE__, transition_id,
-        state_machine_.current_state->label, rcl_get_error_string_safe());
-      return false;
+      RCUTILS_LOG_ERROR("Unable to start transition %u from current state %s: %s",
+        transition_id, state_machine_.current_state->label, rcl_get_error_string_safe())
+      return RCL_RET_ERROR;
     }
 
     rcl_lifecycle_ret_t cb_success = execute_callback(
@@ -299,37 +300,35 @@ public:
     if (rcl_lifecycle_trigger_transition(
         &state_machine_, cb_success, true) != RCL_RET_OK)
     {
-      fprintf(stderr, "Failed to finish transition %u. Current state is now: %s\n",
-        transition_id, state_machine_.current_state->label);
-      return false;
+      RCUTILS_LOG_ERROR("Failed to finish transition %u. Current state is now: %s",
+        transition_id, state_machine_.current_state->label)
+      return RCL_RET_ERROR;
     }
 
     // error handling ?!
     // TODO(karsten1987): iterate over possible ret value
     if (cb_success == RCL_LIFECYCLE_RET_ERROR) {
+      RCUTILS_LOG_WARN("Error occured. Executing error handling.")
       rcl_lifecycle_ret_t error_resolved = execute_callback(state_machine_.current_state->id,
           initial_state);
       if (error_resolved == RCL_RET_OK) {
-        // fprintf(stderr, "Exception handling was successful\n");
         // We call cleanup on the error state
         if (rcl_lifecycle_trigger_transition(&state_machine_, error_resolved, true) != RCL_RET_OK) {
-          fprintf(stderr, "Failed to call cleanup on error state\n");
-          return false;
+          RCUTILS_LOG_ERROR("Failed to call cleanup on error state");
+          return RCL_RET_ERROR;
         }
-        // fprintf(stderr, "current state after error callback%s\n",
-        //  state_machine_.current_state->label);
       } else {
         // We call shutdown on the error state
         if (rcl_lifecycle_trigger_transition(&state_machine_, error_resolved, true) != RCL_RET_OK) {
-          fprintf(stderr, "Failed to call cleanup on error state\n");
-          return false;
+          RCUTILS_LOG_ERROR("Failed to call cleanup on error state");
+          return RCL_RET_ERROR;
         }
       }
     }
     // This true holds in both cases where the actual callback
     // was successful or not, since at this point we have a valid transistion
     // to either a new primary state or error state
-    return true;
+    return RCL_RET_OK;
   }
 
   rcl_lifecycle_ret_t

--- a/rclcpp_lifecycle/test/test_callback_exceptions.cpp
+++ b/rclcpp_lifecycle/test/test_callback_exceptions.cpp
@@ -69,6 +69,15 @@ TEST_F(TestCallbackExceptions, positive_on_error) {
   EXPECT_EQ(static_cast<size_t>(2), test_node->number_of_callbacks);
 }
 
+TEST_F(TestCallbackExceptions, positive_on_error_with_code) {
+  auto test_node = std::make_shared<PositiveCallbackExceptionNode>("testnode");
+
+  EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
+  rcl_lifecycle_ret_t ret = RCL_LIFECYCLE_RET_OK;
+  test_node->configure(ret);
+  EXPECT_EQ(RCL_LIFECYCLE_RET_ERROR, ret);
+}
+
 class NegativeCallbackExceptionNode : public rclcpp_lifecycle::LifecycleNode
 {
 public:
@@ -91,6 +100,7 @@ protected:
     return RCL_LIFECYCLE_RET_FAILURE;
   }
 };
+
 TEST_F(TestCallbackExceptions, negative_on_error) {
   auto test_node = std::make_shared<NegativeCallbackExceptionNode>("testnode");
 
@@ -99,4 +109,13 @@ TEST_F(TestCallbackExceptions, negative_on_error) {
       rclcpp_lifecycle::Transition(Transition::TRANSITION_CONFIGURE)).id());
   // check if all callbacks were successfully overwritten
   EXPECT_EQ(static_cast<size_t>(2), test_node->number_of_callbacks);
+}
+
+TEST_F(TestCallbackExceptions, negative_on_error_with_code) {
+  auto test_node = std::make_shared<NegativeCallbackExceptionNode>("testnode");
+
+  EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
+  rcl_lifecycle_ret_t ret = RCL_RET_OK;
+  test_node->configure(ret);
+  EXPECT_EQ(RCL_LIFECYCLE_RET_ERROR, ret);
 }

--- a/rclcpp_lifecycle/test/test_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_node.cpp
@@ -35,10 +35,6 @@ struct BadMood
 {
   static constexpr rcl_lifecycle_ret_t cb_ret = RCL_LIFECYCLE_RET_FAILURE;
 };
-struct VeryBadMood
-{
-  static constexpr rcl_lifecycle_ret_t cb_ret = RCL_LIFECYCLE_RET_ERROR;
-};
 
 class TestDefaultStateMachine : public ::testing::Test
 {
@@ -142,6 +138,30 @@ TEST_F(TestDefaultStateMachine, trigger_transition) {
       rclcpp_lifecycle::Transition(Transition::TRANSITION_CLEANUP)).id());
   EXPECT_EQ(State::PRIMARY_STATE_FINALIZED, test_node->trigger_transition(
       rclcpp_lifecycle::Transition(Transition::TRANSITION_SHUTDOWN)).id());
+}
+
+TEST_F(TestDefaultStateMachine, trigger_transition_with_error_code) {
+  auto test_node = std::make_shared<EmptyLifecycleNode>("testnode");
+
+  rcl_lifecycle_ret_t ret = RCL_LIFECYCLE_RET_ERROR;
+  test_node->configure(ret);
+  EXPECT_EQ(RCL_LIFECYCLE_RET_OK, ret);
+  ret = RCL_LIFECYCLE_RET_ERROR;
+
+  test_node->activate(ret);
+  EXPECT_EQ(RCL_LIFECYCLE_RET_OK, ret);
+  ret = RCL_LIFECYCLE_RET_ERROR;
+
+  test_node->deactivate(ret);
+  EXPECT_EQ(RCL_LIFECYCLE_RET_OK, ret);
+  ret = RCL_LIFECYCLE_RET_ERROR;
+
+  test_node->cleanup(ret);
+  EXPECT_EQ(RCL_LIFECYCLE_RET_OK, ret);
+  ret = RCL_LIFECYCLE_RET_ERROR;
+
+  test_node->shutdown(ret);
+  EXPECT_EQ(RCL_LIFECYCLE_RET_OK, ret);
 }
 
 TEST_F(TestDefaultStateMachine, good_mood) {


### PR DESCRIPTION
two changes in this PR:

1.) remove `fprintf`s and replace them with `RCUTILS_LOG..`
2.) every state change has now an additional parameter to see whether the action went to an erroneous state while transitioning. 

CI:
linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2917)](http://ci.ros2.org/job/ci_linux/2917/)
osx: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2361)](http://ci.ros2.org/job/ci_osx/2361/)
windows: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3041)](http://ci.ros2.org/job/ci_windows/3041/)
 