### PR TITLE
Allow creating parameter client from constructor of Node subclass

### DIFF
--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -64,6 +64,12 @@ public:
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_parameters);
 
   RCLCPP_PUBLIC
+  AsyncParametersClient(
+    rclcpp::node::Node * node,
+    const std::string & remote_node_name = "",
+    const rmw_qos_profile_t & qos_profile = rmw_qos_profile_parameters);
+
+  RCLCPP_PUBLIC
   std::shared_future<std::vector<rclcpp::parameter::ParameterVariant>>
   get_parameters(
     const std::vector<std::string> & names,

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -101,6 +101,19 @@ AsyncParametersClient::AsyncParametersClient(
     qos_profile)
 {}
 
+AsyncParametersClient::AsyncParametersClient(
+  rclcpp::node::Node * node,
+  const std::string & remote_node_name,
+  const rmw_qos_profile_t & qos_profile)
+: AsyncParametersClient(
+    node->get_node_base_interface(),
+    node->get_node_topics_interface(),
+    node->get_node_graph_interface(),
+    node->get_node_services_interface(),
+    remote_node_name,
+    qos_profile)
+{}
+
 std::shared_future<std::vector<rclcpp::parameter::ParameterVariant>>
 AsyncParametersClient::get_parameters(
   const std::vector<std::string> & names,


### PR DESCRIPTION
Closes ros2/rclcpp#409

I only did this for parameter clients: parameter services still need to be created outside of the constructor, but this is not something that we expect users to have to do manually in the long term.