### PR TITLE
Remove e.g. `node::` namespaces and namespace escalation

### DIFF
--- a/rclcpp/include/rclcpp/any_executable.hpp
+++ b/rclcpp/include/rclcpp/any_executable.hpp
@@ -45,7 +45,7 @@ struct AnyExecutable
   rclcpp::SubscriptionBase::SharedPtr subscription;
   rclcpp::SubscriptionBase::SharedPtr subscription_intra_process;
   rclcpp::timer::TimerBase::SharedPtr timer;
-  rclcpp::service::ServiceBase::SharedPtr service;
+  rclcpp::ServiceBase::SharedPtr service;
   rclcpp::ClientBase::SharedPtr client;
   // These are used to keep the scope on the containing items
   rclcpp::callback_group::CallbackGroup::SharedPtr callback_group;

--- a/rclcpp/include/rclcpp/any_executable.hpp
+++ b/rclcpp/include/rclcpp/any_executable.hpp
@@ -44,7 +44,7 @@ struct AnyExecutable
   // Only one of the following pointers will be set.
   rclcpp::SubscriptionBase::SharedPtr subscription;
   rclcpp::SubscriptionBase::SharedPtr subscription_intra_process;
-  rclcpp::timer::TimerBase::SharedPtr timer;
+  rclcpp::TimerBase::SharedPtr timer;
   rclcpp::ServiceBase::SharedPtr service;
   rclcpp::ClientBase::SharedPtr client;
   // These are used to keep the scope on the containing items

--- a/rclcpp/include/rclcpp/any_executable.hpp
+++ b/rclcpp/include/rclcpp/any_executable.hpp
@@ -46,7 +46,7 @@ struct AnyExecutable
   rclcpp::SubscriptionBase::SharedPtr subscription_intra_process;
   rclcpp::timer::TimerBase::SharedPtr timer;
   rclcpp::service::ServiceBase::SharedPtr service;
-  rclcpp::client::ClientBase::SharedPtr client;
+  rclcpp::ClientBase::SharedPtr client;
   // These are used to keep the scope on the containing items
   rclcpp::callback_group::CallbackGroup::SharedPtr callback_group;
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base;

--- a/rclcpp/include/rclcpp/any_executable.hpp
+++ b/rclcpp/include/rclcpp/any_executable.hpp
@@ -42,8 +42,8 @@ struct AnyExecutable
   virtual ~AnyExecutable();
 
   // Only one of the following pointers will be set.
-  rclcpp::subscription::SubscriptionBase::SharedPtr subscription;
-  rclcpp::subscription::SubscriptionBase::SharedPtr subscription_intra_process;
+  rclcpp::SubscriptionBase::SharedPtr subscription;
+  rclcpp::SubscriptionBase::SharedPtr subscription_intra_process;
   rclcpp::timer::TimerBase::SharedPtr timer;
   rclcpp::service::ServiceBase::SharedPtr service;
   rclcpp::client::ClientBase::SharedPtr client;

--- a/rclcpp/include/rclcpp/any_service_callback.hpp
+++ b/rclcpp/include/rclcpp/any_service_callback.hpp
@@ -27,9 +27,6 @@
 namespace rclcpp
 {
 
-namespace any_service_callback
-{
-
 template<typename ServiceT>
 class AnyServiceCallback
 {
@@ -100,7 +97,6 @@ public:
   }
 };
 
-}  // namespace any_service_callback
 }  // namespace rclcpp
 
 #endif  // RCLCPP__ANY_SERVICE_CALLBACK_HPP_

--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -30,9 +30,6 @@
 namespace rclcpp
 {
 
-namespace any_subscription_callback
-{
-
 template<typename MessageT, typename Alloc>
 class AnySubscriptionCallback
 {
@@ -209,7 +206,6 @@ private:
   MessageDeleter message_deleter_;
 };
 
-}  // namespace any_subscription_callback
 }  // namespace rclcpp
 
 #endif  // RCLCPP__ANY_SUBSCRIPTION_CALLBACK_HPP_

--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -63,7 +63,7 @@ public:
   get_subscription_ptrs() const;
 
   RCLCPP_PUBLIC
-  const std::vector<rclcpp::timer::TimerBase::WeakPtr> &
+  const std::vector<rclcpp::TimerBase::WeakPtr> &
   get_timer_ptrs() const;
 
   RCLCPP_PUBLIC
@@ -91,7 +91,7 @@ protected:
 
   RCLCPP_PUBLIC
   void
-  add_timer(const rclcpp::timer::TimerBase::SharedPtr timer_ptr);
+  add_timer(const rclcpp::TimerBase::SharedPtr timer_ptr);
 
   RCLCPP_PUBLIC
   void
@@ -105,7 +105,7 @@ protected:
   // Mutex to protect the subsequent vectors of pointers.
   mutable std::mutex mutex_;
   std::vector<rclcpp::SubscriptionBase::WeakPtr> subscription_ptrs_;
-  std::vector<rclcpp::timer::TimerBase::WeakPtr> timer_ptrs_;
+  std::vector<rclcpp::TimerBase::WeakPtr> timer_ptrs_;
   std::vector<rclcpp::ServiceBase::WeakPtr> service_ptrs_;
   std::vector<rclcpp::ClientBase::WeakPtr> client_ptrs_;
   std::atomic_bool can_be_taken_from_;

--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -67,7 +67,7 @@ public:
   get_timer_ptrs() const;
 
   RCLCPP_PUBLIC
-  const std::vector<rclcpp::service::ServiceBase::WeakPtr> &
+  const std::vector<rclcpp::ServiceBase::WeakPtr> &
   get_service_ptrs() const;
 
   RCLCPP_PUBLIC
@@ -95,7 +95,7 @@ protected:
 
   RCLCPP_PUBLIC
   void
-  add_service(const rclcpp::service::ServiceBase::SharedPtr service_ptr);
+  add_service(const rclcpp::ServiceBase::SharedPtr service_ptr);
 
   RCLCPP_PUBLIC
   void
@@ -106,7 +106,7 @@ protected:
   mutable std::mutex mutex_;
   std::vector<rclcpp::SubscriptionBase::WeakPtr> subscription_ptrs_;
   std::vector<rclcpp::timer::TimerBase::WeakPtr> timer_ptrs_;
-  std::vector<rclcpp::service::ServiceBase::WeakPtr> service_ptrs_;
+  std::vector<rclcpp::ServiceBase::WeakPtr> service_ptrs_;
   std::vector<rclcpp::ClientBase::WeakPtr> client_ptrs_;
   std::atomic_bool can_be_taken_from_;
 };

--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -59,7 +59,7 @@ public:
   explicit CallbackGroup(CallbackGroupType group_type);
 
   RCLCPP_PUBLIC
-  const std::vector<rclcpp::subscription::SubscriptionBase::WeakPtr> &
+  const std::vector<rclcpp::SubscriptionBase::WeakPtr> &
   get_subscription_ptrs() const;
 
   RCLCPP_PUBLIC
@@ -87,7 +87,7 @@ protected:
 
   RCLCPP_PUBLIC
   void
-  add_subscription(const rclcpp::subscription::SubscriptionBase::SharedPtr subscription_ptr);
+  add_subscription(const rclcpp::SubscriptionBase::SharedPtr subscription_ptr);
 
   RCLCPP_PUBLIC
   void
@@ -104,7 +104,7 @@ protected:
   CallbackGroupType type_;
   // Mutex to protect the subsequent vectors of pointers.
   mutable std::mutex mutex_;
-  std::vector<rclcpp::subscription::SubscriptionBase::WeakPtr> subscription_ptrs_;
+  std::vector<rclcpp::SubscriptionBase::WeakPtr> subscription_ptrs_;
   std::vector<rclcpp::timer::TimerBase::WeakPtr> timer_ptrs_;
   std::vector<rclcpp::service::ServiceBase::WeakPtr> service_ptrs_;
   std::vector<rclcpp::client::ClientBase::WeakPtr> client_ptrs_;

--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -71,7 +71,7 @@ public:
   get_service_ptrs() const;
 
   RCLCPP_PUBLIC
-  const std::vector<rclcpp::client::ClientBase::WeakPtr> &
+  const std::vector<rclcpp::ClientBase::WeakPtr> &
   get_client_ptrs() const;
 
   RCLCPP_PUBLIC
@@ -99,7 +99,7 @@ protected:
 
   RCLCPP_PUBLIC
   void
-  add_client(const rclcpp::client::ClientBase::SharedPtr client_ptr);
+  add_client(const rclcpp::ClientBase::SharedPtr client_ptr);
 
   CallbackGroupType type_;
   // Mutex to protect the subsequent vectors of pointers.
@@ -107,7 +107,7 @@ protected:
   std::vector<rclcpp::SubscriptionBase::WeakPtr> subscription_ptrs_;
   std::vector<rclcpp::timer::TimerBase::WeakPtr> timer_ptrs_;
   std::vector<rclcpp::service::ServiceBase::WeakPtr> service_ptrs_;
-  std::vector<rclcpp::client::ClientBase::WeakPtr> client_ptrs_;
+  std::vector<rclcpp::ClientBase::WeakPtr> client_ptrs_;
   std::atomic_bool can_be_taken_from_;
 };
 

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -47,9 +47,6 @@ namespace node_interfaces
 class NodeBaseInterface;
 }  // namespace node_interfaces
 
-namespace client
-{
-
 class ClientBase
 {
 public:
@@ -282,7 +279,6 @@ private:
   std::mutex pending_requests_mutex_;
 };
 
-}  // namespace client
 }  // namespace rclcpp
 
 #endif  // RCLCPP__CLIENT_HPP_

--- a/rclcpp/include/rclcpp/context.hpp
+++ b/rclcpp/include/rclcpp/context.hpp
@@ -30,9 +30,6 @@
 namespace rclcpp
 {
 
-namespace context
-{
-
 class Context
 {
 public:
@@ -72,7 +69,6 @@ private:
   std::mutex mutex_;
 };
 
-}  // namespace context
 }  // namespace rclcpp
 
 #endif  // RCLCPP__CONTEXT_HPP_

