### PR TITLE
Make sure the rclcpp tests depend on rosidl_runtime_cpp.

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -101,6 +101,9 @@ if(BUILD_TESTING)
 
   find_package(rmw_implementation_cmake REQUIRED)
 
+  find_package(rosidl_runtime_cpp REQUIRED)
+  include_directories(${rosidl_runtime_cpp_INCLUDE_DIRS})
+
   ament_add_gtest(test_client test/test_client.cpp)
   if(TARGET test_client)
     target_include_directories(test_client PUBLIC

--- a/rclcpp/package.xml
+++ b/rclcpp/package.xml
@@ -32,6 +32,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rmw</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>
+  <test_depend>rosidl_runtime_cpp</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

connects to ros2/ros2#393

See CI in ros2/rosidl#231