### PR TITLE
move callback

### DIFF
--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -105,7 +105,7 @@ public:
       auto cb = std::bind(&LifecycleNodeInterfaceImpl::on_change_state, this,
           std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
       rclcpp::any_service_callback::AnyServiceCallback<ChangeStateSrv> any_cb;
-      any_cb.set(cb);
+      any_cb.set(std::move(cb));
 
       srv_change_state_ = std::make_shared<rclcpp::service::Service<ChangeStateSrv>>(
         node_base_interface_->get_shared_rcl_node_handle(),


### PR DESCRIPTION
connects to ros2/rclcpp#385

ci:
linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3339)](http://ci.ros2.org/job/ci_linux/3339/)
osx: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2669)](http://ci.ros2.org/job/ci_osx/2669/)
win: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3389)](http://ci.ros2.org/job/ci_windows/3389/) (unrelated test failures)