### PR TITLE
freeing Time members in destructor, adding copy constructor / assignment operator

### DIFF
--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -39,6 +39,9 @@ public:
   explicit Time(uint64_t nanoseconds, rcl_time_source_type_t clock = RCL_SYSTEM_TIME);
 
   RCLCPP_PUBLIC
+  Time(const Time & rhs);
+
+  RCLCPP_PUBLIC
   Time(const builtin_interfaces::msg::Time & time_msg);  // NOLINT
 
   RCLCPP_PUBLIC
@@ -46,6 +49,10 @@ public:
 
   RCLCPP_PUBLIC
   operator builtin_interfaces::msg::Time() const;
+
+  RCLCPP_PUBLIC
+  void
+  operator=(const Time & rhs);
 
   RCLCPP_PUBLIC
   void

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -103,7 +103,7 @@ Time::Time(uint64_t nanoseconds, rcl_time_source_type_t clock)
 }
 
 Time::Time(const Time & rhs)
-: rcl_time_source_(rhs.rcl_time_source_),
+: rcl_time_source_(init_time_source(rhs.rcl_time_source_.type)),
   rcl_time_(init_time_point(rcl_time_source_))
 {
   rcl_time_.nanoseconds = rhs.rcl_time_.nanoseconds;
@@ -142,7 +142,7 @@ Time::operator builtin_interfaces::msg::Time() const
 void
 Time::operator=(const Time & rhs)
 {
-  rcl_time_source_ = rhs.rcl_time_source_;
+  rcl_time_source_ = init_time_source(rhs.rcl_time_source_.type);
   rcl_time_ = init_time_point(rcl_time_source_);
   rcl_time_.nanoseconds = rhs.rcl_time_.nanoseconds;
 }

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -79,7 +79,7 @@ Time::now(rcl_time_source_type_t clock)
     rclcpp::exceptions::throw_from_rcl_error(
       ret, "could not get current time stamp");
   }
-
+  fprintf(stderr, "leaving now() with time source %d\n", now.rcl_time_.time_source->type);
   return now;
 }
 
@@ -100,6 +100,13 @@ Time::Time(uint64_t nanoseconds, rcl_time_source_type_t clock)
   rcl_time_(init_time_point(rcl_time_source_))
 {
   rcl_time_.nanoseconds = nanoseconds;
+}
+
+Time::Time(const Time & rhs)
+: rcl_time_source_(rhs.rcl_time_source_),
+  rcl_time_(init_time_point(rcl_time_source_))
+{
+  rcl_time_.nanoseconds = rhs.rcl_time_.nanoseconds;
 }
 
 Time::Time(const builtin_interfaces::msg::Time & time_msg)  // NOLINT
@@ -127,6 +134,14 @@ Time::operator builtin_interfaces::msg::Time() const
   msg_time.sec = static_cast<std::int32_t>(RCL_NS_TO_S(rcl_time_.nanoseconds));
   msg_time.nanosec = static_cast<std::uint32_t>(rcl_time_.nanoseconds % (1000 * 1000 * 1000));
   return msg_time;
+}
+
+void
+Time::operator=(const Time & rhs)
+{
+  rcl_time_source_ = rhs.rcl_time_source_;
+  rcl_time_ = init_time_point(rcl_time_source_);
+  rcl_time_.nanoseconds = rhs.rcl_time_.nanoseconds;
 }
 
 void

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -123,6 +123,9 @@ Time::Time(const builtin_interfaces::msg::Time & time_msg)  // NOLINT
 
 Time::~Time()
 {
+  if (rcl_time_source_fini(&rcl_time_source_) != RCL_RET_OK) {
+    RCUTILS_LOG_FATAL("failed to reclaim rcl_time_source_t in destructor of rclcpp::Time")
+  }
   if (rcl_time_point_fini(&rcl_time_) != RCL_RET_OK) {
     RCUTILS_LOG_FATAL("failed to reclaim rcl_time_point_t in destructor of rclcpp::Time")
   }

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -79,7 +79,6 @@ Time::now(rcl_time_source_type_t clock)
     rclcpp::exceptions::throw_from_rcl_error(
       ret, "could not get current time stamp");
   }
-  fprintf(stderr, "leaving now() with time source %d\n", now.rcl_time_.time_source->type);
   return now;
 }
 

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -79,6 +79,7 @@ Time::now(rcl_time_source_type_t clock)
     rclcpp::exceptions::throw_from_rcl_error(
       ret, "could not get current time stamp");
   }
+
   return now;
 }
 

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -102,8 +102,8 @@ TEST(TestTime, operators) {
   EXPECT_EQ(sub.nanoseconds(), young.nanoseconds() - old.nanoseconds());
   EXPECT_EQ(sub, young - old);
 
-  rclcpp::Time system_time(1, 0, RCL_SYSTEM_TIME);
-  rclcpp::Time steady_time(2, 0, RCL_STEADY_TIME);
+  rclcpp::Time system_time(0, 0, RCL_SYSTEM_TIME);
+  rclcpp::Time steady_time(0, 0, RCL_STEADY_TIME);
 
   EXPECT_ANY_THROW((void)(system_time == steady_time));
   EXPECT_ANY_THROW((void)(system_time <= steady_time));

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -123,6 +123,16 @@ TEST(TestTime, operators) {
   EXPECT_ANY_THROW((void)(now > later));
   EXPECT_ANY_THROW((void)(now + later));
   EXPECT_ANY_THROW((void)(now - later));
+
+  for (auto time_source : {RCL_ROS_TIME, RCL_SYSTEM_TIME, RCL_STEADY_TIME}) {
+    rclcpp::Time time = rclcpp::Time(0, 0, time_source);
+    rclcpp::Time copy_constructor_time = time;
+    rclcpp::Time assignment_op_time = rclcpp::Time(1, 0, time_source);
+    assignment_op_time = time;
+
+    EXPECT_TRUE(time == copy_constructor_time);
+    EXPECT_TRUE(time == assignment_op_time);
+  }
 }
 
 TEST(TestTime, overflows) {

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -126,7 +126,7 @@ TEST(TestTime, operators) {
 
   for (auto time_source : {RCL_ROS_TIME, RCL_SYSTEM_TIME, RCL_STEADY_TIME}) {
     rclcpp::Time time = rclcpp::Time(0, 0, time_source);
-    rclcpp::Time copy_constructor_time = time;
+    rclcpp::Time copy_constructor_time(time);
     rclcpp::Time assignment_op_time = rclcpp::Time(1, 0, time_source);
     assignment_op_time = time;
 


### PR DESCRIPTION
Connects to ros2/rclcpp#357

add a copy constructor to the rclcpp::Time class which is necessary to fix the windows debug tests.
I tested it locally on my windows machine.

CI:
[![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3141)](http://ci.ros2.org/job/ci_windows/3141/)