### PR TITLE
Implement rclcpp-specific logging macros [taking name not object]

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -66,20 +66,21 @@ set(${PROJECT_NAME}_SRCS
 
 # "watch" template for changes
 configure_file(
- "resource/logging.hpp.em"
- "logging.hpp.em.watch"
- COPYONLY)
+  "resource/logging.hpp.em"
+  "logging.hpp.em.watch"
+  COPYONLY
+)
 # generate header with logging macros
 set(python_code
- "import em"
- "em.invoke(['-o', 'include/rclcpp/logging.hpp', '${CMAKE_CURRENT_SOURCE_DIR}/resource/logging.hpp.em'])")
+  "import em"
+  "em.invoke(['-o', 'include/rclcpp/logging.hpp', '${CMAKE_CURRENT_SOURCE_DIR}/resource/logging.hpp.em'])")
 string(REPLACE ";" "$<SEMICOLON>" python_code "${python_code}")
 add_custom_command(OUTPUT include/rclcpp/logging.hpp
- COMMAND ${CMAKE_COMMAND} -E make_directory "include/rclcpp"
- COMMAND ${PYTHON_EXECUTABLE} ARGS -c "${python_code}"
- DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/logging.hpp.em.watch"
- COMMENT "Expanding logging.hpp.em"
- VERBATIM
+  COMMAND ${CMAKE_COMMAND} -E make_directory "include/rclcpp"
+  COMMAND ${PYTHON_EXECUTABLE} ARGS -c "${python_code}"
+  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/logging.hpp.em.watch"
+  COMMENT "Expanding logging.hpp.em"
+  VERBATIM
 )
 list(APPEND ${PROJECT_NAME}_SRCS
   include/rclcpp/logging.hpp)

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -272,6 +272,9 @@ if(BUILD_TESTING)
       "rcl")
     target_link_libraries(test_time ${PROJECT_NAME})
   endif()
+
+  ament_add_gmock(test_logging test/test_logging.cpp)
+  target_link_libraries(test_logging ${PROJECT_NAME})
 endif()
 
 ament_package(

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -64,6 +64,27 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/utilities.cpp
 )
 
+# "watch" template for changes
+configure_file(
+ "resource/logging.hpp.em"
+ "logging.hpp.em.watch"
+ COPYONLY)
+# generate header with logging macros
+set(python_code
+ "import em"
+ "em.invoke(['-o', 'include/rclcpp/logging.hpp', '${CMAKE_CURRENT_SOURCE_DIR}/resource/logging.hpp.em'])")
+string(REPLACE ";" "$<SEMICOLON>" python_code "${python_code}")
+add_custom_command(OUTPUT include/rclcpp/logging.hpp
+ COMMAND ${CMAKE_COMMAND} -E make_directory "include/rclcpp"
+ COMMAND ${PYTHON_EXECUTABLE} ARGS -c "${python_code}"
+ DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/logging.hpp.em.watch"
+ COMMENT "Expanding logging.hpp.em"
+ VERBATIM
+)
+list(APPEND ${PROJECT_NAME}_SRCS
+  include/rclcpp/logging.hpp)
+include_directories("${CMAKE_CURRENT_BINARY_DIR}/include")
+
 add_library(${PROJECT_NAME} SHARED
   ${${PROJECT_NAME}_SRCS})
 ament_target_dependencies(${PROJECT_NAME}
@@ -263,6 +284,6 @@ install(
 )
 
 install(
-  DIRECTORY include/
+  DIRECTORY include/ ${CMAKE_CURRENT_BINARY_DIR}/include/
   DESTINATION include
 )

--- a/rclcpp/Doxyfile
+++ b/rclcpp/Doxyfile
@@ -4,7 +4,12 @@ PROJECT_NAME           = "rclcpp"
 PROJECT_NUMBER         = master
 PROJECT_BRIEF          = "C++ ROS Client Library API"
 
+# Use these lines to include the generated logging.hpp (update install path if needed)
+#INPUT                  = ../../../../install_isolated/rclcpp/include
+#STRIP_FROM_PATH        = /Users/william/ros2_ws/install_isolated/rclcpp/include
+# Otherwise just generate for the local (non-generated header files)
 INPUT                  = ./include
+
 RECURSIVE              = YES
 OUTPUT_DIRECTORY       = doc_output
 

--- a/rclcpp/include/rclcpp/logging.hpp
+++ b/rclcpp/include/rclcpp/logging.hpp
@@ -1,0 +1,37 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__LOGGING_HPP_
+#define RCLCPP__LOGGING_HPP_
+
+#include "rcutils/logging_macros.h"
+
+#ifdef ROS_PACKAGE_NAME
+#define RCLCPP_CONSOLE_PACKAGE_NAME ROS_PACKAGE_NAME
+#else
+#define RCLCPP_CONSOLE_PACKAGE_NAME "unknown_package"
+#endif
+
+#define RCLCPP_CONSOLE_NAME_PREFIX RCLCPP_CONSOLE_PACKAGE_NAME
+#define RCLCPP_CONSOLE_DEFAULT_NAME RCLCPP_CONSOLE_NAME_PREFIX
+
+#define ROS_INFO(...) RCUTILS_LOG_INFO_NAMED(RCLCPP_CONSOLE_DEFAULT_NAME, __VA_ARGS__)
+
+#define ROS_INFO_NAMED(name, ...) RCUTILS_LOG_INFO_NAMED( \
+  (std::string(RCLCPP_CONSOLE_DEFAULT_NAME) + "." + name).c_str(), __VA_ARGS__)
+
+#define ROS_INFO_FULLNAMED(name, ...) RCUTILS_LOG_INFO_NAMED( \
+  std::string(name).c_str(), __VA_ARGS__)
+
+#endif  // RCLCPP__LOGGING_HPP_

