### PR TITLE
parameter client takes node interfaces

### DIFF
--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -30,6 +30,7 @@
 #include "rcl_interfaces/srv/set_parameters.hpp"
 #include "rcl_interfaces/srv/set_parameters_atomically.hpp"
 #include "rclcpp/executors.hpp"
+#include "rclcpp/create_subscription.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/node.hpp"
 #include "rclcpp/parameter.hpp"
@@ -125,7 +126,7 @@ public:
       false,  // ignore_local_publications,
       false,  // use_intra_process_comms_,
       msg_mem_strat,
-      std::make_shared<Alloc>);
+      std::make_shared<Alloc>());
   }
 
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -48,6 +48,14 @@ public:
 
   RCLCPP_PUBLIC
   AsyncParametersClient(
+    const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
+    const rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_interface,
+    const rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_interface,
+    const std::string & remote_node_name = "",
+    const rmw_qos_profile_t & qos_profile = rmw_qos_profile_parameters);
+
+  RCLCPP_PUBLIC
+  AsyncParametersClient(
     const rclcpp::node::Node::SharedPtr node,
     const std::string & remote_node_name = "",
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_parameters);

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -34,7 +34,7 @@ AsyncParametersClient::AsyncParametersClient(
   if (remote_node_name != "") {
     remote_node_name_ = remote_node_name;
   } else {
-    remote_node_name_ = node_->get_name();
+    remote_node_name_ = node_base_interface->get_name();
   }
 
   rcl_client_options_t options = rcl_client_get_default_options();

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -75,7 +75,7 @@ AsyncParametersClient::AsyncParametersClient(
     node_graph_interface,
     remote_node_name_ + "/" + parameter_service_names::list_parameters,
     options);
-  auto list_parameters_base = std::dynamic_pointer_cast<ClientBase>(get_parameters_client_);
+  auto list_parameters_base = std::dynamic_pointer_cast<ClientBase>(list_parameters_client_);
   node_services_interface->add_client(list_parameters_base, nullptr);
 
   describe_parameters_client_ = Client<rcl_interfaces::srv::DescribeParameters>::make_shared(

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -24,28 +24,80 @@
 using rclcpp::parameter_client::AsyncParametersClient;
 using rclcpp::parameter_client::SyncParametersClient;
 
+RCLCPP_PUBLIC
 AsyncParametersClient::AsyncParametersClient(
-  const rclcpp::node::Node::SharedPtr node,
+  const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
+  const rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_interface,
+  const rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_interface,
   const std::string & remote_node_name,
   const rmw_qos_profile_t & qos_profile)
-: node_(node)
 {
   if (remote_node_name != "") {
     remote_node_name_ = remote_node_name;
   } else {
     remote_node_name_ = node_->get_name();
   }
-  get_parameters_client_ = node_->create_client<rcl_interfaces::srv::GetParameters>(
-    remote_node_name_ + "/" + parameter_service_names::get_parameters, qos_profile);
-  get_parameter_types_client_ = node_->create_client<rcl_interfaces::srv::GetParameterTypes>(
-    remote_node_name_ + "/" + parameter_service_names::get_parameter_types, qos_profile);
-  set_parameters_client_ = node_->create_client<rcl_interfaces::srv::SetParameters>(
-    remote_node_name_ + "/" + parameter_service_names::set_parameters, qos_profile);
-  list_parameters_client_ = node_->create_client<rcl_interfaces::srv::ListParameters>(
-    remote_node_name_ + "/" + parameter_service_names::list_parameters, qos_profile);
-  describe_parameters_client_ = node_->create_client<rcl_interfaces::srv::DescribeParameters>(
-    remote_node_name_ + "/" + parameter_service_names::describe_parameters, qos_profile);
+
+  rcl_client_options_t options = rcl_client_get_default_options();
+  options.qos = qos_profile;
+
+  using rclcpp::client::Client;
+  using rclcpp::client::ClientBase;
+
+  get_parameters_client_ = Client<rcl_interfaces::srv::GetParameters>::make_shared(
+    node_base_interface.get(),
+    node_graph_interface,
+    remote_node_name_ + "/" + parameter_service_names::get_parameters,
+    options);
+  auto get_parameters_base = std::dynamic_pointer_cast<ClientBase>(get_parameters_client_);
+  node_services_interface->add_client(get_parameters_base, nullptr);
+
+  get_parameter_types_client_ = Client<rcl_interfaces::srv::GetParameterTypes>::make_shared(
+    node_base_interface.get(),
+    node_graph_interface,
+    remote_node_name_ + "/" + parameter_service_names::get_parameter_types,
+    options);
+  auto get_parameter_types_base =
+    std::dynamic_pointer_cast<ClientBase>(get_parameter_types_client_);
+  node_services_interface->add_client(get_parameter_types_base, nullptr);
+
+  set_parameters_client_ = Client<rcl_interfaces::srv::SetParameters>::make_shared(
+    node_base_interface.get(),
+    node_graph_interface,
+    remote_node_name_ + "/" + parameter_service_names::set_parameters,
+    options);
+  auto set_parameters_base = std::dynamic_pointer_cast<ClientBase>(set_parameters_client_);
+  node_services_interface->add_client(set_parameters_base, nullptr);
+
+  list_parameters_client_ = Client<rcl_interfaces::srv::ListParameters>::make_shared(
+    node_base_interface.get(),
+    node_graph_interface,
+    remote_node_name_ + "/" + parameter_service_names::list_parameters,
+    options);
+  auto list_parameters_base = std::dynamic_pointer_cast<ClientBase>(get_parameters_client_);
+  node_services_interface->add_client(list_parameters_base, nullptr);
+
+  describe_parameters_client_ = Client<rcl_interfaces::srv::DescribeParameters>::make_shared(
+    node_base_interface.get(),
+    node_graph_interface,
+    remote_node_name_ + "/" + parameter_service_names::describe_parameters,
+    options);
+  auto describe_parameters_base =
+    std::dynamic_pointer_cast<ClientBase>(describe_parameters_client_);
+  node_services_interface->add_client(describe_parameters_base, nullptr);
 }
+
+AsyncParametersClient::AsyncParametersClient(
+  const rclcpp::node::Node::SharedPtr node,
+  const std::string & remote_node_name,
+  const rmw_qos_profile_t & qos_profile)
+: AsyncParametersClient(
+    node->get_node_base_interface(),
+    node->get_node_graph_interface(),
+    node->get_node_services_interface(),
+    remote_node_name,
+    qos_profile)
+{}
 
 std::shared_future<std::vector<rclcpp::parameter::ParameterVariant>>
 AsyncParametersClient::get_parameters(

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -26,10 +26,12 @@ using rclcpp::parameter_client::SyncParametersClient;
 
 AsyncParametersClient::AsyncParametersClient(
   const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
+  const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface,
   const rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_interface,
   const rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_interface,
   const std::string & remote_node_name,
   const rmw_qos_profile_t & qos_profile)
+: node_topics_interface_(node_topics_interface)
 {
   if (remote_node_name != "") {
     remote_node_name_ = remote_node_name;
@@ -92,6 +94,7 @@ AsyncParametersClient::AsyncParametersClient(
   const rmw_qos_profile_t & qos_profile)
 : AsyncParametersClient(
     node->get_node_base_interface(),
+    node->get_node_topics_interface(),
     node->get_node_graph_interface(),
     node->get_node_services_interface(),
     remote_node_name,

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -24,7 +24,6 @@
 using rclcpp::parameter_client::AsyncParametersClient;
 using rclcpp::parameter_client::SyncParametersClient;
 
-RCLCPP_PUBLIC
 AsyncParametersClient::AsyncParametersClient(
   const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
   const rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_interface,


### PR DESCRIPTION
I had to refactor the constructor of the AsyncParameterClient in order to create an instance of it from a lifecycle node.

The current implementation keeps a handle on the original node pointer: 
https://github.com/ros2/rclcpp/blob/b1ed15ebc7e120b7e4e95df4caaf7f942fccbf15/rclcpp/src/rclcpp/parameter_service.cpp#L29
Why is that the case?