### PR TITLE
Escalate more namespaces e.g. rclcpp::Service

### DIFF
--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -150,8 +150,16 @@ namespace rclcpp
 // For example, this next line escalates type "rclcpp:node::Node" to "rclcpp::Node"
 using rclcpp::node::Node;
 using rclcpp::publisher::Publisher;
-using rclcpp::subscription::SubscriptionBase;
+using rclcpp::publisher::PublisherBase;
 using rclcpp::subscription::Subscription;
+using rclcpp::subscription::SubscriptionBase;
+using rclcpp::client::Client;
+using rclcpp::client::ClientBase;
+using rclcpp::service::Service;
+using rclcpp::service::ServiceBase;
+using rclcpp::parameter_client::AsyncParametersClient;
+using rclcpp::parameter_client::SyncParametersClient;
+using rclcpp::parameter_service::ParameterService;
 using rclcpp::rate::GenericRate;
 using rclcpp::rate::WallRate;
 using rclcpp::timer::GenericTimer;


### PR DESCRIPTION
Publishers and subscribers had been escalated but not services and clients. This was causing inconsistent usage in demos

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3646)](http://ci.ros2.org/job/ci_linux/3646/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=826)](http://ci.ros2.org/job/ci_linux-aarch64/826/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2982)](http://ci.ros2.org/job/ci_osx/2982/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3747)](http://ci.ros2.org/job/ci_windows/3747/)