### PR TITLE
Reset the error when rcl_take_response failed

### DIFF
--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -339,7 +339,7 @@ Executor::execute_client(
     response.get());
   if (status == RCL_RET_OK) {
     client->handle_response(request_header, response);
-  } else if (status != RCL_RET_CLIENT_TAKE_FAILED) {
+  } else {
     fprintf(stderr,
       "[rclcpp::error] take response failed for client of service '%s': %s\n",
       client->get_service_name().c_str(), rcl_get_error_string_safe());


### PR DESCRIPTION
When the return value of rcl_take_response() is not equal to RCL_RET_OK,
we need reset the error to avoid being overwritten.