### PR TITLE
work around windows failing debug test

### DIFF
--- a/rclcpp/test/test_time_source.cpp
+++ b/rclcpp/test/test_time_source.cpp
@@ -193,7 +193,7 @@ TEST_F(TestTimeSource, callbacks) {
 
 
   // Change callbacks
-  callback_holder = ros_clock->create_jump_callback(
+  rclcpp::JumpHandler::SharedPtr callback_holder2 = ros_clock->create_jump_callback(
     std::bind(&CallbackObject::pre_callback, &cbo, 2),
     std::bind(&CallbackObject::post_callback, &cbo, std::placeholders::_1, 2),
     jump_threshold);


### PR DESCRIPTION
Fixing regression flagged here: https://github.com/ros2/rclcpp/pull/371#issuecomment-345148104

I'm tracking a full fix in #401

Windows Debug Build: [![Build Status](http://ci.ros2.org/job/ci_windows/3657/badge/icon)](http://ci.ros2.org/job/ci_windows/3657/)