### PR TITLE
use forward slashes instead of double underscores

### DIFF
--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+#include "./parameter_service_names.hpp"
+
 using rclcpp::parameter_client::AsyncParametersClient;
 using rclcpp::parameter_client::SyncParametersClient;
 
@@ -34,15 +36,15 @@ AsyncParametersClient::AsyncParametersClient(
     remote_node_name_ = node_->get_name();
   }
   get_parameters_client_ = node_->create_client<rcl_interfaces::srv::GetParameters>(
-    remote_node_name_ + "/get_parameters", qos_profile);
+    remote_node_name_ + "/" + parameter_service_names::get_parameters, qos_profile);
   get_parameter_types_client_ = node_->create_client<rcl_interfaces::srv::GetParameterTypes>(
-    remote_node_name_ + "/get_parameter_types", qos_profile);
+    remote_node_name_ + "/" + parameter_service_names::get_parameter_types, qos_profile);
   set_parameters_client_ = node_->create_client<rcl_interfaces::srv::SetParameters>(
-    remote_node_name_ + "/set_parameters", qos_profile);
+    remote_node_name_ + "/" + parameter_service_names::set_parameters, qos_profile);
   list_parameters_client_ = node_->create_client<rcl_interfaces::srv::ListParameters>(
-    remote_node_name_ + "/list_parameters", qos_profile);
+    remote_node_name_ + "/" + parameter_service_names::list_parameters, qos_profile);
   describe_parameters_client_ = node_->create_client<rcl_interfaces::srv::DescribeParameters>(
-    remote_node_name_ + "/describe_parameters", qos_profile);
+    remote_node_name_ + "/" + parameter_service_names::describe_parameters, qos_profile);
 }
 
 std::shared_future<std::vector<rclcpp::parameter::ParameterVariant>>

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -34,15 +34,15 @@ AsyncParametersClient::AsyncParametersClient(
     remote_node_name_ = node_->get_name();
   }
   get_parameters_client_ = node_->create_client<rcl_interfaces::srv::GetParameters>(
-    remote_node_name_ + "__get_parameters", qos_profile);
+    remote_node_name_ + "/get_parameters", qos_profile);
   get_parameter_types_client_ = node_->create_client<rcl_interfaces::srv::GetParameterTypes>(
-    remote_node_name_ + "__get_parameter_types", qos_profile);
+    remote_node_name_ + "/get_parameter_types", qos_profile);
   set_parameters_client_ = node_->create_client<rcl_interfaces::srv::SetParameters>(
-    remote_node_name_ + "__set_parameters", qos_profile);
+    remote_node_name_ + "/set_parameters", qos_profile);
   list_parameters_client_ = node_->create_client<rcl_interfaces::srv::ListParameters>(
-    remote_node_name_ + "__list_parameters", qos_profile);
+    remote_node_name_ + "/list_parameters", qos_profile);
   describe_parameters_client_ = node_->create_client<rcl_interfaces::srv::DescribeParameters>(
-    remote_node_name_ + "__describe_parameters", qos_profile);
+    remote_node_name_ + "/describe_parameters", qos_profile);
 }
 
 std::shared_future<std::vector<rclcpp::parameter::ParameterVariant>>

