### PR TITLE
restore . as parameter separator

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -198,7 +198,9 @@ NodeParameters::list_parameters(const std::vector<std::string> & prefixes, uint6
   std::lock_guard<std::mutex> lock(mutex_);
   rcl_interfaces::msg::ListParametersResult result;
 
-  const char separator = '/';
+  // TODO(mikaelarguedas) define parameter separator different from "/" to avoid ambiguity
+  // using "." for now
+  const char separator = '.';
   for (auto & kv : parameters_) {
     bool get_all = (prefixes.size() == 0) &&
       ((depth == rcl_interfaces::srv::ListParameters::Request::DEPTH_RECURSIVE) ||


### PR DESCRIPTION
Follow up of https://github.com/ros2/rclcpp/pull/367#issuecomment-328581361


* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3216)](http://ci.ros2.org/job/ci_linux/3216/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=536)](http://ci.ros2.org/job/ci_linux-aarch64/536/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2572)](http://ci.ros2.org/job/ci_osx/2572/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3283)](http://ci.ros2.org/job/ci_windows/3283/)