### PR TITLE
Fully initialise parameter msgs

### DIFF
--- a/rclcpp/include/rclcpp/parameter.hpp
+++ b/rclcpp/include/rclcpp/parameter.hpp
@@ -46,7 +46,7 @@ class ParameterVariant
 {
 public:
   RCLCPP_PUBLIC
-  ParameterVariant();
+  ParameterVariant(const std::string & name = "");
   RCLCPP_PUBLIC
   explicit ParameterVariant(const std::string & name, const bool bool_value);
   RCLCPP_PUBLIC

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -70,6 +70,9 @@ NodeParameters::set_parameters_atomically(
 
   // TODO(jacquelinekay): handle parameter constraints
   rcl_interfaces::msg::SetParametersResult result;
+  result.successful = false;
+  result.reason = "";
+
   if (parameters_callback_) {
     result = parameters_callback_(parameters);
   } else {
@@ -196,6 +199,8 @@ NodeParameters::list_parameters(const std::vector<std::string> & prefixes, uint6
 {
   std::lock_guard<std::mutex> lock(mutex_);
   rcl_interfaces::msg::ListParametersResult result;
+  result.names = std::vector<std::string>();
+  result.prefixes = std::vector<std::string>();
 
   // TODO(esteve): define parameter separator, use "." for now
   for (auto & kv : parameters_) {

--- a/rclcpp/src/rclcpp/parameter.cpp
+++ b/rclcpp/src/rclcpp/parameter.cpp
@@ -23,49 +23,54 @@
 using rclcpp::parameter::ParameterType;
 using rclcpp::parameter::ParameterVariant;
 
-ParameterVariant::ParameterVariant()
-: name_("")
+ParameterVariant::ParameterVariant(const std::string & name)
+: name_(name)
 {
   value_.type = rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET;
+  value_.bool_value = false;
+  value_.integer_value = 0;
+  value_.double_value = 0.0;
+  value_.string_value = "";
+  value_.bytes_value = std::vector<uint8_t>();
 }
 
 ParameterVariant::ParameterVariant(const std::string & name, const bool bool_value)
-: name_(name)
+: ParameterVariant(name)
 {
   value_.bool_value = bool_value;
   value_.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL;
 }
 
 ParameterVariant::ParameterVariant(const std::string & name, const int int_value)
-: name_(name)
+: ParameterVariant(name)
 {
   value_.integer_value = int_value;
   value_.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
 }
 
 ParameterVariant::ParameterVariant(const std::string & name, const int64_t int_value)
-: name_(name)
+: ParameterVariant(name)
 {
   value_.integer_value = int_value;
   value_.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
 }
 
 ParameterVariant::ParameterVariant(const std::string & name, const float double_value)
-: name_(name)
+: ParameterVariant(name)
 {
   value_.double_value = double_value;
   value_.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
 }
 
 ParameterVariant::ParameterVariant(const std::string & name, const double double_value)
-: name_(name)
+: ParameterVariant(name)
 {
   value_.double_value = double_value;
   value_.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
 }
 
 ParameterVariant::ParameterVariant(const std::string & name, const std::string & string_value)
-: name_(name)
+: ParameterVariant(name)
 {
   value_.string_value = string_value;
   value_.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
@@ -77,7 +82,7 @@ ParameterVariant::ParameterVariant(const std::string & name, const char * string
 
 ParameterVariant::ParameterVariant(
   const std::string & name, const std::vector<uint8_t> & bytes_value)
-: name_(name)
+: ParameterVariant(name)
 {
   value_.bytes_value = bytes_value;
   value_.type = rcl_interfaces::msg::ParameterType::PARAMETER_BYTES;


### PR DESCRIPTION
The first commit (https://github.com/ros2/rclcpp/commit/bf3314ccaeb279b8f711f6f28c5da61c670ece76) prevents the following valgrind error on `test_local_parameters__rmw_fastrtps_cpp.set_parameter_if_not_set` in `test_rclcpp`

```
dhood@osrf-esteve:~/ros2_ws/src/ros2/system_tests [system_tests (master=)]$ valgrind -v ~/ros2_ws/build_isolated/test_rclcpp/gtest_local_parameters__rmw_fastrtps_cpp --gtest_filter=test_local_parameters__rmw_fastrtps_cpp.set_parameter_if_not_set
==3009== Memcheck, a memory error detector
==3009== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==3009== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==3009== Command: /home/dhood/ros2_ws/build_isolated/test_rclcpp/gtest_local_parameters__rmw_fastrtps_cpp --gtest_filter=test_local_parameters__rmw_fastrtps_cpp.set_parameter_if_not_set
==3009== 
--3009-- Valgrind options:
--3009--    -v
--3009-- Contents of /proc/version:
--3009--   Linux version 4.4.0-87-generic (buildd@lcy01-31) (gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4) ) #110-Ubuntu SMP Tue Jul 18 12:55:35 UTC 2017
--3009-- 
--3009-- Arch and hwcaps: AMD64, LittleEndian, amd64-cx16-rdtscp-sse3-avx
--3009-- Page sizes: currently 4096, max supported 4096
--3009-- Valgrind library directory: /usr/lib/valgrind
--3009-- Reading syms from /home/dhood/ros2_ws/build_isolated/test_rclcpp/gtest_local_parameters__rmw_fastrtps_cpp
...
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from test_local_parameters__rmw_fastrtps_cpp
[ RUN      ] test_local_parameters__rmw_fastrtps_cpp.set_parameter_if_not_set
--3009-- REDIR: 0x5c941a0 (libc.so.6:__GI_strcpy) redirected to 0x4c31110 (__GI_strcpy)
--3009-- REDIR: 0x5c948c0 (libc.so.6:strnlen) redirected to 0x4c30ee0 (strnlen)
--3009-- REDIR: 0x5ca8520 (libc.so.6:__GI_strncpy) redirected to 0x4c31310 (__GI_strncpy)
--3009-- REDIR: 0x5c8daa0 (libc.so.6:memalign) redirected to 0x4c2ff20 (memalign)
--3009-- REDIR: 0x5c98890 (libc.so.6:__GI_stpcpy) redirected to 0x4c33f80 (__GI_stpcpy)
--3009-- Reading syms from /home/dhood/ros2_ws/install_isolated/rcl_interfaces/lib/librcl_interfaces__rosidl_typesupport_introspection_cpp.so
==3009== Conditional jump or move depends on uninitialised value(s)
==3009==    at 0x7B8AEEF: rmw_fastrtps_cpp::TypeSupport<rosidl_typesupport_introspection_cpp::MessageMembers>::serializeROSmessage(eprosima::fastcdr::Cdr&, rosidl_typesupport_introspection_cpp::MessageMembers const*, void const*) (TypeSupport_impl.hpp:323)
==3009==    by 0x7B8B122: rmw_fastrtps_cpp::TypeSupport<rosidl_typesupport_introspection_cpp::MessageMembers>::serializeROSmessage(eprosima::fastcdr::Cdr&, rosidl_typesupport_introspection_cpp::MessageMembers const*, void const*) (TypeSupport_impl.hpp:373)
==3009==    by 0x7B8B3F5: rmw_fastrtps_cpp::TypeSupport<rosidl_typesupport_introspection_cpp::MessageMembers>::serializeROSmessage(eprosima::fastcdr::Cdr&, rosidl_typesupport_introspection_cpp::MessageMembers const*, void const*) (TypeSupport_impl.hpp:440)
==3009==    by 0x7B89F1A: rmw_fastrtps_cpp::TypeSupport<rosidl_typesupport_introspection_cpp::MessageMembers>::serializeROSmessage(void const*, eprosima::fastcdr::Cdr&) (TypeSupport_impl.hpp:836)
==3009==    by 0x7B880D5: _serialize_ros_message(void const*, eprosima::fastcdr::Cdr&, void*, char const*) (ros_message_serialization.cpp:30)
==3009==    by 0x7B7BDB0: rmw_publish (rmw_publish.cpp:47)
==3009==    by 0x65EFC0E: rmw_publish (functions.cpp:252)
==3009==    by 0x67FDB67: rcl_publish (publisher.c:206)
==3009==    by 0x5377F7C: rclcpp::publisher::Publisher<rcl_interfaces::msg::ParameterEvent_<std::allocator<void> >, std::allocator<void> >::do_inter_process_publish(rcl_interfaces::msg::ParameterEvent_<std::allocator<void> > const*) (publisher.hpp:282)
==3009==    by 0x5375856: rclcpp::publisher::Publisher<rcl_interfaces::msg::ParameterEvent_<std::allocator<void> >, std::allocator<void> >::publish(std::shared_ptr<rcl_interfaces::msg::ParameterEvent_<std::allocator<void> > > const&) (publisher.hpp:217)
==3009==    by 0x5372629: rclcpp::node_interfaces::NodeParameters::set_parameters_atomically(std::vector<rclcpp::parameter::ParameterVariant, std::allocator<rclcpp::parameter::ParameterVariant> > const&) (node_parameters.cpp:107)
==3009==    by 0x53720EA: rclcpp::node_interfaces::NodeParameters::set_parameters(std::vector<rclcpp::parameter::ParameterVariant, std::allocator<rclcpp::parameter::ParameterVariant> > const&) (node_parameters.cpp:57)
==3009== 
[       OK ] test_local_parameters__rmw_fastrtps_cpp.set_parameter_if_not_set (2466 ms)
[----------] 1 test from test_local_parameters__rmw_fastrtps_cpp (2476 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (2521 ms total)
[  PASSED  ] 1 test.
==3009== 
==3009== HEAP SUMMARY:
==3009==     in use at exit: 94,393 bytes in 45 blocks
==3009==   total heap usage: 6,981 allocs, 6,936 frees, 31,776,851 bytes allocated
==3009== 
==3009== Searching for pointers to 45 not-freed blocks
==3009== Checked 486,560 bytes
==3009== 
==3009== LEAK SUMMARY:
==3009==    definitely lost: 8 bytes in 1 blocks
==3009==    indirectly lost: 48 bytes in 1 blocks
==3009==      possibly lost: 0 bytes in 0 blocks
==3009==    still reachable: 94,337 bytes in 43 blocks
==3009==         suppressed: 0 bytes in 0 blocks
==3009== Rerun with --leak-check=full to see details of leaked memory
==3009== 
==3009== Use --track-origins=yes to see where uninitialised values come from
==3009== ERROR SUMMARY: 2 errors from 1 contexts (suppressed: 0 from 0)
==3009== 
```

The second commit (https://github.com/ros2/rclcpp/commit/5b93dfe76eebfcaf0753188114ff027cd245ed9f) explicitly initialises some messages in other locations that I saw but I can't say for sure if it's necessary or not.

It might be more appropriate for us to set default values in the message definitions themselves: I can adapt this PR if that's the case.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3023)](http://ci.ros2.org/job/ci_linux/3023/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=436)](http://ci.ros2.org/job/ci_linux-aarch64/436/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2433)](http://ci.ros2.org/job/ci_osx/2433/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3107)](http://ci.ros2.org/job/ci_windows/3107/)