### PR TITLE
Fix the dereference to NULL

### DIFF
--- a/rclcpp/src/rclcpp/expand_topic_or_service_name.cpp
+++ b/rclcpp/src/rclcpp/expand_topic_or_service_name.cpp
@@ -136,7 +136,9 @@ rclcpp::expand_topic_or_service_name(
 
       const char * validation_result_string = rmw_node_name_validation_result_string(
         validation_result);
-      validation_result_string = validation_result_string ? validation_result_string : "";
+      if (!validation_result_string) {
+        validation_result_string = "undefined node name type";
+      }
       throw rclcpp::exceptions::InvalidNodeNameError(
               node_name.c_str(),
               validation_result_string,
@@ -161,7 +163,9 @@ rclcpp::expand_topic_or_service_name(
 
       const char * validation_result_string = rmw_namespace_validation_result_string(
         validation_result);
-      validation_result_string = validation_result_string ? validation_result_string : "";
+      if (!validation_result_string) {
+        validation_result_string = "undefined namespace type";
+      }
       throw rclcpp::exceptions::InvalidNamespaceError(
               namespace_.c_str(),
               validation_result_string,
@@ -190,7 +194,10 @@ rclcpp::expand_topic_or_service_name(
   if (validation_result != RMW_TOPIC_VALID) {
     const char * validation_result_string = rmw_full_topic_name_validation_result_string(
       validation_result);
-    validation_result_string = validation_result_string ? validation_result_string : "";
+    if (!validation_result_string) {
+      validation_result_string = "undefined topic name type";
+    }
+
     if (is_service) {
       throw rclcpp::exceptions::InvalidServiceNameError(
               result.c_str(),

--- a/rclcpp/src/rclcpp/expand_topic_or_service_name.cpp
+++ b/rclcpp/src/rclcpp/expand_topic_or_service_name.cpp
@@ -104,8 +104,7 @@ rclcpp::expand_topic_or_service_name(
 
       if (validation_result == RCL_TOPIC_NAME_VALID) {
         throw std::runtime_error("topic name unexpectedly valid");
-      }
-      eles {
+      } else {
         const char * validation_message =
           rcl_topic_name_validation_result_string(validation_result);
         if (is_service) {

--- a/rclcpp/src/rclcpp/expand_topic_or_service_name.cpp
+++ b/rclcpp/src/rclcpp/expand_topic_or_service_name.cpp
@@ -102,9 +102,7 @@ rclcpp::expand_topic_or_service_name(
         throw_from_rcl_error(ret);
       }
 
-      if (validation_result == RCL_TOPIC_NAME_VALID) {
-        throw std::runtime_error("topic name unexpectedly valid");
-      } else {
+      if (validation_result != RCL_TOPIC_NAME_VALID) {
         const char * validation_message =
           rcl_topic_name_validation_result_string(validation_result);
         if (is_service) {
@@ -114,6 +112,8 @@ rclcpp::expand_topic_or_service_name(
           using rclcpp::exceptions::InvalidTopicNameError;
           throw InvalidTopicNameError(name.c_str(), validation_message, invalid_index);
         }
+      } else {
+        throw std::runtime_error("topic name unexpectedly valid");
       }
 
       // if invalid node name
@@ -139,6 +139,8 @@ rclcpp::expand_topic_or_service_name(
                 node_name.c_str(),
                 rmw_node_name_validation_result_string(validation_result),
                 invalid_index);
+      } else {
+        throw std::runtime_error("invalid rcl node name but valid rmw node name");
       }
 
       // if invalid namespace
@@ -164,6 +166,8 @@ rclcpp::expand_topic_or_service_name(
                 namespace_.c_str(),
                 rmw_namespace_validation_result_string(validation_result),
                 invalid_index);
+      } else {
+        throw std::runtime_error("invalid rcl namespace but valid rmw namespace");
       }
       // something else happened
     } else {

--- a/rclcpp/src/rclcpp/expand_topic_or_service_name.cpp
+++ b/rclcpp/src/rclcpp/expand_topic_or_service_name.cpp
@@ -133,9 +133,13 @@ rclcpp::expand_topic_or_service_name(
           RCL_RET_ERROR, "failed to validate node name",
           rmw_get_error_state(), rmw_reset_error);
       }
+
+      const char * validation_result_string = rmw_node_name_validation_result_string(
+        validation_result);
+      validation_result_string = validation_result_string ? validation_result_string : "";
       throw rclcpp::exceptions::InvalidNodeNameError(
               node_name.c_str(),
-              rmw_node_name_validation_result_string(validation_result),
+              validation_result_string,
               invalid_index);
       // if invalid namespace
     } else if (ret == RCL_RET_NODE_INVALID_NAMESPACE) {
@@ -154,9 +158,13 @@ rclcpp::expand_topic_or_service_name(
           RCL_RET_ERROR, "failed to validate namespace",
           rmw_get_error_state(), rmw_reset_error);
       }
+
+      const char * validation_result_string = rmw_namespace_validation_result_string(
+        validation_result);
+      validation_result_string = validation_result_string ? validation_result_string : "";
       throw rclcpp::exceptions::InvalidNamespaceError(
               namespace_.c_str(),
-              rmw_namespace_validation_result_string(validation_result),
+              validation_result_string,
               invalid_index);
       // something else happened
     } else {
@@ -180,15 +188,18 @@ rclcpp::expand_topic_or_service_name(
       rmw_get_error_state(), rmw_reset_error);
   }
   if (validation_result != RMW_TOPIC_VALID) {
+    const char * validation_result_string = rmw_full_topic_name_validation_result_string(
+      validation_result);
+    validation_result_string = validation_result_string ? validation_result_string : "";
     if (is_service) {
       throw rclcpp::exceptions::InvalidServiceNameError(
               result.c_str(),
-              rmw_full_topic_name_validation_result_string(validation_result),
+              validation_result_string,
               invalid_index);
     } else {
       throw rclcpp::exceptions::InvalidTopicNameError(
               result.c_str(),
-              rmw_full_topic_name_validation_result_string(validation_result),
+              validation_result_string,
               invalid_index);
     }
   }

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -107,15 +107,12 @@ NodeBase::NodeBase(
         throw_from_rcl_error(RCL_RET_ERROR, "failed to validate node name");
       }
 
-      const char * validation_result_string = rmw_node_name_validation_result_string(
-        validation_result);
-      if (!validation_result_string) {
-        validation_result_string = "undefined node name type";
+      if (validation_result != RMW_NODE_NAME_VALID) {
+        throw rclcpp::exceptions::InvalidNodeNameError(
+                node_name.c_str(),
+                rmw_node_name_validation_result_string(validation_result),
+                invalid_index);
       }
-      throw rclcpp::exceptions::InvalidNodeNameError(
-              node_name.c_str(),
-              validation_result_string,
-              invalid_index);
     }
 
     if (ret == RCL_RET_NODE_INVALID_NAMESPACE) {
@@ -131,17 +128,13 @@ NodeBase::NodeBase(
         throw_from_rcl_error(RCL_RET_ERROR, "failed to validate namespace");
       }
 
-      const char * validation_result_string = rmw_namespace_validation_result_string(
-        validation_result);
-      if (!validation_result_string) {
-        validation_result_string = "undefind namespace type";
+      if (validation_result != RMW_NAMESPACE_VALID) {
+        throw rclcpp::exceptions::InvalidNamespaceError(
+                namespace_.c_str(),
+                rmw_namespace_validation_result_string(validation_result),
+                invalid_index);
       }
-      throw rclcpp::exceptions::InvalidNamespaceError(
-              namespace_.c_str(),
-              rmw_namespace_validation_result_string(validation_result),
-              invalid_index);
     }
-
     throw_from_rcl_error(ret, "failed to initialize rcl node");
   }
 

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -112,6 +112,8 @@ NodeBase::NodeBase(
                 node_name.c_str(),
                 rmw_node_name_validation_result_string(validation_result),
                 invalid_index);
+      } else {
+        throw std::runtime_error("valid rmw node name but invalid rcl node name");
       }
     }
 
@@ -133,6 +135,8 @@ NodeBase::NodeBase(
                 namespace_.c_str(),
                 rmw_namespace_validation_result_string(validation_result),
                 invalid_index);
+      } else {
+        throw std::runtime_error("valid rmw node namespace but invalid rcl node namespace");
       }
     }
     throw_from_rcl_error(ret, "failed to initialize rcl node");

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -106,9 +106,15 @@ NodeBase::NodeBase(
         }
         throw_from_rcl_error(RCL_RET_ERROR, "failed to validate node name");
       }
+
+      const char * validation_result_string = rmw_node_name_validation_result_string(
+        validation_result);
+      if (!validation_result_string) {
+        validation_result_string = "undefined node name type";
+      }
       throw rclcpp::exceptions::InvalidNodeNameError(
               node_name.c_str(),
-              rmw_node_name_validation_result_string(validation_result),
+              validation_result_string,
               invalid_index);
     }
 
@@ -123,6 +129,12 @@ NodeBase::NodeBase(
           throw_from_rcl_error(RCL_RET_INVALID_ARGUMENT, "failed to validate namespace");
         }
         throw_from_rcl_error(RCL_RET_ERROR, "failed to validate namespace");
+      }
+
+      const char * validation_result_string = rmw_namespace_validation_result_string(
+        validation_result);
+      if (!validation_result_string) {
+        validation_result_string = "undefind namespace type";
       }
       throw rclcpp::exceptions::InvalidNamespaceError(
               namespace_.c_str(),


### PR DESCRIPTION
`rmw_*_validation_result_string(validation_result)` may return NULL,
and it's dereferenced by passing arg to `NameValidationError`, this 
leads unexpected behaviors and NULL is deprecated to use in C++ now.

Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>

Connects to ros2/rmw#130