--- a/rclcpp/include/rclcpp/macros.hpp
+++ b/rclcpp/include/rclcpp/macros.hpp
@@ -110,6 +110,4 @@
 #define RCLCPP_STRING_JOIN(arg1, arg2) RCLCPP_DO_STRING_JOIN(arg1, arg2)
 #define RCLCPP_DO_STRING_JOIN(arg1, arg2) arg1 ## arg2
 
-#define RCLCPP_INFO(Args) std::cout << Args << std::endl;
-
 #endif  // RCLCPP__MACROS_HPP_

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -126,6 +126,7 @@
 #include <memory>
 
 #include "rclcpp/executors.hpp"
+#include "rclcpp/logging.hpp"
 #include "rclcpp/node.hpp"
 #include "rclcpp/parameter.hpp"
 #include "rclcpp/parameter_client.hpp"

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -110,6 +110,13 @@
  *   - rclcpp::context::Context
  *   - rclcpp/context.hpp
  *   - rclcpp/contexts/default_context.hpp
+ * - Logging macros:
+ *   - Some examples (not exhaustive):
+ *     - RCLCPP_DEBUG()
+ *     - RCLCPP_INFO()
+ *     - RCLCPP_WARN_ONCE()
+ *     - RCLCPP_ERROR_SKIPFIRST()
+ *   - rclcpp/logging.hpp
  * - Various utilities:
  *   - rclcpp/function_traits.hpp
  *   - rclcpp/macros.hpp

--- a/rclcpp/package.xml
+++ b/rclcpp/package.xml
@@ -27,6 +27,7 @@
 
   <exec_depend>ament_cmake</exec_depend>
 
+  <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -29,17 +29,16 @@
 #define RCLCPP_CONSOLE_DEFAULT_NAME RCLCPP_CONSOLE_NAME_PREFIX
 
 @{
-import rcutils.logging
 from rcutils.logging import feature_combinations
-from rcutils.logging import get_macro_arguments
-from rcutils.logging import get_macro_parameters
+from rcutils.logging import get_suffix_from_features
 from rcutils.logging import severities
 }@
 @[for severity in severities]@
 /** @@name Logging macros for severity @(severity).
  */
 ///@@{
-@[ for suffix in [s for s in feature_combinations if 'NAMED' not in s]]@
+@[ for feature_combination in [fc for fc in feature_combinations if 'named' not in fc]]@
+@{suffix = get_suffix_from_features(feature_combination)}@
 #define ROS_@(severity)@(suffix)(...) RCUTILS_LOG_@(severity)@(suffix)_NAMED(RCLCPP_CONSOLE_DEFAULT_NAME, __VA_ARGS__)
 
 #define ROS_@(severity)@(suffix)_NAMED(name, ...) RCUTILS_LOG_@(severity)@(suffix)_NAMED( \

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -19,15 +19,6 @@
 
 #include "rcutils/logging_macros.h"
 
