### PR TITLE
sync parameter takes optional remote node name

### DIFF
--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -170,12 +170,14 @@ public:
   RCLCPP_PUBLIC
   explicit SyncParametersClient(
     rclcpp::node::Node::SharedPtr node,
+    const std::string & remote_node_name = "",
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_parameters);
 
   RCLCPP_PUBLIC
   SyncParametersClient(
     rclcpp::executor::Executor::SharedPtr executor,
     rclcpp::node::Node::SharedPtr node,
+    const std::string & remote_node_name = "",
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_parameters);
 
   RCLCPP_PUBLIC

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -314,20 +314,24 @@ AsyncParametersClient::wait_for_service_nanoseconds(std::chrono::nanoseconds tim
 
 SyncParametersClient::SyncParametersClient(
   rclcpp::node::Node::SharedPtr node,
+  const std::string & remote_node_name,
   const rmw_qos_profile_t & qos_profile)
-: node_(node)
-{
-  executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-  async_parameters_client_ = std::make_shared<AsyncParametersClient>(node, "", qos_profile);
-}
+: SyncParametersClient(
+    std::make_shared<rclcpp::executors::SingleThreadedExecutor>(),
+    node,
+    remote_node_name,
+    qos_profile)
+{}
 
 SyncParametersClient::SyncParametersClient(
   rclcpp::executor::Executor::SharedPtr executor,
   rclcpp::node::Node::SharedPtr node,
+  const std::string & remote_node_name,
   const rmw_qos_profile_t & qos_profile)
 : executor_(executor), node_(node)
 {
-  async_parameters_client_ = std::make_shared<AsyncParametersClient>(node, "", qos_profile);
+  async_parameters_client_ =
+    std::make_shared<AsyncParametersClient>(node, remote_node_name, qos_profile);
 }
 
 std::vector<rclcpp::parameter::ParameterVariant>


### PR DESCRIPTION
connects to ros2/rclcpp#365

ci:
win: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3318)](http://ci.ros2.org/job/ci_windows/3318/)  warnings unrelated
linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3277)](http://ci.ros2.org/job/ci_linux/3277/)
osx: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2611)](http://ci.ros2.org/job/ci_osx/2611/)