--- a/rclcpp/include/rclcpp/contexts/default_context.hpp
+++ b/rclcpp/include/rclcpp/contexts/default_context.hpp
@@ -25,7 +25,7 @@ namespace contexts
 namespace default_context
 {
 
-class DefaultContext : public rclcpp::context::Context
+class DefaultContext : public rclcpp::Context
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(DefaultContext)

--- a/rclcpp/include/rclcpp/create_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_subscription.hpp
@@ -27,7 +27,7 @@ namespace rclcpp
 {
 
 template<typename MessageT, typename CallbackT, typename AllocatorT, typename SubscriptionT>
-typename rclcpp::subscription::Subscription<MessageT, AllocatorT>::SharedPtr
+typename rclcpp::Subscription<MessageT, AllocatorT>::SharedPtr
 create_subscription(
   rclcpp::node_interfaces::NodeTopicsInterface * node_topics,
   const std::string & topic_name,

--- a/rclcpp/include/rclcpp/event.hpp
+++ b/rclcpp/include/rclcpp/event.hpp
@@ -23,8 +23,6 @@
 
 namespace rclcpp
 {
-namespace event
-{
 
 class Event
 {
@@ -52,7 +50,6 @@ private:
   std::atomic_bool state_;
 };
 
-}  // namespace event
 }  // namespace rclcpp
 
 #endif  // RCLCPP__EVENT_HPP_

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -38,10 +38,7 @@ namespace rclcpp
 {
 
 // Forward declaration is used in convenience method signature.
-namespace node
-{
 class Node;
-}  // namespace node
 
 namespace executor
 {
@@ -124,7 +121,7 @@ public:
   /// Convenience function which takes Node and forwards NodeBaseInterface.
   RCLCPP_PUBLIC
   virtual void
-  add_node(std::shared_ptr<rclcpp::node::Node> node_ptr, bool notify = true);
+  add_node(std::shared_ptr<rclcpp::Node> node_ptr, bool notify = true);
 
   /// Remove a node from the executor.
   /**
@@ -140,7 +137,7 @@ public:
   /// Convenience function which takes Node and forwards NodeBaseInterface.
   RCLCPP_PUBLIC
   virtual void
-  remove_node(std::shared_ptr<rclcpp::node::Node> node_ptr, bool notify = true);
+  remove_node(std::shared_ptr<rclcpp::Node> node_ptr, bool notify = true);
 
   /// Add a node to executor, execute the next available unit of work, and remove the node.
   /**
@@ -162,7 +159,7 @@ public:
   }
 
   /// Convenience function which takes Node and forwards NodeBaseInterface.
-  template<typename NodeT = rclcpp::node::Node, typename T = std::milli>
+  template<typename NodeT = rclcpp::Node, typename T = std::milli>
   void
   spin_node_once(
     std::shared_ptr<NodeT> node,
@@ -185,7 +182,7 @@ public:
   /// Convenience function which takes Node and forwards NodeBaseInterface.
   RCLCPP_PUBLIC
   void
-  spin_node_some(std::shared_ptr<rclcpp::node::Node> node);
+  spin_node_some(std::shared_ptr<rclcpp::Node> node);
 
   /// Complete all available queued work without blocking.
   /**

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -312,7 +312,7 @@ protected:
 
   RCLCPP_PUBLIC
   static void
-  execute_client(rclcpp::client::ClientBase::SharedPtr client);
+  execute_client(rclcpp::ClientBase::SharedPtr client);
 
   RCLCPP_PUBLIC
   void

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -295,12 +295,12 @@ protected:
   RCLCPP_PUBLIC
   static void
   execute_subscription(
-    rclcpp::subscription::SubscriptionBase::SharedPtr subscription);
+    rclcpp::SubscriptionBase::SharedPtr subscription);
 
   RCLCPP_PUBLIC
   static void
   execute_intra_process_subscription(
-    rclcpp::subscription::SubscriptionBase::SharedPtr subscription);
+    rclcpp::SubscriptionBase::SharedPtr subscription);
 
   RCLCPP_PUBLIC
   static void

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -308,7 +308,7 @@ protected:
 
   RCLCPP_PUBLIC
   static void
-  execute_service(rclcpp::service::ServiceBase::SharedPtr service);
+  execute_service(rclcpp::ServiceBase::SharedPtr service);
 
   RCLCPP_PUBLIC
   static void

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -304,7 +304,7 @@ protected:
 
   RCLCPP_PUBLIC
   static void
-  execute_timer(rclcpp::timer::TimerBase::SharedPtr timer);
+  execute_timer(rclcpp::TimerBase::SharedPtr timer);
 
   RCLCPP_PUBLIC
   static void
@@ -324,7 +324,7 @@ protected:
 
   RCLCPP_PUBLIC
   rclcpp::callback_group::CallbackGroup::SharedPtr
-  get_group_by_timer(rclcpp::timer::TimerBase::SharedPtr timer);
+  get_group_by_timer(rclcpp::TimerBase::SharedPtr timer);
 
   RCLCPP_PUBLIC
   void

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -233,7 +233,7 @@ public:
     }
     std::chrono::nanoseconds timeout_left = timeout_ns;
 
-    while (rclcpp::utilities::ok()) {
+    while (rclcpp::ok()) {
       // Do one item of work.
       spin_once(timeout_left);
       // Check if the future is set, return SUCCESS if it is.

--- a/rclcpp/include/rclcpp/executors.hpp
+++ b/rclcpp/include/rclcpp/executors.hpp
@@ -50,7 +50,7 @@ spin(rclcpp::Node::SharedPtr node_ptr);
 namespace executors
 {
 
-using rclcpp::executors::multi_threaded_executor::MultiThreadedExecutor;
+using rclcpp::executors::MultiThreadedExecutor;
 using rclcpp::executors::SingleThreadedExecutor;
 
 /// Spin (blocking) until the future is complete, it times out waiting, or rclcpp is interrupted.

--- a/rclcpp/include/rclcpp/executors.hpp
+++ b/rclcpp/include/rclcpp/executors.hpp
@@ -35,7 +35,7 @@ spin_some(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr);
 
 RCLCPP_PUBLIC
 void
-spin_some(rclcpp::node::Node::SharedPtr node_ptr);
+spin_some(rclcpp::Node::SharedPtr node_ptr);
 
 /// Create a default single-threaded executor and spin the specified node.
 /** \param[in] node_ptr Shared pointer to the node to spin. */
@@ -45,7 +45,7 @@ spin(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr);
 
 RCLCPP_PUBLIC
 void
-spin(rclcpp::node::Node::SharedPtr node_ptr);
+spin(rclcpp::Node::SharedPtr node_ptr);
 
 namespace executors
 {
@@ -81,7 +81,7 @@ spin_node_until_future_complete(
   return retcode;
 }
 
-template<typename NodeT = rclcpp::node::Node, typename ResponseT, typename TimeT = std::milli>
+template<typename NodeT = rclcpp::Node, typename ResponseT, typename TimeT = std::milli>
 rclcpp::executor::FutureReturnCode
 spin_node_until_future_complete(
   rclcpp::executor::Executor & executor,
@@ -109,7 +109,7 @@ spin_until_future_complete(
   return executors::spin_node_until_future_complete<FutureT>(executor, node_ptr, future, timeout);
 }
 
-template<typename NodeT = rclcpp::node::Node, typename FutureT, typename TimeT = std::milli>
+template<typename NodeT = rclcpp::Node, typename FutureT, typename TimeT = std::milli>
 rclcpp::executor::FutureReturnCode
 spin_until_future_complete(
   std::shared_ptr<NodeT> node_ptr,

--- a/rclcpp/include/rclcpp/executors.hpp
+++ b/rclcpp/include/rclcpp/executors.hpp
@@ -51,7 +51,7 @@ namespace executors
 {
 
 using rclcpp::executors::multi_threaded_executor::MultiThreadedExecutor;
-using rclcpp::executors::single_threaded_executor::SingleThreadedExecutor;
+using rclcpp::executors::SingleThreadedExecutor;
 
 /// Spin (blocking) until the future is complete, it times out waiting, or rclcpp is interrupted.
 /**

--- a/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
@@ -28,8 +28,6 @@ namespace rclcpp
 {
 namespace executors
 {
-namespace multi_threaded_executor
-{
 
 class MultiThreadedExecutor : public executor::Executor
 {
@@ -63,7 +61,6 @@ private:
   size_t number_of_threads_;
 };
 
-}  // namespace multi_threaded_executor
 }  // namespace executors
 }  // namespace rclcpp
 

--- a/rclcpp/include/rclcpp/executors/single_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/single_threaded_executor.hpp
@@ -34,8 +34,6 @@ namespace rclcpp
 {
 namespace executors
 {
-namespace single_threaded_executor
-{
 
 /// Single-threaded executor implementation
 // This is the default executor created by rclcpp::spin.
@@ -64,7 +62,6 @@ private:
   RCLCPP_DISABLE_COPY(SingleThreadedExecutor)
 };
 
-}  // namespace single_threaded_executor
 }  // namespace executors
 }  // namespace rclcpp
 

--- a/rclcpp/include/rclcpp/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager.hpp
@@ -149,7 +149,7 @@ public:
    */
   RCLCPP_PUBLIC
   uint64_t
-  add_subscription(subscription::SubscriptionBase::SharedPtr subscription);
+  add_subscription(SubscriptionBase::SharedPtr subscription);
 
   /// Unregister a subscription using the subscription's unique id.
   /**

--- a/rclcpp/include/rclcpp/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager.hpp
@@ -187,14 +187,14 @@ public:
   template<typename MessageT, typename Alloc>
   uint64_t
   add_publisher(
-    typename publisher::Publisher<MessageT, Alloc>::SharedPtr publisher,
+    typename Publisher<MessageT, Alloc>::SharedPtr publisher,
     size_t buffer_size = 0)
   {
     auto id = IntraProcessManager::get_next_unique_id();
     size_t size = buffer_size > 0 ? buffer_size : publisher->get_queue_size();
     auto mrb = mapped_ring_buffer::MappedRingBuffer<
       MessageT,
-      typename publisher::Publisher<MessageT, Alloc>::MessageAlloc
+      typename Publisher<MessageT, Alloc>::MessageAlloc
       >::make_shared(size, publisher->get_allocator());
     impl_->add_publisher(id, publisher, mrb, size);
     return id;

--- a/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
@@ -55,7 +55,7 @@ public:
 
   virtual void add_publisher(
     uint64_t id,
-    publisher::PublisherBase::WeakPtr publisher,
+    PublisherBase::WeakPtr publisher,
     mapped_ring_buffer::MappedRingBufferBase::SharedPtr mrb,
     size_t size) = 0;
 
@@ -118,7 +118,7 @@ public:
 
   void add_publisher(
     uint64_t id,
-    publisher::PublisherBase::WeakPtr publisher,
+    PublisherBase::WeakPtr publisher,
     mapped_ring_buffer::MappedRingBufferBase::SharedPtr mrb,
     size_t size)
   {
@@ -286,7 +286,7 @@ private:
 
     PublisherInfo() = default;
 
-    publisher::PublisherBase::WeakPtr publisher;
+    PublisherBase::WeakPtr publisher;
     std::atomic<uint64_t> sequence_number;
     mapped_ring_buffer::MappedRingBufferBase::SharedPtr buffer;
 

--- a/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
@@ -48,7 +48,7 @@ public:
   ~IntraProcessManagerImplBase() = default;
 
   virtual void
-  add_subscription(uint64_t id, subscription::SubscriptionBase::SharedPtr subscription) = 0;
+  add_subscription(uint64_t id, SubscriptionBase::SharedPtr subscription) = 0;
 
   virtual void
   remove_subscription(uint64_t intra_process_subscription_id) = 0;
@@ -92,7 +92,7 @@ public:
   ~IntraProcessManagerImpl() = default;
 
   void
-  add_subscription(uint64_t id, subscription::SubscriptionBase::SharedPtr subscription)
+  add_subscription(uint64_t id, SubscriptionBase::SharedPtr subscription)
   {
     subscriptions_[id] = subscription;
     // subscription->get_topic_name() -> const char * can be used as the key,
@@ -258,9 +258,9 @@ private:
 
   using AllocSet = std::set<uint64_t, std::less<uint64_t>, RebindAlloc<uint64_t>>;
   using SubscriptionMap = std::unordered_map<
-      uint64_t, subscription::SubscriptionBase::WeakPtr,
+      uint64_t, SubscriptionBase::WeakPtr,
       std::hash<uint64_t>, std::equal_to<uint64_t>,
-      RebindAlloc<std::pair<const uint64_t, subscription::SubscriptionBase::WeakPtr>>>;
+      RebindAlloc<std::pair<const uint64_t, SubscriptionBase::WeakPtr>>>;
 
   struct strcmp_wrapper : public std::binary_function<const char *, const char *, bool>
   {

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -86,7 +86,7 @@ public:
     const rcl_subscription_t * subscriber_handle,
     const WeakNodeVector & weak_nodes);
 
-  static rclcpp::service::ServiceBase::SharedPtr
+  static rclcpp::ServiceBase::SharedPtr
   get_service_by_handle(const rcl_service_t * service_handle, const WeakNodeVector & weak_nodes);
 
   static rclcpp::ClientBase::SharedPtr
@@ -104,7 +104,7 @@ public:
 
   static rclcpp::callback_group::CallbackGroup::SharedPtr
   get_group_by_service(
-    rclcpp::service::ServiceBase::SharedPtr service,
+    rclcpp::ServiceBase::SharedPtr service,
     const WeakNodeVector & weak_nodes);
 
   static rclcpp::callback_group::CallbackGroup::SharedPtr

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -81,7 +81,7 @@ public:
   virtual rcl_allocator_t
   get_allocator() = 0;
 
-  static rclcpp::subscription::SubscriptionBase::SharedPtr
+  static rclcpp::SubscriptionBase::SharedPtr
   get_subscription_by_handle(
     const rcl_subscription_t * subscriber_handle,
     const WeakNodeVector & weak_nodes);
@@ -99,7 +99,7 @@ public:
 
   static rclcpp::callback_group::CallbackGroup::SharedPtr
   get_group_by_subscription(
-    rclcpp::subscription::SubscriptionBase::SharedPtr subscription,
+    rclcpp::SubscriptionBase::SharedPtr subscription,
     const WeakNodeVector & weak_nodes);
 
   static rclcpp::callback_group::CallbackGroup::SharedPtr

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -89,7 +89,7 @@ public:
   static rclcpp::service::ServiceBase::SharedPtr
   get_service_by_handle(const rcl_service_t * service_handle, const WeakNodeVector & weak_nodes);
 
-  static rclcpp::client::ClientBase::SharedPtr
+  static rclcpp::ClientBase::SharedPtr
   get_client_by_handle(const rcl_client_t * client_handle, const WeakNodeVector & weak_nodes);
 
   static rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
@@ -109,7 +109,7 @@ public:
 
   static rclcpp::callback_group::CallbackGroup::SharedPtr
   get_group_by_client(
-    rclcpp::client::ClientBase::SharedPtr client,
+    rclcpp::ClientBase::SharedPtr client,
     const WeakNodeVector & weak_nodes);
 };
 

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -244,7 +244,7 @@ public:
 
   /* Create and return a Service. */
   template<typename ServiceT, typename CallbackT>
-  typename rclcpp::service::Service<ServiceT>::SharedPtr
+  typename rclcpp::Service<ServiceT>::SharedPtr
   create_service(
     const std::string & service_name,
     CallbackT && callback,

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -236,7 +236,7 @@ public:
 
   /* Create and return a Client. */
   template<typename ServiceT>
-  typename rclcpp::client::Client<ServiceT>::SharedPtr
+  typename rclcpp::Client<ServiceT>::SharedPtr
   create_client(
     const std::string & service_name,
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_services_default,

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -350,7 +350,7 @@ public:
    * out of scope.
    */
   RCLCPP_PUBLIC
-  rclcpp::event::Event::SharedPtr
+  rclcpp::Event::SharedPtr
   get_graph_event();
 
   /// Wait for a graph event to occur by waiting on an Event to become set.
@@ -364,7 +364,7 @@ public:
   RCLCPP_PUBLIC
   void
   wait_for_graph_change(
-    rclcpp::event::Event::SharedPtr event,
+    rclcpp::Event::SharedPtr event,
     std::chrono::nanoseconds timeout);
 
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -60,9 +60,6 @@
 namespace rclcpp
 {
 
-namespace node
-{
-
 /// Node is the single point of entry for creating publishers and subscribers.
 class Node : public std::enable_shared_from_this<Node>
 {
@@ -432,7 +429,6 @@ private:
   bool use_intra_process_comms_;
 };
 
-}  // namespace node
 }  // namespace rclcpp
 
 #ifndef RCLCPP__NODE_IMPL_HPP_

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -79,7 +79,7 @@ public:
     const std::string & namespace_ = "",
     bool use_intra_process_comms = false);
 
-  /// Create a node based on the node name and a rclcpp::context::Context.
+  /// Create a node based on the node name and a rclcpp::Context.
   /**
    * \param[in] node_name Name of the node.
    * \param[in] namespace_ Namespace of the node.
@@ -91,7 +91,7 @@ public:
   Node(
     const std::string & node_name,
     const std::string & namespace_,
-    rclcpp::context::Context::SharedPtr context,
+    rclcpp::Context::SharedPtr context,
     bool use_intra_process_comms = false);
 
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -228,7 +228,7 @@ public:
    * \param[in] group Callback group to execute this timer's callback in.
    */
   template<typename DurationT = std::milli, typename CallbackT>
-  typename rclcpp::timer::WallTimer<CallbackT>::SharedPtr
+  typename rclcpp::WallTimer<CallbackT>::SharedPtr
   create_wall_timer(
     std::chrono::duration<int64_t, DurationT> period,
     CallbackT callback,

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -178,7 +178,7 @@ public:
     typename MessageT,
     typename CallbackT,
     typename Alloc = std::allocator<void>,
-    typename SubscriptionT = rclcpp::subscription::Subscription<MessageT, Alloc>>
+    typename SubscriptionT = rclcpp::Subscription<MessageT, Alloc>>
   std::shared_ptr<SubscriptionT>
   create_subscription(
     const std::string & topic_name,
@@ -209,7 +209,7 @@ public:
     typename MessageT,
     typename CallbackT,
     typename Alloc = std::allocator<void>,
-    typename SubscriptionT = rclcpp::subscription::Subscription<MessageT, Alloc>>
+    typename SubscriptionT = rclcpp::Subscription<MessageT, Alloc>>
   std::shared_ptr<SubscriptionT>
   create_subscription(
     const std::string & topic_name,

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -137,7 +137,7 @@ public:
    */
   template<
     typename MessageT, typename Alloc = std::allocator<void>,
-    typename PublisherT = ::rclcpp::publisher::Publisher<MessageT, Alloc>>
+    typename PublisherT = ::rclcpp::Publisher<MessageT, Alloc>>
   std::shared_ptr<PublisherT>
   create_publisher(
     const std::string & topic_name, size_t qos_history_depth,
@@ -152,7 +152,7 @@ public:
    */
   template<
     typename MessageT, typename Alloc = std::allocator<void>,
-    typename PublisherT = ::rclcpp::publisher::Publisher<MessageT, Alloc>>
+    typename PublisherT = ::rclcpp::Publisher<MessageT, Alloc>>
   std::shared_ptr<PublisherT>
   create_publisher(
     const std::string & topic_name,

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -214,8 +214,8 @@ Node::set_parameter_if_not_set(
   rclcpp::parameter::ParameterVariant parameter_variant;
   if (!this->get_parameter(name, parameter_variant)) {
     this->set_parameters({
-          rclcpp::parameter::ParameterVariant(name, value),
-        });
+        rclcpp::parameter::ParameterVariant(name, value),
+      });
   }
 }
 

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -49,8 +49,6 @@
 
 namespace rclcpp
 {
-namespace node
-{
 
 template<typename MessageT, typename Alloc, typename PublisherT>
 std::shared_ptr<PublisherT>
@@ -248,7 +246,6 @@ Node::get_parameter_or(
   return got_parameter;
 }
 
-}  // namespace node
 }  // namespace rclcpp
 
 #endif  // RCLCPP__NODE_IMPL_HPP_

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -179,23 +179,23 @@ Node::create_client(
 }
 
 template<typename ServiceT, typename CallbackT>
-typename rclcpp::service::Service<ServiceT>::SharedPtr
+typename rclcpp::Service<ServiceT>::SharedPtr
 Node::create_service(
   const std::string & service_name,
   CallbackT && callback,
   const rmw_qos_profile_t & qos_profile,
   rclcpp::callback_group::CallbackGroup::SharedPtr group)
 {
-  rclcpp::service::AnyServiceCallback<ServiceT> any_service_callback;
+  rclcpp::AnyServiceCallback<ServiceT> any_service_callback;
   any_service_callback.set(std::forward<CallbackT>(callback));
 
   rcl_service_options_t service_options = rcl_service_get_default_options();
   service_options.qos = qos_profile;
 
-  auto serv = service::Service<ServiceT>::make_shared(
+  auto serv = Service<ServiceT>::make_shared(
     node_base_->get_shared_rcl_node_handle(),
     service_name, any_service_callback, service_options);
-  auto serv_base_ptr = std::dynamic_pointer_cast<service::ServiceBase>(serv);
+  auto serv_base_ptr = std::dynamic_pointer_cast<ServiceBase>(serv);
   node_services_->add_service(serv_base_ptr, group);
   return serv;
 }

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -155,7 +155,7 @@ Node::create_wall_timer(
 }
 
 template<typename ServiceT>
-typename client::Client<ServiceT>::SharedPtr
+typename Client<ServiceT>::SharedPtr
 Node::create_client(
   const std::string & service_name,
   const rmw_qos_profile_t & qos_profile,
@@ -164,8 +164,8 @@ Node::create_client(
   rcl_client_options_t options = rcl_client_get_default_options();
   options.qos = qos_profile;
 
-  using rclcpp::client::Client;
-  using rclcpp::client::ClientBase;
+  using rclcpp::Client;
+  using rclcpp::ClientBase;
 
   auto cli = Client<ServiceT>::make_shared(
     node_base_.get(),

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -141,13 +141,13 @@ Node::create_subscription(
 }
 
 template<typename DurationT, typename CallbackT>
-typename rclcpp::timer::WallTimer<CallbackT>::SharedPtr
+typename rclcpp::WallTimer<CallbackT>::SharedPtr
 Node::create_wall_timer(
   std::chrono::duration<int64_t, DurationT> period,
   CallbackT callback,
   rclcpp::callback_group::CallbackGroup::SharedPtr group)
 {
-  auto timer = rclcpp::timer::WallTimer<CallbackT>::make_shared(
+  auto timer = rclcpp::WallTimer<CallbackT>::make_shared(
     std::chrono::duration_cast<std::chrono::nanoseconds>(period),
     std::move(callback));
   node_timers_->add_timer(timer, group);

--- a/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
@@ -39,7 +39,7 @@ public:
   NodeBase(
     const std::string & node_name,
     const std::string & namespace_,
-    rclcpp::context::Context::SharedPtr context);
+    rclcpp::Context::SharedPtr context);
 
   RCLCPP_PUBLIC
   virtual
@@ -57,7 +57,7 @@ public:
 
   RCLCPP_PUBLIC
   virtual
-  rclcpp::context::Context::SharedPtr
+  rclcpp::Context::SharedPtr
   get_context();
 
   RCLCPP_PUBLIC
@@ -118,7 +118,7 @@ public:
 private:
   RCLCPP_DISABLE_COPY(NodeBase)
 
-  rclcpp::context::Context::SharedPtr context_;
+  rclcpp::Context::SharedPtr context_;
 
   std::shared_ptr<rcl_node_t> node_handle_;
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
@@ -56,7 +56,7 @@ public:
   /** \return SharedPtr to the node's context. */
   RCLCPP_PUBLIC
   virtual
-  rclcpp::context::Context::SharedPtr
+  rclcpp::Context::SharedPtr
   get_context() = 0;
 
   /// Return the rcl_node_t node handle (non-const version).

--- a/rclcpp/include/rclcpp/node_interfaces/node_graph.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph.hpp
@@ -96,14 +96,14 @@ public:
 
   RCLCPP_PUBLIC
   virtual
-  rclcpp::event::Event::SharedPtr
+  rclcpp::Event::SharedPtr
   get_graph_event();
 
   RCLCPP_PUBLIC
   virtual
   void
   wait_for_graph_change(
-    rclcpp::event::Event::SharedPtr event,
+    rclcpp::Event::SharedPtr event,
     std::chrono::nanoseconds timeout);
 
   RCLCPP_PUBLIC
@@ -127,7 +127,7 @@ private:
   /// For notifying waiting threads (wait_for_graph_change()) on changes (notify_graph_change()).
   std::condition_variable graph_cv_;
   /// Weak references to graph events out on loan.
-  std::vector<rclcpp::event::Event::WeakPtr> graph_events_;
+  std::vector<rclcpp::Event::WeakPtr> graph_events_;
   /// Number of graph events out on loan, used to determine if the graph should be monitored.
   /** graph_users_count_ is atomic so that it can be accessed without acquiring the graph_mutex_ */
   std::atomic_size_t graph_users_count_;

--- a/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
@@ -113,7 +113,7 @@ public:
    */
   RCLCPP_PUBLIC
   virtual
-  rclcpp::event::Event::SharedPtr
+  rclcpp::Event::SharedPtr
   get_graph_event() = 0;
 
   /// Wait for a graph event to occur by waiting on an Event to become set.
@@ -128,7 +128,7 @@ public:
   virtual
   void
   wait_for_graph_change(
-    rclcpp::event::Event::SharedPtr event,
+    rclcpp::Event::SharedPtr event,
     std::chrono::nanoseconds timeout) = 0;
 
   /// Return the number of on loan graph events, see get_graph_event().

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
@@ -113,7 +113,7 @@ private:
 
   std::map<std::string, rclcpp::parameter::ParameterVariant> parameters_;
 
-  publisher::Publisher<rcl_interfaces::msg::ParameterEvent>::SharedPtr events_publisher_;
+  Publisher<rcl_interfaces::msg::ParameterEvent>::SharedPtr events_publisher_;
 };
 
 }  // namespace node_interfaces

--- a/rclcpp/include/rclcpp/node_interfaces/node_services.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_services.hpp
@@ -52,7 +52,7 @@ public:
   virtual
   void
   add_service(
-    rclcpp::service::ServiceBase::SharedPtr service_base_ptr,
+    rclcpp::ServiceBase::SharedPtr service_base_ptr,
     rclcpp::callback_group::CallbackGroup::SharedPtr group);
 
 private:

--- a/rclcpp/include/rclcpp/node_interfaces/node_services.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_services.hpp
@@ -45,7 +45,7 @@ public:
   virtual
   void
   add_client(
-    rclcpp::client::ClientBase::SharedPtr client_base_ptr,
+    rclcpp::ClientBase::SharedPtr client_base_ptr,
     rclcpp::callback_group::CallbackGroup::SharedPtr group);
 
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/node_interfaces/node_services_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_services_interface.hpp
@@ -36,7 +36,7 @@ public:
   virtual
   void
   add_client(
-    rclcpp::client::ClientBase::SharedPtr client_base_ptr,
+    rclcpp::ClientBase::SharedPtr client_base_ptr,
     rclcpp::callback_group::CallbackGroup::SharedPtr group) = 0;
 
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/node_interfaces/node_services_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_services_interface.hpp
@@ -43,7 +43,7 @@ public:
   virtual
   void
   add_service(
-    rclcpp::service::ServiceBase::SharedPtr service_base_ptr,
+    rclcpp::ServiceBase::SharedPtr service_base_ptr,
     rclcpp::callback_group::CallbackGroup::SharedPtr group) = 0;
 };
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_timers.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_timers.hpp
@@ -45,7 +45,7 @@ public:
   virtual
   void
   add_timer(
-    rclcpp::timer::TimerBase::SharedPtr timer,
+    rclcpp::TimerBase::SharedPtr timer,
     rclcpp::callback_group::CallbackGroup::SharedPtr callback_group);
 
 private:

--- a/rclcpp/include/rclcpp/node_interfaces/node_timers_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_timers_interface.hpp
@@ -36,7 +36,7 @@ public:
   virtual
   void
   add_timer(
-    rclcpp::timer::TimerBase::SharedPtr timer,
+    rclcpp::TimerBase::SharedPtr timer,
     rclcpp::callback_group::CallbackGroup::SharedPtr callback_group) = 0;
 };
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_topics.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_topics.hpp
@@ -47,7 +47,7 @@ public:
 
   RCLCPP_PUBLIC
   virtual
-  rclcpp::publisher::PublisherBase::SharedPtr
+  rclcpp::PublisherBase::SharedPtr
   create_publisher(
     const std::string & topic_name,
     const rclcpp::PublisherFactory & publisher_factory,
@@ -58,7 +58,7 @@ public:
   virtual
   void
   add_publisher(
-    rclcpp::publisher::PublisherBase::SharedPtr publisher);
+    rclcpp::PublisherBase::SharedPtr publisher);
 
   RCLCPP_PUBLIC
   virtual

--- a/rclcpp/include/rclcpp/node_interfaces/node_topics.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_topics.hpp
@@ -62,7 +62,7 @@ public:
 
   RCLCPP_PUBLIC
   virtual
-  rclcpp::subscription::SubscriptionBase::SharedPtr
+  rclcpp::SubscriptionBase::SharedPtr
   create_subscription(
     const std::string & topic_name,
     const rclcpp::SubscriptionFactory & subscription_factory,
@@ -73,7 +73,7 @@ public:
   virtual
   void
   add_subscription(
-    rclcpp::subscription::SubscriptionBase::SharedPtr subscription,
+    rclcpp::SubscriptionBase::SharedPtr subscription,
     rclcpp::callback_group::CallbackGroup::SharedPtr callback_group);
 
 private:

--- a/rclcpp/include/rclcpp/node_interfaces/node_topics_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_topics_interface.hpp
@@ -42,7 +42,7 @@ public:
 
   RCLCPP_PUBLIC
   virtual
-  rclcpp::publisher::PublisherBase::SharedPtr
+  rclcpp::PublisherBase::SharedPtr
   create_publisher(
     const std::string & topic_name,
     const rclcpp::PublisherFactory & publisher_factory,
@@ -53,7 +53,7 @@ public:
   virtual
   void
   add_publisher(
-    rclcpp::publisher::PublisherBase::SharedPtr publisher) = 0;
+    rclcpp::PublisherBase::SharedPtr publisher) = 0;
 
   RCLCPP_PUBLIC
   virtual

--- a/rclcpp/include/rclcpp/node_interfaces/node_topics_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_topics_interface.hpp
@@ -57,7 +57,7 @@ public:
 
   RCLCPP_PUBLIC
   virtual
-  rclcpp::subscription::SubscriptionBase::SharedPtr
+  rclcpp::SubscriptionBase::SharedPtr
   create_subscription(
     const std::string & topic_name,
     const rclcpp::SubscriptionFactory & subscription_factory,
@@ -68,7 +68,7 @@ public:
   virtual
   void
   add_subscription(
-    rclcpp::subscription::SubscriptionBase::SharedPtr subscription,
+    rclcpp::SubscriptionBase::SharedPtr subscription,
     rclcpp::callback_group::CallbackGroup::SharedPtr callback_group) = 0;
 };
 

--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -40,8 +40,6 @@
 
 namespace rclcpp
 {
-namespace parameter_client
-{
 
 class AsyncParametersClient
 {
@@ -273,7 +271,6 @@ private:
   AsyncParametersClient::SharedPtr async_parameters_client_;
 };
 
-}  // namespace parameter_client
 }  // namespace rclcpp
 
 #endif  // RCLCPP__PARAMETER_CLIENT_HPP_

--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -156,14 +156,14 @@ protected:
 
 private:
   const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface_;
-  rclcpp::client::Client<rcl_interfaces::srv::GetParameters>::SharedPtr get_parameters_client_;
-  rclcpp::client::Client<rcl_interfaces::srv::GetParameterTypes>::SharedPtr
+  rclcpp::Client<rcl_interfaces::srv::GetParameters>::SharedPtr get_parameters_client_;
+  rclcpp::Client<rcl_interfaces::srv::GetParameterTypes>::SharedPtr
     get_parameter_types_client_;
-  rclcpp::client::Client<rcl_interfaces::srv::SetParameters>::SharedPtr set_parameters_client_;
-  rclcpp::client::Client<rcl_interfaces::srv::SetParametersAtomically>::SharedPtr
+  rclcpp::Client<rcl_interfaces::srv::SetParameters>::SharedPtr set_parameters_client_;
+  rclcpp::Client<rcl_interfaces::srv::SetParametersAtomically>::SharedPtr
     set_parameters_atomically_client_;
-  rclcpp::client::Client<rcl_interfaces::srv::ListParameters>::SharedPtr list_parameters_client_;
-  rclcpp::client::Client<rcl_interfaces::srv::DescribeParameters>::SharedPtr
+  rclcpp::Client<rcl_interfaces::srv::ListParameters>::SharedPtr list_parameters_client_;
+  rclcpp::Client<rcl_interfaces::srv::DescribeParameters>::SharedPtr
     describe_parameters_client_;
   std::string remote_node_name_;
 };

--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -57,13 +57,13 @@ public:
 
   RCLCPP_PUBLIC
   AsyncParametersClient(
-    const rclcpp::node::Node::SharedPtr node,
+    const rclcpp::Node::SharedPtr node,
     const std::string & remote_node_name = "",
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_parameters);
 
   RCLCPP_PUBLIC
   AsyncParametersClient(
-    rclcpp::node::Node * node,
+    rclcpp::Node * node,
     const std::string & remote_node_name = "",
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_parameters);
 
@@ -173,14 +173,14 @@ public:
 
   RCLCPP_PUBLIC
   explicit SyncParametersClient(
-    rclcpp::node::Node::SharedPtr node,
+    rclcpp::Node::SharedPtr node,
     const std::string & remote_node_name = "",
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_parameters);
 
   RCLCPP_PUBLIC
   SyncParametersClient(
     rclcpp::executor::Executor::SharedPtr executor,
-    rclcpp::node::Node::SharedPtr node,
+    rclcpp::Node::SharedPtr node,
     const std::string & remote_node_name = "",
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_parameters);
 
@@ -267,7 +267,7 @@ public:
 
 private:
   rclcpp::executor::Executor::SharedPtr executor_;
-  rclcpp::node::Node::SharedPtr node_;
+  rclcpp::Node::SharedPtr node_;
   AsyncParametersClient::SharedPtr async_parameters_client_;
 };
 

--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -114,8 +114,8 @@ public:
     typename CallbackT,
     typename Alloc = std::allocator<void>,
     typename SubscriptionT =
-    rclcpp::subscription::Subscription<rcl_interfaces::msg::ParameterEvent, Alloc>>
-  typename rclcpp::subscription::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr
+    rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent, Alloc>>
+  typename rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr
   on_parameter_event(CallbackT && callback)
   {
     using rclcpp::message_memory_strategy::MessageMemoryStrategy;
@@ -246,7 +246,7 @@ public:
     uint64_t depth);
 
   template<typename CallbackT>
-  typename rclcpp::subscription::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr
+  typename rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>::SharedPtr
   on_parameter_event(CallbackT && callback)
   {
     return async_parameters_client_->on_parameter_event(std::forward<CallbackT>(callback));

--- a/rclcpp/include/rclcpp/parameter_service.hpp
+++ b/rclcpp/include/rclcpp/parameter_service.hpp
@@ -32,8 +32,6 @@
 
 namespace rclcpp
 {
-namespace parameter_service
-{
 
 class ParameterService
 {
@@ -58,7 +56,6 @@ private:
   rclcpp::Service<rcl_interfaces::srv::ListParameters>::SharedPtr list_parameters_service_;
 };
 
-}  // namespace parameter_service
 }  // namespace rclcpp
 
 #endif  // RCLCPP__PARAMETER_SERVICE_HPP_

--- a/rclcpp/include/rclcpp/parameter_service.hpp
+++ b/rclcpp/include/rclcpp/parameter_service.hpp
@@ -47,15 +47,15 @@ public:
 
 private:
   const rclcpp::node::Node::SharedPtr node_;
-  rclcpp::service::Service<rcl_interfaces::srv::GetParameters>::SharedPtr get_parameters_service_;
-  rclcpp::service::Service<rcl_interfaces::srv::GetParameterTypes>::SharedPtr
+  rclcpp::Service<rcl_interfaces::srv::GetParameters>::SharedPtr get_parameters_service_;
+  rclcpp::Service<rcl_interfaces::srv::GetParameterTypes>::SharedPtr
     get_parameter_types_service_;
-  rclcpp::service::Service<rcl_interfaces::srv::SetParameters>::SharedPtr set_parameters_service_;
-  rclcpp::service::Service<rcl_interfaces::srv::SetParametersAtomically>::SharedPtr
+  rclcpp::Service<rcl_interfaces::srv::SetParameters>::SharedPtr set_parameters_service_;
+  rclcpp::Service<rcl_interfaces::srv::SetParametersAtomically>::SharedPtr
     set_parameters_atomically_service_;
-  rclcpp::service::Service<rcl_interfaces::srv::DescribeParameters>::SharedPtr
+  rclcpp::Service<rcl_interfaces::srv::DescribeParameters>::SharedPtr
     describe_parameters_service_;
-  rclcpp::service::Service<rcl_interfaces::srv::ListParameters>::SharedPtr list_parameters_service_;
+  rclcpp::Service<rcl_interfaces::srv::ListParameters>::SharedPtr list_parameters_service_;
 };
 
 }  // namespace parameter_service

--- a/rclcpp/include/rclcpp/parameter_service.hpp
+++ b/rclcpp/include/rclcpp/parameter_service.hpp
@@ -40,11 +40,11 @@ public:
 
   RCLCPP_PUBLIC
   explicit ParameterService(
-    const rclcpp::node::Node::SharedPtr node,
+    const rclcpp::Node::SharedPtr node,
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_parameters);
 
 private:
-  const rclcpp::node::Node::SharedPtr node_;
+  const rclcpp::Node::SharedPtr node_;
   rclcpp::Service<rcl_interfaces::srv::GetParameters>::SharedPtr get_parameters_service_;
   rclcpp::Service<rcl_interfaces::srv::GetParameterTypes>::SharedPtr
     get_parameter_types_service_;

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -45,9 +45,6 @@ namespace node_interfaces
 class NodeTopicsInterface;
 }
 
-namespace publisher
-{
-
 class PublisherBase
 {
   friend ::rclcpp::node_interfaces::NodeTopicsInterface;
@@ -304,8 +301,6 @@ protected:
 
   MessageDeleter message_deleter_;
 };
-
-}  // namespace publisher
 
 }  // namespace rclcpp
 

--- a/rclcpp/include/rclcpp/publisher_factory.hpp
+++ b/rclcpp/include/rclcpp/publisher_factory.hpp
@@ -46,7 +46,7 @@ struct PublisherFactory
 {
   // Creates a PublisherT<MessageT, ...> publisher object and returns it as a PublisherBase.
   using PublisherFactoryFunction = std::function<
-      rclcpp::publisher::PublisherBase::SharedPtr(
+      rclcpp::PublisherBase::SharedPtr(
         rclcpp::node_interfaces::NodeBaseInterface * node_base,
         const std::string & topic_name,
         rcl_publisher_options_t & publisher_options)>;
@@ -58,7 +58,7 @@ struct PublisherFactory
   using AddPublisherToIntraProcessManagerFunction = std::function<
       uint64_t(
         rclcpp::intra_process_manager::IntraProcessManager * ipm,
-        rclcpp::publisher::PublisherBase::SharedPtr publisher)>;
+        rclcpp::PublisherBase::SharedPtr publisher)>;
 
   AddPublisherToIntraProcessManagerFunction add_publisher_to_intra_process_manager;
 
@@ -66,7 +66,7 @@ struct PublisherFactory
   // PublisherT::publish() and which handles the intra process transmission of
   // the message being published.
   using SharedPublishCallbackFactoryFunction = std::function<
-      rclcpp::publisher::PublisherBase::StoreMessageCallbackT(
+      rclcpp::PublisherBase::StoreMessageCallbackT(
         rclcpp::intra_process_manager::IntraProcessManager::SharedPtr ipm)>;
 
   SharedPublishCallbackFactoryFunction create_shared_publish_callback;
@@ -96,13 +96,13 @@ create_publisher_factory(std::shared_ptr<Alloc> allocator)
   factory.add_publisher_to_intra_process_manager =
     [](
     rclcpp::intra_process_manager::IntraProcessManager * ipm,
-    rclcpp::publisher::PublisherBase::SharedPtr publisher) -> uint64_t
+    rclcpp::PublisherBase::SharedPtr publisher) -> uint64_t
     {
       return ipm->add_publisher<MessageT, Alloc>(std::dynamic_pointer_cast<PublisherT>(publisher));
     };
 
   // function to create a shared publish callback std::function
-  using StoreMessageCallbackT = rclcpp::publisher::PublisherBase::StoreMessageCallbackT;
+  using StoreMessageCallbackT = rclcpp::PublisherBase::StoreMessageCallbackT;
   factory.create_shared_publish_callback =
     [](rclcpp::intra_process_manager::IntraProcessManager::SharedPtr ipm) -> StoreMessageCallbackT
     {
@@ -129,7 +129,7 @@ create_publisher_factory(std::shared_ptr<Alloc> allocator)
                     "' is incompatible from the publisher type '" + message_type_info.name() + "'");
           }
           MessageT * typed_message_ptr = static_cast<MessageT *>(msg);
-          using MessageDeleter = typename publisher::Publisher<MessageT, Alloc>::MessageDeleter;
+          using MessageDeleter = typename Publisher<MessageT, Alloc>::MessageDeleter;
           std::unique_ptr<MessageT, MessageDeleter> unique_msg(typed_message_ptr);
           uint64_t message_seq =
             ipm->store_intra_process_message<MessageT, Alloc>(publisher_id, unique_msg);

--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -25,8 +25,6 @@
 
 namespace rclcpp
 {
-namespace rate
-{
 
 class RateBase
 {
@@ -116,7 +114,6 @@ private:
 using Rate = GenericRate<std::chrono::system_clock>;
 using WallRate = GenericRate<std::chrono::steady_clock>;
 
-}  // namespace rate
 }  // namespace rclcpp
 
 #endif  // RCLCPP__RATE_HPP_

--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -82,7 +82,7 @@ public:
       return false;
     }
     // Sleep (will get interrupted by ctrl-c, may not sleep full time)
-    rclcpp::utilities::sleep_for(time_to_sleep);
+    rclcpp::sleep_for(time_to_sleep);
     return true;
   }
 

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -18,37 +18,37 @@
  * It consists of these main components:
  *
  * - Node
- *   - rclcpp::node::Node
+ *   - rclcpp::Node
  *   - rclcpp/node.hpp
  * - Publisher
- *   - rclcpp::node::Node::create_publisher()
+ *   - rclcpp::Node::create_publisher()
  *   - rclcpp::Publisher
  *   - rclcpp::Publisher::publish()
  *   - rclcpp/publisher.hpp
  * - Subscription
- *   - rclcpp::node::Node::create_subscription()
+ *   - rclcpp::Node::create_subscription()
  *   - rclcpp::Subscription
  *   - rclcpp/subscription.hpp
  * - Service Client
- *   - rclcpp::node::Node::create_client()
+ *   - rclcpp::Node::create_client()
  *   - rclcpp::Client
  *   - rclcpp/client.hpp
  * - Service Server
- *   - rclcpp::node::Node::create_service()
+ *   - rclcpp::Node::create_service()
  *   - rclcpp::Service
  *   - rclcpp/service.hpp
  * - Timer
- *   - rclcpp::node::Node::create_wall_timer()
+ *   - rclcpp::Node::create_wall_timer()
  *   - rclcpp::WallTimer
  *   - rclcpp::TimerBase
  *   - rclcpp/timer.hpp
  * - Parameters:
- *   - rclcpp::node::Node::set_parameters()
- *   - rclcpp::node::Node::get_parameters()
- *   - rclcpp::node::Node::get_parameter()
- *   - rclcpp::node::Node::describe_parameters()
- *   - rclcpp::node::Node::list_parameters()
- *   - rclcpp::node::Node::register_param_change_callback()
+ *   - rclcpp::Node::set_parameters()
+ *   - rclcpp::Node::get_parameters()
+ *   - rclcpp::Node::get_parameter()
+ *   - rclcpp::Node::describe_parameters()
+ *   - rclcpp::Node::list_parameters()
+ *   - rclcpp::Node::register_param_change_callback()
  *   - rclcpp::parameter::ParameterVariant
  *   - rclcpp::AsyncParametersClient
  *   - rclcpp::SyncParametersClient
@@ -77,21 +77,21 @@
  *   - rclcpp/executors/single_threaded_executor.hpp
  *   - rclcpp/executors/multi_threaded_executor.hpp
  * - CallbackGroups (mechanism for enforcing concurrency rules for callbacks):
- *   - rclcpp::node::Node::create_callback_group()
+ *   - rclcpp::Node::create_callback_group()
  *   - rclcpp::callback_group::CallbackGroup
  *   - rclcpp/callback_group.hpp
  *
  * Additionally, there are some methods for introspecting the ROS graph:
  *
  * - Graph Events (a waitable event object that wakes up when the graph changes):
- *   - rclcpp::node::Node::get_graph_event()
- *   - rclcpp::node::Node::wait_for_graph_change()
+ *   - rclcpp::Node::get_graph_event()
+ *   - rclcpp::Node::wait_for_graph_change()
  *   - rclcpp::event::Event
  * - List topic names and types:
- *   - rclcpp::node::Node::get_topic_names_and_types()
+ *   - rclcpp::Node::get_topic_names_and_types()
  * - Get the number of publishers or subscribers on a topic:
- *   - rclcpp::node::Node::count_publishers()
- *   - rclcpp::node::Node::count_subscribers()
+ *   - rclcpp::Node::count_publishers()
+ *   - rclcpp::Node::count_subscribers()
  *
  * And components related to logging:
  *
@@ -154,8 +154,6 @@ namespace rclcpp
 {
 
 // Namespace escalations.
-// For example, this next line escalates type "rclcpp:node::Node" to "rclcpp::Node"
-using rclcpp::node::Node;
 using ContextSharedPtr = rclcpp::context::Context::SharedPtr;
 using rclcpp::utilities::ok;
 using rclcpp::utilities::shutdown;

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -150,16 +150,4 @@
 #include "rclcpp/utilities.hpp"
 #include "rclcpp/visibility_control.hpp"
 
-namespace rclcpp
-{
-
-// Namespace escalations.
-using rclcpp::utilities::ok;
-using rclcpp::utilities::ok;
-using rclcpp::utilities::shutdown;
-using rclcpp::utilities::init;
-using rclcpp::utilities::sleep_for;
-
-}  // namespace rclcpp
-
 #endif  // RCLCPP__RCLCPP_HPP_

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -27,7 +27,7 @@
  *   - rclcpp/publisher.hpp
  * - Subscription
  *   - rclcpp::node::Node::create_subscription()
- *   - rclcpp::subscription::Subscription
+ *   - rclcpp::Subscription
  *   - rclcpp/subscription.hpp
  * - Service Client
  *   - rclcpp::node::Node::create_client()
@@ -156,8 +156,6 @@ namespace rclcpp
 // Namespace escalations.
 // For example, this next line escalates type "rclcpp:node::Node" to "rclcpp::Node"
 using rclcpp::node::Node;
-using rclcpp::subscription::Subscription;
-using rclcpp::subscription::SubscriptionBase;
 using rclcpp::client::Client;
 using rclcpp::client::ClientBase;
 using rclcpp::service::Service;

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -31,7 +31,7 @@
  *   - rclcpp/subscription.hpp
  * - Service Client
  *   - rclcpp::node::Node::create_client()
- *   - rclcpp::client::Client
+ *   - rclcpp::Client
  *   - rclcpp/client.hpp
  * - Service Server
  *   - rclcpp::node::Node::create_service()
@@ -156,8 +156,6 @@ namespace rclcpp
 // Namespace escalations.
 // For example, this next line escalates type "rclcpp:node::Node" to "rclcpp::Node"
 using rclcpp::node::Node;
-using rclcpp::client::Client;
-using rclcpp::client::ClientBase;
 using rclcpp::service::Service;
 using rclcpp::service::ServiceBase;
 using rclcpp::parameter_client::AsyncParametersClient;

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -86,7 +86,7 @@
  * - Graph Events (a waitable event object that wakes up when the graph changes):
  *   - rclcpp::Node::get_graph_event()
  *   - rclcpp::Node::wait_for_graph_change()
- *   - rclcpp::event::Event
+ *   - rclcpp::Event
  * - List topic names and types:
  *   - rclcpp::Node::get_topic_names_and_types()
  * - Get the number of publishers or subscribers on a topic:

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -66,9 +66,9 @@
  *   - rclcpp::spin()
  *   - rclcpp::spin_some()
  *   - rclcpp::spin_until_future_complete()
- *   - rclcpp::executors::single_threaded_executor::SingleThreadedExecutor
- *   - rclcpp::executors::single_threaded_executor::SingleThreadedExecutor::add_node()
- *   - rclcpp::executors::single_threaded_executor::SingleThreadedExecutor::spin()
+ *   - rclcpp::executors::SingleThreadedExecutor
+ *   - rclcpp::executors::SingleThreadedExecutor::add_node()
+ *   - rclcpp::executors::SingleThreadedExecutor::spin()
  *   - rclcpp::executors::multi_threaded_executor::MultiThreadedExecutor
  *   - rclcpp::executors::multi_threaded_executor::MultiThreadedExecutor::add_node()
  *   - rclcpp::executors::multi_threaded_executor::MultiThreadedExecutor::spin()

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -154,7 +154,7 @@ namespace rclcpp
 {
 
 // Namespace escalations.
-using ContextSharedPtr = rclcpp::context::Context::SharedPtr;
+using rclcpp::utilities::ok;
 using rclcpp::utilities::ok;
 using rclcpp::utilities::shutdown;
 using rclcpp::utilities::init;

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -105,7 +105,7 @@
  * - Logger:
  *   - rclcpp::Logger
  *   - rclcpp/logger.hpp
- *   - rclcpp::node::Node::get_logger()
+ *   - rclcpp::Node::get_logger()
  *
  * Finally, there are many internal API's and utilities:
  *

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -121,7 +121,7 @@
  *   - rclcpp/strategies/allocator_memory_strategy.hpp
  *   - rclcpp/strategies/message_pool_memory_strategy.hpp
  * - Context object which is shared amongst multiple Nodes:
- *   - rclcpp::context::Context
+ *   - rclcpp::Context
  *   - rclcpp/context.hpp
  *   - rclcpp/contexts/default_context.hpp
  * - Various utilities:

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -39,8 +39,8 @@
  *   - rclcpp/service.hpp
  * - Timer
  *   - rclcpp::node::Node::create_wall_timer()
- *   - rclcpp::timer::WallTimer
- *   - rclcpp::timer::TimerBase
+ *   - rclcpp::WallTimer
+ *   - rclcpp::TimerBase
  *   - rclcpp/timer.hpp
  * - Parameters:
  *   - rclcpp::node::Node::set_parameters()
@@ -156,9 +156,6 @@ namespace rclcpp
 // Namespace escalations.
 // For example, this next line escalates type "rclcpp:node::Node" to "rclcpp::Node"
 using rclcpp::node::Node;
-using rclcpp::timer::GenericTimer;
-using rclcpp::timer::TimerBase;
-using rclcpp::timer::WallTimer;
 using ContextSharedPtr = rclcpp::context::Context::SharedPtr;
 using rclcpp::utilities::ok;
 using rclcpp::utilities::shutdown;

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -22,8 +22,8 @@
  *   - rclcpp/node.hpp
  * - Publisher
  *   - rclcpp::node::Node::create_publisher()
- *   - rclcpp::publisher::Publisher
- *   - rclcpp::publisher::Publisher::publish()
+ *   - rclcpp::Publisher
+ *   - rclcpp::Publisher::publish()
  *   - rclcpp/publisher.hpp
  * - Subscription
  *   - rclcpp::node::Node::create_subscription()
@@ -156,8 +156,6 @@ namespace rclcpp
 // Namespace escalations.
 // For example, this next line escalates type "rclcpp:node::Node" to "rclcpp::Node"
 using rclcpp::node::Node;
-using rclcpp::publisher::Publisher;
-using rclcpp::publisher::PublisherBase;
 using rclcpp::subscription::Subscription;
 using rclcpp::subscription::SubscriptionBase;
 using rclcpp::client::Client;

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -50,8 +50,8 @@
  *   - rclcpp::node::Node::list_parameters()
  *   - rclcpp::node::Node::register_param_change_callback()
  *   - rclcpp::parameter::ParameterVariant
- *   - rclcpp::parameter_client::AsyncParametersClient
- *   - rclcpp::parameter_client::SyncParametersClient
+ *   - rclcpp::AsyncParametersClient
+ *   - rclcpp::SyncParametersClient
  *   - rclcpp/parameter.hpp
  *   - rclcpp/parameter_client.hpp
  *   - rclcpp/parameter_service.hpp
@@ -156,8 +156,6 @@ namespace rclcpp
 // Namespace escalations.
 // For example, this next line escalates type "rclcpp:node::Node" to "rclcpp::Node"
 using rclcpp::node::Node;
-using rclcpp::parameter_client::AsyncParametersClient;
-using rclcpp::parameter_client::SyncParametersClient;
 using rclcpp::parameter_service::ParameterService;
 using rclcpp::rate::GenericRate;
 using rclcpp::rate::WallRate;

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -35,7 +35,7 @@
  *   - rclcpp/client.hpp
  * - Service Server
  *   - rclcpp::node::Node::create_service()
- *   - rclcpp::service::Service
+ *   - rclcpp::Service
  *   - rclcpp/service.hpp
  * - Timer
  *   - rclcpp::node::Node::create_wall_timer()
@@ -156,8 +156,6 @@ namespace rclcpp
 // Namespace escalations.
 // For example, this next line escalates type "rclcpp:node::Node" to "rclcpp::Node"
 using rclcpp::node::Node;
-using rclcpp::service::Service;
-using rclcpp::service::ServiceBase;
 using rclcpp::parameter_client::AsyncParametersClient;
 using rclcpp::parameter_client::SyncParametersClient;
 using rclcpp::parameter_service::ParameterService;

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -56,8 +56,8 @@
  *   - rclcpp/parameter_client.hpp
  *   - rclcpp/parameter_service.hpp
  * - Rate:
- *   - rclcpp::rate::Rate
- *   - rclcpp::rate::WallRate
+ *   - rclcpp::Rate
+ *   - rclcpp::WallRate
  *   - rclcpp/rate.hpp
  *
  * There are also some components which help control the execution of callbacks:
@@ -156,8 +156,6 @@ namespace rclcpp
 // Namespace escalations.
 // For example, this next line escalates type "rclcpp:node::Node" to "rclcpp::Node"
 using rclcpp::node::Node;
-using rclcpp::rate::GenericRate;
-using rclcpp::rate::WallRate;
 using rclcpp::timer::GenericTimer;
 using rclcpp::timer::TimerBase;
 using rclcpp::timer::WallTimer;

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -156,7 +156,6 @@ namespace rclcpp
 // Namespace escalations.
 // For example, this next line escalates type "rclcpp:node::Node" to "rclcpp::Node"
 using rclcpp::node::Node;
-using rclcpp::parameter_service::ParameterService;
 using rclcpp::rate::GenericRate;
 using rclcpp::rate::WallRate;
 using rclcpp::timer::GenericTimer;

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -69,9 +69,9 @@
  *   - rclcpp::executors::SingleThreadedExecutor
  *   - rclcpp::executors::SingleThreadedExecutor::add_node()
  *   - rclcpp::executors::SingleThreadedExecutor::spin()
- *   - rclcpp::executors::multi_threaded_executor::MultiThreadedExecutor
- *   - rclcpp::executors::multi_threaded_executor::MultiThreadedExecutor::add_node()
- *   - rclcpp::executors::multi_threaded_executor::MultiThreadedExecutor::spin()
+ *   - rclcpp::executors::MultiThreadedExecutor
+ *   - rclcpp::executors::MultiThreadedExecutor::add_node()
+ *   - rclcpp::executors::MultiThreadedExecutor::spin()
  *   - rclcpp/executor.hpp
  *   - rclcpp/executors.hpp
  *   - rclcpp/executors/single_threaded_executor.hpp

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -35,8 +35,6 @@
 
 namespace rclcpp
 {
-namespace service
-{
 
 class ServiceBase
 {
@@ -223,7 +221,6 @@ private:
   AnyServiceCallback<ServiceT> any_callback_;
 };
 
-}  // namespace service
 }  // namespace rclcpp
 
 #endif  // RCLCPP__SERVICE_HPP_

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -89,8 +89,6 @@ protected:
   bool owns_rcl_handle_ = true;
 };
 
-using any_service_callback::AnyServiceCallback;
-
 template<typename ServiceT>
 class Service : public ServiceBase
 {

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -45,9 +45,6 @@ namespace node_interfaces
 class NodeTopicsInterface;
 }  // namespace node_interfaces
 
-namespace subscription
-{
-
 /// Virtual base class for subscriptions. This pattern allows us to iterate over different template
 /// specializations of Subscription, among other things.
 class SubscriptionBase
@@ -292,7 +289,6 @@ private:
   uint64_t intra_process_subscription_id_;
 };
 
-}  // namespace subscription
 }  // namespace rclcpp
 
 #endif  // RCLCPP__SUBSCRIPTION_HPP_

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -118,8 +118,6 @@ private:
   RCLCPP_DISABLE_COPY(SubscriptionBase)
 };
 
-using any_subscription_callback::AnySubscriptionCallback;
-
 /// Subscription implementation, templated on the type of message this subscription receives.
 template<typename MessageT, typename Alloc = std::allocator<void>>
 class Subscription : public SubscriptionBase

--- a/rclcpp/include/rclcpp/subscription_factory.hpp
+++ b/rclcpp/include/rclcpp/subscription_factory.hpp
@@ -47,7 +47,7 @@ struct SubscriptionFactory
 {
   // Creates a Subscription<MessageT> object and returns it as a SubscriptionBase.
   using SubscriptionFactoryFunction = std::function<
-      rclcpp::subscription::SubscriptionBase::SharedPtr(
+      rclcpp::SubscriptionBase::SharedPtr(
         rclcpp::node_interfaces::NodeBaseInterface * node_base,
         const std::string & topic_name,
         rcl_subscription_options_t & subscription_options)>;
@@ -58,7 +58,7 @@ struct SubscriptionFactory
   using SetupIntraProcessFunction = std::function<
       void(
         rclcpp::intra_process_manager::IntraProcessManager::SharedPtr ipm,
-        rclcpp::subscription::SubscriptionBase::SharedPtr subscription,
+        rclcpp::SubscriptionBase::SharedPtr subscription,
         const rcl_subscription_options_t & subscription_options)>;
 
   SetupIntraProcessFunction setup_intra_process;
@@ -75,12 +75,12 @@ create_subscription_factory(
 {
   SubscriptionFactory factory;
 
-  using rclcpp::subscription::AnySubscriptionCallback;
+  using rclcpp::AnySubscriptionCallback;
   AnySubscriptionCallback<MessageT, Alloc> any_subscription_callback(allocator);
   any_subscription_callback.set(std::forward<CallbackT>(callback));
 
   auto message_alloc =
-    std::make_shared<typename subscription::Subscription<MessageT, Alloc>::MessageAlloc>();
+    std::make_shared<typename Subscription<MessageT, Alloc>::MessageAlloc>();
 
   // factory function that creates a MessageT specific SubscriptionT
   factory.create_typed_subscription =
@@ -88,13 +88,13 @@ create_subscription_factory(
     rclcpp::node_interfaces::NodeBaseInterface * node_base,
     const std::string & topic_name,
     rcl_subscription_options_t & subscription_options
-    ) -> rclcpp::subscription::SubscriptionBase::SharedPtr
+    ) -> rclcpp::SubscriptionBase::SharedPtr
     {
       subscription_options.allocator =
         rclcpp::allocator::get_rcl_allocator<MessageT>(*message_alloc.get());
 
-      using rclcpp::subscription::Subscription;
-      using rclcpp::subscription::SubscriptionBase;
+      using rclcpp::Subscription;
+      using rclcpp::SubscriptionBase;
 
       auto sub = Subscription<MessageT, Alloc>::make_shared(
         node_base->get_shared_rcl_node_handle(),
@@ -110,7 +110,7 @@ create_subscription_factory(
   factory.setup_intra_process =
     [message_alloc](
     rclcpp::intra_process_manager::IntraProcessManager::SharedPtr ipm,
-    rclcpp::subscription::SubscriptionBase::SharedPtr subscription,
+    rclcpp::SubscriptionBase::SharedPtr subscription,
     const rcl_subscription_options_t & subscription_options)
     {
       rclcpp::intra_process_manager::IntraProcessManager::WeakPtr weak_ipm = ipm;
@@ -128,7 +128,7 @@ create_subscription_factory(
         uint64_t publisher_id,
         uint64_t message_sequence,
         uint64_t subscription_id,
-        typename rclcpp::subscription::Subscription<MessageT, Alloc>::MessageUniquePtr & message)
+        typename rclcpp::Subscription<MessageT, Alloc>::MessageUniquePtr & message)
         {
           auto ipm = weak_ipm.lock();
           if (!ipm) {

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -36,13 +36,13 @@ class TimeSource
 {
 public:
   RCLCPP_PUBLIC
-  explicit TimeSource(rclcpp::node::Node::SharedPtr node);
+  explicit TimeSource(rclcpp::Node::SharedPtr node);
 
   RCLCPP_PUBLIC
   TimeSource();
 
   RCLCPP_PUBLIC
-  void attachNode(rclcpp::node::Node::SharedPtr node);
+  void attachNode(rclcpp::Node::SharedPtr node);
 
   RCLCPP_PUBLIC
   void attachNode(

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -77,7 +77,7 @@ private:
   // The subscription for the clock callback
   using MessageT = builtin_interfaces::msg::Time;
   using Alloc = std::allocator<void>;
-  using SubscriptionT = rclcpp::subscription::Subscription<MessageT, Alloc>;
+  using SubscriptionT = rclcpp::Subscription<MessageT, Alloc>;
   std::shared_ptr<SubscriptionT> clock_subscription_;
 
   // The clock callback itself
@@ -88,7 +88,7 @@ private:
 
   // Parameter Event subscription
   using ParamMessageT = rcl_interfaces::msg::ParameterEvent;
-  using ParamSubscriptionT = rclcpp::subscription::Subscription<ParamMessageT, Alloc>;
+  using ParamSubscriptionT = rclcpp::Subscription<ParamMessageT, Alloc>;
   std::shared_ptr<ParamSubscriptionT> parameter_subscription_;
 
   // Callback for parameter updates

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -84,7 +84,7 @@ private:
   void clock_cb(const builtin_interfaces::msg::Time::SharedPtr msg);
 
   // Parameter Client pointer
-  std::shared_ptr<rclcpp::parameter_client::AsyncParametersClient> parameter_client_;
+  std::shared_ptr<rclcpp::AsyncParametersClient> parameter_client_;
 
   // Parameter Event subscription
   using ParamMessageT = rcl_interfaces::msg::ParameterEvent;

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -37,8 +37,6 @@
 
 namespace rclcpp
 {
-namespace timer
-{
 
 class TimerBase
 {
@@ -182,7 +180,6 @@ protected:
 template<typename CallbackType>
 using WallTimer = GenericTimer<CallbackType, std::chrono::steady_clock>;
 
-}  // namespace timer
 }  // namespace rclcpp
 
 #endif  // RCLCPP__TIMER_HPP_

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -44,8 +44,6 @@ std::string to_string(T value)
 
 namespace rclcpp
 {
-namespace utilities
-{
 
 /// Initialize communications via the rmw implementation and set up a global signal handler.
 /**
@@ -111,7 +109,6 @@ RCLCPP_PUBLIC
 bool
 sleep_for(const std::chrono::nanoseconds & nanoseconds);
 
-}  // namespace utilities
 }  // namespace rclcpp
 
 #endif  // RCLCPP__UTILITIES_HPP_

--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -30,7 +30,7 @@ CallbackGroup::get_subscription_ptrs() const
   return subscription_ptrs_;
 }
 
-const std::vector<rclcpp::timer::TimerBase::WeakPtr> &
+const std::vector<rclcpp::TimerBase::WeakPtr> &
 CallbackGroup::get_timer_ptrs() const
 {
   std::lock_guard<std::mutex> lock(mutex_);
@@ -72,7 +72,7 @@ CallbackGroup::add_subscription(
 }
 
 void
-CallbackGroup::add_timer(const rclcpp::timer::TimerBase::SharedPtr timer_ptr)
+CallbackGroup::add_timer(const rclcpp::TimerBase::SharedPtr timer_ptr)
 {
   std::lock_guard<std::mutex> lock(mutex_);
   timer_ptrs_.push_back(timer_ptr);

--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -23,7 +23,7 @@ CallbackGroup::CallbackGroup(CallbackGroupType group_type)
 : type_(group_type), can_be_taken_from_(true)
 {}
 
-const std::vector<rclcpp::subscription::SubscriptionBase::WeakPtr> &
+const std::vector<rclcpp::SubscriptionBase::WeakPtr> &
 CallbackGroup::get_subscription_ptrs() const
 {
   std::lock_guard<std::mutex> lock(mutex_);
@@ -65,7 +65,7 @@ CallbackGroup::type() const
 
 void
 CallbackGroup::add_subscription(
-  const rclcpp::subscription::SubscriptionBase::SharedPtr subscription_ptr)
+  const rclcpp::SubscriptionBase::SharedPtr subscription_ptr)
 {
   std::lock_guard<std::mutex> lock(mutex_);
   subscription_ptrs_.push_back(subscription_ptr);

--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -44,7 +44,7 @@ CallbackGroup::get_service_ptrs() const
   return service_ptrs_;
 }
 
-const std::vector<rclcpp::client::ClientBase::WeakPtr> &
+const std::vector<rclcpp::ClientBase::WeakPtr> &
 CallbackGroup::get_client_ptrs() const
 {
   std::lock_guard<std::mutex> lock(mutex_);
@@ -86,7 +86,7 @@ CallbackGroup::add_service(const rclcpp::service::ServiceBase::SharedPtr service
 }
 
 void
-CallbackGroup::add_client(const rclcpp::client::ClientBase::SharedPtr client_ptr)
+CallbackGroup::add_client(const rclcpp::ClientBase::SharedPtr client_ptr)
 {
   std::lock_guard<std::mutex> lock(mutex_);
   client_ptrs_.push_back(client_ptr);

--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -37,7 +37,7 @@ CallbackGroup::get_timer_ptrs() const
   return timer_ptrs_;
 }
 
-const std::vector<rclcpp::service::ServiceBase::WeakPtr> &
+const std::vector<rclcpp::ServiceBase::WeakPtr> &
 CallbackGroup::get_service_ptrs() const
 {
   std::lock_guard<std::mutex> lock(mutex_);
@@ -79,7 +79,7 @@ CallbackGroup::add_timer(const rclcpp::timer::TimerBase::SharedPtr timer_ptr)
 }
 
 void
-CallbackGroup::add_service(const rclcpp::service::ServiceBase::SharedPtr service_ptr)
+CallbackGroup::add_service(const rclcpp::ServiceBase::SharedPtr service_ptr)
 {
   std::lock_guard<std::mutex> lock(mutex_);
   service_ptrs_.push_back(service_ptr);

--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -27,7 +27,7 @@
 #include "rclcpp/node_interfaces/node_graph_interface.hpp"
 #include "rclcpp/utilities.hpp"
 
-using rclcpp::client::ClientBase;
+using rclcpp::ClientBase;
 using rclcpp::exceptions::InvalidNodeError;
 using rclcpp::exceptions::throw_from_rcl_error;
 

--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -100,7 +100,7 @@ ClientBase::wait_for_service_nanoseconds(std::chrono::nanoseconds timeout)
   }
   // continue forever if timeout is negative, otherwise continue until out of time_to_wait
   do {
-    if (!rclcpp::utilities::ok()) {
+    if (!rclcpp::ok()) {
       return false;
     }
     node_ptr->wait_for_graph_change(event, time_to_wait);

--- a/rclcpp/src/rclcpp/context.cpp
+++ b/rclcpp/src/rclcpp/context.cpp
@@ -14,6 +14,6 @@
 
 #include "rclcpp/context.hpp"
 
-using rclcpp::context::Context;
+using rclcpp::Context;
 
 Context::Context() {}

--- a/rclcpp/src/rclcpp/event.cpp
+++ b/rclcpp/src/rclcpp/event.cpp
@@ -16,8 +16,6 @@
 
 namespace rclcpp
 {
-namespace event
-{
 
 Event::Event()
 : state_(false) {}
@@ -40,5 +38,4 @@ Event::check_and_clear()
   return state_.exchange(false);
 }
 
-}  // namespace event
 }  // namespace rclcpp

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -319,7 +319,7 @@ Executor::execute_timer(
 
 void
 Executor::execute_service(
-  rclcpp::service::ServiceBase::SharedPtr service)
+  rclcpp::ServiceBase::SharedPtr service)
 {
   auto request_header = service->create_request_header();
   std::shared_ptr<void> request = service->create_request();

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -129,7 +129,7 @@ Executor::add_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_pt
 }
 
 void
-Executor::add_node(std::shared_ptr<rclcpp::node::Node> node_ptr, bool notify)
+Executor::add_node(std::shared_ptr<rclcpp::Node> node_ptr, bool notify)
 {
   this->add_node(node_ptr->get_node_base_interface(), notify);
 }
@@ -163,7 +163,7 @@ Executor::remove_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node
 }
 
 void
-Executor::remove_node(std::shared_ptr<rclcpp::node::Node> node_ptr, bool notify)
+Executor::remove_node(std::shared_ptr<rclcpp::Node> node_ptr, bool notify)
 {
   this->remove_node(node_ptr->get_node_base_interface(), notify);
 }
@@ -188,7 +188,7 @@ Executor::spin_node_some(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr n
 }
 
 void
-Executor::spin_node_some(std::shared_ptr<rclcpp::node::Node> node)
+Executor::spin_node_some(std::shared_ptr<rclcpp::Node> node)
 {
   this->spin_node_some(node->get_node_base_interface());
 }

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -312,7 +312,7 @@ Executor::execute_intra_process_subscription(
 
 void
 Executor::execute_timer(
-  rclcpp::timer::TimerBase::SharedPtr timer)
+  rclcpp::TimerBase::SharedPtr timer)
 {
   timer->execute_callback();
 }
@@ -471,7 +471,7 @@ Executor::get_node_by_group(rclcpp::callback_group::CallbackGroup::SharedPtr gro
 }
 
 rclcpp::callback_group::CallbackGroup::SharedPtr
-Executor::get_group_by_timer(rclcpp::timer::TimerBase::SharedPtr timer)
+Executor::get_group_by_timer(rclcpp::TimerBase::SharedPtr timer)
 {
   for (auto & weak_node : weak_nodes_) {
     auto node = weak_node.lock();

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -50,7 +50,7 @@ Executor::Executor(const ExecutorArgs & args)
   // and one for the executor's guard cond (interrupt_guard_condition_)
 
   // Put the global ctrl-c guard condition in
-  memory_strategy_->add_guard_condition(rclcpp::utilities::get_sigint_guard_condition(&wait_set_));
+  memory_strategy_->add_guard_condition(rclcpp::get_sigint_guard_condition(&wait_set_));
 
   // Put the executor's guard condition in
   memory_strategy_->add_guard_condition(&interrupt_guard_condition_);
@@ -97,8 +97,8 @@ Executor::~Executor()
   }
   // Remove and release the sigint guard condition
   memory_strategy_->remove_guard_condition(
-    rclcpp::utilities::get_sigint_guard_condition(&wait_set_));
-  rclcpp::utilities::release_sigint_guard_condition(&wait_set_);
+    rclcpp::get_sigint_guard_condition(&wait_set_));
+  rclcpp::release_sigint_guard_condition(&wait_set_);
 }
 
 void

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -339,7 +339,7 @@ Executor::execute_service(
 
 void
 Executor::execute_client(
-  rclcpp::client::ClientBase::SharedPtr client)
+  rclcpp::ClientBase::SharedPtr client)
 {
   auto request_header = client->create_request_header();
   std::shared_ptr<void> response = client->create_response();

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -269,7 +269,7 @@ Executor::execute_any_executable(AnyExecutable::SharedPtr any_exec)
 
 void
 Executor::execute_subscription(
-  rclcpp::subscription::SubscriptionBase::SharedPtr subscription)
+  rclcpp::SubscriptionBase::SharedPtr subscription)
 {
   std::shared_ptr<void> message = subscription->create_message();
   rmw_message_info_t message_info;
@@ -290,7 +290,7 @@ Executor::execute_subscription(
 
 void
 Executor::execute_intra_process_subscription(
-  rclcpp::subscription::SubscriptionBase::SharedPtr subscription)
+  rclcpp::SubscriptionBase::SharedPtr subscription)
 {
   rcl_interfaces::msg::IntraProcessMessage ipm;
   rmw_message_info_t message_info;

--- a/rclcpp/src/rclcpp/executors.cpp
+++ b/rclcpp/src/rclcpp/executors.cpp
@@ -22,7 +22,7 @@ rclcpp::spin_some(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr
 }
 
 void
-rclcpp::spin_some(rclcpp::node::Node::SharedPtr node_ptr)
+rclcpp::spin_some(rclcpp::Node::SharedPtr node_ptr)
 {
   rclcpp::spin_some(node_ptr->get_node_base_interface());
 }
@@ -37,7 +37,7 @@ rclcpp::spin(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr)
 }
 
 void
-rclcpp::spin(rclcpp::node::Node::SharedPtr node_ptr)
+rclcpp::spin(rclcpp::Node::SharedPtr node_ptr)
 {
   rclcpp::spin(node_ptr->get_node_base_interface());
 }

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -66,11 +66,11 @@ MultiThreadedExecutor::get_number_of_threads()
 void
 MultiThreadedExecutor::run(size_t)
 {
-  while (rclcpp::utilities::ok() && spinning.load()) {
+  while (rclcpp::ok() && spinning.load()) {
     executor::AnyExecutable::SharedPtr any_exec;
     {
       std::lock_guard<std::mutex> wait_lock(wait_mutex_);
-      if (!rclcpp::utilities::ok() || !spinning.load()) {
+      if (!rclcpp::ok() || !spinning.load()) {
         return;
       }
       any_exec = get_next_executable();

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -21,7 +21,7 @@
 #include "rclcpp/utilities.hpp"
 #include "rclcpp/scope_exit.hpp"
 
-using rclcpp::executors::multi_threaded_executor::MultiThreadedExecutor;
+using rclcpp::executors::MultiThreadedExecutor;
 
 MultiThreadedExecutor::MultiThreadedExecutor(const rclcpp::executor::ExecutorArgs & args)
 : executor::Executor(args)

--- a/rclcpp/src/rclcpp/executors/single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/single_threaded_executor.cpp
@@ -15,7 +15,7 @@
 #include "rclcpp/executors/single_threaded_executor.hpp"
 #include "rclcpp/scope_exit.hpp"
 
-using rclcpp::executors::single_threaded_executor::SingleThreadedExecutor;
+using rclcpp::executors::SingleThreadedExecutor;
 
 SingleThreadedExecutor::SingleThreadedExecutor(const rclcpp::executor::ExecutorArgs & args)
 : executor::Executor(args) {}

--- a/rclcpp/src/rclcpp/executors/single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/single_threaded_executor.cpp
@@ -29,7 +29,7 @@ SingleThreadedExecutor::spin()
     throw std::runtime_error("spin() called while already spinning");
   }
   RCLCPP_SCOPE_EXIT(this->spinning.store(false); );
-  while (rclcpp::utilities::ok() && spinning.load()) {
+  while (rclcpp::ok() && spinning.load()) {
     auto any_exec = get_next_executable();
     execute_any_executable(any_exec);
   }

--- a/rclcpp/src/rclcpp/graph_listener.cpp
+++ b/rclcpp/src/rclcpp/graph_listener.cpp
@@ -43,7 +43,7 @@ GraphListener::GraphListener()
     throw_from_rcl_error(ret, "failed to create interrupt guard condition");
   }
 
-  shutdown_guard_condition_ = rclcpp::utilities::get_sigint_guard_condition(&wait_set_);
+  shutdown_guard_condition_ = rclcpp::get_sigint_guard_condition(&wait_set_);
 }
 
 GraphListener::~GraphListener()
@@ -75,7 +75,7 @@ GraphListener::start_if_not_started()
     // This is important to ensure that the wait set is finalized before
     // destruction of static objects occurs.
     std::weak_ptr<GraphListener> weak_this = shared_from_this();
-    rclcpp::utilities::on_shutdown(
+    rclcpp::on_shutdown(
       [weak_this]() {
         auto shared_this = weak_this.lock();
         if (shared_this) {
@@ -335,7 +335,7 @@ GraphListener::shutdown()
       throw_from_rcl_error(ret, "failed to finalize interrupt guard condition");
     }
     if (shutdown_guard_condition_) {
-      rclcpp::utilities::release_sigint_guard_condition(&wait_set_);
+      rclcpp::release_sigint_guard_condition(&wait_set_);
       shutdown_guard_condition_ = nullptr;
     }
     if (is_started_) {

--- a/rclcpp/src/rclcpp/intra_process_manager.cpp
+++ b/rclcpp/src/rclcpp/intra_process_manager.cpp
@@ -31,7 +31,7 @@ IntraProcessManager::~IntraProcessManager()
 
 uint64_t
 IntraProcessManager::add_subscription(
-  rclcpp::subscription::SubscriptionBase::SharedPtr subscription)
+  rclcpp::SubscriptionBase::SharedPtr subscription)
 {
   auto id = IntraProcessManager::get_next_unique_id();
   impl_->add_subscription(id, subscription);

--- a/rclcpp/src/rclcpp/memory_strategy.cpp
+++ b/rclcpp/src/rclcpp/memory_strategy.cpp
@@ -72,7 +72,7 @@ MemoryStrategy::get_service_by_handle(
   return nullptr;
 }
 
-rclcpp::client::ClientBase::SharedPtr
+rclcpp::ClientBase::SharedPtr
 MemoryStrategy::get_client_by_handle(
   const rcl_client_t * client_handle,
   const WeakNodeVector & weak_nodes)
@@ -175,7 +175,7 @@ MemoryStrategy::get_group_by_service(
 
 rclcpp::callback_group::CallbackGroup::SharedPtr
 MemoryStrategy::get_group_by_client(
-  rclcpp::client::ClientBase::SharedPtr client,
+  rclcpp::ClientBase::SharedPtr client,
   const WeakNodeVector & weak_nodes)
 {
   for (auto & weak_node : weak_nodes) {

--- a/rclcpp/src/rclcpp/memory_strategy.cpp
+++ b/rclcpp/src/rclcpp/memory_strategy.cpp
@@ -16,7 +16,7 @@
 
 using rclcpp::memory_strategy::MemoryStrategy;
 
-rclcpp::subscription::SubscriptionBase::SharedPtr
+rclcpp::SubscriptionBase::SharedPtr
 MemoryStrategy::get_subscription_by_handle(
   const rcl_subscription_t * subscriber_handle, const WeakNodeVector & weak_nodes)
 {
@@ -123,7 +123,7 @@ MemoryStrategy::get_node_by_group(
 
 rclcpp::callback_group::CallbackGroup::SharedPtr
 MemoryStrategy::get_group_by_subscription(
-  rclcpp::subscription::SubscriptionBase::SharedPtr subscription,
+  rclcpp::SubscriptionBase::SharedPtr subscription,
   const WeakNodeVector & weak_nodes)
 {
   for (auto & weak_node : weak_nodes) {

--- a/rclcpp/src/rclcpp/memory_strategy.cpp
+++ b/rclcpp/src/rclcpp/memory_strategy.cpp
@@ -46,7 +46,7 @@ MemoryStrategy::get_subscription_by_handle(
   return nullptr;
 }
 
-rclcpp::service::ServiceBase::SharedPtr
+rclcpp::ServiceBase::SharedPtr
 MemoryStrategy::get_service_by_handle(
   const rcl_service_t * service_handle,
   const WeakNodeVector & weak_nodes)
@@ -149,7 +149,7 @@ MemoryStrategy::get_group_by_subscription(
 
 rclcpp::callback_group::CallbackGroup::SharedPtr
 MemoryStrategy::get_group_by_service(
-  rclcpp::service::ServiceBase::SharedPtr service,
+  rclcpp::ServiceBase::SharedPtr service,
   const WeakNodeVector & weak_nodes)
 {
   for (auto & weak_node : weak_nodes) {

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -190,7 +190,7 @@ Node::get_callback_groups() const
   return node_base_->get_callback_groups();
 }
 
-rclcpp::event::Event::SharedPtr
+rclcpp::Event::SharedPtr
 Node::get_graph_event()
 {
   return node_graph_->get_graph_event();
@@ -198,7 +198,7 @@ Node::get_graph_event()
 
 void
 Node::wait_for_graph_change(
-  rclcpp::event::Event::SharedPtr event,
+  rclcpp::Event::SharedPtr event,
   std::chrono::nanoseconds timeout)
 {
   node_graph_->wait_for_graph_change(event, timeout);

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -32,7 +32,7 @@
 #include "rclcpp/node_interfaces/node_timers.hpp"
 #include "rclcpp/node_interfaces/node_topics.hpp"
 
-using rclcpp::node::Node;
+using rclcpp::Node;
 using rclcpp::exceptions::throw_from_rcl_error;
 
 Node::Node(

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -49,7 +49,7 @@ Node::Node(
 Node::Node(
   const std::string & node_name,
   const std::string & namespace_,
-  rclcpp::context::Context::SharedPtr context,
+  rclcpp::Context::SharedPtr context,
   bool use_intra_process_comms)
 : node_base_(new rclcpp::node_interfaces::NodeBase(node_name, namespace_, context)),
   node_graph_(new rclcpp::node_interfaces::NodeGraph(node_base_.get())),

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -30,7 +30,7 @@ using rclcpp::node_interfaces::NodeBase;
 NodeBase::NodeBase(
   const std::string & node_name,
   const std::string & namespace_,
-  rclcpp::context::Context::SharedPtr context)
+  rclcpp::Context::SharedPtr context)
 : context_(context),
   node_handle_(nullptr),
   default_callback_group_(nullptr),
@@ -176,7 +176,7 @@ NodeBase::get_namespace() const
   return rcl_node_get_namespace(node_handle_.get());
 }
 
-rclcpp::context::Context::SharedPtr
+rclcpp::Context::SharedPtr
 NodeBase::get_context()
 {
   return context_;

--- a/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
@@ -297,7 +297,7 @@ NodeGraph::wait_for_graph_change(
     }
   }
   auto pred = [&event]() {
-      return event->check() || !rclcpp::utilities::ok();
+      return event->check() || !rclcpp::ok();
     };
   std::unique_lock<std::mutex> graph_lock(graph_mutex_);
   if (!pred()) {

--- a/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
@@ -233,7 +233,7 @@ NodeGraph::notify_graph_change()
         std::remove_if(
           graph_events_.begin(),
           graph_events_.end(),
-          [](const rclcpp::event::Event::WeakPtr & wptr) {
+          [](const rclcpp::Event::WeakPtr & wptr) {
             return wptr.expired();
           }),
         graph_events_.end());
@@ -258,10 +258,10 @@ NodeGraph::notify_shutdown()
   graph_cv_.notify_all();
 }
 
-rclcpp::event::Event::SharedPtr
+rclcpp::Event::SharedPtr
 NodeGraph::get_graph_event()
 {
-  auto event = rclcpp::event::Event::make_shared();
+  auto event = rclcpp::Event::make_shared();
   std::lock_guard<std::mutex> graph_changed_lock(graph_mutex_);
   graph_events_.push_back(event);
   graph_users_count_++;
@@ -275,7 +275,7 @@ NodeGraph::get_graph_event()
 
 void
 NodeGraph::wait_for_graph_change(
-  rclcpp::event::Event::SharedPtr event,
+  rclcpp::Event::SharedPtr event,
   std::chrono::nanoseconds timeout)
 {
   using rclcpp::exceptions::InvalidEventError;

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -33,7 +33,7 @@ NodeParameters::NodeParameters(
 : node_topics_(node_topics)
 {
   using MessageT = rcl_interfaces::msg::ParameterEvent;
-  using PublisherT = rclcpp::publisher::Publisher<MessageT>;
+  using PublisherT = rclcpp::Publisher<MessageT>;
   using AllocatorT = std::allocator<void>;
   // TODO(wjwwood): expose this allocator through the Parameter interface.
   auto allocator = std::make_shared<AllocatorT>();

--- a/rclcpp/src/rclcpp/node_interfaces/node_services.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_services.cpp
@@ -54,7 +54,7 @@ NodeServices::add_service(
 
 void
 NodeServices::add_client(
-  rclcpp::client::ClientBase::SharedPtr client_base_ptr,
+  rclcpp::ClientBase::SharedPtr client_base_ptr,
   rclcpp::callback_group::CallbackGroup::SharedPtr group)
 {
   if (group) {

--- a/rclcpp/src/rclcpp/node_interfaces/node_services.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_services.cpp
@@ -27,7 +27,7 @@ NodeServices::~NodeServices()
 
 void
 NodeServices::add_service(
-  rclcpp::service::ServiceBase::SharedPtr service_base_ptr,
+  rclcpp::ServiceBase::SharedPtr service_base_ptr,
   rclcpp::callback_group::CallbackGroup::SharedPtr group)
 {
   if (group) {

--- a/rclcpp/src/rclcpp/node_interfaces/node_timers.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_timers.cpp
@@ -27,7 +27,7 @@ NodeTimers::~NodeTimers()
 
 void
 NodeTimers::add_timer(
-  rclcpp::timer::TimerBase::SharedPtr timer,
+  rclcpp::TimerBase::SharedPtr timer,
   rclcpp::callback_group::CallbackGroup::SharedPtr callback_group)
 {
   if (callback_group) {

--- a/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
@@ -79,7 +79,7 @@ NodeTopics::add_publisher(
   }
 }
 
-rclcpp::subscription::SubscriptionBase::SharedPtr
+rclcpp::SubscriptionBase::SharedPtr
 NodeTopics::create_subscription(
   const std::string & topic_name,
   const rclcpp::SubscriptionFactory & subscription_factory,
@@ -104,7 +104,7 @@ NodeTopics::create_subscription(
 
 void
 NodeTopics::add_subscription(
-  rclcpp::subscription::SubscriptionBase::SharedPtr subscription,
+  rclcpp::SubscriptionBase::SharedPtr subscription,
   rclcpp::callback_group::CallbackGroup::SharedPtr callback_group)
 {
   // Assign to a group.

--- a/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
@@ -30,7 +30,7 @@ NodeTopics::NodeTopics(rclcpp::node_interfaces::NodeBaseInterface * node_base)
 NodeTopics::~NodeTopics()
 {}
 
-rclcpp::publisher::PublisherBase::SharedPtr
+rclcpp::PublisherBase::SharedPtr
 NodeTopics::create_publisher(
   const std::string & topic_name,
   const rclcpp::PublisherFactory & publisher_factory,
@@ -63,7 +63,7 @@ NodeTopics::create_publisher(
 
 void
 NodeTopics::add_publisher(
-  rclcpp::publisher::PublisherBase::SharedPtr publisher)
+  rclcpp::PublisherBase::SharedPtr publisher)
 {
   // The publisher is not added to a callback group or anthing like that for now.
   // It may be stored within the NodeTopics class or the NodeBase class in the future.

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -42,8 +42,8 @@ AsyncParametersClient::AsyncParametersClient(
   rcl_client_options_t options = rcl_client_get_default_options();
   options.qos = qos_profile;
 
-  using rclcpp::client::Client;
-  using rclcpp::client::ClientBase;
+  using rclcpp::Client;
+  using rclcpp::ClientBase;
 
   get_parameters_client_ = Client<rcl_interfaces::srv::GetParameters>::make_shared(
     node_base_interface.get(),
@@ -131,7 +131,7 @@ AsyncParametersClient::get_parameters(
   get_parameters_client_->async_send_request(
     request,
     [request, promise_result, future_result, callback](
-      rclcpp::client::Client<rcl_interfaces::srv::GetParameters>::SharedFuture cb_f)
+      rclcpp::Client<rcl_interfaces::srv::GetParameters>::SharedFuture cb_f)
     {
       std::vector<rclcpp::parameter::ParameterVariant> parameter_variants;
       auto & pvalues = cb_f.get()->values;
@@ -172,7 +172,7 @@ AsyncParametersClient::get_parameter_types(
   get_parameter_types_client_->async_send_request(
     request,
     [promise_result, future_result, callback](
-      rclcpp::client::Client<rcl_interfaces::srv::GetParameterTypes>::SharedFuture cb_f)
+      rclcpp::Client<rcl_interfaces::srv::GetParameterTypes>::SharedFuture cb_f)
     {
       std::vector<rclcpp::parameter::ParameterType> types;
       auto & pts = cb_f.get()->types;
@@ -211,7 +211,7 @@ AsyncParametersClient::set_parameters(
   set_parameters_client_->async_send_request(
     request,
     [promise_result, future_result, callback](
-      rclcpp::client::Client<rcl_interfaces::srv::SetParameters>::SharedFuture cb_f)
+      rclcpp::Client<rcl_interfaces::srv::SetParameters>::SharedFuture cb_f)
     {
       promise_result->set_value(cb_f.get()->results);
       if (callback != nullptr) {
@@ -245,7 +245,7 @@ AsyncParametersClient::set_parameters_atomically(
   set_parameters_atomically_client_->async_send_request(
     request,
     [promise_result, future_result, callback](
-      rclcpp::client::Client<rcl_interfaces::srv::SetParametersAtomically>::SharedFuture cb_f)
+      rclcpp::Client<rcl_interfaces::srv::SetParametersAtomically>::SharedFuture cb_f)
     {
       promise_result->set_value(cb_f.get()->result);
       if (callback != nullptr) {
@@ -276,7 +276,7 @@ AsyncParametersClient::list_parameters(
   list_parameters_client_->async_send_request(
     request,
     [promise_result, future_result, callback](
-      rclcpp::client::Client<rcl_interfaces::srv::ListParameters>::SharedFuture cb_f)
+      rclcpp::Client<rcl_interfaces::srv::ListParameters>::SharedFuture cb_f)
     {
       promise_result->set_value(cb_f.get()->result);
       if (callback != nullptr) {
@@ -302,7 +302,7 @@ AsyncParametersClient::service_is_ready() const
 bool
 AsyncParametersClient::wait_for_service_nanoseconds(std::chrono::nanoseconds timeout)
 {
-  const std::vector<std::shared_ptr<rclcpp::client::ClientBase>> clients = {
+  const std::vector<std::shared_ptr<rclcpp::ClientBase>> clients = {
     get_parameters_client_,
     get_parameter_types_client_,
     set_parameters_client_,

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -21,8 +21,8 @@
 
 #include "./parameter_service_names.hpp"
 
-using rclcpp::parameter_client::AsyncParametersClient;
-using rclcpp::parameter_client::SyncParametersClient;
+using rclcpp::AsyncParametersClient;
+using rclcpp::SyncParametersClient;
 
 AsyncParametersClient::AsyncParametersClient(
   const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -89,7 +89,7 @@ AsyncParametersClient::AsyncParametersClient(
 }
 
 AsyncParametersClient::AsyncParametersClient(
-  const rclcpp::node::Node::SharedPtr node,
+  const rclcpp::Node::SharedPtr node,
   const std::string & remote_node_name,
   const rmw_qos_profile_t & qos_profile)
 : AsyncParametersClient(
@@ -102,7 +102,7 @@ AsyncParametersClient::AsyncParametersClient(
 {}
 
 AsyncParametersClient::AsyncParametersClient(
-  rclcpp::node::Node * node,
+  rclcpp::Node * node,
   const std::string & remote_node_name,
   const rmw_qos_profile_t & qos_profile)
 : AsyncParametersClient(
@@ -326,7 +326,7 @@ AsyncParametersClient::wait_for_service_nanoseconds(std::chrono::nanoseconds tim
 }
 
 SyncParametersClient::SyncParametersClient(
-  rclcpp::node::Node::SharedPtr node,
+  rclcpp::Node::SharedPtr node,
   const std::string & remote_node_name,
   const rmw_qos_profile_t & qos_profile)
 : SyncParametersClient(
@@ -338,7 +338,7 @@ SyncParametersClient::SyncParametersClient(
 
 SyncParametersClient::SyncParametersClient(
   rclcpp::executor::Executor::SharedPtr executor,
-  rclcpp::node::Node::SharedPtr node,
+  rclcpp::Node::SharedPtr node,
   const std::string & remote_node_name,
   const rmw_qos_profile_t & qos_profile)
 : executor_(executor), node_(node)

--- a/rclcpp/src/rclcpp/parameter_service.cpp
+++ b/rclcpp/src/rclcpp/parameter_service.cpp
@@ -24,11 +24,11 @@
 using rclcpp::ParameterService;
 
 ParameterService::ParameterService(
-  const rclcpp::node::Node::SharedPtr node,
+  const rclcpp::Node::SharedPtr node,
   const rmw_qos_profile_t & qos_profile)
 : node_(node)
 {
-  std::weak_ptr<rclcpp::node::Node> captured_node = node_;
+  std::weak_ptr<rclcpp::Node> captured_node = node_;
   get_parameters_service_ = node_->create_service<rcl_interfaces::srv::GetParameters>(
     std::string(node_->get_name()) + "/" + parameter_service_names::get_parameters,
     [captured_node](

--- a/rclcpp/src/rclcpp/parameter_service.cpp
+++ b/rclcpp/src/rclcpp/parameter_service.cpp
@@ -21,7 +21,7 @@
 
 #include "./parameter_service_names.hpp"
 
-using rclcpp::parameter_service::ParameterService;
+using rclcpp::ParameterService;
 
 ParameterService::ParameterService(
   const rclcpp::node::Node::SharedPtr node,

--- a/rclcpp/src/rclcpp/publisher.cpp
+++ b/rclcpp/src/rclcpp/publisher.cpp
@@ -33,7 +33,7 @@
 #include "rclcpp/node.hpp"
 #include "rclcpp/expand_topic_or_service_name.hpp"
 
-using rclcpp::publisher::PublisherBase;
+using rclcpp::PublisherBase;
 
 PublisherBase::PublisherBase(
   rclcpp::node_interfaces::NodeBaseInterface * node_base,

--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -25,7 +25,7 @@
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"
 
-using rclcpp::service::ServiceBase;
+using rclcpp::ServiceBase;
 
 ServiceBase::ServiceBase(
   std::shared_ptr<rcl_node_t> node_handle,

--- a/rclcpp/src/rclcpp/subscription.cpp
+++ b/rclcpp/src/rclcpp/subscription.cpp
@@ -25,7 +25,7 @@
 #include "rmw/rmw.h"
 
 
-using rclcpp::subscription::SubscriptionBase;
+using rclcpp::SubscriptionBase;
 
 SubscriptionBase::SubscriptionBase(
   std::shared_ptr<rcl_node_t> node_handle,

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -33,7 +33,7 @@
 namespace rclcpp
 {
 
-TimeSource::TimeSource(std::shared_ptr<rclcpp::node::Node> node)
+TimeSource::TimeSource(std::shared_ptr<rclcpp::Node> node)
 : ros_time_active_(false)
 {
   this->attachNode(node);
@@ -44,7 +44,7 @@ TimeSource::TimeSource()
 {
 }
 
-void TimeSource::attachNode(rclcpp::node::Node::SharedPtr node)
+void TimeSource::attachNode(rclcpp::Node::SharedPtr node)
 {
   attachNode(
     node->get_node_base_interface(),

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -85,7 +85,7 @@ void TimeSource::attachNode(
     msg_mem_strat,
     allocator);
 
-  parameter_client_ = std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(
+  parameter_client_ = std::make_shared<rclcpp::AsyncParametersClient>(
     node_base_,
     node_topics_,
     node_graph_,

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -17,7 +17,7 @@
 #include <chrono>
 #include <string>
 
-using rclcpp::timer::TimerBase;
+using rclcpp::TimerBase;
 
 TimerBase::TimerBase(std::chrono::nanoseconds period)
 {

--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -157,7 +157,7 @@ signal_handler(int signal_value)
 }
 
 void
-rclcpp::utilities::init(int argc, char * argv[])
+rclcpp::init(int argc, char * argv[])
 {
   g_is_interrupted.store(false);
   if (rcl_init(argc, argv, rcl_get_default_allocator()) != RCL_RET_OK) {
@@ -174,14 +174,14 @@ rclcpp::utilities::init(int argc, char * argv[])
   action.sa_flags = SA_SIGINFO;
   ::old_action = set_sigaction(SIGINT, action);
   // Register an on_shutdown hook to restore the old action.
-  rclcpp::utilities::on_shutdown(
+  rclcpp::on_shutdown(
     []() {
       set_sigaction(SIGINT, ::old_action);
     });
 #else
   ::old_signal_handler = set_signal_handler(SIGINT, ::signal_handler);
   // Register an on_shutdown hook to restore the old signal handler.
-  rclcpp::utilities::on_shutdown(
+  rclcpp::on_shutdown(
     []() {
       set_signal_handler(SIGINT, ::old_signal_handler);
     });
@@ -189,7 +189,7 @@ rclcpp::utilities::init(int argc, char * argv[])
 }
 
 bool
-rclcpp::utilities::ok()
+rclcpp::ok()
 {
   return ::g_signal_status == 0;
 }
@@ -198,7 +198,7 @@ static std::mutex on_shutdown_mutex_;
 static std::vector<std::function<void(void)>> on_shutdown_callbacks_;
 
 void
-rclcpp::utilities::shutdown()
+rclcpp::shutdown()
 {
   trigger_interrupt_guard_condition(SIGINT);
 
@@ -211,14 +211,14 @@ rclcpp::utilities::shutdown()
 }
 
 void
-rclcpp::utilities::on_shutdown(std::function<void(void)> callback)
+rclcpp::on_shutdown(std::function<void(void)> callback)
 {
   std::lock_guard<std::mutex> lock(on_shutdown_mutex_);
   on_shutdown_callbacks_.push_back(callback);
 }
 
 rcl_guard_condition_t *
-rclcpp::utilities::get_sigint_guard_condition(rcl_wait_set_t * wait_set)
+rclcpp::get_sigint_guard_condition(rcl_wait_set_t * wait_set)
 {
   std::lock_guard<std::mutex> lock(g_sigint_guard_cond_handles_mutex);
   auto kv = g_sigint_guard_cond_handles.find(wait_set);
@@ -240,7 +240,7 @@ rclcpp::utilities::get_sigint_guard_condition(rcl_wait_set_t * wait_set)
 }
 
 void
-rclcpp::utilities::release_sigint_guard_condition(rcl_wait_set_t * wait_set)
+rclcpp::release_sigint_guard_condition(rcl_wait_set_t * wait_set)
 {
   std::lock_guard<std::mutex> lock(g_sigint_guard_cond_handles_mutex);
   auto kv = g_sigint_guard_cond_handles.find(wait_set);
@@ -262,7 +262,7 @@ rclcpp::utilities::release_sigint_guard_condition(rcl_wait_set_t * wait_set)
 }
 
 bool
-rclcpp::utilities::sleep_for(const std::chrono::nanoseconds & nanoseconds)
+rclcpp::sleep_for(const std::chrono::nanoseconds & nanoseconds)
 {
   std::chrono::nanoseconds time_left = nanoseconds;
   {

--- a/rclcpp/test/test_client.cpp
+++ b/rclcpp/test/test_client.cpp
@@ -32,7 +32,7 @@ protected:
 
   void SetUp()
   {
-    node = std::make_shared<rclcpp::node::Node>("my_node", "/ns");
+    node = std::make_shared<rclcpp::Node>("my_node", "/ns");
   }
 
   void TearDown()
@@ -40,7 +40,7 @@ protected:
     node.reset();
   }
 
-  rclcpp::node::Node::SharedPtr node;
+  rclcpp::Node::SharedPtr node;
 };
 
 /*

--- a/rclcpp/test/test_executor.cpp
+++ b/rclcpp/test/test_executor.cpp
@@ -38,7 +38,7 @@ protected:
 
   void SetUp()
   {
-    node = std::make_shared<rclcpp::node::Node>("my_node");
+    node = std::make_shared<rclcpp::Node>("my_node");
   }
 
   void TearDown()
@@ -46,7 +46,7 @@ protected:
     node.reset();
   }
 
-  rclcpp::node::Node::SharedPtr node;
+  rclcpp::Node::SharedPtr node;
 };
 
 // Make sure that executors detach from nodes when destructing

--- a/rclcpp/test/test_externally_defined_services.cpp
+++ b/rclcpp/test/test_externally_defined_services.cpp
@@ -67,7 +67,7 @@ TEST_F(TestExternallyDefinedServices, extern_defined_uninitialized) {
   // don't initialize the service
   // expect fail
   try {
-    rclcpp::service::Service<rclcpp::srv::Mock>(
+    rclcpp::Service<rclcpp::srv::Mock>(
       node_handle->get_node_base_interface()->get_shared_rcl_node_handle(),
       &service_handle, cb);
   } catch (const std::runtime_error &) {
@@ -98,7 +98,7 @@ TEST_F(TestExternallyDefinedServices, extern_defined_initialized) {
   rclcpp::any_service_callback::AnyServiceCallback<rclcpp::srv::Mock> cb;
 
   try {
-    rclcpp::service::Service<rclcpp::srv::Mock>(
+    rclcpp::Service<rclcpp::srv::Mock>(
       node_handle->get_node_base_interface()->get_shared_rcl_node_handle(),
       &service_handle, cb);
   } catch (const std::runtime_error &) {
@@ -129,7 +129,7 @@ TEST_F(TestExternallyDefinedServices, extern_defined_destructor) {
 
   {
     // Call constructor
-    rclcpp::service::Service<rclcpp::srv::Mock> srv_cpp(
+    rclcpp::Service<rclcpp::srv::Mock> srv_cpp(
       node_handle->get_node_base_interface()->get_shared_rcl_node_handle(),
       &service_handle, cb);
     // Call destructor

--- a/rclcpp/test/test_externally_defined_services.cpp
+++ b/rclcpp/test/test_externally_defined_services.cpp
@@ -62,7 +62,7 @@ TEST_F(TestExternallyDefinedServices, extern_defined_uninitialized) {
   // mock for externally defined service
   rcl_service_t service_handle = rcl_get_zero_initialized_service();
 
-  rclcpp::any_service_callback::AnyServiceCallback<rclcpp::srv::Mock> cb;
+  rclcpp::AnyServiceCallback<rclcpp::srv::Mock> cb;
 
   // don't initialize the service
   // expect fail
@@ -95,7 +95,7 @@ TEST_F(TestExternallyDefinedServices, extern_defined_initialized) {
     return;
   }
 
-  rclcpp::any_service_callback::AnyServiceCallback<rclcpp::srv::Mock> cb;
+  rclcpp::AnyServiceCallback<rclcpp::srv::Mock> cb;
 
   try {
     rclcpp::Service<rclcpp::srv::Mock>(
@@ -125,7 +125,7 @@ TEST_F(TestExternallyDefinedServices, extern_defined_destructor) {
     FAIL();
     return;
   }
-  rclcpp::any_service_callback::AnyServiceCallback<rclcpp::srv::Mock> cb;
+  rclcpp::AnyServiceCallback<rclcpp::srv::Mock> cb;
 
   {
     // Call constructor

--- a/rclcpp/test/test_externally_defined_services.cpp
+++ b/rclcpp/test/test_externally_defined_services.cpp
@@ -43,7 +43,7 @@ callback(
 {}
 
 TEST_F(TestExternallyDefinedServices, default_behavior) {
-  auto node_handle = rclcpp::node::Node::make_shared("base_node");
+  auto node_handle = rclcpp::Node::make_shared("base_node");
 
   try {
     auto srv = node_handle->create_service<rclcpp::srv::Mock>("test",
@@ -57,7 +57,7 @@ TEST_F(TestExternallyDefinedServices, default_behavior) {
 
 
 TEST_F(TestExternallyDefinedServices, extern_defined_uninitialized) {
-  auto node_handle = rclcpp::node::Node::make_shared("base_node");
+  auto node_handle = rclcpp::Node::make_shared("base_node");
 
   // mock for externally defined service
   rcl_service_t service_handle = rcl_get_zero_initialized_service();
@@ -79,7 +79,7 @@ TEST_F(TestExternallyDefinedServices, extern_defined_uninitialized) {
 }
 
 TEST_F(TestExternallyDefinedServices, extern_defined_initialized) {
-  auto node_handle = rclcpp::node::Node::make_shared("base_node");
+  auto node_handle = rclcpp::Node::make_shared("base_node");
 
   // mock for externally defined service
   rcl_service_t service_handle = rcl_get_zero_initialized_service();
@@ -110,7 +110,7 @@ TEST_F(TestExternallyDefinedServices, extern_defined_initialized) {
 }
 
 TEST_F(TestExternallyDefinedServices, extern_defined_destructor) {
-  auto node_handle = rclcpp::node::Node::make_shared("base_node");
+  auto node_handle = rclcpp::Node::make_shared("base_node");
 
   // mock for externally defined service
   rcl_service_t service_handle = rcl_get_zero_initialized_service();

--- a/rclcpp/test/test_find_weak_nodes.cpp
+++ b/rclcpp/test/test_find_weak_nodes.cpp
@@ -34,8 +34,8 @@ TEST_F(TestFindWeakNodes, allocator_strategy_with_weak_nodes) {
   // A vector of weak pointers to nodes
   auto memory_strategy = std::make_shared<
     rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy<>>();
-  auto existing_node = rclcpp::node::Node::make_shared("existing_node");
-  auto dead_node = rclcpp::node::Node::make_shared("dead_node");
+  auto existing_node = rclcpp::Node::make_shared("existing_node");
+  auto dead_node = rclcpp::Node::make_shared("dead_node");
   rclcpp::memory_strategy::MemoryStrategy::WeakNodeVector weak_nodes;
   weak_nodes.push_back(existing_node->get_node_base_interface());
   weak_nodes.push_back(dead_node->get_node_base_interface());
@@ -59,8 +59,8 @@ TEST_F(TestFindWeakNodes, allocator_strategy_no_weak_nodes) {
   // A vector of weak pointers to nodes, all valid
   auto memory_strategy = std::make_shared<
     rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy<>>();
-  auto existing_node1 = rclcpp::node::Node::make_shared("existing_node1");
-  auto existing_node2 = rclcpp::node::Node::make_shared("existing_node2");
+  auto existing_node1 = rclcpp::Node::make_shared("existing_node1");
+  auto existing_node2 = rclcpp::Node::make_shared("existing_node2");
   rclcpp::memory_strategy::MemoryStrategy::WeakNodeVector weak_nodes;
   weak_nodes.push_back(existing_node1->get_node_base_interface());
   weak_nodes.push_back(existing_node2->get_node_base_interface());

--- a/rclcpp/test/test_intra_process_manager.cpp
+++ b/rclcpp/test/test_intra_process_manager.cpp
@@ -23,8 +23,6 @@
 // Mock up publisher and subscription base to avoid needing an rmw impl.
 namespace rclcpp
 {
-namespace publisher
-{
 namespace mock
 {
 
@@ -80,7 +78,6 @@ public:
 };
 
 }  // namespace mock
-}  // namespace publisher
 }  // namespace rclcpp
 
 namespace rclcpp
@@ -146,13 +143,13 @@ TEST(TestIntraProcessManager, nominal) {
   rclcpp::intra_process_manager::IntraProcessManager ipm;
 
   auto p1 = std::make_shared<
-    rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
+    rclcpp::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
     >();
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 2;
 
   auto p2 = std::make_shared<
-    rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
+    rclcpp::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
     >();
   p2->mock_topic_name = "nominal2";
   p2->mock_queue_size = 10;
@@ -237,7 +234,7 @@ TEST(TestIntraProcessManager, remove_publisher_before_trying_to_take) {
   rclcpp::intra_process_manager::IntraProcessManager ipm;
 
   auto p1 = std::make_shared<
-    rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
+    rclcpp::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
     >();
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 10;
@@ -279,7 +276,7 @@ TEST(TestIntraProcessManager, removed_subscription_affects_take) {
   rclcpp::intra_process_manager::IntraProcessManager ipm;
 
   auto p1 = std::make_shared<
-    rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
+    rclcpp::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
     >();
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 10;
@@ -350,7 +347,7 @@ TEST(TestIntraProcessManager, multiple_subscriptions_one_publisher) {
   rclcpp::intra_process_manager::IntraProcessManager ipm;
 
   auto p1 = std::make_shared<
-    rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
+    rclcpp::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
     >();
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 10;
@@ -422,19 +419,19 @@ TEST(TestIntraProcessManager, multiple_publishers_one_subscription) {
   rclcpp::intra_process_manager::IntraProcessManager ipm;
 
   auto p1 = std::make_shared<
-    rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
+    rclcpp::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
     >();
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 10;
 
   auto p2 = std::make_shared<
-    rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
+    rclcpp::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
     >();
   p2->mock_topic_name = "nominal1";
   p2->mock_queue_size = 10;
 
   auto p3 = std::make_shared<
-    rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
+    rclcpp::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
     >();
   p3->mock_topic_name = "nominal1";
   p3->mock_queue_size = 10;
@@ -522,19 +519,19 @@ TEST(TestIntraProcessManager, multiple_publishers_multiple_subscription) {
   rclcpp::intra_process_manager::IntraProcessManager ipm;
 
   auto p1 = std::make_shared<
-    rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
+    rclcpp::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
     >();
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 10;
 
   auto p2 = std::make_shared<
-    rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
+    rclcpp::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
     >();
   p2->mock_topic_name = "nominal1";
   p2->mock_queue_size = 10;
 
   auto p3 = std::make_shared<
-    rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
+    rclcpp::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
     >();
   p3->mock_topic_name = "nominal1";
   p3->mock_queue_size = 10;
@@ -689,7 +686,7 @@ TEST(TestIntraProcessManager, ring_buffer_displacement) {
   rclcpp::intra_process_manager::IntraProcessManager ipm;
 
   auto p1 = std::make_shared<
-    rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
+    rclcpp::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
     >();
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 2;
@@ -760,7 +757,7 @@ TEST(TestIntraProcessManager, subscription_creation_race_condition) {
   rclcpp::intra_process_manager::IntraProcessManager ipm;
 
   auto p1 = std::make_shared<
-    rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
+    rclcpp::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
     >();
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 2;
@@ -809,7 +806,7 @@ TEST(TestIntraProcessManager, publisher_out_of_scope_take) {
   uint64_t p1_m1_id;
   {
     auto p1 = std::make_shared<
-      rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
+      rclcpp::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
       >();
     p1->mock_topic_name = "nominal1";
     p1->mock_queue_size = 2;
@@ -848,7 +845,7 @@ TEST(TestIntraProcessManager, publisher_out_of_scope_store) {
   uint64_t p1_id;
   {
     auto p1 = std::make_shared<
-      rclcpp::publisher::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
+      rclcpp::mock::Publisher<rcl_interfaces::msg::IntraProcessMessage>
       >();
     p1->mock_topic_name = "nominal1";
     p1->mock_queue_size = 2;

--- a/rclcpp/test/test_intra_process_manager.cpp
+++ b/rclcpp/test/test_intra_process_manager.cpp
@@ -82,8 +82,6 @@ public:
 
 namespace rclcpp
 {
-namespace subscription
-{
 namespace mock
 {
 
@@ -109,7 +107,6 @@ public:
 };
 
 }  // namespace mock
-}  // namespace subscription
 }  // namespace rclcpp
 
 // Prevent rclcpp/publisher.hpp and rclcpp/subscription.hpp from being imported.
@@ -154,7 +151,7 @@ TEST(TestIntraProcessManager, nominal) {
   p2->mock_topic_name = "nominal2";
   p2->mock_queue_size = 10;
 
-  auto s1 = std::make_shared<rclcpp::subscription::mock::SubscriptionBase>();
+  auto s1 = std::make_shared<rclcpp::mock::SubscriptionBase>();
   s1->mock_topic_name = "nominal1";
   s1->mock_queue_size = 10;
 
@@ -239,7 +236,7 @@ TEST(TestIntraProcessManager, remove_publisher_before_trying_to_take) {
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 10;
 
-  auto s1 = std::make_shared<rclcpp::subscription::mock::SubscriptionBase>();
+  auto s1 = std::make_shared<rclcpp::mock::SubscriptionBase>();
   s1->mock_topic_name = "nominal1";
   s1->mock_queue_size = 10;
 
@@ -281,15 +278,15 @@ TEST(TestIntraProcessManager, removed_subscription_affects_take) {
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 10;
 
-  auto s1 = std::make_shared<rclcpp::subscription::mock::SubscriptionBase>();
+  auto s1 = std::make_shared<rclcpp::mock::SubscriptionBase>();
   s1->mock_topic_name = "nominal1";
   s1->mock_queue_size = 10;
 
-  auto s2 = std::make_shared<rclcpp::subscription::mock::SubscriptionBase>();
+  auto s2 = std::make_shared<rclcpp::mock::SubscriptionBase>();
   s2->mock_topic_name = "nominal1";
   s2->mock_queue_size = 10;
 
-  auto s3 = std::make_shared<rclcpp::subscription::mock::SubscriptionBase>();
+  auto s3 = std::make_shared<rclcpp::mock::SubscriptionBase>();
   s3->mock_topic_name = "nominal1";
   s3->mock_queue_size = 10;
 
@@ -352,15 +349,15 @@ TEST(TestIntraProcessManager, multiple_subscriptions_one_publisher) {
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 10;
 
-  auto s1 = std::make_shared<rclcpp::subscription::mock::SubscriptionBase>();
+  auto s1 = std::make_shared<rclcpp::mock::SubscriptionBase>();
   s1->mock_topic_name = "nominal1";
   s1->mock_queue_size = 10;
 
-  auto s2 = std::make_shared<rclcpp::subscription::mock::SubscriptionBase>();
+  auto s2 = std::make_shared<rclcpp::mock::SubscriptionBase>();
   s2->mock_topic_name = "nominal1";
   s2->mock_queue_size = 10;
 
-  auto s3 = std::make_shared<rclcpp::subscription::mock::SubscriptionBase>();
+  auto s3 = std::make_shared<rclcpp::mock::SubscriptionBase>();
   s3->mock_topic_name = "nominal1";
   s3->mock_queue_size = 10;
 
@@ -436,7 +433,7 @@ TEST(TestIntraProcessManager, multiple_publishers_one_subscription) {
   p3->mock_topic_name = "nominal1";
   p3->mock_queue_size = 10;
 
-  auto s1 = std::make_shared<rclcpp::subscription::mock::SubscriptionBase>();
+  auto s1 = std::make_shared<rclcpp::mock::SubscriptionBase>();
   s1->mock_topic_name = "nominal1";
   s1->mock_queue_size = 10;
 
@@ -536,15 +533,15 @@ TEST(TestIntraProcessManager, multiple_publishers_multiple_subscription) {
   p3->mock_topic_name = "nominal1";
   p3->mock_queue_size = 10;
 
-  auto s1 = std::make_shared<rclcpp::subscription::mock::SubscriptionBase>();
+  auto s1 = std::make_shared<rclcpp::mock::SubscriptionBase>();
   s1->mock_topic_name = "nominal1";
   s1->mock_queue_size = 10;
 
-  auto s2 = std::make_shared<rclcpp::subscription::mock::SubscriptionBase>();
+  auto s2 = std::make_shared<rclcpp::mock::SubscriptionBase>();
   s2->mock_topic_name = "nominal1";
   s2->mock_queue_size = 10;
 
-  auto s3 = std::make_shared<rclcpp::subscription::mock::SubscriptionBase>();
+  auto s3 = std::make_shared<rclcpp::mock::SubscriptionBase>();
   s3->mock_topic_name = "nominal1";
   s3->mock_queue_size = 10;
 
@@ -691,7 +688,7 @@ TEST(TestIntraProcessManager, ring_buffer_displacement) {
   p1->mock_topic_name = "nominal1";
   p1->mock_queue_size = 2;
 
-  auto s1 = std::make_shared<rclcpp::subscription::mock::SubscriptionBase>();
+  auto s1 = std::make_shared<rclcpp::mock::SubscriptionBase>();
   s1->mock_topic_name = "nominal1";
   s1->mock_queue_size = 10;
 
@@ -775,7 +772,7 @@ TEST(TestIntraProcessManager, subscription_creation_race_condition) {
   auto p1_m1_id = ipm.store_intra_process_message(p1_id, unique_msg);
   ASSERT_EQ(nullptr, unique_msg);
 
-  auto s1 = std::make_shared<rclcpp::subscription::mock::SubscriptionBase>();
+  auto s1 = std::make_shared<rclcpp::mock::SubscriptionBase>();
   s1->mock_topic_name = "nominal1";
   s1->mock_queue_size = 10;
 
@@ -796,7 +793,7 @@ TEST(TestIntraProcessManager, subscription_creation_race_condition) {
 TEST(TestIntraProcessManager, publisher_out_of_scope_take) {
   rclcpp::intra_process_manager::IntraProcessManager ipm;
 
-  auto s1 = std::make_shared<rclcpp::subscription::mock::SubscriptionBase>();
+  auto s1 = std::make_shared<rclcpp::mock::SubscriptionBase>();
   s1->mock_topic_name = "nominal1";
   s1->mock_queue_size = 10;
 

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -77,11 +77,11 @@ TEST_F(TestNode, get_name_and_namespace) {
 TEST_F(TestNode, get_logger) {
   // Currently the namespace is not taken into account with the node logger name
   {
-    auto node = std::make_shared<rclcpp::node::Node>("my_node");
+    auto node = std::make_shared<rclcpp::Node>("my_node");
     EXPECT_STREQ("my_node", node->get_logger().get_name());
   }
   {
-    auto node = std::make_shared<rclcpp::node::Node>("my_node", "/ns");
+    auto node = std::make_shared<rclcpp::Node>("my_node", "/ns");
     EXPECT_STREQ("my_node", node->get_logger().get_name());
   }
 }

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -35,40 +35,40 @@ protected:
  */
 TEST_F(TestNode, construction_and_destruction) {
   {
-    auto node = std::make_shared<rclcpp::node::Node>("my_node", "/ns");
+    auto node = std::make_shared<rclcpp::Node>("my_node", "/ns");
   }
 
   {
     ASSERT_THROW({
-      auto node = std::make_shared<rclcpp::node::Node>("invalid_node?", "/ns");
+      auto node = std::make_shared<rclcpp::Node>("invalid_node?", "/ns");
     }, rclcpp::exceptions::InvalidNodeNameError);
   }
 
   {
     ASSERT_THROW({
-      auto node = std::make_shared<rclcpp::node::Node>("my_node", "/invalid_ns?");
+      auto node = std::make_shared<rclcpp::Node>("my_node", "/invalid_ns?");
     }, rclcpp::exceptions::InvalidNamespaceError);
   }
 }
 
 TEST_F(TestNode, get_name_and_namespace) {
   {
-    auto node = std::make_shared<rclcpp::node::Node>("my_node", "/ns");
+    auto node = std::make_shared<rclcpp::Node>("my_node", "/ns");
     EXPECT_STREQ("my_node", node->get_name());
     EXPECT_STREQ("/ns", node->get_namespace());
   }
   {
-    auto node = std::make_shared<rclcpp::node::Node>("my_node", "ns");
+    auto node = std::make_shared<rclcpp::Node>("my_node", "ns");
     EXPECT_STREQ("my_node", node->get_name());
     EXPECT_STREQ("/ns", node->get_namespace());
   }
   {
-    auto node = std::make_shared<rclcpp::node::Node>("my_node", "/my/ns");
+    auto node = std::make_shared<rclcpp::Node>("my_node", "/my/ns");
     EXPECT_STREQ("my_node", node->get_name());
     EXPECT_STREQ("/my/ns", node->get_namespace());
   }
   {
-    auto node = std::make_shared<rclcpp::node::Node>("my_node", "my/ns");
+    auto node = std::make_shared<rclcpp::Node>("my_node", "my/ns");
     EXPECT_STREQ("my_node", node->get_name());
     EXPECT_STREQ("/my/ns", node->get_namespace());
   }
@@ -87,14 +87,14 @@ TEST_F(TestNode, get_logger) {
 }
 
 TEST_F(TestNode, get_clock) {
-  auto node = std::make_shared<rclcpp::node::Node>("my_node", "/ns");
+  auto node = std::make_shared<rclcpp::Node>("my_node", "/ns");
   auto ros_clock = node->get_clock();
   EXPECT_TRUE(ros_clock != nullptr);
   EXPECT_EQ(ros_clock->get_clock_type(), RCL_ROS_TIME);
 }
 
 TEST_F(TestNode, now) {
-  auto node = std::make_shared<rclcpp::node::Node>("my_node", "/ns");
+  auto node = std::make_shared<rclcpp::Node>("my_node", "/ns");
   auto clock = node->get_clock();
   auto now_builtin = node->now().nanoseconds();
   auto now_external = clock->now().nanoseconds();

--- a/rclcpp/test/test_publisher.cpp
+++ b/rclcpp/test/test_publisher.cpp
@@ -32,7 +32,7 @@ protected:
 
   void SetUp()
   {
-    node = std::make_shared<rclcpp::node::Node>("my_node", "/ns");
+    node = std::make_shared<rclcpp::Node>("my_node", "/ns");
   }
 
   void TearDown()
@@ -40,7 +40,7 @@ protected:
     node.reset();
   }
 
-  rclcpp::node::Node::SharedPtr node;
+  rclcpp::Node::SharedPtr node;
 };
 
 /*

--- a/rclcpp/test/test_rate.cpp
+++ b/rclcpp/test/test_rate.cpp
@@ -28,7 +28,7 @@ TEST(TestRate, rate_basics) {
   double overrun_ratio = 1.5;
 
   auto start = std::chrono::system_clock::now();
-  rclcpp::rate::Rate r(period);
+  rclcpp::Rate r(period);
   ASSERT_FALSE(r.is_steady());
   ASSERT_TRUE(r.sleep());
   auto one = std::chrono::system_clock::now();
@@ -67,7 +67,7 @@ TEST(TestRate, wall_rate_basics) {
   double overrun_ratio = 1.5;
 
   auto start = std::chrono::steady_clock::now();
-  rclcpp::rate::WallRate r(period);
+  rclcpp::WallRate r(period);
   ASSERT_TRUE(r.is_steady());
   ASSERT_TRUE(r.sleep());
   auto one = std::chrono::steady_clock::now();

--- a/rclcpp/test/test_rate.cpp
+++ b/rclcpp/test/test_rate.cpp
@@ -36,14 +36,14 @@ TEST(TestRate, rate_basics) {
   ASSERT_TRUE(period < delta);
   ASSERT_TRUE(period * overrun_ratio > delta);
 
-  rclcpp::utilities::sleep_for(offset);
+  rclcpp::sleep_for(offset);
   ASSERT_TRUE(r.sleep());
   auto two = std::chrono::system_clock::now();
   delta = two - start;
   ASSERT_TRUE(2 * period < delta);
   ASSERT_TRUE(2 * period * overrun_ratio > delta);
 
-  rclcpp::utilities::sleep_for(offset);
+  rclcpp::sleep_for(offset);
   auto two_offset = std::chrono::system_clock::now();
   r.reset();
   ASSERT_TRUE(r.sleep());
@@ -52,7 +52,7 @@ TEST(TestRate, rate_basics) {
   ASSERT_TRUE(period < delta);
   ASSERT_TRUE(period * overrun_ratio > delta);
 
-  rclcpp::utilities::sleep_for(offset + period);
+  rclcpp::sleep_for(offset + period);
   auto four = std::chrono::system_clock::now();
   ASSERT_FALSE(r.sleep());
   auto five = std::chrono::system_clock::now();
@@ -75,14 +75,14 @@ TEST(TestRate, wall_rate_basics) {
   ASSERT_TRUE(period < delta);
   ASSERT_TRUE(period * overrun_ratio > delta);
 
-  rclcpp::utilities::sleep_for(offset);
+  rclcpp::sleep_for(offset);
   ASSERT_TRUE(r.sleep());
   auto two = std::chrono::steady_clock::now();
   delta = two - start;
   ASSERT_TRUE(2 * period < delta + epsilon);
   ASSERT_TRUE(2 * period * overrun_ratio > delta);
 
-  rclcpp::utilities::sleep_for(offset);
+  rclcpp::sleep_for(offset);
   auto two_offset = std::chrono::steady_clock::now();
   r.reset();
   ASSERT_TRUE(r.sleep());
@@ -91,7 +91,7 @@ TEST(TestRate, wall_rate_basics) {
   ASSERT_TRUE(period < delta);
   ASSERT_TRUE(period * overrun_ratio > delta);
 
-  rclcpp::utilities::sleep_for(offset + period);
+  rclcpp::sleep_for(offset + period);
   auto four = std::chrono::steady_clock::now();
   ASSERT_FALSE(r.sleep());
   auto five = std::chrono::steady_clock::now();

--- a/rclcpp/test/test_service.cpp
+++ b/rclcpp/test/test_service.cpp
@@ -32,7 +32,7 @@ protected:
 
   void SetUp()
   {
-    node = std::make_shared<rclcpp::node::Node>("my_node", "/ns");
+    node = std::make_shared<rclcpp::Node>("my_node", "/ns");
   }
 
   void TearDown()
@@ -40,7 +40,7 @@ protected:
     node.reset();
   }
 
-  rclcpp::node::Node::SharedPtr node;
+  rclcpp::Node::SharedPtr node;
 };
 
 /*

--- a/rclcpp/test/test_subscription.cpp
+++ b/rclcpp/test/test_subscription.cpp
@@ -32,7 +32,7 @@ protected:
 
   void SetUp()
   {
-    node = std::make_shared<rclcpp::node::Node>("my_node", "/ns");
+    node = std::make_shared<rclcpp::Node>("my_node", "/ns");
   }
 
   void TearDown()
@@ -40,7 +40,7 @@ protected:
     node.reset();
   }
 
-  rclcpp::node::Node::SharedPtr node;
+  rclcpp::Node::SharedPtr node;
 };
 
 /*

--- a/rclcpp/test/test_time_source.cpp
+++ b/rclcpp/test/test_time_source.cpp
@@ -334,7 +334,7 @@ TEST_F(TestTimeSource, parameter_activation) {
   ts.attachClock(ros_clock);
   EXPECT_FALSE(ros_clock->ros_time_is_active());
 
-  auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
+  auto parameter_service = std::make_shared<rclcpp::ParameterService>(node);
   auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(node);
 
   using namespace std::chrono_literals;

--- a/rclcpp/test/test_time_source.cpp
+++ b/rclcpp/test/test_time_source.cpp
@@ -335,7 +335,7 @@ TEST_F(TestTimeSource, parameter_activation) {
   EXPECT_FALSE(ros_clock->ros_time_is_active());
 
   auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
-  auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
+  auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(node);
 
   using namespace std::chrono_literals;
   EXPECT_TRUE(parameters_client->wait_for_service(2s));

--- a/rclcpp/test/test_time_source.cpp
+++ b/rclcpp/test/test_time_source.cpp
@@ -39,7 +39,7 @@ protected:
 
   void SetUp()
   {
-    node = std::make_shared<rclcpp::node::Node>("my_node");
+    node = std::make_shared<rclcpp::Node>("my_node");
   }
 
   void TearDown()
@@ -47,7 +47,7 @@ protected:
     node.reset();
   }
 
-  rclcpp::node::Node::SharedPtr node;
+  rclcpp::Node::SharedPtr node;
 };
 
 
@@ -228,7 +228,7 @@ TEST_F(TestTimeSource, callbacks) {
 }
 
 void trigger_clock_changes(
-  rclcpp::node::Node::SharedPtr node)
+  rclcpp::Node::SharedPtr node)
 {
   auto clock_pub = node->create_publisher<builtin_interfaces::msg::Time>("clock",
       rmw_qos_profile_default);

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -83,7 +83,7 @@ public:
     const std::string & namespace_ = "",
     bool use_intra_process_comms = false);
 
-  /// Create a node based on the node name and a rclcpp::context::Context.
+  /// Create a node based on the node name and a rclcpp::Context.
   /**
    * \param[in] node_name Name of the node.
    * \param[in] node_name Namespace of the node.
@@ -95,7 +95,7 @@ public:
   LifecycleNode(
     const std::string & node_name,
     const std::string & namespace_,
-    rclcpp::context::Context::SharedPtr context,
+    rclcpp::Context::SharedPtr context,
     bool use_intra_process_comms = false);
 
   RCLCPP_LIFECYCLE_PUBLIC

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -172,7 +172,7 @@ public:
     typename MessageT,
     typename CallbackT,
     typename Alloc = std::allocator<void>,
-    typename SubscriptionT = rclcpp::subscription::Subscription<MessageT, Alloc>>
+    typename SubscriptionT = rclcpp::Subscription<MessageT, Alloc>>
   std::shared_ptr<SubscriptionT>
   create_subscription(
     const std::string & topic_name,
@@ -202,7 +202,7 @@ public:
     typename MessageT,
     typename CallbackT,
     typename Alloc = std::allocator<void>,
-    typename SubscriptionT = rclcpp::subscription::Subscription<MessageT, Alloc>>
+    typename SubscriptionT = rclcpp::Subscription<MessageT, Alloc>>
   std::shared_ptr<SubscriptionT>
   create_subscription(
     const std::string & topic_name,

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -221,7 +221,7 @@ public:
    * \param[in] group Callback group to execute this timer's callback in.
    */
   template<typename DurationT = std::milli, typename CallbackT>
-  typename rclcpp::timer::WallTimer<CallbackT>::SharedPtr
+  typename rclcpp::WallTimer<CallbackT>::SharedPtr
   create_wall_timer(
     std::chrono::duration<int64_t, DurationT> period,
     CallbackT callback,
@@ -480,7 +480,7 @@ protected:
 
   RCLCPP_LIFECYCLE_PUBLIC
   void
-  add_timer_handle(std::shared_ptr<rclcpp::timer::TimerBase> timer);
+  add_timer_handle(std::shared_ptr<rclcpp::TimerBase> timer);
 
 private:
   RCLCPP_DISABLE_COPY(LifecycleNode)

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -237,7 +237,7 @@ public:
 
   /* Create and return a Service. */
   template<typename ServiceT, typename CallbackT>
-  typename rclcpp::service::Service<ServiceT>::SharedPtr
+  typename rclcpp::Service<ServiceT>::SharedPtr
   create_service(
     const std::string & service_name,
     CallbackT && callback,

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -313,7 +313,7 @@ public:
    * out of scope.
    */
   RCLCPP_LIFECYCLE_PUBLIC
-  rclcpp::event::Event::SharedPtr
+  rclcpp::Event::SharedPtr
   get_graph_event();
 
   /// Wait for a graph event to occur by waiting on an Event to become set.
@@ -326,7 +326,7 @@ public:
   RCLCPP_LIFECYCLE_PUBLIC
   void
   wait_for_graph_change(
-    rclcpp::event::Event::SharedPtr event,
+    rclcpp::Event::SharedPtr event,
     std::chrono::nanoseconds timeout);
 
   RCLCPP_LIFECYCLE_PUBLIC

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -229,7 +229,7 @@ public:
 
   /* Create and return a Client. */
   template<typename ServiceT>
-  typename rclcpp::client::Client<ServiceT>::SharedPtr
+  typename rclcpp::Client<ServiceT>::SharedPtr
   create_client(
     const std::string & service_name,
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_services_default,

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
@@ -90,7 +90,7 @@ LifecycleNode::create_subscription(
 
   return rclcpp::create_subscription<
     MessageT, CallbackT, Alloc,
-    rclcpp::subscription::Subscription<MessageT, Alloc>>(
+    rclcpp::Subscription<MessageT, Alloc>>(
     this->node_topics_.get(),
     topic_name,
     std::forward<CallbackT>(callback),

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
@@ -131,13 +131,13 @@ LifecycleNode::create_subscription(
 }
 
 template<typename DurationT, typename CallbackT>
-typename rclcpp::timer::WallTimer<CallbackT>::SharedPtr
+typename rclcpp::WallTimer<CallbackT>::SharedPtr
 LifecycleNode::create_wall_timer(
   std::chrono::duration<int64_t, DurationT> period,
   CallbackT callback,
   rclcpp::callback_group::CallbackGroup::SharedPtr group)
 {
-  auto timer = rclcpp::timer::WallTimer<CallbackT>::make_shared(
+  auto timer = rclcpp::WallTimer<CallbackT>::make_shared(
     std::chrono::duration_cast<std::chrono::nanoseconds>(period),
     std::move(callback));
   node_timers_->add_timer(timer, group);

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
@@ -145,7 +145,7 @@ LifecycleNode::create_wall_timer(
 }
 
 template<typename ServiceT>
-typename rclcpp::client::Client<ServiceT>::SharedPtr
+typename rclcpp::Client<ServiceT>::SharedPtr
 LifecycleNode::create_client(
   const std::string & service_name,
   const rmw_qos_profile_t & qos_profile,
@@ -154,8 +154,8 @@ LifecycleNode::create_client(
   rcl_client_options_t options = rcl_client_get_default_options();
   options.qos = qos_profile;
 
-  using rclcpp::client::Client;
-  using rclcpp::client::ClientBase;
+  using rclcpp::Client;
+  using rclcpp::ClientBase;
 
   auto cli = Client<ServiceT>::make_shared(
     node_base_.get(),

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
@@ -169,23 +169,23 @@ LifecycleNode::create_client(
 }
 
 template<typename ServiceT, typename CallbackT>
-typename rclcpp::service::Service<ServiceT>::SharedPtr
+typename rclcpp::Service<ServiceT>::SharedPtr
 LifecycleNode::create_service(
   const std::string & service_name,
   CallbackT && callback,
   const rmw_qos_profile_t & qos_profile,
   rclcpp::callback_group::CallbackGroup::SharedPtr group)
 {
-  rclcpp::service::AnyServiceCallback<ServiceT> any_service_callback;
+  rclcpp::AnyServiceCallback<ServiceT> any_service_callback;
   any_service_callback.set(std::forward<CallbackT>(callback));
 
   rcl_service_options_t service_options = rcl_service_get_default_options();
   service_options.qos = qos_profile;
 
-  auto serv = rclcpp::service::Service<ServiceT>::make_shared(
+  auto serv = rclcpp::Service<ServiceT>::make_shared(
     node_base_->get_shared_rcl_node_handle(),
     service_name, any_service_callback, service_options);
-  auto serv_base_ptr = std::dynamic_pointer_cast<rclcpp::service::ServiceBase>(serv);
+  auto serv_base_ptr = std::dynamic_pointer_cast<rclcpp::ServiceBase>(serv);
   node_services_->add_service(serv_base_ptr, group);
   return serv;
 }

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_publisher.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_publisher.hpp
@@ -45,7 +45,7 @@ public:
  */
 template<typename MessageT, typename Alloc = std::allocator<void>>
 class LifecyclePublisher : public LifecyclePublisherInterface,
-  public rclcpp::publisher::Publisher<MessageT, Alloc>
+  public rclcpp::Publisher<MessageT, Alloc>
 {
 public:
   using MessageAllocTraits = rclcpp::allocator::AllocRebind<MessageT, Alloc>;
@@ -58,7 +58,7 @@ public:
     const std::string & topic,
     const rcl_publisher_options_t & publisher_options,
     std::shared_ptr<MessageAlloc> allocator)
-  : rclcpp::publisher::Publisher<MessageT, Alloc>(
+  : rclcpp::Publisher<MessageT, Alloc>(
       node_base, topic, publisher_options, allocator),
     enabled_(false)
   {}
@@ -77,7 +77,7 @@ public:
     if (!enabled_) {
       return;
     }
-    rclcpp::publisher::Publisher<MessageT, Alloc>::publish(msg);
+    rclcpp::Publisher<MessageT, Alloc>::publish(msg);
   }
 
   /// LifecyclePublisher publish function
@@ -92,7 +92,7 @@ public:
     if (!enabled_) {
       return;
     }
-    rclcpp::publisher::Publisher<MessageT, Alloc>::publish(msg);
+    rclcpp::Publisher<MessageT, Alloc>::publish(msg);
   }
 
   /// LifecyclePublisher publish function
@@ -107,7 +107,7 @@ public:
     if (!enabled_) {
       return;
     }
-    rclcpp::publisher::Publisher<MessageT, Alloc>::publish(msg);
+    rclcpp::Publisher<MessageT, Alloc>::publish(msg);
   }
 
   /// LifecyclePublisher publish function
@@ -122,7 +122,7 @@ public:
     if (!enabled_) {
       return;
     }
-    rclcpp::publisher::Publisher<MessageT, Alloc>::publish(msg);
+    rclcpp::Publisher<MessageT, Alloc>::publish(msg);
   }
 
   virtual void
@@ -146,7 +146,7 @@ public:
     if (!enabled_) {
       return;
     }
-    rclcpp::publisher::Publisher<MessageT, Alloc>::publish(msg);
+    rclcpp::Publisher<MessageT, Alloc>::publish(msg);
   }
 
   virtual void

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -209,7 +209,7 @@ LifecycleNode::get_callback_groups() const
   return node_base_->get_callback_groups();
 }
 
-rclcpp::event::Event::SharedPtr
+rclcpp::Event::SharedPtr
 LifecycleNode::get_graph_event()
 {
   return node_graph_->get_graph_event();
@@ -217,7 +217,7 @@ LifecycleNode::get_graph_event()
 
 void
 LifecycleNode::wait_for_graph_change(
-  rclcpp::event::Event::SharedPtr event,
+  rclcpp::Event::SharedPtr event,
   std::chrono::nanoseconds timeout)
 {
   node_graph_->wait_for_graph_change(event, timeout);

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -449,7 +449,7 @@ LifecycleNode::add_publisher_handle(
 }
 
 void
-LifecycleNode::add_timer_handle(std::shared_ptr<rclcpp::timer::TimerBase> timer)
+LifecycleNode::add_timer_handle(std::shared_ptr<rclcpp::TimerBase> timer)
 {
   impl_->add_timer_handle(timer);
 }

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -55,7 +55,7 @@ LifecycleNode::LifecycleNode(
 LifecycleNode::LifecycleNode(
   const std::string & node_name,
   const std::string & namespace_,
-  rclcpp::context::Context::SharedPtr context,
+  rclcpp::Context::SharedPtr context,
   bool use_intra_process_comms)
 : node_base_(new rclcpp::node_interfaces::NodeBase(node_name, namespace_, context)),
   node_graph_(new rclcpp::node_interfaces::NodeGraph(node_base_.get())),

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -107,12 +107,12 @@ public:
       rclcpp::any_service_callback::AnyServiceCallback<ChangeStateSrv> any_cb;
       any_cb.set(std::move(cb));
 
-      srv_change_state_ = std::make_shared<rclcpp::service::Service<ChangeStateSrv>>(
+      srv_change_state_ = std::make_shared<rclcpp::Service<ChangeStateSrv>>(
         node_base_interface_->get_shared_rcl_node_handle(),
         &state_machine_.com_interface.srv_change_state,
         any_cb);
       node_services_interface_->add_service(
-        std::dynamic_pointer_cast<rclcpp::service::ServiceBase>(srv_change_state_),
+        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_change_state_),
         nullptr);
     }
 
@@ -122,12 +122,12 @@ public:
       rclcpp::any_service_callback::AnyServiceCallback<GetStateSrv> any_cb;
       any_cb.set(std::move(cb));
 
-      srv_get_state_ = std::make_shared<rclcpp::service::Service<GetStateSrv>>(
+      srv_get_state_ = std::make_shared<rclcpp::Service<GetStateSrv>>(
         node_base_interface_->get_shared_rcl_node_handle(),
         &state_machine_.com_interface.srv_get_state,
         any_cb);
       node_services_interface_->add_service(
-        std::dynamic_pointer_cast<rclcpp::service::ServiceBase>(srv_get_state_),
+        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_state_),
         nullptr);
     }
 
@@ -137,12 +137,12 @@ public:
       rclcpp::any_service_callback::AnyServiceCallback<GetAvailableStatesSrv> any_cb;
       any_cb.set(std::move(cb));
 
-      srv_get_available_states_ = std::make_shared<rclcpp::service::Service<GetAvailableStatesSrv>>(
+      srv_get_available_states_ = std::make_shared<rclcpp::Service<GetAvailableStatesSrv>>(
         node_base_interface_->get_shared_rcl_node_handle(),
         &state_machine_.com_interface.srv_get_available_states,
         any_cb);
       node_services_interface_->add_service(
-        std::dynamic_pointer_cast<rclcpp::service::ServiceBase>(srv_get_available_states_),
+        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_available_states_),
         nullptr);
     }
 
@@ -153,12 +153,12 @@ public:
       any_cb.set(std::move(cb));
 
       srv_get_available_transitions_ =
-        std::make_shared<rclcpp::service::Service<GetAvailableTransitionsSrv>>(
+        std::make_shared<rclcpp::Service<GetAvailableTransitionsSrv>>(
         node_base_interface_->get_shared_rcl_node_handle(),
         &state_machine_.com_interface.srv_get_available_transitions,
         any_cb);
       node_services_interface_->add_service(
-        std::dynamic_pointer_cast<rclcpp::service::ServiceBase>(srv_get_available_transitions_),
+        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_available_transitions_),
         nullptr);
     }
   }
@@ -404,12 +404,12 @@ public:
 
   using NodeBasePtr = std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>;
   using NodeServicesPtr = std::shared_ptr<rclcpp::node_interfaces::NodeServicesInterface>;
-  using ChangeStateSrvPtr = std::shared_ptr<rclcpp::service::Service<ChangeStateSrv>>;
-  using GetStateSrvPtr = std::shared_ptr<rclcpp::service::Service<GetStateSrv>>;
+  using ChangeStateSrvPtr = std::shared_ptr<rclcpp::Service<ChangeStateSrv>>;
+  using GetStateSrvPtr = std::shared_ptr<rclcpp::Service<GetStateSrv>>;
   using GetAvailableStatesSrvPtr =
-      std::shared_ptr<rclcpp::service::Service<GetAvailableStatesSrv>>;
+      std::shared_ptr<rclcpp::Service<GetAvailableStatesSrv>>;
   using GetAvailableTransitionsSrvPtr =
-      std::shared_ptr<rclcpp::service::Service<GetAvailableTransitionsSrv>>;
+      std::shared_ptr<rclcpp::Service<GetAvailableTransitionsSrv>>;
 
   NodeBasePtr node_base_interface_;
   NodeServicesPtr node_services_interface_;

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -104,7 +104,7 @@ public:
     {  // change_state
       auto cb = std::bind(&LifecycleNodeInterfaceImpl::on_change_state, this,
           std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-      rclcpp::any_service_callback::AnyServiceCallback<ChangeStateSrv> any_cb;
+      rclcpp::AnyServiceCallback<ChangeStateSrv> any_cb;
       any_cb.set(std::move(cb));
 
       srv_change_state_ = std::make_shared<rclcpp::Service<ChangeStateSrv>>(
@@ -119,7 +119,7 @@ public:
     {  // get_state
       auto cb = std::bind(&LifecycleNodeInterfaceImpl::on_get_state, this,
           std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-      rclcpp::any_service_callback::AnyServiceCallback<GetStateSrv> any_cb;
+      rclcpp::AnyServiceCallback<GetStateSrv> any_cb;
       any_cb.set(std::move(cb));
 
       srv_get_state_ = std::make_shared<rclcpp::Service<GetStateSrv>>(
@@ -134,7 +134,7 @@ public:
     {  // get_available_states
       auto cb = std::bind(&LifecycleNodeInterfaceImpl::on_get_available_states, this,
           std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-      rclcpp::any_service_callback::AnyServiceCallback<GetAvailableStatesSrv> any_cb;
+      rclcpp::AnyServiceCallback<GetAvailableStatesSrv> any_cb;
       any_cb.set(std::move(cb));
 
       srv_get_available_states_ = std::make_shared<rclcpp::Service<GetAvailableStatesSrv>>(
@@ -149,7 +149,7 @@ public:
     {  // get_available_transitions
       auto cb = std::bind(&LifecycleNodeInterfaceImpl::on_get_available_transitions, this,
           std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-      rclcpp::any_service_callback::AnyServiceCallback<GetAvailableTransitionsSrv> any_cb;
+      rclcpp::AnyServiceCallback<GetAvailableTransitionsSrv> any_cb;
       any_cb.set(std::move(cb));
 
       srv_get_available_transitions_ =

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -391,7 +391,7 @@ public:
   }
 
   void
-  add_timer_handle(std::shared_ptr<rclcpp::timer::TimerBase> timer)
+  add_timer_handle(std::shared_ptr<rclcpp::TimerBase> timer)
   {
     weak_timers_.push_back(timer);
   }
@@ -420,7 +420,7 @@ public:
 
   // to controllable things
   std::vector<std::weak_ptr<rclcpp_lifecycle::LifecyclePublisherInterface>> weak_pubs_;
-  std::vector<std::weak_ptr<rclcpp::timer::TimerBase>> weak_timers_;
+  std::vector<std::weak_ptr<rclcpp::TimerBase>> weak_timers_;
 };
 
 }  // namespace rclcpp_lifecycle


### PR DESCRIPTION
This is following a decision we made Nov '16 but hadn't followed up on. Summary in https://github.com/ros2/rclcpp/pull/410#issuecomment-348305379.

The reasoning for doing it now is because doing it while in beta we won't have to deprecate the old format. If that's too aggressive we can look into the suggestion in https://github.com/ros2/rclcpp/pull/410#issuecomment-348361651.

My opinion on the priority is that this should be in before we tag but doesn't necessarily need to be in before testing since it will be clear from compilation whether or not it's been done correctly. I have a bunch of changes to other packages ready.

So far I've removed namespaces that only had classes. They are not always exactly matching the class name e.g. `parameter_client::` had `AsyncParamtersClient` and `SyncParametersClient`, so let me know if I went too extreme and we can easily revert individual commits.
- `publisher::`
- `subscription::`
- `client::`
- `service::`
- `parameter_client::`
- `paramter_service::`
- `rate::`
- `timer::`
- `node::`
- `any_service_callback::`
- `any_subscription_callback::`
- `context::`
- `event::`
- `executors::single_threaded_executor::SingleThreadedExecutor` -> `executors::SingleThreadedExecutor`
- `executors::multi_threaded_executor::MultiThreadedExecutor` -> `executors::MultiThreadedExecutor`

I removed the now-unnecessary namespace escalations from `rclcpp/rclcpp.hpp` but left the includes for those files because FWIU we still want users to not have to include the headers themselves.

---

There are some namespaces that have more than just classes so I wanted to check what to do with them:

- `executor::` has `executor::Executor` the class, but also:
  - `executor::AnyExecutable` a struct
  - `executor::FutureReturnCode` an enum
  - `executor::ExecutorArgs` a struct

- `parameter::` has
  - `parameter::ParameterVariant` class
  - `parameter::ParameterType` an enum
  - `parameter::operator<<`

Perhaps just move `rclcpp::executor::Executor` -> `rclcpp:Executor` and leave the others as is?