### PR TITLE
Restore old signal handler after shutdown

### DIFF
--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -167,8 +167,16 @@ rclcpp::utilities::init(int argc, char * argv[])
   action.sa_sigaction = ::signal_handler;
   action.sa_flags = SA_SIGINFO;
   ::old_action = set_sigaction(SIGINT, action);
+  // Register an on_shutdown hook to restore the old action.
+  rclcpp::utilities::on_shutdown([]() {
+    set_sigaction(SIGINT, ::old_action);
+  });
 #else
   ::old_signal_handler = set_signal_handler(SIGINT, ::signal_handler);
+  // Register an on_shutdown hook to restore the old signal handler.
+  rclcpp::utilities::on_shutdown([]() {
+    set_signal_handler(SIGINT, ::old_signal_handler);
+  });
 #endif
 }
 


### PR DESCRIPTION
connects to ros2/rmw_implementation#25

This PR makes two main changes:
1. the original signal handler is restored in an on_shutdown callback. This allows the original signal handler to be called even after rclcpp::shutdown has been called within a process
1. ~~during shutdown, ignore sigints from interrupting the shutdown process. otherwise deadlocks described in https://github.com/ros2/rmw_implementation/issues/25 can occur~~

This has been done to fix flaky tests caused by the deadlock described in https://github.com/ros2/rmw_implementation/issues/25. For it to take effect, it has to be combined with a change such as https://github.com/ros2/demos/commit/190d2f5e14dbcd84600b18e9356e53d254ebff68 so the processes call shutdown. ~~If we were to instead call shutdown in the rclcpp signal handler, that change wouldn't be necessary. Is it appropriate to replace [this block of code](https://github.com/ros2/rclcpp/blob/d090ddc35859901f9e07dac8eeaa1ce262e7a1fc/rclcpp/src/rclcpp/utilities.cpp#L86..L99) with a call to shutdown?~~

I have tried to maintain the preference for sigaction where available, following existing code, but please keep in mind that there may be subtleties of signal handlers that I'm likely to overlook

Standard CI
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2962)](http://ci.ros2.org/job/ci_linux/2962/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=407)](http://ci.ros2.org/job/ci_linux-aarch64/407/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2390)](http://ci.ros2.org/job/ci_osx/2390/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3077)](http://ci.ros2.org/job/ci_windows/3077/)

repeating the list_paramters* tests (usually very flaky): [![Build Status](http://ci.ros2.org/job/ci_linux/2963/badge/icon)](http://ci.ros2.org/job/ci_linux/2963/) (passed 60 times, failed on 60th because of [startup issue](http://ci.ros2.org/job/ci_linux/2963/testReport/junit/(root)/projectroot/test_tutorial_list_parameters__rmw_fastrtps_cpp/) that I understand to be unrelated)