-#ifdef ROS_PACKAGE_NAME
-#define RCLCPP_CONSOLE_PACKAGE_NAME ROS_PACKAGE_NAME
-#else
-#define RCLCPP_CONSOLE_PACKAGE_NAME "unknown_package"
-#endif
-
-#define RCLCPP_CONSOLE_NAME_PREFIX RCLCPP_CONSOLE_PACKAGE_NAME
-#define RCLCPP_CONSOLE_DEFAULT_NAME RCLCPP_CONSOLE_NAME_PREFIX
-
 /**
  * \def RCLCPP_LOG_MIN_SEVERITY
  * Define RCLCPP_LOG_MIN_SEVERITY=RCUTILS_LOG_SEVERITY_[DEBUG|INFO|WARN|ERROR|FATAL]
@@ -81,7 +72,7 @@ from rcutils.logging import severities
 @[ if params]@
 @(''.join(['    ' + p + ', \\\n' for p in params]))@
 @[ end if]@
-    (std::string(RCLCPP_CONSOLE_DEFAULT_NAME) + "." + name).c_str(), \
+    std::string(name).c_str(), \
     __VA_ARGS__)
 
 @[ end for]@

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -43,6 +43,11 @@ from rcutils.logging import feature_combinations
 from rcutils.logging import get_macro_parameters
 from rcutils.logging import get_suffix_from_features
 from rcutils.logging import severities
+
+excluded_features = ['named']
+def is_supported_feature_combination(feature_combination):
+    is_excluded = any([ef in feature_combination for ef in excluded_features])
+    return not is_excluded
 }@
 @[for severity in severities]@
 /** @@name Logging macros for severity @(severity).
@@ -50,14 +55,14 @@ from rcutils.logging import severities
 ///@@{
 #if (RCLCPP_LOG_MIN_SEVERITY > RCLCPP_LOG_MIN_SEVERITY_@(severity))
 // empty logging macros for severity @(severity) when being disabled at compile time
-@[ for feature_combination in [fc for fc in feature_combinations if 'named' not in fc]]@
+@[ for feature_combination in [fc for fc in feature_combinations if is_supported_feature_combination(fc)]]@
 @{suffix = get_suffix_from_features(feature_combination)}@
 /// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
 #define ROS_@(severity)@(suffix)(...)
 @[ end for]@
 
 #else
-@[ for feature_combination in [fc for fc in feature_combinations if 'named' not in fc]]@
+@[ for feature_combination in [fc for fc in feature_combinations if is_supported_feature_combination(fc)]]@
 @{suffix = get_suffix_from_features(feature_combination)}@
 /**
  * \def ROS_@(severity)@(suffix)

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -44,6 +44,7 @@ from rcutils.logging import get_macro_parameters
 from rcutils.logging import get_suffix_from_features
 from rcutils.logging import severities
 
+# TODO(dhood): Implement the throttle macro using time sources available in rclcpp
 excluded_features = ['named', 'throttle']
 def is_supported_feature_combination(feature_combination):
     is_excluded = any([ef in feature_combination for ef in excluded_features])
@@ -81,6 +82,7 @@ def is_supported_feature_combination(feature_combination):
 @[ end for]@
  * \param ... The format string, followed by the variable arguments for the format string
  */
+// TODO(dhood): Replace the name argument with a logger object.
 #define RCLCPP_@(severity)@(suffix)(name, @(''.join([p + ', ' for p in get_macro_parameters(feature_combination).keys()]))...) \
   RCUTILS_LOG_@(severity)@(suffix)_NAMED( \
 @{params = get_macro_parameters(feature_combination).keys()}@

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -1,3 +1,5 @@
+// generated from rclcpp/resource/logging.hpp.em
+
 // Copyright 2017 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,12 +28,28 @@
 #define RCLCPP_CONSOLE_NAME_PREFIX RCLCPP_CONSOLE_PACKAGE_NAME
 #define RCLCPP_CONSOLE_DEFAULT_NAME RCLCPP_CONSOLE_NAME_PREFIX
 
-#define ROS_INFO(...) RCUTILS_LOG_INFO_NAMED(RCLCPP_CONSOLE_DEFAULT_NAME, __VA_ARGS__)
+@{
+import rcutils.logging
+from rcutils.logging import feature_combinations
+from rcutils.logging import get_macro_arguments
+from rcutils.logging import get_macro_parameters
+from rcutils.logging import severities
+}@
+@[for severity in severities]@
+/** @@name Logging macros for severity @(severity).
+ */
+///@@{
+@[ for suffix in [s for s in feature_combinations if 'NAMED' not in s]]@
+#define ROS_@(severity)@(suffix)(...) RCUTILS_LOG_@(severity)@(suffix)_NAMED(RCLCPP_CONSOLE_DEFAULT_NAME, __VA_ARGS__)
 
-#define ROS_INFO_NAMED(name, ...) RCUTILS_LOG_INFO_NAMED( \
+#define ROS_@(severity)@(suffix)_NAMED(name, ...) RCUTILS_LOG_@(severity)@(suffix)_NAMED( \
   (std::string(RCLCPP_CONSOLE_DEFAULT_NAME) + "." + name).c_str(), __VA_ARGS__)
 
-#define ROS_INFO_FULLNAMED(name, ...) RCUTILS_LOG_INFO_NAMED( \
+#define ROS_@(severity)@(suffix)_FULLNAMED(name, ...) RCUTILS_LOG_@(severity)@(suffix)_NAMED( \
   std::string(name).c_str(), __VA_ARGS__)
+@[ end for]@
+///@@}
+
+@[end for]@
 
 #endif  // RCLCPP__LOGGING_HPP_

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -58,14 +58,14 @@ def is_supported_feature_combination(feature_combination):
 @[ for feature_combination in [fc for fc in feature_combinations if is_supported_feature_combination(fc)]]@
 @{suffix = get_suffix_from_features(feature_combination)}@
 /// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
-#define ROS_@(severity)@(suffix)(...)
+#define RCLCPP_@(severity)@(suffix)(...)
 @[ end for]@
 
 #else
 @[ for feature_combination in [fc for fc in feature_combinations if is_supported_feature_combination(fc)]]@
 @{suffix = get_suffix_from_features(feature_combination)}@
 /**
- * \def ROS_@(severity)@(suffix)
+ * \def RCLCPP_@(severity)@(suffix)
  * Log a message with severity @(severity)@
 @[ if feature_combinations[feature_combination].doc_lines]@
  with the following conditions:
@@ -80,7 +80,7 @@ def is_supported_feature_combination(feature_combination):
 @[ end for]@
  * \param ... The format string, followed by the variable arguments for the format string
  */
