### PR TITLE
Improvements to rclcpp::Time

### DIFF
--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -64,6 +64,10 @@ public:
 
   RCLCPP_PUBLIC
   bool
+  operator!=(const rclcpp::Time & rhs) const;
+
+  RCLCPP_PUBLIC
+  bool
   operator<(const rclcpp::Time & rhs) const;
 
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -36,7 +36,7 @@ public:
   Time(int32_t seconds, uint32_t nanoseconds, rcl_time_source_type_t clock = RCL_SYSTEM_TIME);
 
   RCLCPP_PUBLIC
-  explicit Time(uint64_t nanoseconds, rcl_time_source_type_t clock = RCL_SYSTEM_TIME);
+  explicit Time(uint64_t nanoseconds = 0, rcl_time_source_type_t clock = RCL_SYSTEM_TIME);
 
   RCLCPP_PUBLIC
   Time(const Time & rhs);

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -51,11 +51,11 @@ public:
   operator builtin_interfaces::msg::Time() const;
 
   RCLCPP_PUBLIC
-  void
+  Time &
   operator=(const Time & rhs);
 
   RCLCPP_PUBLIC
-  void
+  Time &
   operator=(const builtin_interfaces::msg::Time & time_msg);
 
   RCLCPP_PUBLIC

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -174,6 +174,12 @@ Time::operator==(const rclcpp::Time & rhs) const
 }
 
 bool
+Time::operator!=(const rclcpp::Time & rhs) const
+{
+  return !(*this == rhs);
+}
+
+bool
 Time::operator<(const rclcpp::Time & rhs) const
 {
   if (rcl_time_.time_source->type != rhs.rcl_time_.time_source->type) {

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -139,15 +139,16 @@ Time::operator builtin_interfaces::msg::Time() const
   return msg_time;
 }
 
-void
+Time &
 Time::operator=(const Time & rhs)
 {
   rcl_time_source_ = init_time_source(rhs.rcl_time_source_.type);
   rcl_time_ = init_time_point(rcl_time_source_);
   rcl_time_.nanoseconds = rhs.rcl_time_.nanoseconds;
+  return *this;
 }
 
-void
+Time &
 Time::operator=(const builtin_interfaces::msg::Time & time_msg)
 {
   if (time_msg.sec < 0) {
@@ -159,6 +160,7 @@ Time::operator=(const builtin_interfaces::msg::Time & time_msg)
 
   rcl_time_.nanoseconds = RCL_S_TO_NS(static_cast<uint64_t>(time_msg.sec));
   rcl_time_.nanoseconds += time_msg.nanosec;
+  return *this;
 }
 
 bool

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -93,6 +93,7 @@ TEST(TestTime, operators) {
   EXPECT_TRUE(old <= young);
   EXPECT_TRUE(young >= old);
   EXPECT_FALSE(young == old);
+  EXPECT_TRUE(young != old);
 
   rclcpp::Time add = old + young;
   EXPECT_EQ(add.nanoseconds(), old.nanoseconds() + young.nanoseconds());
@@ -106,6 +107,7 @@ TEST(TestTime, operators) {
   rclcpp::Time steady_time(0, 0, RCL_STEADY_TIME);
 
   EXPECT_ANY_THROW((void)(system_time == steady_time));
+  EXPECT_ANY_THROW((void)(system_time != steady_time));
   EXPECT_ANY_THROW((void)(system_time <= steady_time));
   EXPECT_ANY_THROW((void)(system_time >= steady_time));
   EXPECT_ANY_THROW((void)(system_time < steady_time));
@@ -117,6 +119,7 @@ TEST(TestTime, operators) {
   rclcpp::Time later = rclcpp::Time::now(RCL_STEADY_TIME);
 
   EXPECT_ANY_THROW((void)(now == later));
+  EXPECT_ANY_THROW((void)(now != later));
   EXPECT_ANY_THROW((void)(now <= later));
   EXPECT_ANY_THROW((void)(now >= later));
   EXPECT_ANY_THROW((void)(now < later));


### PR DESCRIPTION
I found these while working on the rviz port.

- Provide a default argument for the single argument constructor, making the class trivially constructible (? not sure if that's the correct term, or maybe trivially default constructible)
  - This is needed to allow it to be used with Qt's signals and slots
- Change the `operator=` methods to return `Time &`
  - https://stackoverflow.com/questions/9072169/why-should-the-assignment-operator-return-a-reference-to-the-object
- Added the `operator!=`