### PR TITLE
Allow client to trigger another service call from its callback

### DIFF
--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -197,7 +197,7 @@ public:
     std::shared_ptr<rmw_request_id_t> request_header,
     std::shared_ptr<void> response)
   {
-    std::lock_guard<std::mutex> lock(pending_requests_mutex_);
+    std::unique_lock<std::mutex> lock(pending_requests_mutex_);
     auto typed_response = std::static_pointer_cast<typename ServiceT::Response>(response);
     int64_t sequence_number = request_header->sequence_number;
     // TODO(esteve) this should throw instead since it is not expected to happen in the first place
@@ -210,6 +210,9 @@ public:
     auto callback = std::get<1>(tuple);
     auto future = std::get<2>(tuple);
     this->pending_requests_.erase(sequence_number);
+    // Unlock here to allow the service to be called recursively from one of its callbacks.
+    lock.unlock();
+
     call_promise->set_value(typed_response);
     callback(future);
   }


### PR DESCRIPTION
In https://github.com/ros2/demos/pull/203/files#diff-a5a151889abb3214250ba9db05358e4bR83 I was trying to call `set_parameters()` on an async parameter client in the callback of another `set_parameters` call, but it would never send the request.

@wjwwood helped me realise it had deadlocked waiting for the mutex.