--- a/rclcpp/src/rclcpp/parameter_service.cpp
+++ b/rclcpp/src/rclcpp/parameter_service.cpp
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+#include "./parameter_service_names.hpp"
+
 using rclcpp::parameter_service::ParameterService;
 
 ParameterService::ParameterService(
@@ -29,7 +31,7 @@ ParameterService::ParameterService(
   std::weak_ptr<rclcpp::node::Node> captured_node = node_;
   // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
   get_parameters_service_ = node_->create_service<rcl_interfaces::srv::GetParameters>(
-    std::string(node_->get_name()) + "/get_parameters",
+    std::string(node_->get_name()) + "/" + parameter_service_names::get_parameters,
     [captured_node](
       const std::shared_ptr<rmw_request_id_t>,
       const std::shared_ptr<rcl_interfaces::srv::GetParameters::Request> request,
@@ -48,7 +50,7 @@ ParameterService::ParameterService(
   );
 
   get_parameter_types_service_ = node_->create_service<rcl_interfaces::srv::GetParameterTypes>(
-    std::string(node_->get_name()) + "/get_parameter_types",
+    std::string(node_->get_name()) + "/" + parameter_service_names::get_parameter_types,
     [captured_node](
       const std::shared_ptr<rmw_request_id_t>,
       const std::shared_ptr<rcl_interfaces::srv::GetParameterTypes::Request> request,
@@ -68,7 +70,7 @@ ParameterService::ParameterService(
   );
 
   set_parameters_service_ = node_->create_service<rcl_interfaces::srv::SetParameters>(
-    std::string(node_->get_name()) + "/set_parameters",
+    std::string(node_->get_name()) + "/" + parameter_service_names::set_parameters,
     [captured_node](
       const std::shared_ptr<rmw_request_id_t>,
       const std::shared_ptr<rcl_interfaces::srv::SetParameters::Request> request,
@@ -90,7 +92,7 @@ ParameterService::ParameterService(
 
   set_parameters_atomically_service_ =
     node_->create_service<rcl_interfaces::srv::SetParametersAtomically>(
-    std::string(node_->get_name()) + "/set_parameters_atomically",
+    std::string(node_->get_name()) + "/" + parameter_service_names::set_parameters_atomically,
     [captured_node](
       const std::shared_ptr<rmw_request_id_t>,
       const std::shared_ptr<rcl_interfaces::srv::SetParametersAtomically::Request> request,
@@ -114,7 +116,7 @@ ParameterService::ParameterService(
   );
 
   describe_parameters_service_ = node_->create_service<rcl_interfaces::srv::DescribeParameters>(
-    std::string(node_->get_name()) + "/describe_parameters",
+    std::string(node_->get_name()) + "/" + parameter_service_names::describe_parameters,
     [captured_node](
       const std::shared_ptr<rmw_request_id_t>,
       const std::shared_ptr<rcl_interfaces::srv::DescribeParameters::Request> request,

--- a/rclcpp/src/rclcpp/parameter_service.cpp
+++ b/rclcpp/src/rclcpp/parameter_service.cpp
@@ -29,7 +29,7 @@ ParameterService::ParameterService(
   std::weak_ptr<rclcpp::node::Node> captured_node = node_;
   // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
   get_parameters_service_ = node_->create_service<rcl_interfaces::srv::GetParameters>(
-    std::string(node_->get_name()) + "__get_parameters",
+    std::string(node_->get_name()) + "/get_parameters",
     [captured_node](
       const std::shared_ptr<rmw_request_id_t>,
       const std::shared_ptr<rcl_interfaces::srv::GetParameters::Request> request,
@@ -48,7 +48,7 @@ ParameterService::ParameterService(
   );
 
   get_parameter_types_service_ = node_->create_service<rcl_interfaces::srv::GetParameterTypes>(
-    std::string(node_->get_name()) + "__get_parameter_types",
+    std::string(node_->get_name()) + "/get_parameter_types",
     [captured_node](
       const std::shared_ptr<rmw_request_id_t>,
       const std::shared_ptr<rcl_interfaces::srv::GetParameterTypes::Request> request,
@@ -68,7 +68,7 @@ ParameterService::ParameterService(
   );
 
   set_parameters_service_ = node_->create_service<rcl_interfaces::srv::SetParameters>(
-    std::string(node_->get_name()) + "__set_parameters",
+    std::string(node_->get_name()) + "/set_parameters",
     [captured_node](
       const std::shared_ptr<rmw_request_id_t>,
       const std::shared_ptr<rcl_interfaces::srv::SetParameters::Request> request,
@@ -90,7 +90,7 @@ ParameterService::ParameterService(
 
   set_parameters_atomically_service_ =
     node_->create_service<rcl_interfaces::srv::SetParametersAtomically>(
-    std::string(node_->get_name()) + "__set_parameters_atomically",
+    std::string(node_->get_name()) + "/set_parameters_atomically",
     [captured_node](
       const std::shared_ptr<rmw_request_id_t>,
       const std::shared_ptr<rcl_interfaces::srv::SetParametersAtomically::Request> request,
@@ -114,7 +114,7 @@ ParameterService::ParameterService(
   );
 
   describe_parameters_service_ = node_->create_service<rcl_interfaces::srv::DescribeParameters>(
-    std::string(node_->get_name()) + "__describe_parameters",
+    std::string(node_->get_name()) + "/describe_parameters",
     [captured_node](
       const std::shared_ptr<rmw_request_id_t>,
       const std::shared_ptr<rcl_interfaces::srv::DescribeParameters::Request> request,
@@ -131,7 +131,7 @@ ParameterService::ParameterService(
   );
 
   list_parameters_service_ = node_->create_service<rcl_interfaces::srv::ListParameters>(
-    std::string(node_->get_name()) + "__list_parameters",
+    std::string(node_->get_name()) + "/list_parameters",
     [captured_node](
       const std::shared_ptr<rmw_request_id_t>,
       const std::shared_ptr<rcl_interfaces::srv::ListParameters::Request> request,

--- a/rclcpp/src/rclcpp/parameter_service.cpp
+++ b/rclcpp/src/rclcpp/parameter_service.cpp
@@ -133,7 +133,7 @@ ParameterService::ParameterService(
   );
 
   list_parameters_service_ = node_->create_service<rcl_interfaces::srv::ListParameters>(
-    std::string(node_->get_name()) + "/list_parameters",
+    std::string(node_->get_name()) + "/" + parameter_service_names::list_parameters,
     [captured_node](
       const std::shared_ptr<rmw_request_id_t>,
       const std::shared_ptr<rcl_interfaces::srv::ListParameters::Request> request,

--- a/rclcpp/src/rclcpp/parameter_service_names.hpp
+++ b/rclcpp/src/rclcpp/parameter_service_names.hpp
@@ -1,0 +1,32 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__PARAMETER_SERVICE_NAMES_HPP_
+#define RCLCPP__PARAMETER_SERVICE_NAMES_HPP_
+
+namespace rclcpp
+{
+namespace parameter_service_names
+{
+
+static constexpr const char * get_parameters = "get_parameters";
+static constexpr const char * get_parameter_types = "get_parameter_types";
+static constexpr const char * set_parameters = "set_parameters";
+static constexpr const char * set_parameters_atomically = "set_parameters_atomically";
+static constexpr const char * describe_parameters = "describe_parameters";
+static constexpr const char * list_parameters = "list_parameters";
+}  // namespace parameter_service_names
+}  // namespace rclcpp
+
+#endif  // RCLCPP__PARAMETER_SERVICE_NAMES_HPP_

--- a/rclcpp/src/rclcpp/parameter_service_names.hpp
+++ b/rclcpp/src/rclcpp/parameter_service_names.hpp
@@ -26,6 +26,7 @@ static constexpr const char * set_parameters = "set_parameters";
 static constexpr const char * set_parameters_atomically = "set_parameters_atomically";
 static constexpr const char * describe_parameters = "describe_parameters";
 static constexpr const char * list_parameters = "list_parameters";
+
 }  // namespace parameter_service_names
 }  // namespace rclcpp
 

--- a/rclcpp/src/rclcpp/parameter_service_names.hpp
+++ b/rclcpp/src/rclcpp/parameter_service_names.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 Open Source Robotics Foundation, Inc.
+// Copyright 2017 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
The current parameter service and client implementation still use double underscores. I believe this has been forgotten to change when namespacing was introduced.

linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3119)](http://ci.ros2.org/job/ci_linux/3119/)
OSX: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2488)](http://ci.ros2.org/job/ci_osx/2488/)
Windows: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3177)](http://ci.ros2.org/job/ci_windows/3177/) (test failures unrelated)