### PR TITLE
Fix static assertion on xcode 9

### DIFF
--- a/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
@@ -266,14 +266,11 @@ private:
     }
   };
 
-  // Make sure allocator given to map has the correct value_type
-  using IDTopic = std::pair<const char *, AllocSet>;
-
   using IDTopicMap = std::map<
-      typename IDTopic::first_type,
-      typename IDTopic::second_type,
+      const char *,
+      AllocSet,
       strcmp_wrapper,
-      RebindAlloc<IDTopic>>;
+      RebindAlloc<std::pair<const char const *, AllocSet>>;
 
   SubscriptionMap subscriptions_;
 

--- a/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
@@ -269,7 +269,7 @@ private:
       const char *,
       AllocSet,
       strcmp_wrapper,
-      RebindAlloc<std::pair<const std::string, AllocSet>>>;
+      RebindAlloc<std::pair<const char *, AllocSet>>>;
 
   SubscriptionMap subscriptions_;
 

--- a/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
@@ -265,11 +265,15 @@ private:
       return std::strcmp(lhs, rhs) < 0;
     }
   };
+
+  // Make sure allocator given to map has the correct value_type
+  using IDTopic = std::pair<const char *, AllocSet>;
+
   using IDTopicMap = std::map<
-      const char *,
-      AllocSet,
+      typename IDTopic::first_type,
+      typename IDTopic::second_type,
       strcmp_wrapper,
-      RebindAlloc<std::pair<const char *, AllocSet>>>;
+      RebindAlloc<IDTopic>>;
 
   SubscriptionMap subscriptions_;
 

--- a/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
@@ -265,12 +265,11 @@ private:
       return std::strcmp(lhs, rhs) < 0;
     }
   };
-
   using IDTopicMap = std::map<
       const char *,
       AllocSet,
       strcmp_wrapper,
-      RebindAlloc<std::pair<const char const *, AllocSet>>;
+      RebindAlloc<std::pair<const char const *, AllocSet>>>;
 
   SubscriptionMap subscriptions_;
 

--- a/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
@@ -269,7 +269,7 @@ private:
       const char *,
       AllocSet,
       strcmp_wrapper,
-      RebindAlloc<std::pair<const char const *, AllocSet>>>;
+      RebindAlloc<std::pair<const char * const, AllocSet>>>;
 
   SubscriptionMap subscriptions_;
 


### PR DESCRIPTION
This makes sure an allocator given to an `std::map` has the correct type.

Testing not yet in progress, resolving random CI issues so I have an OSX machine to test on first.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3269)](http://ci.ros2.org/job/ci_linux/3269/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=554)](http://ci.ros2.org/job/ci_linux-aarch64/554/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2604)](http://ci.ros2.org/job/ci_osx/2604/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3313)](http://ci.ros2.org/job/ci_windows/3313/)

Connects to ros2/rclcpp#378