### PR TITLE
Mirror clock API from Node to LifecycleNode

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -35,6 +35,7 @@
 
 #include "rclcpp/callback_group.hpp"
 #include "rclcpp/client.hpp"
+#include "rclcpp/clock.hpp"
 #include "rclcpp/context.hpp"
 #include "rclcpp/event.hpp"
 #include "rclcpp/logger.hpp"
@@ -52,6 +53,7 @@
 #include "rclcpp/publisher.hpp"
 #include "rclcpp/service.hpp"
 #include "rclcpp/subscription.hpp"
+#include "rclcpp/time.hpp"
 #include "rclcpp/timer.hpp"
 #include "rclcpp/visibility_control.hpp"
 

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -216,7 +216,6 @@ Node::now()
   return node_clock_->get_clock()->now();
 }
 
-
 rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
 Node::get_node_base_interface()
 {
@@ -228,7 +227,6 @@ Node::get_node_clock_interface()
 {
   return node_clock_;
 }
-
 
 rclcpp::node_interfaces::NodeGraphInterface::SharedPtr
 Node::get_node_graph_interface()

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -36,6 +36,7 @@
 #include "rclcpp/macros.hpp"
 #include "rclcpp/message_memory_strategy.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
+#include "rclcpp/node_interfaces/node_clock_interface.hpp"
 #include "rclcpp/node_interfaces/node_graph_interface.hpp"
 #include "rclcpp/node_interfaces/node_logging_interface.hpp"
 #include "rclcpp/node_interfaces/node_parameters_interface.hpp"
@@ -326,10 +327,23 @@ public:
     rclcpp::event::Event::SharedPtr event,
     std::chrono::nanoseconds timeout);
 
+  RCLCPP_LIFECYCLE_PUBLIC
+  rclcpp::Clock::SharedPtr
+  get_clock();
+
+  RCLCPP_LIFECYCLE_PUBLIC
+  rclcpp::Time
+  now();
+
   /// Return the Node's internal NodeBaseInterface implementation.
   RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
   get_node_base_interface();
+
+  /// Return the Node's internal NodeClockInterface implementation.
+  RCLCPP_LIFECYCLE_PUBLIC
+  rclcpp::node_interfaces::NodeClockInterface::SharedPtr
+  get_node_clock_interface();
 
   /// Return the Node's internal NodeGraphInterface implementation.
   RCLCPP_LIFECYCLE_PUBLIC
@@ -480,6 +494,7 @@ private:
   rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_;
   rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_;
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_;
+  rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_;
 
   bool use_intra_process_comms_;
 

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -30,6 +30,7 @@
 
 #include "rclcpp/callback_group.hpp"
 #include "rclcpp/client.hpp"
+#include "rclcpp/clock.hpp"
 #include "rclcpp/context.hpp"
 #include "rclcpp/event.hpp"
 #include "rclcpp/logger.hpp"
@@ -47,6 +48,7 @@
 #include "rclcpp/publisher.hpp"
 #include "rclcpp/service.hpp"
 #include "rclcpp/subscription.hpp"
+#include "rclcpp/time.hpp"
 #include "rclcpp/timer.hpp"
 
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -28,6 +28,7 @@
 #include "rclcpp/logger.hpp"
 #include "rclcpp/node.hpp"
 #include "rclcpp/node_interfaces/node_base.hpp"
+#include "rclcpp/node_interfaces/node_clock.hpp"
 #include "rclcpp/node_interfaces/node_graph.hpp"
 #include "rclcpp/node_interfaces/node_logging.hpp"
 #include "rclcpp/node_interfaces/node_parameters.hpp"
@@ -65,6 +66,12 @@ LifecycleNode::LifecycleNode(
   node_parameters_(new rclcpp::node_interfaces::NodeParameters(
       node_topics_.get(),
       use_intra_process_comms
+    )),
+  node_clock_(new rclcpp::node_interfaces::NodeClock(
+      node_base_,
+      node_topics_,
+      node_graph_,
+      node_services_
     )),
   use_intra_process_comms_(use_intra_process_comms),
   impl_(new LifecycleNodeInterfaceImpl(node_base_, node_services_))
@@ -216,10 +223,28 @@ LifecycleNode::wait_for_graph_change(
   node_graph_->wait_for_graph_change(event, timeout);
 }
 
+rclcpp::Clock::SharedPtr
+LifecycleNode::get_clock()
+{
+  return node_clock_->get_clock();
+}
+
+rclcpp::Time
+LifecycleNode::now()
+{
+  return node_clock_->get_clock()->now();
+}
+
 rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
 LifecycleNode::get_node_base_interface()
 {
   return node_base_;
+}
+
+rclcpp::node_interfaces::NodeClockInterface::SharedPtr
+LifecycleNode::get_node_clock_interface()
+{
+  return node_clock_;
 }
 
 rclcpp::node_interfaces::NodeGraphInterface::SharedPtr


### PR DESCRIPTION
Follow up to #407 for symmetry of the API.

Linux: [![Build Status](http://ci.ros2.org/job/ci_linux/3718/badge/icon)](http://ci.ros2.org/job/ci_linux/3718/)
Linux Aarch64: [![Build Status](http://ci.ros2.org/job/ci_linux-aarch64/876/badge/icon)](http://ci.ros2.org/job/ci_linux-aarch64/876/)
OSX: [![Build Status](http://ci.ros2.org/job/ci_osx/3054/badge/icon)](http://ci.ros2.org/job/ci_osx/3054/)
Windows: [![Build Status](http://ci.ros2.org/job/ci_windows/3814/badge/icon)](http://ci.ros2.org/job/ci_windows/3814/)