### PR TITLE
update rclcpp to use the refactored TimeSource Clock logic

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -31,6 +31,7 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/any_executable.cpp
   src/rclcpp/callback_group.cpp
   src/rclcpp/client.cpp
+  src/rclcpp/clock.cpp
   src/rclcpp/context.cpp
   src/rclcpp/contexts/default_context.cpp
   src/rclcpp/event.cpp

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -59,6 +59,7 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/service.cpp
   src/rclcpp/subscription.cpp
   src/rclcpp/time.cpp
+  src/rclcpp/time_source.cpp
   src/rclcpp/timer.cpp
   src/rclcpp/type_support.cpp
   src/rclcpp/utilities.cpp
@@ -266,6 +267,9 @@ if(BUILD_TESTING)
     endforeach()
   endif()
 
+  ament_add_gmock(test_logging test/test_logging.cpp)
+  target_link_libraries(test_logging ${PROJECT_NAME})
+
   ament_add_gtest(test_time test/test_time.cpp
     APPEND_LIBRARY_DIRS "${append_library_dirs}")
   if(TARGET test_time)
@@ -274,8 +278,13 @@ if(BUILD_TESTING)
     target_link_libraries(test_time ${PROJECT_NAME})
   endif()
 
-  ament_add_gmock(test_logging test/test_logging.cpp)
-  target_link_libraries(test_logging ${PROJECT_NAME})
+  ament_add_gtest(test_time_source test/test_time_source.cpp
+    APPEND_LIBRARY_DIRS "${append_library_dirs}")
+  if(TARGET test_time_source)
+    ament_target_dependencies(test_time_source
+      "rcl")
+    target_link_libraries(test_time_source ${PROJECT_NAME})
+  endif()
 endif()
 
 ament_package(

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -34,6 +34,7 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/clock.cpp
   src/rclcpp/context.cpp
   src/rclcpp/contexts/default_context.cpp
+  src/rclcpp/duration.cpp
   src/rclcpp/event.cpp
   src/rclcpp/exceptions.cpp
   src/rclcpp/executor.cpp
@@ -266,6 +267,14 @@ if(BUILD_TESTING)
       rosidl_target_interfaces(test_externally_defined_services
         mock_msgs ${typesupport_impl_c})
     endforeach()
+  endif()
+
+  ament_add_gtest(test_duration test/test_duration.cpp
+    APPEND_LIBRARY_DIRS "${append_library_dirs}")
+  if(TARGET test_duration)
+    ament_target_dependencies(test_duration
+      "rcl")
+    target_link_libraries(test_duration ${PROJECT_NAME})
   endif()
 
   ament_add_gmock(test_logging test/test_logging.cpp)

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -1,0 +1,56 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__CLOCK_HPP_
+#define RCLCPP__CLOCK_HPP_
+
+#include "rclcpp/time.hpp"
+#include "rclcpp/visibility_control.hpp"
+
+#include "rcl/time.h"
+
+namespace rclcpp
+{
+
+class TimeSource;
+
+class Clock
+{
+public:
+  RCLCPP_PUBLIC
+  explicit Clock(rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
+
+  RCLCPP_PUBLIC
+  ~Clock();
+
+  RCLCPP_PUBLIC
+  Time
+  now();
+
+  RCLCPP_PUBLIC
+  bool
+  isROSTimeActive();
+
+  RCLCPP_PUBLIC
+  rcl_clock_type_t
+  getClockType();
+
+private:
+  rcl_clock_t rcl_clock_;
+  friend TimeSource;  // Allow TimeSource to access the rcl_clock_ datatype.
+};
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__CLOCK_HPP_

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -102,6 +102,10 @@ public:
   get_clock_type();
 
   // Add a callback to invoke if the jump threshold is exceeded.
+  /**
+   * These callback functions must remain valid as long as the
+   * returned shared pointer is valid.
+   */
   RCLCPP_PUBLIC
   JumpHandler::SharedPtr
   create_jump_callback(

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -15,6 +15,7 @@
 #ifndef RCLCPP__CLOCK_HPP_
 #define RCLCPP__CLOCK_HPP_
 
+#include "rclcpp/macros.hpp"
 #include "rclcpp/time.hpp"
 #include "rclcpp/visibility_control.hpp"
 
@@ -25,9 +26,11 @@ namespace rclcpp
 
 class TimeSource;
 
-class Clock
+class Clock : public std::enable_shared_from_this<Clock>
 {
 public:
+  RCLCPP_SMART_PTR_DEFINITIONS(Clock)
+
   RCLCPP_PUBLIC
   explicit Clock(rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
 

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -64,7 +64,7 @@ public:
   is_exceeded(const TimeJump & jump);
 };
 
-class JumpHandler : public std::enable_shared_from_this<JumpHandler>
+class JumpHandler
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(JumpHandler)
@@ -78,7 +78,7 @@ public:
   JumpThreshold notice_threshold;
 };
 
-class Clock : public std::enable_shared_from_this<Clock>
+class Clock
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(Clock)

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -116,7 +116,8 @@ private:
   static void invoke_prejump_callbacks(const std::vector<JumpCallback::SharedPtr> & callbacks);
 
   RCLCPP_PUBLIC
-  static void invoke_postjump_callbacks(const std::vector<JumpCallback::SharedPtr> & callbacks, const TimeJump & jump);
+  static void invoke_postjump_callbacks(const std::vector<JumpCallback::SharedPtr> & callbacks,
+    const TimeJump & jump);
 
   // Internal storage backed by rcl
   rcl_clock_t rcl_clock_;

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -117,10 +117,12 @@ private:
 
   // Invoke callbacks that are valid and outside threshold.
   RCLCPP_PUBLIC
-  static void invoke_prejump_callbacks(const std::vector<JumpHandler::SharedPtr> & callbacks);
+  static void invoke_prejump_callbacks(
+    const std::vector<JumpHandler::SharedPtr> & callbacks);
 
   RCLCPP_PUBLIC
-  static void invoke_postjump_callbacks(const std::vector<JumpHandler::SharedPtr> & callbacks,
+  static void invoke_postjump_callbacks(
+    const std::vector<JumpHandler::SharedPtr> & callbacks,
     const TimeJump & jump);
 
   /// Internal storage backed by rcl

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -69,7 +69,7 @@ public:
     JumpThreshold & threshold);
 
   std::function<void()> pre_callback;
-  std::function<void(TimeJump)> post_callback;
+  std::function<void(const TimeJump &)> post_callback;
   JumpThreshold notice_threshold;
 };
 
@@ -101,7 +101,7 @@ public:
   JumpCallback::SharedPtr
   create_jump_callback(
     std::function<void()> pre_callback,
-    std::function<void(TimeJump)> post_callback,
+    std::function<void(const TimeJump &)> post_callback,
     JumpThreshold & threshold);
 
 private:

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -132,6 +132,7 @@ private:
   /// Internal storage backed by rcl
   rcl_clock_t rcl_clock_;
   friend TimeSource;  /// Allow TimeSource to access the rcl_clock_ datatype.
+  rcl_allocator_t allocator_;
 
   std::mutex callback_list_mutex_;
   std::vector<std::weak_ptr<JumpHandler>> active_jump_handlers_;

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -15,6 +15,11 @@
 #ifndef RCLCPP__CLOCK_HPP_
 #define RCLCPP__CLOCK_HPP_
 
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <vector>
+
 #include "rclcpp/macros.hpp"
 #include "rclcpp/time.hpp"
 #include "rclcpp/visibility_control.hpp"
@@ -25,6 +30,48 @@ namespace rclcpp
 {
 
 class TimeSource;
+
+class TimeJump
+{
+public:
+  typedef enum ClockChange_t
+  {
+    ROS_TIME_NO_CHANGE,
+    ROS_TIME_ACTIVATED,
+    ROS_TIME_DEACTIVATED,
+    SYSTEM_TIME_NO_CHANGE
+  } ClockChange_t;
+
+  ClockChange_t jump_type_;
+  rcl_duration_t delta_;
+};
+
+class JumpThreshold
+{
+public:
+  uint64_t min_forward_;
+  uint64_t min_backward_;
+  bool on_clock_change_;
+
+  // Test if the threshold is exceeded by a TimeJump
+  RCLCPP_PUBLIC
+  bool
+  is_exceeded(const TimeJump & jump);
+};
+
+class JumpCallback : public std::enable_shared_from_this<JumpCallback>
+{
+public:
+  RCLCPP_SMART_PTR_DEFINITIONS(JumpCallback)
+  JumpCallback(
+    std::function<void()> pre_callback,
+    std::function<void(TimeJump)> post_callback,
+    JumpThreshold & threshold);
+
+  std::function<void()> pre_callback;
+  std::function<void(TimeJump)> post_callback;
+  JumpThreshold notice_threshold;
+};
 
 class Clock : public std::enable_shared_from_this<Clock>
 {
@@ -49,9 +96,34 @@ public:
   rcl_clock_type_t
   getClockType();
 
+  // Add a callback to invoke if the jump threshold is exceeded.
+  RCLCPP_PUBLIC
+  JumpCallback::SharedPtr
+  create_jump_callback(
+    std::function<void()> pre_callback,
+    std::function<void(TimeJump)> post_callback,
+    JumpThreshold & threshold);
+
 private:
+  // A method for TimeSource to get a list of callbacks to invoke while updating
+  RCLCPP_PUBLIC
+  std::vector<JumpCallback::SharedPtr>
+  get_triggered_callbacks(const TimeJump & jump);
+
+
+  // Invoke callbacks that are valid and outside threshold.
+  RCLCPP_PUBLIC
+  static void invoke_prejump_callbacks(const std::vector<JumpCallback::SharedPtr> & callbacks);
+
+  RCLCPP_PUBLIC
+  static void invoke_postjump_callbacks(const std::vector<JumpCallback::SharedPtr> & callbacks, const TimeJump & jump);
+
+  // Internal storage backed by rcl
   rcl_clock_t rcl_clock_;
   friend TimeSource;  // Allow TimeSource to access the rcl_clock_ datatype.
+
+  std::mutex callback_list_mutex_;
+  std::vector<std::weak_ptr<JumpCallback>> active_jump_callbacks_;
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -113,7 +113,7 @@ private:
   // A method for TimeSource to get a list of callbacks to invoke while updating
   RCLCPP_PUBLIC
   std::vector<JumpHandler::SharedPtr>
-  get_triggered_callbacks(const TimeJump & jump);
+  get_triggered_callback_handlers(const TimeJump & jump);
 
   // Invoke callbacks that are valid and outside threshold.
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/duration.hpp
+++ b/rclcpp/include/rclcpp/duration.hpp
@@ -23,7 +23,6 @@
 
 namespace rclcpp
 {
-
 class Duration
 {
 public:
@@ -50,11 +49,11 @@ public:
   operator builtin_interfaces::msg::Duration() const;
 
   RCLCPP_PUBLIC
-  void
+  Duration &
   operator=(const Duration & rhs);
 
   RCLCPP_PUBLIC
-  void
+  Duration &
   operator=(const builtin_interfaces::msg::Duration & Duration_msg);
 
   RCLCPP_PUBLIC
@@ -91,18 +90,10 @@ public:
 
   RCLCPP_PUBLIC
   rcl_clock_type_t
-  clock_type() const;
+  get_clock_type() const;
 
 private:
   rcl_duration_t rcl_duration_;
-
-  static
-  void
-  bounds_check_difference(int64_t lhsns, int64_t rhsns, uint64_t max);
-
-  static
-  void
-  bounds_check_sum(int64_t lhsns, int64_t rhsns, uint64_t max);
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/duration.hpp
+++ b/rclcpp/include/rclcpp/duration.hpp
@@ -1,0 +1,110 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__DURATION_HPP_
+#define RCLCPP__DURATION_HPP_
+
+#include "builtin_interfaces/msg/duration.hpp"
+
+#include "rclcpp/visibility_control.hpp"
+
+#include "rcl/time.h"
+
+namespace rclcpp
+{
+
+class Duration
+{
+public:
+  RCLCPP_PUBLIC
+  Duration(int32_t seconds, uint32_t nanoseconds, rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
+
+  RCLCPP_PUBLIC
+  explicit Duration(rcl_duration_value_t nanoseconds,
+    rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
+
+  RCLCPP_PUBLIC
+  Duration(const builtin_interfaces::msg::Duration & duration_msg);  // NOLINT
+
+  RCLCPP_PUBLIC
+  explicit Duration(const rcl_duration_t & duration);
+
+  RCLCPP_PUBLIC
+  Duration(const Duration & rhs);
+
+  RCLCPP_PUBLIC
+  virtual ~Duration();
+
+  RCLCPP_PUBLIC
+  operator builtin_interfaces::msg::Duration() const;
+
+  RCLCPP_PUBLIC
+  void
+  operator=(const Duration & rhs);
+
+  RCLCPP_PUBLIC
+  void
+  operator=(const builtin_interfaces::msg::Duration & Duration_msg);
+
+  RCLCPP_PUBLIC
+  bool
+  operator==(const rclcpp::Duration & rhs) const;
+
+  RCLCPP_PUBLIC
+  bool
+  operator<(const rclcpp::Duration & rhs) const;
+
+  RCLCPP_PUBLIC
+  bool
+  operator<=(const rclcpp::Duration & rhs) const;
+
+  RCLCPP_PUBLIC
+  bool
+  operator>=(const rclcpp::Duration & rhs) const;
+
+  RCLCPP_PUBLIC
+  bool
+  operator>(const rclcpp::Duration & rhs) const;
+
+  RCLCPP_PUBLIC
+  Duration
+  operator+(const rclcpp::Duration & rhs) const;
+
+  RCLCPP_PUBLIC
+  Duration
+  operator-(const rclcpp::Duration & rhs) const;
+
+  RCLCPP_PUBLIC
+  rcl_duration_value_t
+  nanoseconds() const;
+
+  RCLCPP_PUBLIC
+  rcl_clock_type_t
+  clock_type() const;
+
+private:
+  rcl_duration_t rcl_duration_;
+
+  static
+  void
+  bounds_check_difference(int64_t lhsns, int64_t rhsns, uint64_t max);
+
+  static
+  void
+  bounds_check_sum(int64_t lhsns, int64_t rhsns, uint64_t max);
+};
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__DURATION_HPP_

--- a/rclcpp/include/rclcpp/duration.hpp
+++ b/rclcpp/include/rclcpp/duration.hpp
@@ -35,7 +35,9 @@ public:
     rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
 
   RCLCPP_PUBLIC
-  Duration(const builtin_interfaces::msg::Duration & duration_msg);  // NOLINT
+  Duration(
+    const builtin_interfaces::msg::Duration & duration_msg,
+    rcl_clock_type_t ros_duration = RCL_ROS_TIME);
 
   RCLCPP_PUBLIC
   explicit Duration(const rcl_duration_t & duration);

--- a/rclcpp/include/rclcpp/duration.hpp
+++ b/rclcpp/include/rclcpp/duration.hpp
@@ -30,7 +30,8 @@ public:
   Duration(int32_t seconds, uint32_t nanoseconds, rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
 
   RCLCPP_PUBLIC
-  explicit Duration(rcl_duration_value_t nanoseconds,
+  explicit Duration(
+    rcl_duration_value_t nanoseconds,
     rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
 
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/duration.hpp
+++ b/rclcpp/include/rclcpp/duration.hpp
@@ -15,11 +15,11 @@
 #ifndef RCLCPP__DURATION_HPP_
 #define RCLCPP__DURATION_HPP_
 
+#include <chrono>
+
 #include "builtin_interfaces/msg/duration.hpp"
-
-#include "rclcpp/visibility_control.hpp"
-
 #include "rcl/time.h"
+#include "rclcpp/visibility_control.hpp"
 
 namespace rclcpp
 {
@@ -27,17 +27,19 @@ class Duration
 {
 public:
   RCLCPP_PUBLIC
-  Duration(int32_t seconds, uint32_t nanoseconds, rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
+  Duration(int32_t seconds, uint32_t nanoseconds);
 
   RCLCPP_PUBLIC
   explicit Duration(
-    rcl_duration_value_t nanoseconds,
-    rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
+    rcl_duration_value_t nanoseconds);
+
+  RCLCPP_PUBLIC
+  explicit Duration(
+    std::chrono::nanoseconds nanoseconds);
 
   RCLCPP_PUBLIC
   Duration(
-    const builtin_interfaces::msg::Duration & duration_msg,
-    rcl_clock_type_t ros_duration = RCL_ROS_TIME);
+    const builtin_interfaces::msg::Duration & duration_msg);
 
   RCLCPP_PUBLIC
   explicit Duration(const rcl_duration_t & duration);
@@ -90,10 +92,6 @@ public:
   RCLCPP_PUBLIC
   rcl_duration_value_t
   nanoseconds() const;
-
-  RCLCPP_PUBLIC
-  rcl_clock_type_t
-  get_clock_type() const;
 
 private:
   rcl_duration_t rcl_duration_;

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -35,10 +35,7 @@ public:
   Time(int32_t seconds, uint32_t nanoseconds, rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
 
   RCLCPP_PUBLIC
-  Time(int32_t seconds, uint32_t nanoseconds, rcl_time_source_type_t clock = RCL_SYSTEM_TIME);
-
-  RCLCPP_PUBLIC
-  explicit Time(uint64_t nanoseconds = 0, rcl_time_source_type_t clock = RCL_SYSTEM_TIME);
+  explicit Time(uint64_t nanoseconds = 0, rcl_clock_type_t clock = RCL_SYSTEM_TIME);
 
   RCLCPP_PUBLIC
   Time(const Time & rhs);

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -85,22 +85,32 @@ public:
   operator>(const rclcpp::Time & rhs) const;
 
   RCLCPP_PUBLIC
-  Duration
-  operator+(const rclcpp::Time & rhs) const;
-  // TODO(tfoote) does time + time make sense to implement?
+  Time
+  operator+(const rclcpp::Duration & rhs) const;
 
   RCLCPP_PUBLIC
   Duration
   operator-(const rclcpp::Time & rhs) const;
 
   RCLCPP_PUBLIC
+  Time
+  operator-(const rclcpp::Duration & rhs) const;
+
+  RCLCPP_PUBLIC
   rcl_time_point_value_t
   nanoseconds() const;
+
+  RCLCPP_PUBLIC
+  rcl_clock_type_t
+  get_clock_type() const;
 
 private:
   rcl_time_point_t rcl_time_;
   friend Clock;  // Allow clock to manipulate internal data
 };
+
+Time
+operator+(const rclcpp::Duration & lhs, const rclcpp::Time & rhs);
 
 }  // namespace rclcpp
 

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -117,6 +117,14 @@ public:
   Time
   now();
 
+  RCLCPP_PUBLIC
+  bool
+  isROSTimeActive();
+
+  RCLCPP_PUBLIC
+  rcl_clock_type_t
+  getClockType();
+
 private:
   rcl_clock_t rcl_clock_;
   friend TimeSource;  // Allow TimeSource to acces the rcl_clock_ datatype.

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -43,6 +43,9 @@ public:
 
   RCLCPP_PUBLIC
   Time(const builtin_interfaces::msg::Time & time_msg);  // NOLINT
+  
+  RCLCPP_PUBLIC
+  Time(const rcl_time_point_t & time_point);
 
   RCLCPP_PUBLIC
   virtual ~Time();

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -25,6 +25,7 @@ namespace rclcpp
 {
 
 class Clock;
+class TimeSource;
 
 class Time
 {
@@ -110,11 +111,15 @@ public:
   explicit Clock(rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
 
   RCLCPP_PUBLIC
+  ~Clock();
+
+  RCLCPP_PUBLIC
   Time
   now();
 
 private:
   rcl_clock_t rcl_clock_;
+  friend TimeSource;  // Allow TimeSource to acces the rcl_clock_ datatype.
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -41,7 +41,9 @@ public:
   Time(const Time & rhs);
 
   RCLCPP_PUBLIC
-  Time(const builtin_interfaces::msg::Time & time_msg);  // NOLINT
+  Time(
+    const builtin_interfaces::msg::Time & time_msg,
+    rcl_clock_type_t ros_time = RCL_ROS_TIME);
 
   RCLCPP_PUBLIC
   explicit Time(const rcl_time_point_t & time_point);

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -21,6 +21,8 @@
 
 #include "rcl/time.h"
 
+#include "rclcpp/duration.hpp"
+
 namespace rclcpp
 {
 
@@ -86,15 +88,16 @@ public:
   operator>(const rclcpp::Time & rhs) const;
 
   RCLCPP_PUBLIC
-  Time
+  Duration
   operator+(const rclcpp::Time & rhs) const;
+  // TODO(tfoote) does time + time make sense to implement?
 
   RCLCPP_PUBLIC
-  Time
+  Duration
   operator-(const rclcpp::Time & rhs) const;
 
   RCLCPP_PUBLIC
-  uint64_t
+  rcl_time_point_value_t
   nanoseconds() const;
 
 private:

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -45,7 +45,7 @@ public:
   Time(const builtin_interfaces::msg::Time & time_msg);  // NOLINT
 
   RCLCPP_PUBLIC
-  Time(const rcl_time_point_t & time_point);
+  explicit Time(const rcl_time_point_t & time_point);
 
   RCLCPP_PUBLIC
   virtual ~Time();
@@ -99,19 +99,19 @@ public:
 
 private:
   rcl_time_point_t rcl_time_;
-  friend Clock; // Allow clock to manipulate internal data
+  friend Clock;  // Allow clock to manipulate internal data
 };
 
-//TODO(tfoote) move to own file
+// TODO(tfoote) move to own file
 class Clock
 {
 public:
   RCLCPP_PUBLIC
-  Clock(rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
+  explicit Clock(rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
 
   RCLCPP_PUBLIC
   Time
-  now(rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
+  now();
 
 private:
   rcl_clock_t rcl_clock_;

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -25,7 +25,6 @@ namespace rclcpp
 {
 
 class Clock;
-class TimeSource;
 
 class Time
 {
@@ -101,33 +100,6 @@ public:
 private:
   rcl_time_point_t rcl_time_;
   friend Clock;  // Allow clock to manipulate internal data
-};
-
-// TODO(tfoote) move to own file
-class Clock
-{
-public:
-  RCLCPP_PUBLIC
-  explicit Clock(rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
-
-  RCLCPP_PUBLIC
-  ~Clock();
-
-  RCLCPP_PUBLIC
-  Time
-  now();
-
-  RCLCPP_PUBLIC
-  bool
-  isROSTimeActive();
-
-  RCLCPP_PUBLIC
-  rcl_clock_type_t
-  getClockType();
-
-private:
-  rcl_clock_t rcl_clock_;
-  friend TimeSource;  // Allow TimeSource to acces the rcl_clock_ datatype.
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -24,13 +24,13 @@
 namespace rclcpp
 {
 
+class Clock;
+
 class Time
 {
 public:
   RCLCPP_PUBLIC
-  static
-  Time
-  now(rcl_time_source_type_t clock = RCL_SYSTEM_TIME);
+  Time(int32_t seconds, uint32_t nanoseconds, rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
 
   RCLCPP_PUBLIC
   Time(int32_t seconds, uint32_t nanoseconds, rcl_time_source_type_t clock = RCL_SYSTEM_TIME);
@@ -43,7 +43,7 @@ public:
 
   RCLCPP_PUBLIC
   Time(const builtin_interfaces::msg::Time & time_msg);  // NOLINT
-  
+
   RCLCPP_PUBLIC
   Time(const rcl_time_point_t & time_point);
 
@@ -98,8 +98,23 @@ public:
   nanoseconds() const;
 
 private:
-  rcl_time_source_t rcl_time_source_;
   rcl_time_point_t rcl_time_;
+  friend Clock; // Allow clock to manipulate internal data
+};
+
+//TODO(tfoote) move to own file
+class Clock
+{
+public:
+  RCLCPP_PUBLIC
+  Clock(rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
+
+  RCLCPP_PUBLIC
+  Time
+  now(rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
+
+private:
+  rcl_clock_t rcl_clock_;
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -20,7 +20,10 @@
 
 #include "rcl/time.h"
 
+#include "rcl_interfaces/msg/parameter_event.hpp"
+
 #include "rclcpp/node.hpp"
+#include "rclcpp/parameter_client.hpp"
 
 
 namespace rclcpp
@@ -66,6 +69,20 @@ private:
   // The clock callback itself
   void clock_cb(const builtin_interfaces::msg::Time::SharedPtr msg);
 
+  // Parameter Client pointer
+  std::shared_ptr<rclcpp::parameter_client::AsyncParametersClient> parameter_client_;
+
+  // Parameter Event subscription
+  using ParamMessageT = rcl_interfaces::msg::ParameterEvent;
+  using ParamSubscriptionT = rclcpp::subscription::Subscription<ParamMessageT, Alloc>;
+  std::shared_ptr<ParamSubscriptionT> parameter_subscription_;
+
+  // Callback for parameter updates
+  void on_parameter_event(const rcl_interfaces::msg::ParameterEvent::SharedPtr event);
+
+  // An enum to hold the parameter state
+  enum UseSimTimeParameterState {UNSET, SET_TRUE, SET_FALSE};
+  UseSimTimeParameterState parameter_state_;
 
   // An internal method to use in the clock callback that iterates and enables all clocks
   void enableROSTime();

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -57,26 +57,34 @@ private:
   // Preserve the node reference
   std::shared_ptr<rclcpp::node::Node> node_;
 
+  // The subscription for the clock callback
   using MessageT = builtin_interfaces::msg::Time;
   using Alloc = std::allocator<void>;
   using SubscriptionT = rclcpp::subscription::Subscription<MessageT, Alloc>;
-  // The subscription for the clock callback
   std::shared_ptr<SubscriptionT> clock_subscription_;
 
   // The clock callback itself
   void clock_cb(const builtin_interfaces::msg::Time::SharedPtr msg);
+
+
+  // An internal method to use in the clock callback that iterates and enables all clocks
   void enableROSTime();
+  // An internal method to use in the clock callback that iterates and disables all clocks
   void disableROSTime();
 
   // Internal helper functions used inside iterators
-  void enableROSTime(std::shared_ptr<rclcpp::Clock> clock);
-  void disableROSTime(std::shared_ptr<rclcpp::Clock> clock);
-  void setClock(const builtin_interfaces::msg::Time::SharedPtr msg,
+  static void enableROSTime(std::shared_ptr<rclcpp::Clock> clock);
+  static void disableROSTime(std::shared_ptr<rclcpp::Clock> clock);
+  static void setClock(const builtin_interfaces::msg::Time::SharedPtr msg,
     std::shared_ptr<rclcpp::Clock> clock);
 
+  // Local storage of validity of ROS time
+  // This is needed when new clocks are added.
   bool ros_time_valid_;
 
+  // A lock to protect iterating the associated_clocks_ field.
   std::mutex clock_list_lock_;
+  // A vector to store references to associated clocks.
   std::vector<std::shared_ptr<rclcpp::Clock>> associated_clocks_;
 };
 

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -1,0 +1,60 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__TIME_SOURCE_HPP_
+#define RCLCPP__TIME_SOURCE_HPP_
+
+#include "rcl/time.h"
+
+#include "rclcpp/node.hpp"
+
+
+namespace rclcpp
+{
+
+class TimeSource
+{
+public:
+  RCLCPP_PUBLIC
+  TimeSource(std::shared_ptr<rclcpp::node::Node> node);
+
+  RCLCPP_PUBLIC
+  ~TimeSource();
+
+  RCLCPP_PUBLIC
+  Time
+  now(rcl_time_source_type_t clock = RCL_ROS_TIME);
+  
+  // TODO(tfoote) add register callback for time jumps
+  
+private:
+  // Preserve the node reference
+  std::shared_ptr<rclcpp::node::Node> node_;
+  
+  using MessageT = builtin_interfaces::msg::Time;
+  using Alloc = std::allocator<void>;
+  using SubscriptionT = rclcpp::subscription::Subscription<MessageT, Alloc>;
+  //The subscription for the clock callback
+  std::shared_ptr<SubscriptionT> clock_subscription_;
+
+  // The clock callback itself
+  void clock_cb(const builtin_interfaces::msg::Time::SharedPtr msg);
+  
+  rcl_time_source_t ros_time_source_;
+  rcl_time_source_t system_time_source_;
+};
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__TIME_SOURCE_HPP_

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -30,6 +30,15 @@ public:
   TimeSource(std::shared_ptr<rclcpp::node::Node> node);
 
   RCLCPP_PUBLIC
+  TimeSource();
+
+  RCLCPP_PUBLIC
+  void attachNode(std::shared_ptr<rclcpp::node::Node> node);
+
+  RCLCPP_PUBLIC
+  void detachNode();
+
+  RCLCPP_PUBLIC
   ~TimeSource();
 
   RCLCPP_PUBLIC
@@ -50,7 +59,13 @@ private:
 
   // The clock callback itself
   void clock_cb(const builtin_interfaces::msg::Time::SharedPtr msg);
+  void initializeData();
+  void enableROSTime();
+  void disableROSTime();
+
+  bool ros_time_valid_;
   
+  //Data Storage
   rcl_time_source_t ros_time_source_;
   rcl_time_source_t system_time_source_;
 };

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -24,6 +24,7 @@
 
 namespace rclcpp
 {
+class Clock;
 
 class TimeSource
 {
@@ -39,6 +40,12 @@ public:
 
   RCLCPP_PUBLIC
   void detachNode();
+
+  RCLCPP_PUBLIC
+  void attachClock(std::shared_ptr<rclcpp::Clock> clock);
+
+  RCLCPP_PUBLIC
+  void detachClock(std::shared_ptr<rclcpp::Clock> clock);
 
   RCLCPP_PUBLIC
   ~TimeSource();
@@ -61,8 +68,13 @@ private:
   void enableROSTime();
   void disableROSTime();
 
+  void setClock(const builtin_interfaces::msg::Time::SharedPtr msg,
+      std::shared_ptr<rclcpp::Clock> clock);
+
   bool ros_time_valid_;
 
+  std::mutex clock_list_lock_;
+  std::vector<std::shared_ptr<rclcpp::Clock> > associated_clocks_;
   // Data Storage
   rcl_clock_t ros_clock_;
 };

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -43,10 +43,6 @@ public:
   RCLCPP_PUBLIC
   ~TimeSource();
 
-  RCLCPP_PUBLIC
-  Time
-  now(rcl_clock_type_t clock_type = RCL_ROS_TIME);
-
   // TODO(tfoote) add register callback for time jumps
 
 private:
@@ -69,7 +65,6 @@ private:
 
   // Data Storage
   rcl_clock_t ros_clock_;
-  rcl_clock_t system_clock_;
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -16,6 +16,7 @@
 #define RCLCPP__TIME_SOURCE_HPP_
 
 #include <memory>
+#include <vector>
 
 #include "rcl/time.h"
 
@@ -64,19 +65,19 @@ private:
 
   // The clock callback itself
   void clock_cb(const builtin_interfaces::msg::Time::SharedPtr msg);
-  void initializeData();
   void enableROSTime();
   void disableROSTime();
 
+  // Internal helper functions used inside iterators
+  void enableROSTime(std::shared_ptr<rclcpp::Clock> clock);
+  void disableROSTime(std::shared_ptr<rclcpp::Clock> clock);
   void setClock(const builtin_interfaces::msg::Time::SharedPtr msg,
-      std::shared_ptr<rclcpp::Clock> clock);
+    std::shared_ptr<rclcpp::Clock> clock);
 
   bool ros_time_valid_;
 
   std::mutex clock_list_lock_;
-  std::vector<std::shared_ptr<rclcpp::Clock> > associated_clocks_;
-  // Data Storage
-  rcl_clock_t ros_clock_;
+  std::vector<std::shared_ptr<rclcpp::Clock>> associated_clocks_;
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -43,14 +43,14 @@ public:
 
   RCLCPP_PUBLIC
   Time
-  now(rcl_time_source_type_t clock = RCL_ROS_TIME);
-  
+  now(rcl_clock_type_t clock_type = RCL_ROS_TIME);
+
   // TODO(tfoote) add register callback for time jumps
-  
+
 private:
   // Preserve the node reference
   std::shared_ptr<rclcpp::node::Node> node_;
-  
+
   using MessageT = builtin_interfaces::msg::Time;
   using Alloc = std::allocator<void>;
   using SubscriptionT = rclcpp::subscription::Subscription<MessageT, Alloc>;
@@ -64,12 +64,12 @@ private:
   void disableROSTime();
 
   bool ros_time_valid_;
-  
+
   //Data Storage
-  rcl_time_source_t ros_time_source_;
-  rcl_time_source_t system_time_source_;
+  rcl_clock_t ros_clock_;
+  rcl_clock_t system_clock_;
 };
 
 }  // namespace rclcpp
 
-#endif  // RCLCPP__TIME_SOURCE_HPP_
+#endif  // RCLCPP__clock_HPP_

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -15,6 +15,8 @@
 #ifndef RCLCPP__TIME_SOURCE_HPP_
 #define RCLCPP__TIME_SOURCE_HPP_
 
+#include <memory>
+
 #include "rcl/time.h"
 
 #include "rclcpp/node.hpp"
@@ -27,7 +29,7 @@ class TimeSource
 {
 public:
   RCLCPP_PUBLIC
-  TimeSource(std::shared_ptr<rclcpp::node::Node> node);
+  explicit TimeSource(std::shared_ptr<rclcpp::node::Node> node);
 
   RCLCPP_PUBLIC
   TimeSource();
@@ -54,7 +56,7 @@ private:
   using MessageT = builtin_interfaces::msg::Time;
   using Alloc = std::allocator<void>;
   using SubscriptionT = rclcpp::subscription::Subscription<MessageT, Alloc>;
-  //The subscription for the clock callback
+  // The subscription for the clock callback
   std::shared_ptr<SubscriptionT> clock_subscription_;
 
   // The clock callback itself
@@ -65,11 +67,11 @@ private:
 
   bool ros_time_valid_;
 
-  //Data Storage
+  // Data Storage
   rcl_clock_t ros_clock_;
   rcl_clock_t system_clock_;
 };
 
 }  // namespace rclcpp
 
-#endif  // RCLCPP__clock_HPP_
+#endif  // RCLCPP__TIME_SOURCE_HPP_

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -34,22 +34,22 @@ class TimeSource
 {
 public:
   RCLCPP_PUBLIC
-  explicit TimeSource(std::shared_ptr<rclcpp::node::Node> node);
+  explicit TimeSource(rclcpp::node::Node::SharedPtr node);
 
   RCLCPP_PUBLIC
   TimeSource();
 
   RCLCPP_PUBLIC
-  void attachNode(std::shared_ptr<rclcpp::node::Node> node);
+  void attachNode(rclcpp::node::Node::SharedPtr node);
 
   RCLCPP_PUBLIC
   void detachNode();
 
   RCLCPP_PUBLIC
-  void attachClock(std::shared_ptr<rclcpp::Clock> clock);
+  void attachClock(rclcpp::Clock::SharedPtr clock);
 
   RCLCPP_PUBLIC
-  void detachClock(std::shared_ptr<rclcpp::Clock> clock);
+  void detachClock(rclcpp::Clock::SharedPtr clock);
 
   RCLCPP_PUBLIC
   ~TimeSource();
@@ -58,7 +58,7 @@ public:
 
 private:
   // Preserve the node reference
-  std::shared_ptr<rclcpp::node::Node> node_;
+  rclcpp::node::Node::SharedPtr node_;
 
   // The subscription for the clock callback
   using MessageT = builtin_interfaces::msg::Time;
@@ -90,10 +90,10 @@ private:
   void disableROSTime();
 
   // Internal helper functions used inside iterators
-  static void enableROSTime(std::shared_ptr<rclcpp::Clock> clock);
-  static void disableROSTime(std::shared_ptr<rclcpp::Clock> clock);
+  static void enableROSTime(rclcpp::Clock::SharedPtr clock);
+  static void disableROSTime(rclcpp::Clock::SharedPtr clock);
   static void setClock(const builtin_interfaces::msg::Time::SharedPtr msg,
-    std::shared_ptr<rclcpp::Clock> clock);
+    rclcpp::Clock::SharedPtr clock);
 
   // Local storage of validity of ROS time
   // This is needed when new clocks are added.
@@ -102,7 +102,7 @@ private:
   // A lock to protect iterating the associated_clocks_ field.
   std::mutex clock_list_lock_;
   // A vector to store references to associated clocks.
-  std::vector<std::shared_ptr<rclcpp::Clock>> associated_clocks_;
+  std::vector<rclcpp::Clock::SharedPtr> associated_clocks_;
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -92,7 +92,8 @@ private:
   // Internal helper functions used inside iterators
   static void enableROSTime(rclcpp::Clock::SharedPtr clock);
   static void disableROSTime(rclcpp::Clock::SharedPtr clock);
-  static void setClock(const builtin_interfaces::msg::Time::SharedPtr msg,
+  static void setClock(
+    const builtin_interfaces::msg::Time::SharedPtr msg,
     rclcpp::Clock::SharedPtr clock);
 
   // Local storage of validity of ROS time

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -85,13 +85,13 @@ private:
   UseSimTimeParameterState parameter_state_;
 
   // An internal method to use in the clock callback that iterates and enables all clocks
-  void enableROSTime();
+  void enable_ros_time();
   // An internal method to use in the clock callback that iterates and disables all clocks
-  void disableROSTime();
+  void disable_ros_time();
 
   // Internal helper functions used inside iterators
-  static void enableROSTime(rclcpp::Clock::SharedPtr clock);
-  static void disableROSTime(rclcpp::Clock::SharedPtr clock);
+  static void enable_ros_time(rclcpp::Clock::SharedPtr clock);
+  static void disable_ros_time(rclcpp::Clock::SharedPtr clock);
   static void setClock(
     const builtin_interfaces::msg::Time::SharedPtr msg,
     rclcpp::Clock::SharedPtr clock);

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -97,7 +97,9 @@ private:
 
   // Local storage of validity of ROS time
   // This is needed when new clocks are added.
-  bool ros_time_valid_;
+  bool ros_time_active_;
+  // Last set message to be passed to newly registered clocks
+  builtin_interfaces::msg::Time::SharedPtr last_msg_set_;
 
   // A lock to protect iterating the associated_clocks_ field.
   std::mutex clock_list_lock_;

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -45,6 +45,10 @@ public:
   RCLCPP_PUBLIC
   void detachNode();
 
+  /// Attach a clock to the time source to be updated
+  /**
+   * \throws std::invalid_argument if node is nullptr
+   */
   RCLCPP_PUBLIC
   void attachClock(rclcpp::Clock::SharedPtr clock);
 

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -54,8 +54,6 @@ public:
   RCLCPP_PUBLIC
   ~TimeSource();
 
-  // TODO(tfoote) add register callback for time jumps
-
 private:
   // Preserve the node reference
   rclcpp::node::Node::SharedPtr node_;
@@ -92,8 +90,9 @@ private:
   // Internal helper functions used inside iterators
   static void enable_ros_time(rclcpp::Clock::SharedPtr clock);
   static void disable_ros_time(rclcpp::Clock::SharedPtr clock);
-  static void setClock(
+  static void set_clock(
     const builtin_interfaces::msg::Time::SharedPtr msg,
+    bool set_ros_time_enabled,
     rclcpp::Clock::SharedPtr clock);
 
   // Local storage of validity of ROS time

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -1,0 +1,83 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/clock.hpp"
+
+#include <utility>
+
+#include "builtin_interfaces/msg/time.hpp"
+
+#include "rcl/time.h"
+
+#include "rclcpp/exceptions.hpp"
+
+#include "rcutils/logging_macros.h"
+
+namespace rclcpp
+{
+
+Time
+Clock::now()
+{
+  Time now(0, 0, rcl_clock_.type);
+
+  auto ret = rcl_time_point_get_now(&rcl_clock_, &now.rcl_time_);
+  if (ret != RCL_RET_OK) {
+    rclcpp::exceptions::throw_from_rcl_error(
+      ret, "could not get current time stamp");
+  }
+
+  return now;
+}
+
+bool
+Clock::isROSTimeActive()
+{
+  if (!rcl_clock_valid(&rcl_clock_)) {
+    RCUTILS_LOG_ERROR("ROS time not valid!");
+    return false;
+  }
+
+  bool is_enabled;
+  auto ret = rcl_is_enabled_ros_time_override(&rcl_clock_, &is_enabled);
+  if (ret != RCL_RET_OK) {
+    RCUTILS_LOG_ERROR("Failed to check ros_time_override_status");
+  }
+  return is_enabled;
+}
+
+rcl_clock_type_t
+Clock::getClockType()
+{
+  return rcl_clock_.type;
+}
+
+Clock::Clock(rcl_clock_type_t clock_type)
+{
+  auto ret = rcl_clock_init(clock_type, &rcl_clock_);
+  if (ret != RCL_RET_OK) {
+    rclcpp::exceptions::throw_from_rcl_error(
+      ret, "could not get current time stamp");
+  }
+}
+
+Clock::~Clock()
+{
+  auto ret = rcl_clock_fini(&rcl_clock_);
+  if (ret != RCL_RET_OK) {
+    RCUTILS_LOG_ERROR("Failed to fini rcl clock.");
+  }
+}
+
+}  // namespace rclcpp

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -26,6 +26,22 @@
 
 namespace rclcpp
 {
+Clock::Clock(rcl_clock_type_t clock_type)
+{
+  auto ret = rcl_clock_init(clock_type, &rcl_clock_);
+  if (ret != RCL_RET_OK) {
+    rclcpp::exceptions::throw_from_rcl_error(
+      ret, "could not get current time stamp");
+  }
+}
+
+Clock::~Clock()
+{
+  auto ret = rcl_clock_fini(&rcl_clock_);
+  if (ret != RCL_RET_OK) {
+    RCUTILS_LOG_ERROR("Failed to fini rcl clock.");
+  }
+}
 
 Time
 Clock::now()
@@ -63,21 +79,5 @@ Clock::getClockType()
   return rcl_clock_.type;
 }
 
-Clock::Clock(rcl_clock_type_t clock_type)
-{
-  auto ret = rcl_clock_init(clock_type, &rcl_clock_);
-  if (ret != RCL_RET_OK) {
-    rclcpp::exceptions::throw_from_rcl_error(
-      ret, "could not get current time stamp");
-  }
-}
-
-Clock::~Clock()
-{
-  auto ret = rcl_clock_fini(&rcl_clock_);
-  if (ret != RCL_RET_OK) {
-    RCUTILS_LOG_ERROR("Failed to fini rcl clock.");
-  }
-}
 
 }  // namespace rclcpp

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -94,7 +94,8 @@ Clock::isROSTimeActive()
   bool is_enabled;
   auto ret = rcl_is_enabled_ros_time_override(&rcl_clock_, &is_enabled);
   if (ret != RCL_RET_OK) {
-    RCUTILS_LOG_ERROR("Failed to check ros_time_override_status");
+    rclcpp::exceptions::throw_from_rcl_error(
+      ret, "Failed to check ros_time_override_status");
   }
   return is_enabled;
 }

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -108,7 +108,7 @@ Clock::getClockType()
 rclcpp::JumpCallback::SharedPtr
 Clock::create_jump_callback(
   std::function<void()> pre_callback,
-  std::function<void(TimeJump)> post_callback,
+  std::function<void(const TimeJump &)> post_callback,
   JumpThreshold & threshold)
 {
   // JumpCallback jump_callback;

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -56,8 +56,8 @@ JumpHandler::JumpHandler(
 
 Clock::Clock(rcl_clock_type_t clock_type)
 {
-  rcl_allocator_t allocator = rcl_get_default_allocator();
-  auto ret = rcl_clock_init(clock_type, &rcl_clock_, &allocator);
+  allocator_ = rcl_get_default_allocator();
+  auto ret = rcl_clock_init(clock_type, &rcl_clock_, &allocator_);
   if (ret != RCL_RET_OK) {
     rclcpp::exceptions::throw_from_rcl_error(
       ret, "could not get current time stamp");
@@ -66,8 +66,7 @@ Clock::Clock(rcl_clock_type_t clock_type)
 
 Clock::~Clock()
 {
-  rcl_allocator_t allocator = rcl_get_default_allocator();
-  auto ret = rcl_clock_fini(&rcl_clock_, &allocator);
+  auto ret = rcl_clock_fini(&rcl_clock_);
   if (ret != RCL_RET_OK) {
     RCUTILS_LOG_ERROR("Failed to fini rcl clock.");
   }

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -125,7 +125,7 @@ Clock::create_jump_callback(
 }
 
 std::vector<JumpHandler::SharedPtr>
-Clock::get_triggered_callbacks(const TimeJump & jump)
+Clock::get_triggered_callback_handlers(const TimeJump & jump)
 {
   std::vector<JumpHandler::SharedPtr> callbacks;
   std::lock_guard<std::mutex> guard(callback_list_mutex_);

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -56,7 +56,8 @@ JumpHandler::JumpHandler(
 
 Clock::Clock(rcl_clock_type_t clock_type)
 {
-  auto ret = rcl_clock_init(clock_type, &rcl_clock_);
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  auto ret = rcl_clock_init(clock_type, &rcl_clock_, &allocator);
   if (ret != RCL_RET_OK) {
     rclcpp::exceptions::throw_from_rcl_error(
       ret, "could not get current time stamp");
@@ -65,7 +66,8 @@ Clock::Clock(rcl_clock_type_t clock_type)
 
 Clock::~Clock()
 {
-  auto ret = rcl_clock_fini(&rcl_clock_);
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  auto ret = rcl_clock_fini(&rcl_clock_, &allocator);
   if (ret != RCL_RET_OK) {
     RCUTILS_LOG_ERROR("Failed to fini rcl clock.");
   }

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -142,7 +142,8 @@ Clock::get_triggered_callbacks(const TimeJump & jump)
 }
 
 void
-Clock::invoke_prejump_callbacks(const std::vector<JumpHandler::SharedPtr> & callbacks)
+Clock::invoke_prejump_callbacks(
+  const std::vector<JumpHandler::SharedPtr> & callbacks)
 {
   for (const auto cb : callbacks) {
     cb->pre_callback();
@@ -150,7 +151,8 @@ Clock::invoke_prejump_callbacks(const std::vector<JumpHandler::SharedPtr> & call
 }
 
 void
-Clock::invoke_postjump_callbacks(const std::vector<JumpHandler::SharedPtr> & callbacks,
+Clock::invoke_postjump_callbacks(
+  const std::vector<JumpHandler::SharedPtr> & callbacks,
   const TimeJump & jump)
 {
   for (auto cb : callbacks) {

--- a/rclcpp/src/rclcpp/duration.cpp
+++ b/rclcpp/src/rclcpp/duration.cpp
@@ -63,9 +63,10 @@ Duration::Duration(const Duration & rhs)
   rcl_duration_.clock_type = rhs.rcl_duration_.clock_type;
 }
 
-Duration::Duration(const builtin_interfaces::msg::Duration & duration_msg)  // NOLINT
+Duration::Duration(
+  const builtin_interfaces::msg::Duration & duration_msg,
+  rcl_clock_type_t ros_duration)
 {
-  rcl_clock_type_t ros_duration = RCL_ROS_TIME;  // TODO(tfoote) hard coded ROS here
   rcl_duration_ = init_duration(ros_duration);
 
   rcl_duration_.nanoseconds = RCL_S_TO_NS(static_cast<uint64_t>(duration_msg.sec));

--- a/rclcpp/src/rclcpp/duration.cpp
+++ b/rclcpp/src/rclcpp/duration.cpp
@@ -1,0 +1,248 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <utility>
+#include <limits>
+
+#include "rclcpp/clock.hpp"
+#include "rclcpp/time.hpp"
+
+#include "builtin_interfaces/msg/duration.hpp"
+
+#include "rcl/time.h"
+
+#include "rclcpp/exceptions.hpp"
+
+#include "rcutils/logging_macros.h"
+
+namespace
+{
+
+rcl_duration_t
+init_duration(rcl_clock_type_t & clock_type)
+{
+  rcl_duration_t duration;
+  duration.clock_type = clock_type;
+
+  return duration;
+}
+
+}  // namespace
+
+
+namespace rclcpp
+{
+
+Duration::Duration(int32_t seconds, uint32_t nanoseconds, rcl_clock_type_t clock_type)
+: rcl_duration_(init_duration(clock_type))
+{
+  rcl_duration_.nanoseconds = RCL_S_TO_NS(static_cast<int64_t>(seconds));
+  rcl_duration_.nanoseconds += nanoseconds;
+}
+
+Duration::Duration(int64_t nanoseconds, rcl_clock_type_t clock_type)
+: rcl_duration_(init_duration(clock_type))
+{
+  rcl_duration_.nanoseconds = nanoseconds;
+}
+
+Duration::Duration(const Duration & rhs)
+{
+  rcl_duration_.nanoseconds = rhs.rcl_duration_.nanoseconds;
+  rcl_duration_.clock_type = rhs.rcl_duration_.clock_type;
+}
+
+Duration::Duration(const builtin_interfaces::msg::Duration & duration_msg)  // NOLINT
+{
+  rcl_clock_type_t ros_duration = RCL_ROS_TIME;  // TODO(tfoote) hard coded ROS here
+  rcl_duration_ = init_duration(ros_duration);
+  if (duration_msg.sec < 0) {
+    throw std::runtime_error("cannot store a negative duration point in rclcpp::Duration");
+  }
+
+  rcl_duration_.nanoseconds = RCL_S_TO_NS(static_cast<uint64_t>(duration_msg.sec));
+  rcl_duration_.nanoseconds += duration_msg.nanosec;
+}
+
+Duration::Duration(const rcl_duration_t & duration)
+: rcl_duration_(duration)
+{
+  // noop
+}
+
+Duration::~Duration()
+{
+}
+
+Duration::operator builtin_interfaces::msg::Duration() const
+{
+  builtin_interfaces::msg::Duration msg_duration;
+  msg_duration.sec = static_cast<std::int32_t>(RCL_NS_TO_S(rcl_duration_.nanoseconds));
+  msg_duration.nanosec =
+    static_cast<std::uint32_t>(rcl_duration_.nanoseconds % (1000 * 1000 * 1000));
+  return msg_duration;
+}
+
+void
+Duration::operator=(const Duration & rhs)
+{
+  rcl_duration_.nanoseconds = rhs.rcl_duration_.nanoseconds;
+  rcl_duration_.clock_type = rhs.rcl_duration_.clock_type;
+}
+
+void
+Duration::operator=(const builtin_interfaces::msg::Duration & duration_msg)
+{
+  if (duration_msg.sec < 0) {
+    throw std::runtime_error("cannot store a negative duration point in rclcpp::Duration");
+  }
+
+
+  rcl_clock_type_t ros_duration = RCL_ROS_TIME;
+  rcl_duration_ = init_duration(ros_duration);  // TODO(tfoote) hard coded ROS here
+
+  rcl_duration_.nanoseconds = RCL_S_TO_NS(static_cast<int64_t>(duration_msg.sec));
+  rcl_duration_.nanoseconds += duration_msg.nanosec;
+}
+
+bool
+Duration::operator==(const rclcpp::Duration & rhs) const
+{
+  if (rcl_duration_.clock_type != rhs.rcl_duration_.clock_type) {
+    throw std::runtime_error("can't compare durations with different duration sources");
+  }
+
+  return rcl_duration_.nanoseconds == rhs.rcl_duration_.nanoseconds;
+}
+
+bool
+Duration::operator<(const rclcpp::Duration & rhs) const
+{
+  if (rcl_duration_.clock_type != rhs.rcl_duration_.clock_type) {
+    throw std::runtime_error("can't compare durations with different duration sources");
+  }
+
+  return rcl_duration_.nanoseconds < rhs.rcl_duration_.nanoseconds;
+}
+
+bool
+Duration::operator<=(const rclcpp::Duration & rhs) const
+{
+  if (rcl_duration_.clock_type != rhs.rcl_duration_.clock_type) {
+    throw std::runtime_error("can't compare durations with different duration sources");
+  }
+
+  return rcl_duration_.nanoseconds <= rhs.rcl_duration_.nanoseconds;
+}
+
+bool
+Duration::operator>=(const rclcpp::Duration & rhs) const
+{
+  if (rcl_duration_.clock_type != rhs.rcl_duration_.clock_type) {
+    throw std::runtime_error("can't compare durations with different duration sources");
+  }
+
+  return rcl_duration_.nanoseconds >= rhs.rcl_duration_.nanoseconds;
+}
+
+bool
+Duration::operator>(const rclcpp::Duration & rhs) const
+{
+  if (rcl_duration_.clock_type != rhs.rcl_duration_.clock_type) {
+    throw std::runtime_error("can't compare durations with different duration sources");
+  }
+
+  return rcl_duration_.nanoseconds > rhs.rcl_duration_.nanoseconds;
+}
+
+Duration
+Duration::operator+(const rclcpp::Duration & rhs) const
+{
+  if (rcl_duration_.clock_type != rhs.rcl_duration_.clock_type) {
+    throw std::runtime_error("can't add durations with different duration sources");
+  }
+
+  bounds_check_sum(
+    this->rcl_duration_.nanoseconds,
+    rhs.rcl_duration_.nanoseconds,
+    std::numeric_limits<rcl_duration_value_t>::max());
+  return Duration(
+    rcl_duration_.nanoseconds + rhs.rcl_duration_.nanoseconds,
+    rcl_duration_.clock_type);
+}
+
+void
+Duration::bounds_check_difference(int64_t lhsns, int64_t rhsns, uint64_t max)
+{
+  auto abs_lhs = (uint64_t)std::abs(lhsns);
+  auto abs_rhs = (uint64_t)std::abs(rhsns);
+
+  if (lhsns > 0 && rhsns < 0) {
+    if (abs_lhs + abs_rhs > (uint64_t) max) {
+      throw std::overflow_error("duration subtraction leads to int64_t overflow");
+    }
+  } else if (lhsns < 0 && rhsns > 0) {
+    if (abs_lhs + abs_rhs > (uint64_t) max) {
+      throw std::underflow_error("duration subtraction leads to int64_t underflow");
+    }
+  }
+}
+
+void
+Duration::bounds_check_sum(int64_t lhsns, int64_t rhsns, uint64_t max)
+{
+  auto abs_lhs = (uint64_t)std::abs(lhsns);
+  auto abs_rhs = (uint64_t)std::abs(rhsns);
+
+  if (lhsns > 0 && rhsns > 0) {
+    if (abs_lhs + abs_rhs > (uint64_t) max) {
+      throw std::overflow_error("addition leads to int64_t overflow");
+    }
+  } else if (lhsns < 0 && rhsns < 0) {
+    if (abs_lhs + abs_rhs > (uint64_t) max) {
+      throw std::underflow_error("addition leads to int64_t underflow");
+    }
+  }
+}
+
+Duration
+Duration::operator-(const rclcpp::Duration & rhs) const
+{
+  if (rcl_duration_.clock_type != rhs.rcl_duration_.clock_type) {
+    throw std::runtime_error("can't subtract durations with different duration sources");
+  }
+
+  bounds_check_difference(
+    this->rcl_duration_.nanoseconds,
+    rhs.rcl_duration_.nanoseconds,
+    std::numeric_limits<rcl_duration_value_t>::max());
+
+  return Duration(
+    rcl_duration_.nanoseconds - rhs.rcl_duration_.nanoseconds,
+    rcl_duration_.clock_type);
+}
+
+rcl_duration_value_t
+Duration::nanoseconds() const
+{
+  return rcl_duration_.nanoseconds;
+}
+
+rcl_clock_type_t
+Duration::clock_type() const
+{
+  return rcl_duration_.clock_type;
+}
+
+}  // namespace rclcpp

--- a/rclcpp/src/rclcpp/duration.cpp
+++ b/rclcpp/src/rclcpp/duration.cpp
@@ -67,9 +67,6 @@ Duration::Duration(const builtin_interfaces::msg::Duration & duration_msg)  // N
 {
   rcl_clock_type_t ros_duration = RCL_ROS_TIME;  // TODO(tfoote) hard coded ROS here
   rcl_duration_ = init_duration(ros_duration);
-  if (duration_msg.sec < 0) {
-    throw std::runtime_error("cannot store a negative duration point in rclcpp::Duration");
-  }
 
   rcl_duration_.nanoseconds = RCL_S_TO_NS(static_cast<uint64_t>(duration_msg.sec));
   rcl_duration_.nanoseconds += duration_msg.nanosec;

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -83,6 +83,14 @@ Clock::Clock(rcl_clock_type_t clock_type)
   }
 }
 
+Clock::~Clock()
+{
+  auto ret = rcl_clock_fini(&rcl_clock_);
+  if (ret != RCL_RET_OK) {
+    RCUTILS_LOG_ERROR("Failed to fini rcl clock.");
+  }
+}
+
 Time::Time(int32_t seconds, uint32_t nanoseconds, rcl_clock_type_t clock_type)
 : rcl_time_(init_time_point(clock_type))
 {

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "rclcpp/time.hpp"
-
 #include <utility>
+
+#include "rclcpp/clock.hpp"
+#include "rclcpp/time.hpp"
 
 #include "builtin_interfaces/msg/time.hpp"
 
@@ -59,59 +60,6 @@ init_time_point(rcl_clock_type_t & clock)
 
 namespace rclcpp
 {
-
-Time
-Clock::now()
-{
-  Time now(0, 0, rcl_clock_.type);
-
-  auto ret = rcl_time_point_get_now(&rcl_clock_, &now.rcl_time_);
-  if (ret != RCL_RET_OK) {
-    rclcpp::exceptions::throw_from_rcl_error(
-      ret, "could not get current time stamp");
-  }
-
-  return now;
-}
-
-bool
-Clock::isROSTimeActive()
-{
-  if (!rcl_clock_valid(&rcl_clock_)) {
-    RCUTILS_LOG_ERROR("ROS time not valid!");
-    return false;
-  }
-
-  bool is_enabled;
-  auto ret = rcl_is_enabled_ros_time_override(&rcl_clock_, &is_enabled);
-  if (ret != RCL_RET_OK) {
-    RCUTILS_LOG_ERROR("Failed to check ros_time_override_status");
-  }
-  return is_enabled;
-}
-
-rcl_clock_type_t
-Clock::getClockType()
-{
-  return rcl_clock_.type;
-}
-
-Clock::Clock(rcl_clock_type_t clock_type)
-{
-  auto ret = rcl_clock_init(clock_type, &rcl_clock_);
-  if (ret != RCL_RET_OK) {
-    rclcpp::exceptions::throw_from_rcl_error(
-      ret, "could not get current time stamp");
-  }
-}
-
-Clock::~Clock()
-{
-  auto ret = rcl_clock_fini(&rcl_clock_);
-  if (ret != RCL_RET_OK) {
-    RCUTILS_LOG_ERROR("Failed to fini rcl clock.");
-  }
-}
 
 Time::Time(int32_t seconds, uint32_t nanoseconds, rcl_clock_type_t clock_type)
 : rcl_time_(init_time_point(clock_type))

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -28,20 +28,6 @@
 namespace
 {
 
-rcl_clock_t
-init_clock(rcl_clock_type_t clock_type = RCL_SYSTEM_TIME)
-{
-  rcl_clock_t clock;
-  auto ret = rcl_clock_init(clock_type, &clock);
-
-  if (ret != RCL_RET_OK) {
-    rclcpp::exceptions::throw_from_rcl_error(
-      ret, "could not initialize time source");
-  }
-
-  return clock;
-}
-
 rcl_time_point_t
 init_time_point(rcl_clock_type_t & clock)
 {

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -74,6 +74,28 @@ Clock::now()
   return now;
 }
 
+bool
+Clock::isROSTimeActive()
+{
+  if (!rcl_clock_valid(&rcl_clock_)) {
+    RCUTILS_LOG_ERROR("ROS time not valid!");
+    return false;
+  }
+
+  bool is_enabled;
+  auto ret = rcl_is_enabled_ros_time_override(&rcl_clock_, &is_enabled);
+  if (ret != RCL_RET_OK) {
+    RCUTILS_LOG_ERROR("Failed to check ros_time_override_status");
+  }
+  return is_enabled;
+}
+
+rcl_clock_type_t
+Clock::getClockType()
+{
+  return rcl_clock_.type;
+}
+
 Clock::Clock(rcl_clock_type_t clock_type)
 {
   auto ret = rcl_clock_init(clock_type, &rcl_clock_);

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -179,10 +179,6 @@ Time::operator>(const rclcpp::Time & rhs) const
 Time
 Time::operator+(const rclcpp::Duration & rhs) const
 {
-  if (this->get_clock_type() != rhs.get_clock_type()) {
-    throw std::runtime_error("can't add times with different time sources");
-  }
-
   if (rhs.nanoseconds() > 0 && (uint64_t)rhs.nanoseconds() >
     std::numeric_limits<rcl_time_point_value_t>::max() -
     (rcl_time_point_value_t)this->nanoseconds())
@@ -212,16 +208,12 @@ Time::operator-(const rclcpp::Time & rhs) const
     }
   }
 
-  return Duration(rcl_time_.nanoseconds - rhs.rcl_time_.nanoseconds, rcl_time_.clock_type);
+  return Duration(rcl_time_.nanoseconds - rhs.rcl_time_.nanoseconds);
 }
 
 Time
 Time::operator-(const rclcpp::Duration & rhs) const
 {
-  if (rcl_time_.clock_type != rhs.get_clock_type()) {
-    throw std::runtime_error("can't subtract times with different time sources");
-  }
-
   if (rhs.nanoseconds() > 0 && rcl_time_.nanoseconds >
     std::numeric_limits<rcl_time_point_value_t>::max() - (uint64_t)rhs.nanoseconds())
   {
@@ -251,16 +243,12 @@ Time::get_clock_type() const
 Time
 operator+(const rclcpp::Duration & lhs, const rclcpp::Time & rhs)
 {
-  if (lhs.get_clock_type() != rhs.get_clock_type()) {
-    throw std::runtime_error("can't add times with different time sources");
-  }
-
   if (rhs.nanoseconds() >
     std::numeric_limits<rcl_time_point_value_t>::max() - (rcl_time_point_value_t)lhs.nanoseconds())
   {
     throw std::overflow_error("addition leads to uint64_t overflow");
   }
-  return Time(lhs.nanoseconds() + rhs.nanoseconds(), lhs.get_clock_type());
+  return Time(lhs.nanoseconds() + rhs.nanoseconds(), rhs.get_clock_type());
 }
 
 

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -66,9 +66,10 @@ Time::Time(const Time & rhs)
   rcl_time_.nanoseconds = rhs.rcl_time_.nanoseconds;
 }
 
-Time::Time(const builtin_interfaces::msg::Time & time_msg)  // NOLINT
+Time::Time(
+  const builtin_interfaces::msg::Time & time_msg,
+  rcl_clock_type_t ros_time)
 {
-  rcl_clock_type_t ros_time = RCL_ROS_TIME;  // TODO(tfoote) hard coded ROS here
   rcl_time_ = init_time_point(ros_time);
   if (time_msg.sec < 0) {
     throw std::runtime_error("cannot store a negative time point in rclcpp::Time");

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -61,8 +61,7 @@ Time::Time(uint64_t nanoseconds, rcl_clock_type_t clock_type)
 }
 
 Time::Time(const Time & rhs)
-: rcl_time_source_(init_time_source(rhs.rcl_time_source_.type)),
-  rcl_time_(init_time_point(rcl_time_source_))
+: rcl_time_(rhs.rcl_time_)
 {
   rcl_time_.nanoseconds = rhs.rcl_time_.nanoseconds;
 }
@@ -100,9 +99,7 @@ Time::operator builtin_interfaces::msg::Time() const
 Time &
 Time::operator=(const Time & rhs)
 {
-  rcl_time_source_ = init_time_source(rhs.rcl_time_source_.type);
-  rcl_time_ = init_time_point(rcl_time_source_);
-  rcl_time_.nanoseconds = rhs.rcl_time_.nanoseconds;
+  rcl_time_ = rhs.rcl_time_;
   return *this;
 }
 

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -203,12 +203,12 @@ Time::operator-(const rclcpp::Time & rhs) const
   {
     throw std::underflow_error("time subtraction leads to int64_t overflow");
   }
-  // TODO(tfoote) the below check won't work for larger times
-  if ((int64_t)rcl_time_.nanoseconds <
-    (int64_t)rhs.rcl_time_.nanoseconds -
-    (int64_t) std::abs(std::numeric_limits<rcl_duration_value_t>::min()))
-  {
-    throw std::underflow_error("time subtraction leads to int64_t underflow");
+
+  if (rcl_time_.nanoseconds < rhs.rcl_time_.nanoseconds) {
+    rcl_time_point_value_t negative_delta = rhs.rcl_time_.nanoseconds - rcl_time_.nanoseconds;
+    if (negative_delta > (uint64_t) std::numeric_limits<rcl_duration_value_t>::min()) {
+      throw std::underflow_error("time subtraction leads to int64_t underflow");
+    }
   }
 
   return Duration(rcl_time_.nanoseconds - rhs.rcl_time_.nanoseconds, rcl_time_.clock_type);

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -61,18 +61,9 @@ namespace rclcpp
 {
 
 Time
-Clock::now(rcl_clock_type_t clock_type)
+Clock::now()
 {
-  // TODO(karsten1987): This impl throws explicitely on RCL_ROS_TIME
-  // we have to do this, because rcl_clock_init returns RCL_RET_OK
-  // for RCL_ROS_TIME, however defaults to system time under the hood.
-  // ref: https://github.com/ros2/rcl/blob/master/rcl/src/rcl/time.c#L66-L77
-  // This section can be removed when rcl supports ROS_TIME correctly.
-  if (clock_type == RCL_ROS_TIME) {
-    throw std::runtime_error("RCL_ROS_TIME is currently not implemented.");
-  }
-
-  Time now(0, 0, clock_type);
+  Time now(0, 0, rcl_clock_.type);
 
   auto ret = rcl_time_point_get_now(&rcl_clock_, &now.rcl_time_);
   if (ret != RCL_RET_OK) {
@@ -118,7 +109,7 @@ Time::Time(const Time & rhs)
 
 Time::Time(const builtin_interfaces::msg::Time & time_msg)  // NOLINT
 {
-  rcl_clock_type_t ros_time = RCL_ROS_TIME; // TODO(tfoote) hard coded ROS here
+  rcl_clock_type_t ros_time = RCL_ROS_TIME;  // TODO(tfoote) hard coded ROS here
   rcl_time_ = init_time_point(ros_time);
   if (time_msg.sec < 0) {
     throw std::runtime_error("cannot store a negative time point in rclcpp::Time");

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -29,15 +29,10 @@ namespace
 {
 
 rcl_time_point_t
-init_time_point(rcl_clock_type_t & clock)
+init_time_point(rcl_clock_type_t & clock_type)
 {
   rcl_time_point_t time_point;
-  auto ret = rcl_time_point_init(&time_point, &clock);
-
-  if (ret != RCL_RET_OK) {
-    rclcpp::exceptions::throw_from_rcl_error(
-      ret, "could not initialize time point");
-  }
+  time_point.clock_type = clock_type;
 
   return time_point;
 }
@@ -91,12 +86,6 @@ Time::Time(const rcl_time_point_t & time_point)
 
 Time::~Time()
 {
-  if (rcl_time_source_fini(&rcl_time_source_) != RCL_RET_OK) {
-    RCUTILS_LOG_FATAL("failed to reclaim rcl_time_source_t in destructor of rclcpp::Time")
-  }
-  if (rcl_time_point_fini(&rcl_time_) != RCL_RET_OK) {
-    RCUTILS_LOG_FATAL("failed to reclaim rcl_time_point_t in destructor of rclcpp::Time")
-  }
 }
 
 Time::operator builtin_interfaces::msg::Time() const

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -110,7 +110,7 @@ Time::Time(const Time & rhs)
 }
 
 Time::Time(const builtin_interfaces::msg::Time & time_msg)  // NOLINT
-: rcl_time_source_(init_time_source(RCL_SYSTEM_TIME)),
+: rcl_time_source_(init_time_source(RCL_ROS_TIME)),
   rcl_time_(init_time_point(rcl_time_source_))
 {
   if (time_msg.sec < 0) {
@@ -119,6 +119,13 @@ Time::Time(const builtin_interfaces::msg::Time & time_msg)  // NOLINT
 
   rcl_time_.nanoseconds = RCL_S_TO_NS(static_cast<uint64_t>(time_msg.sec));
   rcl_time_.nanoseconds += time_msg.nanosec;
+}
+
+Time::Time(const rcl_time_point_t& time_point)
+: rcl_time_source_(*(time_point.time_source)),
+  rcl_time_(time_point)
+{
+  // noop
 }
 
 Time::~Time()

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -183,7 +183,8 @@ Time::operator+(const rclcpp::Duration & rhs) const
   }
 
   if (rhs.nanoseconds() > 0 && (uint64_t)rhs.nanoseconds() >
-    std::numeric_limits<rcl_time_point_value_t>::max() - (rcl_time_point_value_t)this->nanoseconds())
+    std::numeric_limits<rcl_time_point_value_t>::max() -
+    (rcl_time_point_value_t)this->nanoseconds())
   {
     throw std::overflow_error("addition leads to uint64_t overflow");
   }

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -1,0 +1,117 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/node.hpp"
+#include "rclcpp/time.hpp"
+#include "rclcpp/time_source.hpp"
+
+
+#include <utility>
+
+#include "builtin_interfaces/msg/time.hpp"
+
+#include "rcl/time.h"
+
+#include "rclcpp/exceptions.hpp"
+
+#include "rcutils/logging_macros.h"
+
+namespace rclcpp
+{
+
+Time
+TimeSource::now(rcl_time_source_type_t clock)
+{
+  // TODO(karsten1987): This impl throws explicitely on RCL_ROS_TIME
+  // we have to do this, because rcl_time_source_init returns RCL_RET_OK
+  // for RCL_ROS_TIME, however defaults to system time under the hood.
+  // ref: https://github.com/ros2/rcl/blob/master/rcl/src/rcl/time.c#L66-L77
+  // This section can be removed when rcl supports ROS_TIME correctly.
+  // if (clock == RCL_ROS_TIME) {
+  //   throw std::runtime_error("RCL_ROS_TIME is currently not implemented.");
+  // }
+  // 
+  Time now(0, 0, clock);
+  // 
+  // auto ret = rcl_time_point_get_now(&now.rcl_time_);
+  // if (ret != RCL_RET_OK) {
+  //   rclcpp::exceptions::throw_from_rcl_error(
+  //     ret, "could not get current time stamp");
+  // }
+
+  return now;
+}
+
+TimeSource::TimeSource(std::shared_ptr<rclcpp::node::Node> node)
+: node_(node)
+{
+  // TODO(tfoote): Update QOS
+  clock_subscription_ = node_->create_subscription<builtin_interfaces::msg::Time>(
+    "clock", std::bind(&TimeSource::clock_cb, this, std::placeholders::_1), rmw_qos_profile_default);
+    
+  auto ret1 = rcl_time_source_init(RCL_ROS_TIME, &ros_time_source_);
+  if (ret1 != RCL_RET_OK) {
+    RCUTILS_LOG_ERROR("Failed to initialize ROS time source");
+  }
+  auto ret2 = rcl_time_source_init(RCL_ROS_TIME, &system_time_source_);
+  if (ret2 != RCL_RET_OK) {
+    RCUTILS_LOG_ERROR("Failed to initialize SYSTEM time source");
+  }  
+}
+
+TimeSource::~TimeSource()
+{
+  auto ret1 = rcl_time_source_fini(&ros_time_source_);
+  if (ret1 != RCL_RET_OK) {
+    RCUTILS_LOG_ERROR("Failed to fini ROS time source");
+  }
+  auto ret2 = rcl_time_source_fini(&system_time_source_);
+  if (ret2 != RCL_RET_OK) {
+    RCUTILS_LOG_ERROR("Failed to fini SYSTEM time source");
+  }
+}
+
+void TimeSource::clock_cb(const builtin_interfaces::msg::Time::SharedPtr msg)
+{
+  RCUTILS_LOG_INFO("Got clock message");
+  
+  bool is_enabled;
+  auto ret = rcl_is_enabled_ros_time_override(&ros_time_source_, &is_enabled);
+  if (ret != RCL_RET_OK) {
+      RCUTILS_LOG_ERROR("Failed to check ros_time_override_status");
+  }
+  if (!is_enabled)
+  {
+   ret = rcl_enable_ros_time_override(&ros_time_source_);
+   if (ret != RCL_RET_OK) {
+       RCUTILS_LOG_ERROR("Failed to enable ros_time_override_status");
+   }
+  }
+  //TODO(tfoote) switch this to be based on if there are clock publishers
+  //TODO(tfoote) also setup disable
+  
+  rcl_time_point_t clock_time;
+  ret = rcl_time_point_init(&clock_time, &ros_time_source_);
+  if (ret != RCL_RET_OK) {
+      RCUTILS_LOG_ERROR("Failed to init ros_time_point");
+  }
+  clock_time.nanoseconds = msg->sec * 1e9 + msg->nanosec;
+  ret = rcl_set_ros_time_override(&ros_time_source_, clock_time.nanoseconds);
+  if (ret != RCL_RET_OK) {
+      RCUTILS_LOG_ERROR("Failed to set ros_time_override_status");
+  }
+}
+
+
+}  // namespace rclcpp

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -21,6 +21,7 @@
 
 #include "rcutils/logging_macros.h"
 
+#include "rclcpp/clock.hpp"
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/node.hpp"
 #include "rclcpp/time.hpp"

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -36,6 +36,10 @@ TimeSource::now(rcl_time_source_type_t clock)
   rcl_time_point_t now_time_point;
 
   if (clock == RCL_ROS_TIME){
+    if (!this->ros_time_valid_) {
+      throw std::invalid_argument("Timesource ROS connection invalid, RCL_ROS_TIME cannot get now.");
+    }
+
     auto ret = rcl_time_point_init(&now_time_point, &ros_time_source_);
     if (ret != RCL_RET_OK) {
       rclcpp::exceptions::throw_from_rcl_error(
@@ -64,12 +68,37 @@ TimeSource::now(rcl_time_source_type_t clock)
 }
 
 TimeSource::TimeSource(std::shared_ptr<rclcpp::node::Node> node)
-: node_(node)
+: ros_time_valid_(false)
 {
+  this->initializeData();
+  this->attachNode(node);
+}
+
+TimeSource::TimeSource()
+: ros_time_valid_(false)
+{
+  this->initializeData();
+}
+
+void TimeSource::attachNode(std::shared_ptr<rclcpp::node::Node> node)
+{
+  node_ = node;
   // TODO(tfoote): Update QOS
   clock_subscription_ = node_->create_subscription<builtin_interfaces::msg::Time>(
     "clock", std::bind(&TimeSource::clock_cb, this, std::placeholders::_1), rmw_qos_profile_default);
-    
+  //TODO(tfoote): Check for time related parameters here too
+  this->ros_time_valid_ = true;
+}
+
+void TimeSource::detachNode()
+{
+  this->ros_time_valid_ = false;
+  clock_subscription_.reset();
+  node_.reset();
+  disableROSTime();
+}
+
+void TimeSource::initializeData(){
   auto ret1 = rcl_time_source_init(RCL_ROS_TIME, &ros_time_source_);
   if (ret1 != RCL_RET_OK) {
     RCUTILS_LOG_ERROR("Failed to initialize ROS time source");
@@ -77,11 +106,14 @@ TimeSource::TimeSource(std::shared_ptr<rclcpp::node::Node> node)
   auto ret2 = rcl_time_source_init(RCL_ROS_TIME, &system_time_source_);
   if (ret2 != RCL_RET_OK) {
     RCUTILS_LOG_ERROR("Failed to initialize SYSTEM time source");
-  }  
+  }
 }
 
 TimeSource::~TimeSource()
 {
+  if (node_) {
+    this->detachNode();
+  }
   auto ret1 = rcl_time_source_fini(&ros_time_source_);
   if (ret1 != RCL_RET_OK) {
     RCUTILS_LOG_ERROR("Failed to fini ROS time source");
@@ -94,8 +126,25 @@ TimeSource::~TimeSource()
 
 void TimeSource::clock_cb(const builtin_interfaces::msg::Time::SharedPtr msg)
 {
-  RCUTILS_LOG_INFO("Got clock message");
-  
+  // RCUTILS_LOG_INFO("Got clock message");
+  enableROSTime();
+  //TODO(tfoote) switch this to be based on if there are clock publishers
+  //TODO(tfoote) also setup disable
+
+  //TODO(tfoote) Use a time import/export method from rclcpp Time pending
+  rcl_time_point_t clock_time;
+  auto ret = rcl_time_point_init(&clock_time, &ros_time_source_);
+  if (ret != RCL_RET_OK) {
+      RCUTILS_LOG_ERROR("Failed to init ros_time_point");
+  }
+  clock_time.nanoseconds = msg->sec * 1e9 + msg->nanosec;
+  ret = rcl_set_ros_time_override(&ros_time_source_, clock_time.nanoseconds);
+  if (ret != RCL_RET_OK) {
+      RCUTILS_LOG_ERROR("Failed to set ros_time_override_status");
+  }
+}
+
+void TimeSource::enableROSTime(){
   bool is_enabled;
   auto ret = rcl_is_enabled_ros_time_override(&ros_time_source_, &is_enabled);
   if (ret != RCL_RET_OK) {
@@ -108,20 +157,21 @@ void TimeSource::clock_cb(const builtin_interfaces::msg::Time::SharedPtr msg)
        RCUTILS_LOG_ERROR("Failed to enable ros_time_override_status");
    }
   }
-  //TODO(tfoote) switch this to be based on if there are clock publishers
-  //TODO(tfoote) also setup disable
-  
-  rcl_time_point_t clock_time;
-  ret = rcl_time_point_init(&clock_time, &ros_time_source_);
-  if (ret != RCL_RET_OK) {
-      RCUTILS_LOG_ERROR("Failed to init ros_time_point");
-  }
-  clock_time.nanoseconds = msg->sec * 1e9 + msg->nanosec;
-  ret = rcl_set_ros_time_override(&ros_time_source_, clock_time.nanoseconds);
-  if (ret != RCL_RET_OK) {
-      RCUTILS_LOG_ERROR("Failed to set ros_time_override_status");
-  }
 }
 
+void TimeSource::disableROSTime(){
+  bool is_enabled;
+  auto ret = rcl_is_enabled_ros_time_override(&ros_time_source_, &is_enabled);
+  if (ret != RCL_RET_OK) {
+      RCUTILS_LOG_ERROR("Failed to check ros_time_override_status");
+  }
+  if (!is_enabled)
+  {
+   ret = rcl_disable_ros_time_override(&ros_time_source_);
+   if (ret != RCL_RET_OK) {
+       RCUTILS_LOG_ERROR("Failed to disable ros_time_override_status");
+   }
+  }
+}
 
 }  // namespace rclcpp

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -33,23 +33,33 @@ namespace rclcpp
 Time
 TimeSource::now(rcl_time_source_type_t clock)
 {
-  // TODO(karsten1987): This impl throws explicitely on RCL_ROS_TIME
-  // we have to do this, because rcl_time_source_init returns RCL_RET_OK
-  // for RCL_ROS_TIME, however defaults to system time under the hood.
-  // ref: https://github.com/ros2/rcl/blob/master/rcl/src/rcl/time.c#L66-L77
-  // This section can be removed when rcl supports ROS_TIME correctly.
-  // if (clock == RCL_ROS_TIME) {
-  //   throw std::runtime_error("RCL_ROS_TIME is currently not implemented.");
-  // }
-  // 
-  Time now(0, 0, clock);
-  // 
-  // auto ret = rcl_time_point_get_now(&now.rcl_time_);
-  // if (ret != RCL_RET_OK) {
-  //   rclcpp::exceptions::throw_from_rcl_error(
-  //     ret, "could not get current time stamp");
-  // }
+  rcl_time_point_t now_time_point;
 
+  if (clock == RCL_ROS_TIME){
+    auto ret = rcl_time_point_init(&now_time_point, &ros_time_source_);
+    if (ret != RCL_RET_OK) {
+      rclcpp::exceptions::throw_from_rcl_error(
+        ret, "could not get init time_point");
+      }
+  }
+  else if (clock == RCL_SYSTEM_TIME){
+    auto ret2 = rcl_time_point_init(&now_time_point, &system_time_source_);
+    if (ret2 != RCL_RET_OK) {
+      rclcpp::exceptions::throw_from_rcl_error(
+        ret2, "could not get init time_point");
+      }
+  }
+  else {
+    RCUTILS_LOG_ERROR("INVALID TIME TYPE");
+  }
+
+  auto ret3 = rcl_time_point_get_now(&now_time_point);
+  if (ret3 != RCL_RET_OK) {
+    rclcpp::exceptions::throw_from_rcl_error(
+      ret3, "could not get current time stamp");
+  }
+
+  Time now(now_time_point);
   return now;
 }
 

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -109,7 +109,7 @@ void TimeSource::setClock(const builtin_interfaces::msg::Time::SharedPtr msg,
     RCUTILS_LOG_ERROR("Failed to init ros_time_point");
   }
   clock_time.nanoseconds = msg->sec * 1e9 + msg->nanosec;
-  ret = rcl_set_ros_time_override(&(clock->rcl_clock_.type), clock_time.nanoseconds);
+  ret = rcl_set_ros_time_override(&(clock->rcl_clock_), clock_time.nanoseconds);
   if (ret != RCL_RET_OK) {
     RCUTILS_LOG_ERROR("Failed to set ros_time_override_status");
   }

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -138,7 +138,7 @@ void TimeSource::enableROSTime()
 {
   std::lock_guard<std::mutex> guard(clock_list_lock_);
   for (auto it = associated_clocks_.begin(); it != associated_clocks_.end(); ++it) {
-    disableROSTime(*it);
+    enableROSTime(*it);
   }
 }
 
@@ -146,7 +146,7 @@ void TimeSource::disableROSTime()
 {
   std::lock_guard<std::mutex> guard(clock_list_lock_);
   for (auto it = associated_clocks_.begin(); it != associated_clocks_.end(); ++it) {
-    enableROSTime(*it);
+    disableROSTime(*it);
   }
 }
 

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -12,20 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "rclcpp/node.hpp"
-#include "rclcpp/time.hpp"
-#include "rclcpp/time_source.hpp"
-
-
+#include <memory>
 #include <utility>
 
 #include "builtin_interfaces/msg/time.hpp"
 
 #include "rcl/time.h"
 
-#include "rclcpp/exceptions.hpp"
-
 #include "rcutils/logging_macros.h"
+
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/time.hpp"
+#include "rclcpp/time_source.hpp"
+
 
 namespace rclcpp
 {
@@ -37,7 +37,8 @@ TimeSource::now(rcl_clock_type_t clock)
 
   if (clock == RCL_ROS_TIME) {
     if (!this->ros_time_valid_) {
-      throw std::invalid_argument("Timesource ROS connection invalid, RCL_ROS_TIME cannot get now.");
+      throw std::invalid_argument("Timesource ROS connection invalid,"
+              " RCL_ROS_TIME cannot get now.");
     }
 
     auto ret = rcl_time_point_init(&now_time_point, &ros_clock_.type);
@@ -89,7 +90,7 @@ void TimeSource::attachNode(std::shared_ptr<rclcpp::node::Node> node)
   clock_subscription_ = node_->create_subscription<builtin_interfaces::msg::Time>(
     "clock", std::bind(&TimeSource::clock_cb, this, std::placeholders::_1),
     rmw_qos_profile_default);
-  //TODO(tfoote): Check for time related parameters here too
+  // TODO(tfoote): Check for time related parameters here too
   this->ros_time_valid_ = true;
 }
 
@@ -132,10 +133,10 @@ void TimeSource::clock_cb(const builtin_interfaces::msg::Time::SharedPtr msg)
 {
   // RCUTILS_LOG_INFO("Got clock message");
   enableROSTime();
-  //TODO(tfoote) switch this to be based on if there are clock publishers or use_sim_time
-  //TODO(tfoote) also setup disable
+  // TODO(tfoote) switch this to be based on if there are clock publishers or use_sim_time
+  // TODO(tfoote) also setup disable
 
-  //TODO(tfoote) Use a time import/export method from rclcpp Time pending
+  // TODO(tfoote) Use a time import/export method from rclcpp Time pending
   rcl_time_point_t clock_time;
   auto ret = rcl_time_point_init(&clock_time, &ros_clock_.type);
   if (ret != RCL_RET_OK) {

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -94,25 +94,16 @@ void TimeSource::setClock(const builtin_interfaces::msg::Time::SharedPtr msg,
   std::shared_ptr<rclcpp::Clock> clock)
 {
   rcl_time_point_t now;
-  auto ret4 = rcl_time_point_init(&now, &(clock->rcl_clock_.type));
-  if (ret4 != RCL_RET_OK) {
-    RCUTILS_LOG_ERROR("Failed to init ros_time_point");
-    rcutils_reset_error();
-  }
 
   // TODO(tfoote) Use a time import/export method from rclcpp Time pending
   rcl_time_point_t clock_time;
-  auto ret = rcl_time_point_init(&clock_time, &(clock->rcl_clock_.type));
-  if (ret != RCL_RET_OK) {
-    RCUTILS_LOG_ERROR("Failed to init ros_time_point");
-    rcutils_reset_error();
-  }
+
   clock_time.nanoseconds = msg->sec * 1e9 + msg->nanosec;
 
   
   // TODO(tfoote) Move enabledROS time logic here.
   rclcpp::TimeJump jump;
-  ret = rcl_time_point_get_now(&(clock->rcl_clock_), &now);
+  auto ret = rcl_time_point_get_now(&(clock->rcl_clock_), &now);
   if (ret != RCL_RET_OK) {
     RCUTILS_LOG_ERROR("Failed to get now before setting time");
   }
@@ -132,18 +123,6 @@ void TimeSource::setClock(const builtin_interfaces::msg::Time::SharedPtr msg,
     rcutils_reset_error();
   }
   clock->invoke_postjump_callbacks(active_callbacks, jump);
-
-  auto ret2 = rcl_time_point_fini(&clock_time);
-  if (ret2 != RCL_RET_OK) {
-    RCUTILS_LOG_ERROR("Failed to fini clock_time");
-    rcutils_reset_error();
-  }
-  
-  auto ret3 = rcl_time_point_fini(&now);
-  if (ret3 != RCL_RET_OK) {
-    RCUTILS_LOG_ERROR("Failed to fini now");
-    rcutils_reset_error();
-  }
 }
 
 void TimeSource::clock_cb(const builtin_interfaces::msg::Time::SharedPtr msg)

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -128,8 +128,6 @@ void TimeSource::set_clock(
     return;
   }
 
-  // TODO(tfoote) potential race condition with callback object going out of scope
-  // Document to user requirments
   auto active_callbacks = clock->get_triggered_callback_handlers(jump);
   clock->invoke_prejump_callbacks(active_callbacks);
 

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -62,7 +62,7 @@ void TimeSource::detachNode()
   clock_subscription_.reset();
   parameter_client_.reset();
   node_.reset();
-  disableROSTime();
+  disable_ros_time();
 }
 
 void TimeSource::attachClock(std::shared_ptr<rclcpp::Clock> clock)
@@ -119,7 +119,7 @@ void TimeSource::clock_cb(const builtin_interfaces::msg::Time::SharedPtr msg)
 {
   // RCUTILS_LOG_INFO("Got clock message");
   if (!this->ros_time_valid_) {
-    enableROSTime();
+    enable_ros_time();
   }
   // TODO(tfoote) switch this to be based on if there are clock publishers or use_sim_time
   // TODO(tfoote) also setup disable
@@ -139,10 +139,10 @@ void TimeSource::on_parameter_event(const rcl_interfaces::msg::ParameterEvent::S
         bool value = new_parameter.value.bool_value;
         if (value) {
           parameter_state_ = SET_TRUE;
-          enableROSTime();
+          enable_ros_time();
         } else {
           parameter_state_ = SET_FALSE;
-          disableROSTime();
+          disable_ros_time();
         }
       }
     }
@@ -153,10 +153,10 @@ void TimeSource::on_parameter_event(const rcl_interfaces::msg::ParameterEvent::S
         bool value = changed_parameter.value.bool_value;
         if (value) {
           parameter_state_ = SET_TRUE;
-          enableROSTime();
+          enable_ros_time();
         } else {
           parameter_state_ = SET_FALSE;
-          disableROSTime();
+          disable_ros_time();
         }
       }
     }
@@ -169,7 +169,7 @@ void TimeSource::on_parameter_event(const rcl_interfaces::msg::ParameterEvent::S
   }
 }
 
-void TimeSource::enableROSTime(std::shared_ptr<rclcpp::Clock> clock)
+void TimeSource::enable_ros_time(std::shared_ptr<rclcpp::Clock> clock)
 {
   auto ret = rcl_enable_ros_time_override(&clock->rcl_clock_);
   if (ret != RCL_RET_OK) {
@@ -178,7 +178,7 @@ void TimeSource::enableROSTime(std::shared_ptr<rclcpp::Clock> clock)
   }
 }
 
-void TimeSource::disableROSTime(std::shared_ptr<rclcpp::Clock> clock)
+void TimeSource::disable_ros_time(std::shared_ptr<rclcpp::Clock> clock)
 {
   auto ret = rcl_disable_ros_time_override(&clock->rcl_clock_);
   if (ret != RCL_RET_OK) {
@@ -187,7 +187,7 @@ void TimeSource::disableROSTime(std::shared_ptr<rclcpp::Clock> clock)
   }
 }
 
-void TimeSource::enableROSTime()
+void TimeSource::enable_ros_time()
 {
   if (ros_time_valid_) {
     // already enabled no-op
@@ -200,11 +200,11 @@ void TimeSource::enableROSTime()
   // Update all attached clocks
   std::lock_guard<std::mutex> guard(clock_list_lock_);
   for (auto it = associated_clocks_.begin(); it != associated_clocks_.end(); ++it) {
-    enableROSTime(*it);
+    enable_ros_time(*it);
   }
 }
 
-void TimeSource::disableROSTime()
+void TimeSource::disable_ros_time()
 {
   if (!ros_time_valid_) {
     // already disabled no-op
@@ -217,7 +217,7 @@ void TimeSource::disableROSTime()
   // Update all attached clocks
   std::lock_guard<std::mutex> guard(clock_list_lock_);
   for (auto it = associated_clocks_.begin(); it != associated_clocks_.end(); ++it) {
-    disableROSTime(*it);
+    disable_ros_time(*it);
   }
 }
 

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -90,7 +90,8 @@ TimeSource::~TimeSource()
   }
 }
 
-void TimeSource::setClock(const builtin_interfaces::msg::Time::SharedPtr msg,
+void TimeSource::setClock(
+  const builtin_interfaces::msg::Time::SharedPtr msg,
   std::shared_ptr<rclcpp::Clock> clock)
 {
   // TODO(tfoote) Move enabledROS time logic here.

--- a/rclcpp/test/test_duration.cpp
+++ b/rclcpp/test/test_duration.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <chrono>
 #include <limits>
 #include <string>
 
@@ -23,6 +24,9 @@
 #include "rclcpp/clock.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/duration.hpp"
+
+
+using namespace std::chrono_literals;
 
 class TestDuration : public ::testing::Test
 {
@@ -50,63 +54,24 @@ TEST(TestDuration, operators) {
   EXPECT_EQ(sub.nanoseconds(), (rcl_duration_value_t)(young.nanoseconds() - old.nanoseconds()));
   EXPECT_EQ(sub, young - old);
 
-  rclcpp::Duration system_duration(0, 0, RCL_SYSTEM_TIME);
-  rclcpp::Duration steady_duration(0, 0, RCL_STEADY_TIME);
+  rclcpp::Duration time = rclcpp::Duration(0, 0);
+  rclcpp::Duration copy_constructor_duration(time);
+  rclcpp::Duration assignment_op_duration = rclcpp::Duration(1, 0);
+  assignment_op_duration = time;
 
-  EXPECT_ANY_THROW((void)(system_duration == steady_duration));
-  EXPECT_ANY_THROW((void)(system_duration <= steady_duration));
-  EXPECT_ANY_THROW((void)(system_duration >= steady_duration));
-  EXPECT_ANY_THROW((void)(system_duration < steady_duration));
-  EXPECT_ANY_THROW((void)(system_duration > steady_duration));
-  EXPECT_ANY_THROW((void)(system_duration + steady_duration));
-  EXPECT_ANY_THROW((void)(system_duration - steady_duration));
+  EXPECT_TRUE(time == copy_constructor_duration);
+  EXPECT_TRUE(time == assignment_op_duration);
+}
 
-  rclcpp::Clock ros_clock(RCL_ROS_TIME);
-  rclcpp::Clock steady_clock(RCL_STEADY_TIME);
-  rclcpp::Clock system_clock(RCL_SYSTEM_TIME);
-
-  rclcpp::Duration steadytime = steady_clock.now() - steady_clock.now();
-  rclcpp::Duration systemtime = system_clock.now() - system_clock.now();
-  // Force RCL_ROS_TIME
-  rclcpp::Duration rostime = rclcpp::Duration(steadytime.nanoseconds(), RCL_ROS_TIME);
-
-  EXPECT_EQ(RCL_ROS_TIME, rostime.get_clock_type());
-  EXPECT_EQ(RCL_STEADY_TIME, steadytime.get_clock_type());
-  EXPECT_EQ(RCL_SYSTEM_TIME, systemtime.get_clock_type());
-
-  EXPECT_ANY_THROW((void)(rostime == steadytime));
-  EXPECT_ANY_THROW((void)(rostime <= steadytime));
-  EXPECT_ANY_THROW((void)(rostime >= steadytime));
-  EXPECT_ANY_THROW((void)(rostime < steadytime));
-  EXPECT_ANY_THROW((void)(rostime > steadytime));
-  EXPECT_ANY_THROW((void)(rostime + steadytime));
-  EXPECT_ANY_THROW((void)(rostime - steadytime));
-
-  EXPECT_ANY_THROW((void)(rostime == systemtime));
-  EXPECT_ANY_THROW((void)(rostime <= systemtime));
-  EXPECT_ANY_THROW((void)(rostime >= systemtime));
-  EXPECT_ANY_THROW((void)(rostime < systemtime));
-  EXPECT_ANY_THROW((void)(rostime > systemtime));
-  EXPECT_ANY_THROW((void)(rostime + systemtime));
-  EXPECT_ANY_THROW((void)(rostime - systemtime));
-
-  EXPECT_ANY_THROW((void)(systemtime == steadytime));
-  EXPECT_ANY_THROW((void)(systemtime <= steadytime));
-  EXPECT_ANY_THROW((void)(systemtime >= steadytime));
-  EXPECT_ANY_THROW((void)(systemtime < steadytime));
-  EXPECT_ANY_THROW((void)(systemtime > steadytime));
-  EXPECT_ANY_THROW((void)(systemtime + steadytime));
-  EXPECT_ANY_THROW((void)(systemtime - steadytime));
-
-  for (auto time_source : {RCL_ROS_TIME, RCL_SYSTEM_TIME, RCL_STEADY_TIME}) {
-    rclcpp::Duration time = rclcpp::Duration(0, 0, time_source);
-    rclcpp::Duration copy_constructor_duration(time);
-    rclcpp::Duration assignment_op_duration = rclcpp::Duration(1, 0, time_source);
-    assignment_op_duration = time;
-
-    EXPECT_TRUE(time == copy_constructor_duration);
-    EXPECT_TRUE(time == assignment_op_duration);
-  }
+TEST(TestDuration, chrono_overloads) {
+  int64_t ns = 123456789l;
+  auto chrono_ns = std::chrono::nanoseconds(ns);
+  auto d1 = rclcpp::Duration(ns);
+  auto d2 = rclcpp::Duration(chrono_ns);
+  auto d3 = rclcpp::Duration(123456789ns);
+  EXPECT_EQ(d1, d2);
+  EXPECT_EQ(d1, d3);
+  EXPECT_EQ(d2, d3);
 }
 
 TEST(TestDuration, overflows) {

--- a/rclcpp/test/test_duration.cpp
+++ b/rclcpp/test/test_duration.cpp
@@ -70,9 +70,9 @@ TEST(TestDuration, operators) {
   // Force RCL_ROS_TIME
   rclcpp::Duration rostime = rclcpp::Duration(steadytime.nanoseconds(), RCL_ROS_TIME);
 
-  EXPECT_EQ(RCL_ROS_TIME, rostime.clock_type());
-  EXPECT_EQ(RCL_STEADY_TIME, steadytime.clock_type());
-  EXPECT_EQ(RCL_SYSTEM_TIME, systemtime.clock_type());
+  EXPECT_EQ(RCL_ROS_TIME, rostime.get_clock_type());
+  EXPECT_EQ(RCL_STEADY_TIME, steadytime.get_clock_type());
+  EXPECT_EQ(RCL_SYSTEM_TIME, systemtime.get_clock_type());
 
   EXPECT_ANY_THROW((void)(rostime == steadytime));
   EXPECT_ANY_THROW((void)(rostime <= steadytime));

--- a/rclcpp/test/test_duration.cpp
+++ b/rclcpp/test/test_duration.cpp
@@ -1,0 +1,123 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <limits>
+#include <string>
+
+#include "rcl/error_handling.h"
+#include "rcl/time.h"
+#include "rclcpp/clock.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/duration.hpp"
+
+class TestDuration : public ::testing::Test
+{
+};
+
+// TEST(TestDuration, conversions) {
+// TODO(tfoote) Implement conversion methods
+// }
+
+TEST(TestDuration, operators) {
+  rclcpp::Duration old(1, 0);
+  rclcpp::Duration young(2, 0);
+
+  EXPECT_TRUE(old < young);
+  EXPECT_TRUE(young > old);
+  EXPECT_TRUE(old <= young);
+  EXPECT_TRUE(young >= old);
+  EXPECT_FALSE(young == old);
+
+  rclcpp::Duration add = old + young;
+  EXPECT_EQ(add.nanoseconds(), (rcl_duration_value_t)(old.nanoseconds() + young.nanoseconds()));
+  EXPECT_EQ(add, old + young);
+
+  rclcpp::Duration sub = young - old;
+  EXPECT_EQ(sub.nanoseconds(), (rcl_duration_value_t)(young.nanoseconds() - old.nanoseconds()));
+  EXPECT_EQ(sub, young - old);
+
+  rclcpp::Duration system_duration(0, 0, RCL_SYSTEM_TIME);
+  rclcpp::Duration steady_duration(0, 0, RCL_STEADY_TIME);
+
+  EXPECT_ANY_THROW((void)(system_duration == steady_duration));
+  EXPECT_ANY_THROW((void)(system_duration <= steady_duration));
+  EXPECT_ANY_THROW((void)(system_duration >= steady_duration));
+  EXPECT_ANY_THROW((void)(system_duration < steady_duration));
+  EXPECT_ANY_THROW((void)(system_duration > steady_duration));
+  EXPECT_ANY_THROW((void)(system_duration + steady_duration));
+  EXPECT_ANY_THROW((void)(system_duration - steady_duration));
+
+  rclcpp::Clock ros_clock(RCL_ROS_TIME);
+  rclcpp::Clock steady_clock(RCL_STEADY_TIME);
+  rclcpp::Clock system_clock(RCL_SYSTEM_TIME);
+
+  rclcpp::Duration steadytime = steady_clock.now() - steady_clock.now();
+  rclcpp::Duration systemtime = system_clock.now() - system_clock.now();
+  // Force RCL_ROS_TIME
+  rclcpp::Duration rostime = rclcpp::Duration(steadytime.nanoseconds(), RCL_ROS_TIME);
+
+  EXPECT_EQ(RCL_ROS_TIME, rostime.clock_type());
+  EXPECT_EQ(RCL_STEADY_TIME, steadytime.clock_type());
+  EXPECT_EQ(RCL_SYSTEM_TIME, systemtime.clock_type());
+
+  EXPECT_ANY_THROW((void)(rostime == steadytime));
+  EXPECT_ANY_THROW((void)(rostime <= steadytime));
+  EXPECT_ANY_THROW((void)(rostime >= steadytime));
+  EXPECT_ANY_THROW((void)(rostime < steadytime));
+  EXPECT_ANY_THROW((void)(rostime > steadytime));
+  EXPECT_ANY_THROW((void)(rostime + steadytime));
+  EXPECT_ANY_THROW((void)(rostime - steadytime));
+
+  EXPECT_ANY_THROW((void)(rostime == systemtime));
+  EXPECT_ANY_THROW((void)(rostime <= systemtime));
+  EXPECT_ANY_THROW((void)(rostime >= systemtime));
+  EXPECT_ANY_THROW((void)(rostime < systemtime));
+  EXPECT_ANY_THROW((void)(rostime > systemtime));
+  EXPECT_ANY_THROW((void)(rostime + systemtime));
+  EXPECT_ANY_THROW((void)(rostime - systemtime));
+
+  EXPECT_ANY_THROW((void)(systemtime == steadytime));
+  EXPECT_ANY_THROW((void)(systemtime <= steadytime));
+  EXPECT_ANY_THROW((void)(systemtime >= steadytime));
+  EXPECT_ANY_THROW((void)(systemtime < steadytime));
+  EXPECT_ANY_THROW((void)(systemtime > steadytime));
+  EXPECT_ANY_THROW((void)(systemtime + steadytime));
+  EXPECT_ANY_THROW((void)(systemtime - steadytime));
+
+  for (auto time_source : {RCL_ROS_TIME, RCL_SYSTEM_TIME, RCL_STEADY_TIME}) {
+    rclcpp::Duration time = rclcpp::Duration(0, 0, time_source);
+    rclcpp::Duration copy_constructor_duration(time);
+    rclcpp::Duration assignment_op_duration = rclcpp::Duration(1, 0, time_source);
+    assignment_op_duration = time;
+
+    EXPECT_TRUE(time == copy_constructor_duration);
+    EXPECT_TRUE(time == assignment_op_duration);
+  }
+}
+
+TEST(TestDuration, overflows) {
+  rclcpp::Duration max(std::numeric_limits<rcl_duration_value_t>::max());
+  rclcpp::Duration min(std::numeric_limits<rcl_duration_value_t>::min());
+
+  rclcpp::Duration one(1);
+  rclcpp::Duration negative_one(-1);
+
+  EXPECT_THROW(max + one, std::overflow_error);
+  EXPECT_THROW(min - one, std::underflow_error);
+  EXPECT_THROW(negative_one + min, std::underflow_error);
+  EXPECT_THROW(negative_one - max, std::underflow_error);
+}

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -20,6 +20,7 @@
 
 #include "rcl/error_handling.h"
 #include "rcl/time.h"
+#include "rclcpp/clock.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/time.hpp"
 

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -32,6 +32,17 @@ protected:
   }
 };
 
+TEST(TestTime, clock_type_access) {
+  rclcpp::Clock ros_clock(RCL_ROS_TIME);
+  EXPECT_EQ(RCL_ROS_TIME, ros_clock.getClockType());
+
+  rclcpp::Clock system_clock(RCL_SYSTEM_TIME);
+  EXPECT_EQ(RCL_SYSTEM_TIME, system_clock.getClockType());
+
+  rclcpp::Clock steady_clock(RCL_STEADY_TIME);
+  EXPECT_EQ(RCL_STEADY_TIME, steady_clock.getClockType());
+}
+
 TEST(TestTime, time_sources) {
   using builtin_interfaces::msg::Time;
   rclcpp::Clock ros_clock(RCL_ROS_TIME);

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -35,13 +35,13 @@ protected:
 
 TEST(TestTime, clock_type_access) {
   rclcpp::Clock ros_clock(RCL_ROS_TIME);
-  EXPECT_EQ(RCL_ROS_TIME, ros_clock.getClockType());
+  EXPECT_EQ(RCL_ROS_TIME, ros_clock.get_clock_type());
 
   rclcpp::Clock system_clock(RCL_SYSTEM_TIME);
-  EXPECT_EQ(RCL_SYSTEM_TIME, system_clock.getClockType());
+  EXPECT_EQ(RCL_SYSTEM_TIME, system_clock.get_clock_type());
 
   rclcpp::Clock steady_clock(RCL_STEADY_TIME);
-  EXPECT_EQ(RCL_STEADY_TIME, steady_clock.getClockType());
+  EXPECT_EQ(RCL_STEADY_TIME, steady_clock.get_clock_type());
 }
 
 TEST(TestTime, time_sources) {
@@ -114,10 +114,6 @@ TEST(TestTime, operators) {
   EXPECT_FALSE(young == old);
   EXPECT_TRUE(young != old);
 
-  rclcpp::Duration add = old + young;
-  EXPECT_EQ(add.nanoseconds(), (rcl_duration_value_t)(old.nanoseconds() + young.nanoseconds()));
-  EXPECT_EQ(add, old + young);
-
   rclcpp::Duration sub = young - old;
   EXPECT_EQ(sub.nanoseconds(), (rcl_duration_value_t)(young.nanoseconds() - old.nanoseconds()));
   EXPECT_EQ(sub, young - old);
@@ -131,7 +127,6 @@ TEST(TestTime, operators) {
   EXPECT_ANY_THROW((void)(system_time >= steady_time));
   EXPECT_ANY_THROW((void)(system_time < steady_time));
   EXPECT_ANY_THROW((void)(system_time > steady_time));
-  EXPECT_ANY_THROW((void)(system_time + steady_time));
   EXPECT_ANY_THROW((void)(system_time - steady_time));
 
   rclcpp::Clock system_clock(RCL_ROS_TIME);
@@ -146,7 +141,6 @@ TEST(TestTime, operators) {
   EXPECT_ANY_THROW((void)(now >= later));
   EXPECT_ANY_THROW((void)(now < later));
   EXPECT_ANY_THROW((void)(now > later));
-  EXPECT_ANY_THROW((void)(now + later));
   EXPECT_ANY_THROW((void)(now - later));
 
   for (auto time_source : {RCL_ROS_TIME, RCL_SYSTEM_TIME, RCL_STEADY_TIME}) {
@@ -161,9 +155,10 @@ TEST(TestTime, operators) {
 }
 
 TEST(TestTime, overflows) {
-  rclcpp::Time max(std::numeric_limits<rcl_time_point_value_t>::max());
-  rclcpp::Time one(1);
+  rclcpp::Time max_time(std::numeric_limits<rcl_time_point_value_t>::max());
+  rclcpp::Time min_time(std::numeric_limits<rcl_time_point_value_t>::min());
+  rclcpp::Duration one(1);
 
-  EXPECT_THROW(max + one, std::overflow_error);
-  EXPECT_THROW(one - max, std::underflow_error);
+  EXPECT_THROW(max_time + one, std::overflow_error);
+  EXPECT_THROW(min_time - one, std::underflow_error);
 }

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -35,17 +35,18 @@ protected:
 TEST(TestTime, time_sources) {
   using builtin_interfaces::msg::Time;
   rclcpp::Clock ros_clock(RCL_ROS_TIME);
-  // TODO(Karsten1987): Fix this test once ROS_TIME is implemented
-  EXPECT_ANY_THROW(ros_clock.now());
+  Time ros_now = ros_clock.now();
+  EXPECT_NE(0, ros_now.sec);
+  EXPECT_NE(0u, ros_now.nanosec);
 
   rclcpp::Clock system_clock(RCL_ROS_TIME);
-  Time system_now = system_clock.now(RCL_SYSTEM_TIME);
+  Time system_now = system_clock.now();
   EXPECT_NE(0, system_now.sec);
   EXPECT_NE(0u, system_now.nanosec);
 
   // TODO(tfoote) restore steady
   rclcpp::Clock steady_clock(RCL_STEADY_TIME);
-  Time steady_now = steady_clock.now(RCL_STEADY_TIME);
+  Time steady_now = steady_clock.now();
   EXPECT_NE(0, steady_now.sec);
   EXPECT_NE(0u, steady_now.nanosec);
 
@@ -124,8 +125,8 @@ TEST(TestTime, operators) {
   rclcpp::Clock system_clock(RCL_ROS_TIME);
   rclcpp::Clock steady_clock(RCL_STEADY_TIME);
 
-  rclcpp::Time now = system_clock.now(RCL_SYSTEM_TIME);
-  rclcpp::Time later = steady_clock.now(RCL_STEADY_TIME);
+  rclcpp::Time now = system_clock.now();
+  rclcpp::Time later = steady_clock.now();
 
   EXPECT_ANY_THROW((void)(now == later));
   EXPECT_ANY_THROW((void)(now != later));

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -114,12 +114,12 @@ TEST(TestTime, operators) {
   EXPECT_FALSE(young == old);
   EXPECT_TRUE(young != old);
 
-  rclcpp::Time add = old + young;
-  EXPECT_EQ(add.nanoseconds(), old.nanoseconds() + young.nanoseconds());
+  rclcpp::Duration add = old + young;
+  EXPECT_EQ(add.nanoseconds(), (rcl_duration_value_t)(old.nanoseconds() + young.nanoseconds()));
   EXPECT_EQ(add, old + young);
 
-  rclcpp::Time sub = young - old;
-  EXPECT_EQ(sub.nanoseconds(), young.nanoseconds() - old.nanoseconds());
+  rclcpp::Duration sub = young - old;
+  EXPECT_EQ(sub.nanoseconds(), (rcl_duration_value_t)(young.nanoseconds() - old.nanoseconds()));
   EXPECT_EQ(sub, young - old);
 
   rclcpp::Time system_time(0, 0, RCL_SYSTEM_TIME);
@@ -161,7 +161,7 @@ TEST(TestTime, operators) {
 }
 
 TEST(TestTime, overflows) {
-  rclcpp::Time max(std::numeric_limits<uint64_t>::max());
+  rclcpp::Time max(std::numeric_limits<rcl_time_point_value_t>::max());
   rclcpp::Time one(1);
 
   EXPECT_THROW(max + one, std::overflow_error);

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -60,11 +60,6 @@ TEST(TestTime, time_sources) {
   Time steady_now = steady_clock.now();
   EXPECT_NE(0, steady_now.sec);
   EXPECT_NE(0u, steady_now.nanosec);
-
-  // // default
-  // Time default_now = rclcpp::Time::now();
-  // EXPECT_NE(0, default_now.sec);
-  // EXPECT_NE(0u, default_now.nanosec);
 }
 
 TEST(TestTime, conversions) {

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -34,25 +34,31 @@ protected:
 
 TEST(TestTime, time_sources) {
   using builtin_interfaces::msg::Time;
+  rclcpp::Clock ros_clock(RCL_ROS_TIME);
   // TODO(Karsten1987): Fix this test once ROS_TIME is implemented
-  EXPECT_ANY_THROW(rclcpp::Time::now(RCL_ROS_TIME));
+  EXPECT_ANY_THROW(ros_clock.now());
 
-  Time system_now = rclcpp::Time::now(RCL_SYSTEM_TIME);
+  rclcpp::Clock system_clock(RCL_ROS_TIME);
+  Time system_now = system_clock.now(RCL_SYSTEM_TIME);
   EXPECT_NE(0, system_now.sec);
   EXPECT_NE(0u, system_now.nanosec);
 
-  Time steady_now = rclcpp::Time::now(RCL_STEADY_TIME);
+  // TODO(tfoote) restore steady
+  rclcpp::Clock steady_clock(RCL_STEADY_TIME);
+  Time steady_now = steady_clock.now(RCL_STEADY_TIME);
   EXPECT_NE(0, steady_now.sec);
   EXPECT_NE(0u, steady_now.nanosec);
 
-  // default
-  Time default_now = rclcpp::Time::now();
-  EXPECT_NE(0, default_now.sec);
-  EXPECT_NE(0u, default_now.nanosec);
+  // // default
+  // Time default_now = rclcpp::Time::now();
+  // EXPECT_NE(0, default_now.sec);
+  // EXPECT_NE(0u, default_now.nanosec);
 }
 
 TEST(TestTime, conversions) {
-  rclcpp::Time now = rclcpp::Time::now();
+  rclcpp::Clock system_clock(RCL_ROS_TIME);
+
+  rclcpp::Time now = system_clock.now();
   builtin_interfaces::msg::Time now_msg = now;
 
   rclcpp::Time now_again = now_msg;
@@ -115,8 +121,11 @@ TEST(TestTime, operators) {
   EXPECT_ANY_THROW((void)(system_time + steady_time));
   EXPECT_ANY_THROW((void)(system_time - steady_time));
 
-  rclcpp::Time now = rclcpp::Time::now(RCL_SYSTEM_TIME);
-  rclcpp::Time later = rclcpp::Time::now(RCL_STEADY_TIME);
+  rclcpp::Clock system_clock(RCL_ROS_TIME);
+  rclcpp::Clock steady_clock(RCL_STEADY_TIME);
+
+  rclcpp::Time now = system_clock.now(RCL_SYSTEM_TIME);
+  rclcpp::Time later = steady_clock.now(RCL_STEADY_TIME);
 
   EXPECT_ANY_THROW((void)(now == later));
   EXPECT_ANY_THROW((void)(now != later));

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -56,7 +56,6 @@ TEST(TestTime, time_sources) {
   EXPECT_NE(0, system_now.sec);
   EXPECT_NE(0u, system_now.nanosec);
 
-  // TODO(tfoote) restore steady
   rclcpp::Clock steady_clock(RCL_STEADY_TIME);
   Time steady_now = steady_clock.now();
   EXPECT_NE(0, steady_now.sec);

--- a/rclcpp/test/test_time_source.cpp
+++ b/rclcpp/test/test_time_source.cpp
@@ -1,0 +1,73 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <limits>
+#include <string>
+
+#include "rcl/error_handling.h"
+#include "rcl/time.h"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/time.hpp"
+#include "rclcpp/time_source.hpp"
+
+class TestTimeSource : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void SetUp()
+  {
+    node = std::make_shared<rclcpp::node::Node>("my_node");
+  }
+
+  void TearDown()
+  {
+    node.reset();
+  }
+
+  rclcpp::node::Node::SharedPtr node;
+};
+
+
+TEST_F(TestTimeSource, tripwire){
+  rclcpp::TimeSource ts(node);
+  
+
+}
+
+TEST_F(TestTimeSource, clock)
+{
+  rclcpp::TimeSource ts(node);
+  
+  auto clock_pub = node->create_publisher<builtin_interfaces::msg::Time>("clock", rmw_qos_profile_default);
+  
+  rclcpp::WallRate loop_rate(1);
+  for (int i = 0; i < 10; ++i)
+  {
+    if (!rclcpp::ok()) break; // Break for ctrl-c
+    auto msg = std::make_shared<builtin_interfaces::msg::Time>();
+    msg->sec = i;
+    msg->nanosec = 1000;
+    clock_pub->publish(msg);
+    rclcpp::spin_some(node);
+    std::cout << "Publishing: '" << msg->sec << ".000000" << msg->nanosec << "'" << std::endl;
+    loop_rate.sleep();
+  }
+}

--- a/rclcpp/test/test_time_source.cpp
+++ b/rclcpp/test/test_time_source.cpp
@@ -63,19 +63,16 @@ TEST_F(TestTimeSource, reattach) {
   ASSERT_NO_THROW(ts.attachNode(node));
 }
 
-TEST_F(TestTimeSource, ROS_time_valid) {
-  rclcpp::TimeSource ts;
-  // Try reattach
-  ASSERT_THROW(ts.now(), std::invalid_argument);
-  ASSERT_THROW(ts.now(RCL_ROS_TIME), std::invalid_argument);
-  ASSERT_NO_THROW(ts.now(RCL_SYSTEM_TIME));
-
-  ts.attachNode(node);
-
-  ASSERT_NO_THROW(ts.now());
-  ASSERT_NO_THROW(ts.now(RCL_ROS_TIME));
-  ASSERT_NO_THROW(ts.now(RCL_SYSTEM_TIME));
-}
+// TEST_F(TestTimeSource, ROS_time_valid) {
+//   rclcpp::TimeSource ts;
+//   // Try reattach
+//   // TODO(tfoote) reenabled using external clock
+//   ASSERT_THROW(ts.now(), std::invalid_argument);
+//
+//   ts.attachNode(node);
+//
+//   ASSERT_NO_THROW(ts.now());
+// }
 
 TEST_F(TestTimeSource, clock) {
   rclcpp::TimeSource ts(node);
@@ -104,9 +101,10 @@ TEST_F(TestTimeSource, clock) {
   auto t_low = rclcpp::Time(1, 0, RCL_ROS_TIME);
   auto t_high = rclcpp::Time(10, 100000, RCL_ROS_TIME);
 
-  auto t_out = ts.now();
-
-  EXPECT_NE(0, t_out.nanoseconds());
-  EXPECT_LT(t_low.nanoseconds(), t_out.nanoseconds());
-  EXPECT_GT(t_high.nanoseconds(), t_out.nanoseconds());
+// // TODO(tfoote) restore with external clock
+//   auto t_out = ts.now();
+//
+//   EXPECT_NE(0, t_out.nanoseconds());
+//   EXPECT_LT(t_low.nanoseconds(), t_out.nanoseconds());
+//   EXPECT_GT(t_high.nanoseconds(), t_out.nanoseconds());
 }

--- a/rclcpp/test/test_time_source.cpp
+++ b/rclcpp/test/test_time_source.cpp
@@ -46,7 +46,7 @@ protected:
 };
 
 
-TEST_F(TestTimeSource, detachUnattached){
+TEST_F(TestTimeSource, detachUnattached) {
   rclcpp::TimeSource ts;
 
   ASSERT_NO_THROW(ts.detachNode());
@@ -56,14 +56,14 @@ TEST_F(TestTimeSource, detachUnattached){
 
 }
 
-TEST_F(TestTimeSource, reattach){
+TEST_F(TestTimeSource, reattach) {
   rclcpp::TimeSource ts;
   //Try reattach
   ASSERT_NO_THROW(ts.attachNode(node));
   ASSERT_NO_THROW(ts.attachNode(node));
 }
 
-TEST_F(TestTimeSource, ROS_time_valid){
+TEST_F(TestTimeSource, ROS_time_valid) {
   rclcpp::TimeSource ts;
   //Try reattach
   ASSERT_THROW(ts.now(), std::invalid_argument);
@@ -77,22 +77,21 @@ TEST_F(TestTimeSource, ROS_time_valid){
   ASSERT_NO_THROW(ts.now(RCL_SYSTEM_TIME));
 }
 
-
-
-TEST_F(TestTimeSource, clock)
-{
+TEST_F(TestTimeSource, clock) {
   rclcpp::TimeSource ts(node);
 
   // builtin_interfaces::msg::Time::SharedPtr last_msg;
   // auto clock_sub = node->create_subscription<builtin_interfaces::msg::Time>(
   //   "clock", [&](builtin_interfaces::msg::Time::SharedPtr msg) {last_msg = msg;}, rmw_qos_profile_default);
 
-  auto clock_pub = node->create_publisher<builtin_interfaces::msg::Time>("clock", rmw_qos_profile_default);
+  auto clock_pub = node->create_publisher<builtin_interfaces::msg::Time>("clock",
+      rmw_qos_profile_default);
 
   rclcpp::WallRate loop_rate(10);
-  for (int i = 0; i < 10; ++i)
-  {
-    if (!rclcpp::ok()) break; // Break for ctrl-c
+  for (int i = 0; i < 10; ++i) {
+    if (!rclcpp::ok()) {
+      break; // Break for ctrl-c
+    }
     auto msg = std::make_shared<builtin_interfaces::msg::Time>();
     msg->sec = i;
     msg->nanosec = 1000;

--- a/rclcpp/test/test_time_source.cpp
+++ b/rclcpp/test/test_time_source.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <memory>
 #include <string>
 
 #include "rcl/error_handling.h"
@@ -51,21 +52,20 @@ TEST_F(TestTimeSource, detachUnattached) {
 
   ASSERT_NO_THROW(ts.detachNode());
 
-  //Try multiple detach to see if error
+  // Try multiple detach to see if error
   ASSERT_NO_THROW(ts.detachNode());
-
 }
 
 TEST_F(TestTimeSource, reattach) {
   rclcpp::TimeSource ts;
-  //Try reattach
+  // Try reattach
   ASSERT_NO_THROW(ts.attachNode(node));
   ASSERT_NO_THROW(ts.attachNode(node));
 }
 
 TEST_F(TestTimeSource, ROS_time_valid) {
   rclcpp::TimeSource ts;
-  //Try reattach
+  // Try reattach
   ASSERT_THROW(ts.now(), std::invalid_argument);
   ASSERT_THROW(ts.now(RCL_ROS_TIME), std::invalid_argument);
   ASSERT_NO_THROW(ts.now(RCL_SYSTEM_TIME));
@@ -82,7 +82,8 @@ TEST_F(TestTimeSource, clock) {
 
   // builtin_interfaces::msg::Time::SharedPtr last_msg;
   // auto clock_sub = node->create_subscription<builtin_interfaces::msg::Time>(
-  //   "clock", [&](builtin_interfaces::msg::Time::SharedPtr msg) {last_msg = msg;}, rmw_qos_profile_default);
+  //   "clock", [&](builtin_interfaces::msg::Time::SharedPtr msg) {last_msg = msg;},
+  //   rmw_qos_profile_default);
 
   auto clock_pub = node->create_publisher<builtin_interfaces::msg::Time>("clock",
       rmw_qos_profile_default);
@@ -90,7 +91,7 @@ TEST_F(TestTimeSource, clock) {
   rclcpp::WallRate loop_rate(10);
   for (int i = 0; i < 10; ++i) {
     if (!rclcpp::ok()) {
-      break; // Break for ctrl-c
+      break;  // Break for ctrl-c
     }
     auto msg = std::make_shared<builtin_interfaces::msg::Time>();
     msg->sec = i;

--- a/rclcpp/test/test_time_source.cpp
+++ b/rclcpp/test/test_time_source.cpp
@@ -21,6 +21,7 @@
 
 #include "rcl/error_handling.h"
 #include "rcl/time.h"
+#include "rclcpp/clock.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/time.hpp"
 #include "rclcpp/time_source.hpp"

--- a/rclcpp/test/test_time_source.cpp
+++ b/rclcpp/test/test_time_source.cpp
@@ -46,22 +46,49 @@ protected:
 };
 
 
-TEST_F(TestTimeSource, tripwire){
-  rclcpp::TimeSource ts(node);
-  
+TEST_F(TestTimeSource, detachUnattached){
+  rclcpp::TimeSource ts;
+
+  ASSERT_NO_THROW(ts.detachNode());
+
+  //Try multiple detach to see if error
+  ASSERT_NO_THROW(ts.detachNode());
 
 }
+
+TEST_F(TestTimeSource, reattach){
+  rclcpp::TimeSource ts;
+  //Try reattach
+  ASSERT_NO_THROW(ts.attachNode(node));
+  ASSERT_NO_THROW(ts.attachNode(node));
+}
+
+TEST_F(TestTimeSource, ROS_time_valid){
+  rclcpp::TimeSource ts;
+  //Try reattach
+  ASSERT_THROW(ts.now(), std::invalid_argument);
+  ASSERT_THROW(ts.now(RCL_ROS_TIME), std::invalid_argument);
+  ASSERT_NO_THROW(ts.now(RCL_SYSTEM_TIME));
+
+  ts.attachNode(node);
+
+  ASSERT_NO_THROW(ts.now());
+  ASSERT_NO_THROW(ts.now(RCL_ROS_TIME));
+  ASSERT_NO_THROW(ts.now(RCL_SYSTEM_TIME));
+}
+
+
 
 TEST_F(TestTimeSource, clock)
 {
   rclcpp::TimeSource ts(node);
-  builtin_interfaces::msg::Time::SharedPtr last_msg;
-  
-  auto clock_sub = node->create_subscription<builtin_interfaces::msg::Time>(
-    "clock", [&](builtin_interfaces::msg::Time::SharedPtr msg) {last_msg = msg; std::cout << "got clock? " << msg->sec << std::endl;}, rmw_qos_profile_default);
+
+  // builtin_interfaces::msg::Time::SharedPtr last_msg;
+  // auto clock_sub = node->create_subscription<builtin_interfaces::msg::Time>(
+  //   "clock", [&](builtin_interfaces::msg::Time::SharedPtr msg) {last_msg = msg;}, rmw_qos_profile_default);
 
   auto clock_pub = node->create_publisher<builtin_interfaces::msg::Time>("clock", rmw_qos_profile_default);
-  
+
   rclcpp::WallRate loop_rate(10);
   for (int i = 0; i < 10; ++i)
   {
@@ -70,7 +97,7 @@ TEST_F(TestTimeSource, clock)
     msg->sec = i;
     msg->nanosec = 1000;
     clock_pub->publish(msg);
-    std::cout << "Publishing: '" << msg->sec << ".000000" << msg->nanosec << "'" << std::endl;
+    // std::cout << "Publishing: '" << msg->sec << ".000000" << msg->nanosec << "'" << std::endl;
     rclcpp::spin_some(node);
     loop_rate.sleep();
   }

--- a/rclcpp/test/test_time_source.cpp
+++ b/rclcpp/test/test_time_source.cpp
@@ -90,11 +90,6 @@ TEST_F(TestTimeSource, clock) {
   ts.attachClock(ros_clock);
   EXPECT_FALSE(ros_clock->ros_time_is_active());
 
-  // builtin_interfaces::msg::Time::SharedPtr last_msg;
-  // auto clock_sub = node->create_subscription<builtin_interfaces::msg::Time>(
-  //   "clock", [&](builtin_interfaces::msg::Time::SharedPtr msg) {last_msg = msg;},
-  //   rmw_qos_profile_default);
-
   auto clock_pub = node->create_publisher<builtin_interfaces::msg::Time>("clock",
       rmw_qos_profile_default);
   rclcpp::WallRate loop_rate(50);

--- a/rclcpp/test/test_time_source.cpp
+++ b/rclcpp/test/test_time_source.cpp
@@ -95,7 +95,6 @@ TEST_F(TestTimeSource, clock) {
 
   auto clock_pub = node->create_publisher<builtin_interfaces::msg::Time>("clock",
       rmw_qos_profile_default);
-
   rclcpp::WallRate loop_rate(50);
   for (int i = 0; i < 5; ++i) {
     if (!rclcpp::ok()) {
@@ -125,16 +124,19 @@ TEST_F(TestTimeSource, clock) {
 class CallbackObject
 {
 public:
-  CallbackObject():
-    last_precallback_id_(0),
+  CallbackObject()
+  : last_precallback_id_(0),
     last_postcallback_id_(0)
   {}
   int last_precallback_id_;
-  void pre_callback(int id){ last_precallback_id_ = id;};
+  void pre_callback(int id) {last_precallback_id_ = id;}
 
   int last_postcallback_id_;
   rclcpp::TimeJump last_timejump_;
-  void post_callback(const rclcpp::TimeJump & jump, int id){ last_postcallback_id_ = id; last_timejump_ = jump;};
+  void post_callback(const rclcpp::TimeJump & jump, int id)
+  {
+    last_postcallback_id_ = id; last_timejump_ = jump;
+  }
 };
 
 TEST_F(TestTimeSource, callbacks) {
@@ -151,8 +153,7 @@ TEST_F(TestTimeSource, callbacks) {
   rclcpp::JumpCallback::SharedPtr callback_holder = ros_clock->create_jump_callback(
     std::bind(&CallbackObject::pre_callback, &cbo, 1),
     std::bind(&CallbackObject::post_callback, &cbo, std::placeholders::_1, 1),
-    jump_threshold
-  );
+    jump_threshold);
 
   EXPECT_EQ(0, cbo.last_precallback_id_);
   EXPECT_EQ(0, cbo.last_postcallback_id_);
@@ -198,8 +199,7 @@ TEST_F(TestTimeSource, callbacks) {
   callback_holder = ros_clock->create_jump_callback(
     std::bind(&CallbackObject::pre_callback, &cbo, 2),
     std::bind(&CallbackObject::post_callback, &cbo, std::placeholders::_1, 2),
-    jump_threshold
-  );
+    jump_threshold);
 
   for (int i = 0; i < 5; ++i) {
     if (!rclcpp::ok()) {

--- a/rclcpp/test/test_time_source.cpp
+++ b/rclcpp/test/test_time_source.cpp
@@ -117,7 +117,7 @@ TEST_F(TestTimeSource, clock) {
 
   auto t_out = ros_clock->now();
 
-  EXPECT_NE(0, t_out.nanoseconds());
+  EXPECT_NE(0UL, t_out.nanoseconds());
   EXPECT_LT(t_low.nanoseconds(), t_out.nanoseconds());
   EXPECT_GT(t_high.nanoseconds(), t_out.nanoseconds());
 }

--- a/rclcpp/test/test_time_source.cpp
+++ b/rclcpp/test/test_time_source.cpp
@@ -70,23 +70,23 @@ TEST_F(TestTimeSource, ROS_time_valid) {
   // TODO(tfoote) reenabled using external clock
   auto ros_clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
 
-  EXPECT_FALSE(ros_clock->isROSTimeActive());
+  EXPECT_FALSE(ros_clock->ros_time_is_active());
   ts.attachClock(ros_clock);
   auto now = ros_clock->now();
 
-  EXPECT_FALSE(ros_clock->isROSTimeActive());
+  EXPECT_FALSE(ros_clock->ros_time_is_active());
 
   ts.attachNode(node);
 
-  EXPECT_FALSE(ros_clock->isROSTimeActive());
+  EXPECT_FALSE(ros_clock->ros_time_is_active());
 }
 
 TEST_F(TestTimeSource, clock) {
   rclcpp::TimeSource ts(node);
   auto ros_clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
-  EXPECT_FALSE(ros_clock->isROSTimeActive());
+  EXPECT_FALSE(ros_clock->ros_time_is_active());
   ts.attachClock(ros_clock);
-  EXPECT_FALSE(ros_clock->isROSTimeActive());
+  EXPECT_FALSE(ros_clock->ros_time_is_active());
 
   // builtin_interfaces::msg::Time::SharedPtr last_msg;
   // auto clock_sub = node->create_subscription<builtin_interfaces::msg::Time>(
@@ -112,7 +112,7 @@ TEST_F(TestTimeSource, clock) {
   auto t_high = rclcpp::Time(10, 100000, RCL_ROS_TIME);
 
   // Now that we've recieved a message it should be active with parameter unset
-  EXPECT_TRUE(ros_clock->isROSTimeActive());
+  EXPECT_TRUE(ros_clock->ros_time_is_active());
 
   auto t_out = ros_clock->now();
 
@@ -150,7 +150,7 @@ TEST_F(TestTimeSource, callbacks) {
   auto ros_clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
 
   // Register a callback for time jumps
-  rclcpp::JumpCallback::SharedPtr callback_holder = ros_clock->create_jump_callback(
+  rclcpp::JumpHandler::SharedPtr callback_holder = ros_clock->create_jump_callback(
     std::bind(&CallbackObject::pre_callback, &cbo, 1),
     std::bind(&CallbackObject::post_callback, &cbo, std::placeholders::_1, 1),
     jump_threshold);
@@ -158,10 +158,10 @@ TEST_F(TestTimeSource, callbacks) {
   EXPECT_EQ(0, cbo.last_precallback_id_);
   EXPECT_EQ(0, cbo.last_postcallback_id_);
 
-  EXPECT_FALSE(ros_clock->isROSTimeActive());
+  EXPECT_FALSE(ros_clock->ros_time_is_active());
 
   ts.attachClock(ros_clock);
-  EXPECT_FALSE(ros_clock->isROSTimeActive());
+  EXPECT_FALSE(ros_clock->ros_time_is_active());
 
   auto clock_pub = node->create_publisher<builtin_interfaces::msg::Time>("clock",
       rmw_qos_profile_default);
@@ -186,7 +186,7 @@ TEST_F(TestTimeSource, callbacks) {
   EXPECT_EQ(1, cbo.last_postcallback_id_);
 
   // Now that we've recieved a message it should be active with parameter unset
-  EXPECT_TRUE(ros_clock->isROSTimeActive());
+  EXPECT_TRUE(ros_clock->ros_time_is_active());
 
   auto t_out = ros_clock->now();
 
@@ -218,7 +218,7 @@ TEST_F(TestTimeSource, callbacks) {
   EXPECT_EQ(2, cbo.last_postcallback_id_);
 
   // Now that we've recieved a message it should be active with parameter unset
-  EXPECT_TRUE(ros_clock->isROSTimeActive());
+  EXPECT_TRUE(ros_clock->ros_time_is_active());
 
   t_out = ros_clock->now();
 
@@ -231,10 +231,10 @@ TEST_F(TestTimeSource, callbacks) {
 TEST_F(TestTimeSource, parameter_activation) {
   rclcpp::TimeSource ts(node);
   auto ros_clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
-  EXPECT_FALSE(ros_clock->isROSTimeActive());
+  EXPECT_FALSE(ros_clock->ros_time_is_active());
 
   ts.attachClock(ros_clock);
-  EXPECT_FALSE(ros_clock->isROSTimeActive());
+  EXPECT_FALSE(ros_clock->ros_time_is_active());
 
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
@@ -248,7 +248,7 @@ TEST_F(TestTimeSource, parameter_activation) {
     EXPECT_TRUE(result.successful);
   }
   rclcpp::spin_some(node);
-  EXPECT_TRUE(ros_clock->isROSTimeActive());
+  EXPECT_TRUE(ros_clock->ros_time_is_active());
 
 
   set_parameters_results = parameters_client->set_parameters({
@@ -257,7 +257,7 @@ TEST_F(TestTimeSource, parameter_activation) {
   for (auto & result : set_parameters_results) {
     EXPECT_TRUE(result.successful);
   }
-  EXPECT_TRUE(ros_clock->isROSTimeActive());
+  EXPECT_TRUE(ros_clock->ros_time_is_active());
 
   set_parameters_results = parameters_client->set_parameters({
     rclcpp::parameter::ParameterVariant("use_sim_time", false)
@@ -265,7 +265,7 @@ TEST_F(TestTimeSource, parameter_activation) {
   for (auto & result : set_parameters_results) {
     EXPECT_TRUE(result.successful);
   }
-  EXPECT_FALSE(ros_clock->isROSTimeActive());
+  EXPECT_FALSE(ros_clock->ros_time_is_active());
 
   set_parameters_results = parameters_client->set_parameters({
     rclcpp::parameter::ParameterVariant("use_sim_time", rclcpp::parameter::PARAMETER_NOT_SET)
@@ -273,5 +273,5 @@ TEST_F(TestTimeSource, parameter_activation) {
   for (auto & result : set_parameters_results) {
     EXPECT_TRUE(result.successful);
   }
-  EXPECT_FALSE(ros_clock->isROSTimeActive());
+  EXPECT_FALSE(ros_clock->ros_time_is_active());
 }

--- a/rclcpp/test/test_time_source.cpp
+++ b/rclcpp/test/test_time_source.cpp
@@ -66,18 +66,20 @@ TEST_F(TestTimeSource, reattach) {
 
 TEST_F(TestTimeSource, ROS_time_valid) {
   rclcpp::TimeSource ts;
-  // Try reattach
-  // TODO(tfoote) reenabled using external clock
   auto ros_clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
 
   EXPECT_FALSE(ros_clock->ros_time_is_active());
   ts.attachClock(ros_clock);
   auto now = ros_clock->now();
-
   EXPECT_FALSE(ros_clock->ros_time_is_active());
 
   ts.attachNode(node);
+  EXPECT_FALSE(ros_clock->ros_time_is_active());
 
+  ts.detachNode();
+  EXPECT_FALSE(ros_clock->ros_time_is_active());
+
+  ts.attachNode(node);
   EXPECT_FALSE(ros_clock->ros_time_is_active());
 }
 


### PR DESCRIPTION
Connects to ros2/rcl#164
Continuing to follow up ros2/design#144

This implements a TimeSource in rclcpp, adds the Clock class. 

This still has many of the in progress commits, I'd suggest focusing on the overall diff. I'll clean up the history later.

@wjwwood Do you still have the Time/Duration updates pending?

Another question that is not resolved yet is how to make setting a Clock up easily with a Node. The current design is very modular but requires overhead to connect the TimeSource, node, and Clock all together. Suggestions for integrating them into the Node API would be appreciated, however I will probably hold off on that for this round and just say use the modular API. 
`Clock clock; TimeSource ts(node); ts.associateClock(clock);`

Before this passes CI a set of coordinated changes to all usages of rclcpp::Time::now() like above.