### PR TITLE
Fix Compiler Error For GCC 8

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -200,11 +200,11 @@ NodeParameters::list_parameters(const std::vector<std::string> & prefixes, uint6
 
   // TODO(mikaelarguedas) define parameter separator different from "/" to avoid ambiguity
   // using "." for now
-  const char separator = '.';
+  const char * separator = ".";
   for (auto & kv : parameters_) {
     bool get_all = (prefixes.size() == 0) &&
       ((depth == rcl_interfaces::srv::ListParameters::Request::DEPTH_RECURSIVE) ||
-      (static_cast<uint64_t>(std::count(kv.first.begin(), kv.first.end(), separator)) < depth));
+      (static_cast<uint64_t>(std::count(kv.first.begin(), kv.first.end(), *separator)) < depth));
     bool prefix_matches = std::any_of(prefixes.cbegin(), prefixes.cend(),
         [&kv, &depth, &separator](const std::string & prefix) {
           if (kv.first == prefix) {
@@ -214,7 +214,7 @@ NodeParameters::list_parameters(const std::vector<std::string> & prefixes, uint6
             std::string substr = kv.first.substr(length);
             // Cast as unsigned integer to avoid warning
             return (depth == rcl_interfaces::srv::ListParameters::Request::DEPTH_RECURSIVE) ||
-            (static_cast<uint64_t>(std::count(substr.begin(), substr.end(), separator)) < depth);
+            (static_cast<uint64_t>(std::count(substr.begin(), substr.end(), *separator)) < depth);
           }
           return false;
         });


### PR DESCRIPTION
It seems the interface for `std::count` has been modified. This fixes the following compiler error.

```
+++ Building 'rclcpp'
Running cmake because arguments have changed.
==> '. /home/allenh1/ros2_ws/build/rclcpp/cmake__build.sh && /usr/bin/cmake /home/allenh1/ros2_ws/src/ros2/rclcpp/rclcpp -DBUILD_TESTING=0 -DAMENT_CMAKE_SYMLINK_INSTALL=1 -DPYTHON_INSTALL_DIR=install/lib/python3.5/site-packages -DCMAKE_CXX_COMPILER=g++ -DCMAKE_COMPILER=gcc -DCMAKE_INSTALL_PREFIX=/home/allenh1/ros2_ws/install' in '/home/allenh1/ros2_ws/build/rclcpp'
-- The C compiler identification is GNU 6.4.0
-- The CXX compiler identification is GNU 8.0.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /home/allenh1/bin/g++
-- Check for working CXX compiler: /home/allenh1/bin/g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found ament_cmake: 0.0.3 (/home/allenh1/ros2_ws/install/share/ament_cmake/cmake)
-- Found PythonInterp: /usr/bin/python3 (found suitable version "3.5.4", minimum required is "3") 
-- Using PYTHON_EXECUTABLE: /usr/bin/python3
-- Override CMake install command with custom implementation using symlinks instead of copying resources
-- Found builtin_interfaces: 0.0.3 (/home/allenh1/ros2_ws/install/share/builtin_interfaces/cmake)
-- Found rcl: 0.0.3 (/home/allenh1/ros2_ws/install/share/rcl/cmake)
-- Found rmw_implementation_cmake: 0.0.3 (/home/allenh1/ros2_ws/install/share/rmw_implementation_cmake/cmake)
-- Using RMW implementation 'rmw_fastrtps_cpp' as default
-- Found rmw_fastrtps_cpp: 0.0.3 (/home/allenh1/ros2_ws/install/share/rmw_fastrtps_cpp/cmake)
-- Found fastrtps_cmake_module: 0.0.3 (/home/allenh1/ros2_ws/install/share/fastrtps_cmake_module/cmake)
-- Found FastRTPS: /home/allenh1/ros2_ws/install/include  
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_COMPILER
    PYTHON_INSTALL_DIR


-- Build files have been written to: /home/allenh1/ros2_ws/build/rclcpp
==> '. /home/allenh1/ros2_ws/build/rclcpp/cmake__build.sh && /usr/bin/make -j8 -l8' in '/home/allenh1/ros2_ws/build/rclcpp'
[  2%] Expanding logging.hpp.em
Scanning dependencies of target rclcpp
[  5%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/any_executable.cpp.o
[  7%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/callback_group.cpp.o
[ 10%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/client.cpp.o
[ 15%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/context.cpp.o
[ 15%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/clock.cpp.o
[ 17%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/duration.cpp.o
[ 20%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/contexts/default_context.cpp.o
[ 23%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/event.cpp.o
[ 25%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/exceptions.cpp.o
[ 28%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/executor.cpp.o
[ 30%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/executors.cpp.o
[ 33%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/expand_topic_or_service_name.cpp.o
[ 35%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/executors/multi_threaded_executor.cpp.o
[ 38%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/executors/single_threaded_executor.cpp.o
[ 41%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/graph_listener.cpp.o
[ 43%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/intra_process_manager.cpp.o
[ 46%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/intra_process_manager_impl.cpp.o
[ 48%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/memory_strategies.cpp.o
[ 51%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/memory_strategy.cpp.o
[ 53%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/node.cpp.o
[ 56%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/node_interfaces/node_base.cpp.o
[ 58%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/node_interfaces/node_graph.cpp.o
[ 61%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/node_interfaces/node_parameters.cpp.o
[ 64%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/node_interfaces/node_services.cpp.o
[ 66%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/node_interfaces/node_timers.cpp.o
[ 69%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/node_interfaces/node_topics.cpp.o
/home/allenh1/ros2_ws/src/ros2/rclcpp/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp: In lambda function:
/home/allenh1/ros2_ws/src/ros2/rclcpp/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp:217:86: error: lvalue required as unary ‘&’ operand
             (static_cast<uint64_t>(std::count(substr.begin(), substr.end(), separator)) < depth);
                                                                                      ^
[ 71%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/parameter.cpp.o
[ 74%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/parameter_client.cpp.o
[ 76%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/parameter_service.cpp.o
[ 79%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/publisher.cpp.o
[ 82%] Building CXX object CMakeFiles/rclcpp.dir/src/rclcpp/service.cpp.o
make[2]: *** [CMakeFiles/rclcpp.dir/build.make:596: CMakeFiles/rclcpp.dir/src/rclcpp/node_interfaces/node_parameters.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:100: CMakeFiles/rclcpp.dir/all] Error 2
make: *** [Makefile:130: all] Error 2

<== Command '. /home/allenh1/ros2_ws/build/rclcpp/cmake__build.sh && /usr/bin/make -j8 -l8' failed in '/home/allenh1/ros2_ws/build/rclcpp' with exit code '2'
<== Command '. /home/allenh1/ros2_ws/build/rclcpp/cmake__build.sh && /usr/bin/make -j8 -l8' failed in '/home/allenh1/ros2_ws/build/rclcpp' with exit code '2'
```