-#define ROS_@(severity)@(suffix)(name, @(''.join([p + ', ' for p in get_macro_parameters(feature_combination).keys()]))...) \
+#define RCLCPP_@(severity)@(suffix)(name, @(''.join([p + ', ' for p in get_macro_parameters(feature_combination).keys()]))...) \
   RCUTILS_LOG_@(severity)@(suffix)_NAMED( \
 @{params = get_macro_parameters(feature_combination).keys()}@
 @[ if params]@

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -44,7 +44,7 @@ from rcutils.logging import get_macro_parameters
 from rcutils.logging import get_suffix_from_features
 from rcutils.logging import severities
 
-excluded_features = ['named']
+excluded_features = ['named', 'throttle']
 def is_supported_feature_combination(feature_combination):
     is_excluded = any([ef in feature_combination for ef in excluded_features])
     return not is_excluded

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -54,8 +54,6 @@ from rcutils.logging import severities
 @{suffix = get_suffix_from_features(feature_combination)}@
 /// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
 #define ROS_@(severity)@(suffix)(...)
-#define ROS_@(severity)@(suffix)_NAMED(name, ...)
-#define ROS_@(severity)@(suffix)_FULLNAMED(name, ...)
 @[ end for]@
 
 #else
@@ -77,9 +75,7 @@ from rcutils.logging import severities
 @[ end for]@
  * \param ... The format string, followed by the variable arguments for the format string
  */
-#define ROS_@(severity)@(suffix)(...) RCUTILS_LOG_@(severity)@(suffix)_NAMED(RCLCPP_CONSOLE_DEFAULT_NAME, __VA_ARGS__)
-
-#define ROS_@(severity)@(suffix)_NAMED(name, @(''.join([p + ', ' for p in get_macro_parameters(feature_combination).keys()]))...) \
+#define ROS_@(severity)@(suffix)(name, @(''.join([p + ', ' for p in get_macro_parameters(feature_combination).keys()]))...) \
   RCUTILS_LOG_@(severity)@(suffix)_NAMED( \
 @{params = get_macro_parameters(feature_combination).keys()}@
 @[ if params]@
@@ -87,9 +83,6 @@ from rcutils.logging import severities
 @[ end if]@
     (std::string(RCLCPP_CONSOLE_DEFAULT_NAME) + "." + name).c_str(), \
     __VA_ARGS__)
-
-#define ROS_@(severity)@(suffix)_FULLNAMED(name, ...) RCUTILS_LOG_@(severity)@(suffix)_NAMED( \
-  std::string(name).c_str(), __VA_ARGS__)
 
 @[ end for]@
 #endif

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -75,6 +75,7 @@ def is_supported_feature_combination(feature_combination):
 @[ for doc_line in feature_combinations[feature_combination].doc_lines]@
  * @(doc_line)
 @[ end for]@
+ * \param name The name of the logger
 @[ for param_name, doc_line in feature_combinations[feature_combination].params.items()]@
  * \param @(param_name) @(doc_line)
 @[ end for]@

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -19,13 +19,22 @@
 
 #include "rcutils/logging_macros.h"
 
+// These are used for compiling out logging macros lower than a minimum severity.
+#define RCLCPP_LOG_MIN_SEVERITY_DEBUG 0
+#define RCLCPP_LOG_MIN_SEVERITY_INFO 1
+#define RCLCPP_LOG_MIN_SEVERITY_WARN 2
+#define RCLCPP_LOG_MIN_SEVERITY_ERROR 3
+#define RCLCPP_LOG_MIN_SEVERITY_FATAL 4
+#define RCLCPP_LOG_MIN_SEVERITY_NONE 5
+
 /**
  * \def RCLCPP_LOG_MIN_SEVERITY
- * Define RCLCPP_LOG_MIN_SEVERITY=RCUTILS_LOG_SEVERITY_[DEBUG|INFO|WARN|ERROR|FATAL]
+ * Define RCLCPP_LOG_MIN_SEVERITY=RCLCPP_LOG_MIN_SEVERITY_[DEBUG|INFO|WARN|ERROR|FATAL]
  * in your build options to compile out anything below that severity.
+ * Use RCUTILS_LOG_MIN_SEVERITY_NONE to compile out all macros.
  */
 #ifndef RCLCPP_LOG_MIN_SEVERITY
-#define RCLCPP_LOG_MIN_SEVERITY RCUTILS_LOG_SEVERITY_DEBUG
+#define RCLCPP_LOG_MIN_SEVERITY RCLCPP_LOG_MIN_SEVERITY_DEBUG
 #endif
 
 
@@ -39,7 +48,7 @@ from rcutils.logging import severities
 /** @@name Logging macros for severity @(severity).
  */
 ///@@{
