### PR TITLE
lock around taking the buffer and deciding to get a copy of the message or popping it

### DIFF
--- a/rclcpp/include/rclcpp/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager.hpp
@@ -23,6 +23,7 @@
 #include <exception>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 #include <set>
 
@@ -315,6 +316,7 @@ public:
     message = nullptr;
 
     size_t target_subs_size = 0;
+    std::lock_guard<std::mutex> lock(take_mutex_);
     mapped_ring_buffer::MappedRingBufferBase::SharedPtr buffer = impl_->take_intra_process_message(
       intra_process_publisher_id,
       message_sequence_number,
@@ -346,6 +348,7 @@ private:
   get_next_unique_id();
 
   IntraProcessManagerImplBase::SharedPtr impl_;
+  std::mutex take_mutex_;
 };
 
 }  // namespace intra_process_manager


### PR DESCRIPTION
This fixes a race condition in the following use case:

* two subscribers are waiting for the received message
* two threads are handling callbacks
* thread A calls the `take_intra_process_message` function
  * returning a handle for the buffer
  * setting `target_subs_size` to > 0 (since there is another subscriber waiting for the same message)
* now thread A gets interrupted
* thread B calls the `take_intra_process_message` function
  * returning a handle for the same buffer
  * setting `target_subs_size` to 0 (since there is no other subscriber waiting for the same message anymore)
  * continues with calling `pop_at_key`
* now thread A continues
  * continues with calling `get_copy_at_key` but can't get the message anymore

Therefore the call to `take_intra_process_message` and the following call to either `get_copy_at_key` or `pop_at_key` needs to be wrapped in a mutex.

This fixes part of this flaky test: `test_multithreaded__rmw_fastrtps_cpp.multi_consumer_intra_process` (see ros2/build_cop#41).

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2984)](http://ci.ros2.org/job/ci_linux/2984/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=420)](http://ci.ros2.org/job/ci_linux-aarch64/420/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2410)](http://ci.ros2.org/job/ci_osx/2410/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3090)](http://ci.ros2.org/job/ci_windows/3090/)