### PR TITLE
detach nodes from executors in destruction.

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -277,6 +277,14 @@ if(BUILD_TESTING)
     target_link_libraries(test_duration ${PROJECT_NAME})
   endif()
 
+  ament_add_gtest(test_executor test/test_executor.cpp
+    APPEND_LIBRARY_DIRS "${append_library_dirs}")
+  if(TARGET test_executor)
+    ament_target_dependencies(test_executor
+      "rcl")
+    target_link_libraries(test_executor ${PROJECT_NAME})
+  endif()
+
   ament_add_gmock(test_logging test/test_logging.cpp)
   target_link_libraries(test_logging ${PROJECT_NAME})
 

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -73,6 +73,16 @@ Executor::Executor(const ExecutorArgs & args)
 
 Executor::~Executor()
 {
+  // Disassocate all nodes
+  for (auto & weak_node : weak_nodes_) {
+    auto node = weak_node.lock();
+    if (node) {
+      std::atomic_bool & has_executor = node->get_associated_with_executor_atomic();
+      has_executor.store(false);
+    }
+  }
+  weak_nodes_.clear();
+
   // Finalize the waitset.
   if (rcl_wait_set_fini(&waitset_) != RCL_RET_OK) {
     fprintf(stderr,

--- a/rclcpp/test/test_executor.cpp
+++ b/rclcpp/test/test_executor.cpp
@@ -1,0 +1,62 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <limits>
+#include <memory>
+#include <string>
+
+#include "rcl/error_handling.h"
+#include "rcl/time.h"
+#include "rclcpp/clock.hpp"
+#include "rclcpp/duration.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+using namespace std::chrono_literals;
+
+class TestExcutors : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void SetUp()
+  {
+    node = std::make_shared<rclcpp::node::Node>("my_node");
+  }
+
+  void TearDown()
+  {
+    node.reset();
+  }
+
+  rclcpp::node::Node::SharedPtr node;
+};
+
+// Make sure that executors detach from nodes when destructing
+TEST_F(TestExcutors, detachOnDestruction) {
+  {
+    rclcpp::executors::SingleThreadedExecutor executor;
+    executor.add_node(node);
+  }
+  {
+    rclcpp::executors::SingleThreadedExecutor executor;
+    EXPECT_NO_THROW(executor.add_node(node));
+  }
+}


### PR DESCRIPTION
I ran into this exception when writing unit tests for time_source. The nodes should be cleared from being associated with the executor when the executor is destructing. Otherwise the node can never be reused.

Linux: [![Build Status](http://ci.ros2.org/job/ci_linux/3581/badge/icon)](http://ci.ros2.org/job/ci_linux/3581/)
Linux aarch64 [![Build Status](http://ci.ros2.org/job/ci_linux-aarch64/777/badge/icon)](http://ci.ros2.org/job/ci_linux-aarch64/777/)
OSX: [![Build Status](http://ci.ros2.org/job/ci_osx/2921/badge/icon)](http://ci.ros2.org/job/ci_osx/2921/)
WIndow:  [![Build Status](http://ci.ros2.org/job/ci_windows/3674/badge/icon)](http://ci.ros2.org/job/ci_windows/3674/)