-#if (RCLCPP_LOG_MIN_SEVERITY > RCUTILS_LOG_SEVERITY_@(severity))
+#if (RCLCPP_LOG_MIN_SEVERITY > RCLCPP_LOG_MIN_SEVERITY_@(severity))
 // empty logging macros for severity @(severity) when being disabled at compile time
 @[ for feature_combination in [fc for fc in feature_combinations if 'named' not in fc]]@
 @{suffix = get_suffix_from_features(feature_combination)}@

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -28,6 +28,16 @@
 #define RCLCPP_CONSOLE_NAME_PREFIX RCLCPP_CONSOLE_PACKAGE_NAME
 #define RCLCPP_CONSOLE_DEFAULT_NAME RCLCPP_CONSOLE_NAME_PREFIX
 
+/**
+ * \def RCLCPP_LOG_MIN_SEVERITY
+ * Define RCLCPP_LOG_MIN_SEVERITY=RCUTILS_LOG_SEVERITY_[DEBUG|INFO|WARN|ERROR|FATAL]
+ * in your build options to compile out anything below that severity.
+ */
+#ifndef RCLCPP_LOG_MIN_SEVERITY
+#define RCLCPP_LOG_MIN_SEVERITY RCUTILS_LOG_SEVERITY_DEBUG
+#endif
+
+
 @{
 from rcutils.logging import feature_combinations
 from rcutils.logging import get_suffix_from_features
@@ -37,6 +47,17 @@ from rcutils.logging import severities
 /** @@name Logging macros for severity @(severity).
  */
 ///@@{
+#if (RCLCPP_LOG_MIN_SEVERITY > RCUTILS_LOG_SEVERITY_@(severity))
+// empty logging macros for severity @(severity) when being disabled at compile time
+@[ for feature_combination in [fc for fc in feature_combinations if 'named' not in fc]]@
+@{suffix = get_suffix_from_features(feature_combination)}@
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define ROS_@(severity)@(suffix)(...)
+#define ROS_@(severity)@(suffix)_NAMED(name, ...)
+#define ROS_@(severity)@(suffix)_FULLNAMED(name, ...)
+@[ end for]@
+
+#else
 @[ for feature_combination in [fc for fc in feature_combinations if 'named' not in fc]]@
 @{suffix = get_suffix_from_features(feature_combination)}@
 #define ROS_@(severity)@(suffix)(...) RCUTILS_LOG_@(severity)@(suffix)_NAMED(RCLCPP_CONSOLE_DEFAULT_NAME, __VA_ARGS__)
@@ -47,6 +68,7 @@ from rcutils.logging import severities
 #define ROS_@(severity)@(suffix)_FULLNAMED(name, ...) RCUTILS_LOG_@(severity)@(suffix)_NAMED( \
   std::string(name).c_str(), __VA_ARGS__)
 @[ end for]@
+#endif
 ///@@}
 
 @[end for]@

--- a/rclcpp/test/test_logging.cpp
+++ b/rclcpp/test/test_logging.cpp
@@ -79,8 +79,8 @@ TEST_F(TestLoggingMacros, test_logging_named) {
   EXPECT_TRUE(g_last_log_event.location != NULL);
   if (g_last_log_event.location) {
     EXPECT_STREQ("TestBody", g_last_log_event.location->function_name);
-    EXPECT_THAT(g_last_log_event.location->file_name, EndsWith("test_logging_macros.cpp"));
-    EXPECT_EQ(78u, g_last_log_event.location->line_number);
+    EXPECT_THAT(g_last_log_event.location->file_name, EndsWith("test_logging.cpp"));
+    EXPECT_EQ(76u, g_last_log_event.location->line_number);
   }
   EXPECT_EQ(RCUTILS_LOG_SEVERITY_DEBUG, g_last_log_event.level);
   EXPECT_EQ("name", g_last_log_event.name);
@@ -88,12 +88,12 @@ TEST_F(TestLoggingMacros, test_logging_named) {
 
   // Test different name inputs
   std::string std_string_name = "name";
-  ROS_DEBUG(std_string_name, "message %d", i);
+  ROS_DEBUG(std_string_name, "message");
   EXPECT_EQ("name", g_last_log_event.name);
-  const char * c_string_name[5] = "name";
-  ROS_DEBUG(c_string_name, "message %d", i);
+  const char * c_string_name = "name";
+  ROS_DEBUG(c_string_name, "message");
   EXPECT_EQ("name", g_last_log_event.name);
-  ROS_DEBUG(std_string_name + c_string_name, "message %d", i);
+  ROS_DEBUG(std_string_name + c_string_name, "message");
   EXPECT_EQ("namename", g_last_log_event.name);
 }
 
@@ -103,7 +103,7 @@ TEST_F(TestLoggingMacros, test_logging_once) {
   }
   EXPECT_EQ(1u, g_log_calls);
   EXPECT_EQ(RCUTILS_LOG_SEVERITY_INFO, g_last_log_event.level);
-  EXPECT_EQ("", g_last_log_event.name);
+  EXPECT_EQ("name", g_last_log_event.name);
   EXPECT_EQ("message 1", g_last_log_event.message);
 }
 
