### PR TITLE
alias lifecycle_msgs with rclcpp_lifecycle constants

### DIFF
--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/state.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/state.hpp
@@ -17,6 +17,10 @@
 
 #include <string>
 
+#include "lifecycle_msgs/msg/state.hpp"
+
+#include "rcl_lifecycle/data_types.h"
+
 #include "rclcpp_lifecycle/visibility_control.h"
 
 // forward declare rcl_state_t
@@ -24,6 +28,17 @@ typedef struct rcl_lifecycle_state_t rcl_lifecycle_state_t;
 
 namespace rclcpp_lifecycle
 {
+
+static constexpr uint8_t PRIMARY_STATE_UNKNOWN =
+  lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN;
+static constexpr uint8_t PRIMARY_STATE_UNCONFIGURED =
+  lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED;
+static constexpr uint8_t PRIMARY_STATE_INACTIVE =
+  lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE;
+static constexpr uint8_t PRIMARY_STATE_ACTIVE =
+  lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE;
+static constexpr uint8_t PRIMARY_STATE_FINALIZED =
+  lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED;
 
 class State
 {

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/transition.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/transition.hpp
@@ -17,6 +17,10 @@
 
 #include <string>
 
+#include "lifecycle_msgs/msg/transition.hpp"
+
+#include "rcl_lifecycle/data_types.h"
+
 #include "rclcpp_lifecycle/state.hpp"
 #include "rclcpp_lifecycle/visibility_control.h"
 
@@ -25,6 +29,13 @@ typedef struct rcl_lifecycle_transition_t rcl_lifecycle_transition_t;
 
 namespace rclcpp_lifecycle
 {
+
+static constexpr rcl_lifecycle_transition_key_t TRANSITION_CALLBACK_SUCCESS =
+  lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+static constexpr rcl_lifecycle_transition_key_t TRANSITION_CALLBACK_FAILURE =
+  lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE;
+static constexpr rcl_lifecycle_transition_key_t TRANSITION_CALLBACK_ERROR =
+  lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR;
 
 class Transition
 {

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -188,7 +188,7 @@ public:
     // 1. return is the actual transition
     // 2. return is whether an error occurred or not
     resp->success =
-      (cb_return_code == lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS);
+      (cb_return_code == TRANSITION_CALLBACK_SUCCESS);
   }
 
   void
@@ -313,11 +313,11 @@ public:
 
     // error handling ?!
     // TODO(karsten1987): iterate over possible ret value
-    if (cb_return_code == lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR) {
+    if (cb_return_code == TRANSITION_CALLBACK_ERROR) {
       RCUTILS_LOG_WARN("Error occurred while doing error handling.")
       rcl_lifecycle_transition_key_t error_resolved = execute_callback(
         state_machine_.current_state->id, initial_state);
-      if (error_resolved == lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS) {
+      if (error_resolved == TRANSITION_CALLBACK_SUCCESS) {
         // We call cleanup on the error state
         if (rcl_lifecycle_trigger_transition(&state_machine_, error_resolved, true) != RCL_RET_OK) {
           RCUTILS_LOG_ERROR("Failed to call cleanup on error state")
@@ -341,8 +341,7 @@ public:
   execute_callback(unsigned int cb_id, const State & previous_state)
   {
     // in case no callback was attached, we forward directly
-    rcl_lifecycle_transition_key_t cb_success =
-      lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+    rcl_lifecycle_transition_key_t cb_success = TRANSITION_CALLBACK_SUCCESS;
 
     auto it = cb_map_.find(cb_id);
     if (it != cb_map_.end()) {
@@ -357,7 +356,7 @@ public:
         // fprintf(stderr, "Original error msg: %s\n", e.what());
         // maybe directly go for error handling here
         // and pass exception along with it
-        cb_success = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR;
+        cb_success = TRANSITION_CALLBACK_ERROR;
       }
     }
     return cb_success;

--- a/rclcpp_lifecycle/test/test_callback_exceptions.cpp
+++ b/rclcpp_lifecycle/test/test_callback_exceptions.cpp
@@ -24,9 +24,6 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
-using lifecycle_msgs::msg::State;
-using lifecycle_msgs::msg::Transition;
-
 class TestCallbackExceptions : public ::testing::Test
 {
 protected:
@@ -57,16 +54,16 @@ protected:
   on_error(const rclcpp_lifecycle::State &)
   {
     ++number_of_callbacks;
-    return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+    return rclcpp_lifecycle::TRANSITION_CALLBACK_SUCCESS;
   }
 };
 
 TEST_F(TestCallbackExceptions, positive_on_error) {
   auto test_node = std::make_shared<PositiveCallbackExceptionNode>("testnode");
 
-  EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
-  EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->trigger_transition(
-      rclcpp_lifecycle::Transition(Transition::TRANSITION_CONFIGURE)).id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_UNCONFIGURED, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE)).id());
   // check if all callbacks were successfully overwritten
   EXPECT_EQ(static_cast<size_t>(2), test_node->number_of_callbacks);
 }
@@ -74,10 +71,10 @@ TEST_F(TestCallbackExceptions, positive_on_error) {
 TEST_F(TestCallbackExceptions, positive_on_error_with_code) {
   auto test_node = std::make_shared<PositiveCallbackExceptionNode>("testnode");
 
-  EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
-  rcl_lifecycle_transition_key_t ret = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
+  rcl_lifecycle_transition_key_t ret = rclcpp_lifecycle::TRANSITION_CALLBACK_SUCCESS;
   test_node->configure(ret);
-  EXPECT_EQ(lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR, ret);
+  EXPECT_EQ(rclcpp_lifecycle::TRANSITION_CALLBACK_ERROR, ret);
 }
 
 class NegativeCallbackExceptionNode : public rclcpp_lifecycle::LifecycleNode
@@ -101,16 +98,16 @@ protected:
   on_error(const rclcpp_lifecycle::State &)
   {
     ++number_of_callbacks;
-    return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE;
+    return rclcpp_lifecycle::TRANSITION_CALLBACK_FAILURE;
   }
 };
 
 TEST_F(TestCallbackExceptions, negative_on_error) {
   auto test_node = std::make_shared<NegativeCallbackExceptionNode>("testnode");
 
-  EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
-  EXPECT_EQ(State::PRIMARY_STATE_FINALIZED, test_node->trigger_transition(
-      rclcpp_lifecycle::Transition(Transition::TRANSITION_CONFIGURE)).id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_FINALIZED, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE)).id());
   // check if all callbacks were successfully overwritten
   EXPECT_EQ(static_cast<size_t>(2), test_node->number_of_callbacks);
 }
@@ -118,8 +115,8 @@ TEST_F(TestCallbackExceptions, negative_on_error) {
 TEST_F(TestCallbackExceptions, negative_on_error_with_code) {
   auto test_node = std::make_shared<NegativeCallbackExceptionNode>("testnode");
 
-  EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
   rcl_lifecycle_transition_key_t ret = RCL_RET_OK;
   test_node->configure(ret);
-  EXPECT_EQ(lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR, ret);
+  EXPECT_EQ(rclcpp_lifecycle::TRANSITION_CALLBACK_ERROR, ret);
 }

--- a/rclcpp_lifecycle/test/test_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_node.cpp
@@ -24,18 +24,15 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
-using lifecycle_msgs::msg::State;
-using lifecycle_msgs::msg::Transition;
-
 struct GoodMood
 {
   static constexpr rcl_lifecycle_transition_key_t cb_ret =
-    lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+    rclcpp_lifecycle::TRANSITION_CALLBACK_SUCCESS;
 };
 struct BadMood
 {
   static constexpr rcl_lifecycle_transition_key_t cb_ret =
-    lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE;
+    rclcpp_lifecycle::TRANSITION_CALLBACK_FAILURE;
 };
 
 class TestDefaultStateMachine : public ::testing::Test
@@ -69,7 +66,7 @@ protected:
   rcl_lifecycle_transition_key_t
   on_configure(const rclcpp_lifecycle::State &)
   {
-    EXPECT_EQ(State::TRANSITION_STATE_CONFIGURING, get_current_state().id());
+    EXPECT_EQ(lifecycle_msgs::msg::State::TRANSITION_STATE_CONFIGURING, get_current_state().id());
     ++number_of_callbacks;
     return Mood::cb_ret;
   }
@@ -77,7 +74,7 @@ protected:
   rcl_lifecycle_transition_key_t
   on_activate(const rclcpp_lifecycle::State &)
   {
-    EXPECT_EQ(State::TRANSITION_STATE_ACTIVATING, get_current_state().id());
+    EXPECT_EQ(lifecycle_msgs::msg::State::TRANSITION_STATE_ACTIVATING, get_current_state().id());
     ++number_of_callbacks;
     return Mood::cb_ret;
   }
@@ -85,7 +82,7 @@ protected:
   rcl_lifecycle_transition_key_t
   on_deactivate(const rclcpp_lifecycle::State &)
   {
-    EXPECT_EQ(State::TRANSITION_STATE_DEACTIVATING, get_current_state().id());
+    EXPECT_EQ(lifecycle_msgs::msg::State::TRANSITION_STATE_DEACTIVATING, get_current_state().id());
     ++number_of_callbacks;
     return Mood::cb_ret;
   }
@@ -93,7 +90,7 @@ protected:
   rcl_lifecycle_transition_key_t
   on_cleanup(const rclcpp_lifecycle::State &)
   {
-    EXPECT_EQ(State::TRANSITION_STATE_CLEANINGUP, get_current_state().id());
+    EXPECT_EQ(lifecycle_msgs::msg::State::TRANSITION_STATE_CLEANINGUP, get_current_state().id());
     ++number_of_callbacks;
     return Mood::cb_ret;
   }
@@ -101,7 +98,7 @@ protected:
   rcl_lifecycle_transition_key_t
   on_shutdown(const rclcpp_lifecycle::State &)
   {
-    EXPECT_EQ(State::TRANSITION_STATE_SHUTTINGDOWN, get_current_state().id());
+    EXPECT_EQ(lifecycle_msgs::msg::State::TRANSITION_STATE_SHUTTINGDOWN, get_current_state().id());
     ++number_of_callbacks;
     return Mood::cb_ret;
   }
@@ -114,80 +111,80 @@ template<>
 rcl_lifecycle_transition_key_t
 MoodyLifecycleNode<GoodMood>::on_error(const rclcpp_lifecycle::State &)
 {
-  EXPECT_EQ(State::TRANSITION_STATE_ERRORPROCESSING, get_current_state().id());
+  EXPECT_EQ(lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING, get_current_state().id());
   ADD_FAILURE();
-  return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR;
+  return rclcpp_lifecycle::TRANSITION_CALLBACK_ERROR;
 }
 template<>
 rcl_lifecycle_transition_key_t
 MoodyLifecycleNode<BadMood>::on_error(const rclcpp_lifecycle::State &)
 {
-  EXPECT_EQ(State::TRANSITION_STATE_ERRORPROCESSING, get_current_state().id());
+  EXPECT_EQ(lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING, get_current_state().id());
   ++number_of_callbacks;
-  return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+  return rclcpp_lifecycle::TRANSITION_CALLBACK_SUCCESS;
 }
 
 TEST_F(TestDefaultStateMachine, empty_initializer) {
   auto test_node = std::make_shared<EmptyLifecycleNode>("testnode");
   EXPECT_STREQ("testnode", test_node->get_name());
   EXPECT_STREQ("/", test_node->get_namespace());
-  EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
 }
 
 TEST_F(TestDefaultStateMachine, trigger_transition) {
   auto test_node = std::make_shared<EmptyLifecycleNode>("testnode");
 
-  EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
-  EXPECT_EQ(State::PRIMARY_STATE_INACTIVE, test_node->trigger_transition(
-      rclcpp_lifecycle::Transition(Transition::TRANSITION_CONFIGURE)).id());
-  EXPECT_EQ(State::PRIMARY_STATE_ACTIVE, test_node->trigger_transition(
-      rclcpp_lifecycle::Transition(Transition::TRANSITION_ACTIVATE)).id());
-  EXPECT_EQ(State::PRIMARY_STATE_INACTIVE, test_node->trigger_transition(
-      rclcpp_lifecycle::Transition(Transition::TRANSITION_DEACTIVATE)).id());
-  EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->trigger_transition(
-      rclcpp_lifecycle::Transition(Transition::TRANSITION_CLEANUP)).id());
-  EXPECT_EQ(State::PRIMARY_STATE_FINALIZED, test_node->trigger_transition(
-      rclcpp_lifecycle::Transition(Transition::TRANSITION_SHUTDOWN)).id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_INACTIVE, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE)).id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_ACTIVE, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE)).id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_INACTIVE, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE)).id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_UNCONFIGURED, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP)).id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_FINALIZED, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(lifecycle_msgs::msg::Transition::TRANSITION_SHUTDOWN)).id());
 }
 
 TEST_F(TestDefaultStateMachine, trigger_transition_with_error_code) {
   auto test_node = std::make_shared<EmptyLifecycleNode>("testnode");
 
-  rcl_lifecycle_transition_key_t ret = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR;
+  rcl_lifecycle_transition_key_t ret = rclcpp_lifecycle::TRANSITION_CALLBACK_ERROR;
   test_node->configure(ret);
-  EXPECT_EQ(lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ret);
-  ret = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR;
+  EXPECT_EQ(rclcpp_lifecycle::TRANSITION_CALLBACK_SUCCESS, ret);
+  ret = rclcpp_lifecycle::TRANSITION_CALLBACK_ERROR;
 
   test_node->activate(ret);
-  EXPECT_EQ(lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ret);
-  ret = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR;
+  EXPECT_EQ(rclcpp_lifecycle::TRANSITION_CALLBACK_SUCCESS, ret);
+  ret = rclcpp_lifecycle::TRANSITION_CALLBACK_ERROR;
 
   test_node->deactivate(ret);
-  EXPECT_EQ(lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ret);
-  ret = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR;
+  EXPECT_EQ(rclcpp_lifecycle::TRANSITION_CALLBACK_SUCCESS, ret);
+  ret = rclcpp_lifecycle::TRANSITION_CALLBACK_ERROR;
 
   test_node->cleanup(ret);
-  EXPECT_EQ(lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ret);
-  ret = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR;
+  EXPECT_EQ(rclcpp_lifecycle::TRANSITION_CALLBACK_SUCCESS, ret);
+  ret = rclcpp_lifecycle::TRANSITION_CALLBACK_ERROR;
 
   test_node->shutdown(ret);
-  EXPECT_EQ(lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ret);
+  EXPECT_EQ(rclcpp_lifecycle::TRANSITION_CALLBACK_SUCCESS, ret);
 }
 
 TEST_F(TestDefaultStateMachine, good_mood) {
   auto test_node = std::make_shared<MoodyLifecycleNode<GoodMood>>("testnode");
 
-  EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
-  EXPECT_EQ(State::PRIMARY_STATE_INACTIVE, test_node->trigger_transition(
-      rclcpp_lifecycle::Transition(Transition::TRANSITION_CONFIGURE)).id());
-  EXPECT_EQ(State::PRIMARY_STATE_ACTIVE, test_node->trigger_transition(
-      rclcpp_lifecycle::Transition(Transition::TRANSITION_ACTIVATE)).id());
-  EXPECT_EQ(State::PRIMARY_STATE_INACTIVE, test_node->trigger_transition(
-      rclcpp_lifecycle::Transition(Transition::TRANSITION_DEACTIVATE)).id());
-  EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->trigger_transition(
-      rclcpp_lifecycle::Transition(Transition::TRANSITION_CLEANUP)).id());
-  EXPECT_EQ(State::PRIMARY_STATE_FINALIZED, test_node->trigger_transition(
-      rclcpp_lifecycle::Transition(Transition::TRANSITION_SHUTDOWN)).id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_INACTIVE, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE)).id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_ACTIVE, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE)).id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_INACTIVE, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE)).id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_UNCONFIGURED, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP)).id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_FINALIZED, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(lifecycle_msgs::msg::Transition::TRANSITION_SHUTDOWN)).id());
 
   // check if all callbacks were successfully overwritten
   EXPECT_EQ(static_cast<size_t>(5), test_node->number_of_callbacks);
@@ -196,9 +193,9 @@ TEST_F(TestDefaultStateMachine, good_mood) {
 TEST_F(TestDefaultStateMachine, bad_mood) {
   auto test_node = std::make_shared<MoodyLifecycleNode<BadMood>>("testnode");
 
-  EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
-  EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->trigger_transition(
-      rclcpp_lifecycle::Transition(Transition::TRANSITION_CONFIGURE)).id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
+  EXPECT_EQ(rclcpp_lifecycle::PRIMARY_STATE_UNCONFIGURED, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE)).id());
 
   // check if all callbacks were successfully overwritten
   EXPECT_EQ(static_cast<size_t>(1), test_node->number_of_callbacks);


### PR DESCRIPTION
static constexpr aliases for lifecycle_msgs. This is mainly a convenience change.


ci:
[![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3032)](http://ci.ros2.org/job/ci_linux/3032/)
[![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2438)](http://ci.ros2.org/job/ci_osx/2438/)
[![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3110)](http://ci.ros2.org/job/ci_windows/3110/)