@@ -125,7 +125,7 @@ bool mod3()
 TEST_F(TestLoggingMacros, test_logging_function) {
   for (int i : {1, 2, 3, 4, 5, 6}) {
     g_counter = i;
-    ROS_INFO_FUNCTION(&mod3, "message %d", i);
+    ROS_INFO_FUNCTION("name", &mod3, "message %d", i);
   }
   EXPECT_EQ(4u, g_log_calls);
   EXPECT_EQ("message 5", g_last_log_event.message);

--- a/rclcpp/test/test_logging.cpp
+++ b/rclcpp/test/test_logging.cpp
@@ -1,0 +1,179 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <chrono>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "rclcpp/logging.hpp"
+#include "rcutils/logging.h"
+#include "rcutils/time.h"
+
+using ::testing::EndsWith;
+
+size_t g_log_calls = 0;
+
+struct LogEvent
+{
+  rcutils_log_location_t * location;
+  int level;
+  std::string name;
+  std::string message;
+};
+LogEvent g_last_log_event;
+
+class TestLoggingMacros : public ::testing::Test
+{
+public:
+  rcutils_logging_output_handler_t previous_output_handler;
+  void SetUp()
+  {
+    g_log_calls = 0;
+    ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
+    rcutils_logging_set_default_severity_threshold(RCUTILS_LOG_SEVERITY_DEBUG);
+
+    auto rcutils_logging_console_output_handler = [](
+      rcutils_log_location_t * location,
+      int level, const char * name, const char * format, va_list * args) -> void
+      {
+        g_log_calls += 1;
+        g_last_log_event.location = location;
+        g_last_log_event.level = level;
+        g_last_log_event.name = name ? name : "";
+        char buffer[1024];
+        vsnprintf(buffer, sizeof(buffer), format, *args);
+        g_last_log_event.message = buffer;
+      };
+
+    this->previous_output_handler = rcutils_logging_get_output_handler();
+    rcutils_logging_set_output_handler(rcutils_logging_console_output_handler);
+  }
+
+  void TearDown()
+  {
+    rcutils_logging_set_output_handler(this->previous_output_handler);
+    g_rcutils_logging_initialized = false;
+    EXPECT_FALSE(g_rcutils_logging_initialized);
+  }
+};
+
+TEST_F(TestLoggingMacros, test_logging_named) {
+  for (int i : {1, 2, 3}) {
+    ROS_DEBUG("name", "message %d", i);
+  }
+  EXPECT_EQ(3u, g_log_calls);
+  EXPECT_TRUE(g_last_log_event.location != NULL);
+  if (g_last_log_event.location) {
+    EXPECT_STREQ("TestBody", g_last_log_event.location->function_name);
+    EXPECT_THAT(g_last_log_event.location->file_name, EndsWith("test_logging_macros.cpp"));
+    EXPECT_EQ(78u, g_last_log_event.location->line_number);
+  }
+  EXPECT_EQ(RCUTILS_LOG_SEVERITY_DEBUG, g_last_log_event.level);
+  EXPECT_EQ("name", g_last_log_event.name);
+  EXPECT_EQ("message 3", g_last_log_event.message);
+
+  // Test different name inputs
+  std::string std_string_name = "name";
+  ROS_DEBUG(std_string_name, "message %d", i);
+  EXPECT_EQ("name", g_last_log_event.name);
+  const char * c_string_name[5] = "name";
+  ROS_DEBUG(c_string_name, "message %d", i);
+  EXPECT_EQ("name", g_last_log_event.name);
+  ROS_DEBUG(std_string_name + c_string_name, "message %d", i);
+  EXPECT_EQ("namename", g_last_log_event.name);
+}
+
+TEST_F(TestLoggingMacros, test_logging_once) {
+  for (int i : {1, 2, 3}) {
+    ROS_INFO_ONCE("name", "message %d", i);
+  }
+  EXPECT_EQ(1u, g_log_calls);
+  EXPECT_EQ(RCUTILS_LOG_SEVERITY_INFO, g_last_log_event.level);
+  EXPECT_EQ("", g_last_log_event.name);
+  EXPECT_EQ("message 1", g_last_log_event.message);
+}
+
+TEST_F(TestLoggingMacros, test_logging_expression) {
+  for (int i : {1, 2, 3, 4, 5, 6}) {
+    ROS_INFO_EXPRESSION("name", i % 3, "message %d", i);
+  }
+  EXPECT_EQ(4u, g_log_calls);
+  EXPECT_EQ("message 5", g_last_log_event.message);
+}
+
+int g_counter = 0;
+
+bool mod3()
+{
+  return (g_counter % 3) != 0;
+}
+
+TEST_F(TestLoggingMacros, test_logging_function) {
+  for (int i : {1, 2, 3, 4, 5, 6}) {
+    g_counter = i;
+    ROS_INFO_FUNCTION(&mod3, "message %d", i);
+  }
+  EXPECT_EQ(4u, g_log_calls);
+  EXPECT_EQ("message 5", g_last_log_event.message);
+}
+
+TEST_F(TestLoggingMacros, test_logging_skipfirst) {
+  for (uint32_t i : {1, 2, 3, 4, 5}) {
+    RCUTILS_LOG_WARN_SKIPFIRST("message %u", i);
+    EXPECT_EQ(i - 1, g_log_calls);
+  }
+}
+
+TEST_F(TestLoggingMacros, test_logging_throttle) {
+  for (int i : {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}) {
+    RCUTILS_LOG_ERROR_THROTTLE(RCUTILS_STEADY_TIME, 50 /* ms */, "throttled message %d", i)
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(30ms);
+  }
+  EXPECT_EQ(5u, g_log_calls);
+  EXPECT_EQ(RCUTILS_LOG_SEVERITY_ERROR, g_last_log_event.level);
+  EXPECT_EQ("", g_last_log_event.name);
+  EXPECT_EQ("throttled message 8", g_last_log_event.message);
+}
+
+TEST_F(TestLoggingMacros, test_logging_skipfirst_throttle) {
+  for (int i : {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}) {
+    RCUTILS_LOG_FATAL_SKIPFIRST_THROTTLE(
+      RCUTILS_STEADY_TIME, 50 /* ms */, "throttled message %d", i)
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(30ms);
+  }
+  EXPECT_EQ(4u, g_log_calls);
+  EXPECT_EQ(RCUTILS_LOG_SEVERITY_FATAL, g_last_log_event.level);
+  EXPECT_EQ("", g_last_log_event.name);
+  EXPECT_EQ("throttled message 8", g_last_log_event.message);
+}
+
+TEST_F(TestLoggingMacros, test_logger_hierarchy) {
+  ASSERT_EQ(
+    RCUTILS_RET_OK,
+    rcutils_logging_set_logger_severity_threshold(
+      "rcutils_test_logging_macros_cpp", RCUTILS_LOG_SEVERITY_WARN));
+  RCUTILS_LOG_INFO_NAMED("rcutils_test_logging_macros_cpp.testing.x.y.x", "message");
+  // check that no call was made to the underlying log function
+  EXPECT_EQ(0u, g_log_calls);
+
+  // check that nameless log calls get the default severity threshold
+  rcutils_logging_set_default_severity_threshold(RCUTILS_LOG_SEVERITY_INFO);
+  RCUTILS_LOG_DEBUG("message");
+  EXPECT_EQ(0u, g_log_calls);
+}

--- a/rclcpp/test/test_logging.cpp
+++ b/rclcpp/test/test_logging.cpp
@@ -75,7 +75,7 @@ public:
 
 TEST_F(TestLoggingMacros, test_logging_named) {
   for (int i : {1, 2, 3}) {
-    ROS_DEBUG("name", "message %d", i);
+    RCLCPP_DEBUG("name", "message %d", i);
   }
   EXPECT_EQ(3u, g_log_calls);
   EXPECT_TRUE(g_last_log_event.location != NULL);
@@ -90,25 +90,25 @@ TEST_F(TestLoggingMacros, test_logging_named) {
 
   // Test different name inputs
   std::string std_string_name = "name";
-  ROS_DEBUG(std_string_name, "message");
+  RCLCPP_DEBUG(std_string_name, "message");
   EXPECT_EQ("name", g_last_log_event.name);
 
   const char * c_string_name = "name";
-  ROS_DEBUG(c_string_name, "message");
+  RCLCPP_DEBUG(c_string_name, "message");
   EXPECT_EQ("name", g_last_log_event.name);
 
-  ROS_DEBUG(std_string_name + c_string_name, "message");
+  RCLCPP_DEBUG(std_string_name + c_string_name, "message");
   EXPECT_EQ("namename", g_last_log_event.name);
 
-  ROS_DEBUG(RCLCPP_TEST_LOGGING_MACRO_NAME, "message");
+  RCLCPP_DEBUG(RCLCPP_TEST_LOGGING_MACRO_NAME, "message");
   EXPECT_EQ(RCLCPP_TEST_LOGGING_MACRO_NAME, g_last_log_event.name);
-  ROS_DEBUG(std::string(RCLCPP_TEST_LOGGING_MACRO_NAME) + std_string_name, "message");
+  RCLCPP_DEBUG(std::string(RCLCPP_TEST_LOGGING_MACRO_NAME) + std_string_name, "message");
   EXPECT_EQ("namename", g_last_log_event.name);
 }
 
 TEST_F(TestLoggingMacros, test_logging_once) {
   for (int i : {1, 2, 3}) {
-    ROS_INFO_ONCE("name", "message %d", i);
+    RCLCPP_INFO_ONCE("name", "message %d", i);
   }
   EXPECT_EQ(1u, g_log_calls);
   EXPECT_EQ(RCUTILS_LOG_SEVERITY_INFO, g_last_log_event.level);
@@ -117,7 +117,7 @@ TEST_F(TestLoggingMacros, test_logging_once) {
 
   // Check that different instances have independent contexts
   for (int i : {1, 2, 3}) {
-    ROS_INFO_ONCE("name", "second message %d", i);
+    RCLCPP_INFO_ONCE("name", "second message %d", i);
   }
   EXPECT_EQ(2u, g_log_calls);  // 1 for each instance of "once" log call
   EXPECT_EQ(RCUTILS_LOG_SEVERITY_INFO, g_last_log_event.level);
@@ -127,7 +127,7 @@ TEST_F(TestLoggingMacros, test_logging_once) {
 
 TEST_F(TestLoggingMacros, test_logging_expression) {
   for (int i : {1, 2, 3, 4, 5, 6}) {
-    ROS_INFO_EXPRESSION("name", i % 3, "message %d", i);
+    RCLCPP_INFO_EXPRESSION("name", i % 3, "message %d", i);
   }
   EXPECT_EQ(4u, g_log_calls);
   EXPECT_EQ("message 5", g_last_log_event.message);
@@ -143,7 +143,7 @@ bool mod3()
 TEST_F(TestLoggingMacros, test_logging_function) {
   for (int i : {1, 2, 3, 4, 5, 6}) {
     g_counter = i;
-    ROS_INFO_FUNCTION("name", &mod3, "message %d", i);
+    RCLCPP_INFO_FUNCTION("name", &mod3, "message %d", i);
   }
   EXPECT_EQ(4u, g_log_calls);
   EXPECT_EQ("message 5", g_last_log_event.message);
@@ -151,7 +151,7 @@ TEST_F(TestLoggingMacros, test_logging_function) {
 
 TEST_F(TestLoggingMacros, test_logging_skipfirst) {
   for (uint32_t i : {1, 2, 3, 4, 5}) {
-    ROS_WARN_SKIPFIRST("name", "message %u", i);
+    RCLCPP_WARN_SKIPFIRST("name", "message %u", i);
     EXPECT_EQ(i - 1, g_log_calls);
   }
 }

--- a/rclcpp/test/test_logging.cpp
+++ b/rclcpp/test/test_logging.cpp
@@ -155,28 +155,3 @@ TEST_F(TestLoggingMacros, test_logging_skipfirst) {
     EXPECT_EQ(i - 1, g_log_calls);
   }
 }
-
-TEST_F(TestLoggingMacros, test_logging_throttle) {
-  for (int i : {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}) {
-    ROS_ERROR_THROTTLE("name", RCUTILS_STEADY_TIME, 50 /* ms */, "throttled message %d", i)
-    using namespace std::chrono_literals;
-    std::this_thread::sleep_for(30ms);
-  }
-  EXPECT_EQ(5u, g_log_calls);
-  EXPECT_EQ(RCUTILS_LOG_SEVERITY_ERROR, g_last_log_event.level);
-  EXPECT_EQ("", g_last_log_event.name);
-  EXPECT_EQ("throttled message 8", g_last_log_event.message);
-}
-
-TEST_F(TestLoggingMacros, test_logging_skipfirst_throttle) {
-  for (int i : {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}) {
-    ROS_FATAL_SKIPFIRST_THROTTLE(
-      "name", RCUTILS_STEADY_TIME, 50 /* ms */, "throttled message %d", i)
-    using namespace std::chrono_literals;
-    std::this_thread::sleep_for(30ms);
-  }
-  EXPECT_EQ(4u, g_log_calls);
-  EXPECT_EQ(RCUTILS_LOG_SEVERITY_FATAL, g_last_log_event.level);
-  EXPECT_EQ("", g_last_log_event.name);
-  EXPECT_EQ("throttled message 8", g_last_log_event.message);
-}

--- a/rclcpp/test/test_logging.cpp
+++ b/rclcpp/test/test_logging.cpp
@@ -115,11 +115,12 @@ TEST_F(TestLoggingMacros, test_logging_once) {
   EXPECT_EQ("name", g_last_log_event.name);
   EXPECT_EQ("message 1", g_last_log_event.message);
 
-  // Check that different instances have independent contexts
+  // Check that another instance has a context that's independent to the call above's
+  g_log_calls = 0;
   for (int i : {1, 2, 3}) {
     RCLCPP_INFO_ONCE("name", "second message %d", i);
   }
-  EXPECT_EQ(2u, g_log_calls);  // 1 for each instance of "once" log call
+  EXPECT_EQ(1u, g_log_calls);
   EXPECT_EQ(RCUTILS_LOG_SEVERITY_INFO, g_last_log_event.level);
   EXPECT_EQ("name", g_last_log_event.name);
   EXPECT_EQ("second message 1", g_last_log_event.message);


### PR DESCRIPTION
~Requires ros2/ament_cmake_ros#2~

These are wrappers around rcutils' logging macros (see details below) ~that inject the package name as the default name/prefix name, based on the decision in https://github.com/ros2/demos/pull/184~