### PR TITLE
Fix 393

### DIFF
--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -91,14 +91,14 @@ if(BUILD_TESTING)
     target_link_libraries(test_state_wrapper ${PROJECT_NAME})
   endif()
   ament_add_gtest(test_transition_wrapper test/test_transition_wrapper.cpp)
- if(TARGET test_transition_wrapper)
-   target_include_directories(test_transition_wrapper PUBLIC
-     ${rcl_lifecycle_INCLUDE_DIRS}
-     ${rclcpp_INCLUDE_DIRS}
-     ${rclcpp_lifecycle_INCLUDE_DIRS}
-   )
-   target_link_libraries(test_transition_wrapper ${PROJECT_NAME})
- endif()
+  if(TARGET test_transition_wrapper)
+    target_include_directories(test_transition_wrapper PUBLIC
+      ${rcl_lifecycle_INCLUDE_DIRS}
+      ${rclcpp_INCLUDE_DIRS}
+      ${rclcpp_lifecycle_INCLUDE_DIRS}
+    )
+    target_link_libraries(test_transition_wrapper ${PROJECT_NAME})
+  endif()
 endif()
 
 ament_export_dependencies(rclcpp)

--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -90,6 +90,15 @@ if(BUILD_TESTING)
     )
     target_link_libraries(test_state_wrapper ${PROJECT_NAME})
   endif()
+  ament_add_gtest(test_transition_wrapper test/test_transition_wrapper.cpp)
+ if(TARGET test_transition_wrapper)
+   target_include_directories(test_transition_wrapper PUBLIC
+     ${rcl_lifecycle_INCLUDE_DIRS}
+     ${rclcpp_INCLUDE_DIRS}
+     ${rclcpp_lifecycle_INCLUDE_DIRS}
+   )
+   target_link_libraries(test_transition_wrapper ${PROJECT_NAME})
+ endif()
 endif()
 
 ament_export_dependencies(rclcpp)

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/state.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/state.hpp
@@ -19,6 +19,8 @@
 
 #include "rclcpp_lifecycle/visibility_control.h"
 
+#include "rcutils/allocator.h"
+
 // forward declare rcl_state_t
 typedef struct rcl_lifecycle_state_t rcl_lifecycle_state_t;
 
@@ -29,13 +31,18 @@ class State
 {
 public:
   RCLCPP_LIFECYCLE_PUBLIC
-  State();
+  State(rcutils_allocator_t allocator = rcutils_get_default_allocator());
 
   RCLCPP_LIFECYCLE_PUBLIC
-  State(uint8_t id, const std::string & label);
+  State(
+    uint8_t id,
+    const std::string & label,
+    rcutils_allocator_t allocator = rcutils_get_default_allocator());
 
   RCLCPP_LIFECYCLE_PUBLIC
-  explicit State(const rcl_lifecycle_state_t * rcl_lifecycle_state_handle);
+  explicit State(
+    const rcl_lifecycle_state_t * rcl_lifecycle_state_handle,
+    rcutils_allocator_t allocator = rcutils_get_default_allocator());
 
   RCLCPP_LIFECYCLE_PUBLIC
   virtual ~State();
@@ -49,8 +56,11 @@ public:
   label() const;
 
 protected:
+  rcutils_allocator_t allocator_;
+
   bool owns_rcl_state_handle_;
-  const rcl_lifecycle_state_t * state_handle_;
+
+  rcl_lifecycle_state_t * state_handle_;
 };
 
 }  // namespace rclcpp_lifecycle

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/state.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/state.hpp
@@ -31,7 +31,7 @@ class State
 {
 public:
   RCLCPP_LIFECYCLE_PUBLIC
-  State(rcutils_allocator_t allocator = rcutils_get_default_allocator());
+  explicit State(rcutils_allocator_t allocator = rcutils_get_default_allocator());
 
   RCLCPP_LIFECYCLE_PUBLIC
   State(

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/state.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/state.hpp
@@ -56,15 +56,15 @@ public:
   label() const;
 
 protected:
+  RCLCPP_LIFECYCLE_PUBLIC
+  void
+  reset();
+
   rcutils_allocator_t allocator_;
 
   bool owns_rcl_state_handle_;
 
   rcl_lifecycle_state_t * state_handle_;
-
-  RCLCPP_LIFECYCLE_PUBLIC
-  void
-  reset();
 };
 
 }  // namespace rclcpp_lifecycle

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/state.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/state.hpp
@@ -61,6 +61,10 @@ protected:
   bool owns_rcl_state_handle_;
 
   rcl_lifecycle_state_t * state_handle_;
+
+  RCLCPP_LIFECYCLE_PUBLIC
+  void
+  reset();
 };
 
 }  // namespace rclcpp_lifecycle

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/transition.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/transition.hpp
@@ -71,15 +71,15 @@ public:
   goal_state() const;
 
 protected:
+  RCLCPP_LIFECYCLE_PUBLIC
+  void
+  reset();
+
   rcutils_allocator_t allocator_;
 
   bool owns_rcl_transition_handle_;
 
   rcl_lifecycle_transition_t * transition_handle_;
-
-  RCLCPP_LIFECYCLE_PUBLIC
-  void
-  reset();
 };
 
 }  // namespace rclcpp_lifecycle

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/transition.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/transition.hpp
@@ -20,6 +20,8 @@
 #include "rclcpp_lifecycle/state.hpp"
 #include "rclcpp_lifecycle/visibility_control.h"
 
+#include "rcutils/allocator.h"
+
 // forward declare rcl_transition_t
 typedef struct rcl_lifecycle_transition_t rcl_lifecycle_transition_t;
 
@@ -33,15 +35,21 @@ public:
   Transition() = delete;
 
   RCLCPP_LIFECYCLE_PUBLIC
-  explicit Transition(uint8_t id, const std::string & label = "");
+  explicit Transition(
+    uint8_t id,
+    const std::string & label = "",
+    rcutils_allocator_t allocator = rcutils_get_default_allocator());
 
   RCLCPP_LIFECYCLE_PUBLIC
   Transition(
     uint8_t id, const std::string & label,
-    State && start, State && goal);
+    State && start, State && goal,
+    rcutils_allocator_t allocator = rcutils_get_default_allocator());
 
   RCLCPP_LIFECYCLE_PUBLIC
-  explicit Transition(const rcl_lifecycle_transition_t * rcl_lifecycle_transition_handle);
+  explicit Transition(
+    const rcl_lifecycle_transition_t * rcl_lifecycle_transition_handle,
+    rcutils_allocator_t allocator = rcutils_get_default_allocator());
 
   RCLCPP_LIFECYCLE_PUBLIC
   virtual ~Transition();
@@ -63,9 +71,11 @@ public:
   goal_state() const;
 
 protected:
+  rcutils_allocator_t allocator_;
+
   bool owns_rcl_transition_handle_;
 
-  const rcl_lifecycle_transition_t * transition_handle_;
+  rcl_lifecycle_transition_t * transition_handle_;
 };
 
 }  // namespace rclcpp_lifecycle

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/transition.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/transition.hpp
@@ -76,6 +76,10 @@ protected:
   bool owns_rcl_transition_handle_;
 
   rcl_lifecycle_transition_t * transition_handle_;
+
+  RCLCPP_LIFECYCLE_PUBLIC
+  void
+  reset();
 };
 
 }  // namespace rclcpp_lifecycle

--- a/rclcpp_lifecycle/src/state.cpp
+++ b/rclcpp_lifecycle/src/state.cpp
@@ -76,12 +76,18 @@ State::~State()
 uint8_t
 State::id() const
 {
+  if (!state_handle_) {
+    throw std::runtime_error("Error in state! Internal state_handle is NULL.");
+  }
   return state_handle_->id;
 }
 
 std::string
 State::label() const
 {
+  if (!state_handle_) {
+    throw std::runtime_error("Error in state! Internal state_handle is NULL.");
+  }
   return state_handle_->label;
 }
 
@@ -90,6 +96,9 @@ State::reset()
 {
   if (!owns_rcl_state_handle_) {
     state_handle_ = nullptr;
+  }
+
+  if (!state_handle_) {
     return;
   }
 
@@ -100,4 +109,5 @@ State::reset()
   allocator_.deallocate(state_handle_, allocator_.state);
   state_handle_ = nullptr;
 }
+
 }  // namespace rclcpp_lifecycle

--- a/rclcpp_lifecycle/src/state.cpp
+++ b/rclcpp_lifecycle/src/state.cpp
@@ -25,35 +25,53 @@
 namespace rclcpp_lifecycle
 {
 
-State::State()
-: State(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN, "unknown")
+State::State(rcutils_allocator_t allocator)
+: State(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN, "unknown", allocator)
 {}
 
-State::State(uint8_t id, const std::string & label)
-: owns_rcl_state_handle_(true)
+State::State(
+  uint8_t id,
+  const std::string & label,
+  rcutils_allocator_t allocator)
+: allocator_(allocator),
+  owns_rcl_state_handle_(true),
+  state_handle_(nullptr)
 {
   if (label.empty()) {
     throw std::runtime_error("Lifecycle State cannot have an empty label.");
   }
 
-  auto state_handle = new rcl_lifecycle_state_t;
+  auto state_handle = reinterpret_cast<rcl_lifecycle_state_t *>(
+    allocator_.allocate(sizeof(rcl_lifecycle_state_t), allocator_.state));
+  if (!state_handle) {
+    throw std::runtime_error("failed to allocate memory for rcl_lifecycle_state_t");
+  }
   state_handle->id = id;
   state_handle->label =
-    rcutils_strndup(label.c_str(), label.size(), rcutils_get_default_allocator());
+    rcutils_strndup(label.c_str(), label.size(), allocator_);
 
   state_handle_ = state_handle;
 }
 
-State::State(const rcl_lifecycle_state_t * rcl_lifecycle_state_handle)
-: owns_rcl_state_handle_(false)
+State::State(
+  const rcl_lifecycle_state_t * rcl_lifecycle_state_handle,
+  rcutils_allocator_t allocator)
+: allocator_(allocator),
+  owns_rcl_state_handle_(false),
+  state_handle_(nullptr)
 {
-  state_handle_ = rcl_lifecycle_state_handle;
+  state_handle_ = const_cast<rcl_lifecycle_state_t *>(rcl_lifecycle_state_handle);
 }
 
 State::~State()
 {
   if (owns_rcl_state_handle_) {
-    delete state_handle_;
+    if (state_handle_->label) {
+      allocator_.deallocate(const_cast<char *>(state_handle_->label), allocator_.state);
+      state_handle_->label = nullptr;
+    }
+    allocator_.deallocate(state_handle_, allocator_.state);
+    state_handle_ = nullptr;
   }
 }
 
@@ -61,7 +79,7 @@ uint8_t
 State::id() const
 {
   if (!state_handle_) {
-    throw std::runtime_error("Error in state! Internal state_handle is NULL.");
+    throw std::runtime_error("internal state_handle is null");
   }
   return state_handle_->id;
 }
@@ -70,7 +88,7 @@ std::string
 State::label() const
 {
   if (!state_handle_) {
-    throw std::runtime_error("Error in state! Internal state_handle is NULL.");
+    throw std::runtime_error("internal state_handle is null");
   }
   return state_handle_->label;
 }

--- a/rclcpp_lifecycle/src/transition.cpp
+++ b/rclcpp_lifecycle/src/transition.cpp
@@ -100,7 +100,6 @@ Transition::Transition(
 
 Transition::~Transition()
 {
-    // nothing to free here
   if (!transition_handle_) {
     owns_rcl_transition_handle_ = false;
     return;

--- a/rclcpp_lifecycle/src/transition.cpp
+++ b/rclcpp_lifecycle/src/transition.cpp
@@ -14,20 +14,34 @@
 
 #include "rclcpp_lifecycle/transition.hpp"
 
-#include <lifecycle_msgs/msg/transition.hpp>
-#include <rcl_lifecycle/data_types.h>
-
 #include <string>
+
+#include "lifecycle_msgs/msg/transition.hpp"
+
+#include "rcl_lifecycle/data_types.h"
+
+#include "rcutils/allocator.h"
+#include "rcutils/strdup.h"
 
 namespace rclcpp_lifecycle
 {
 
-Transition::Transition(uint8_t id, const std::string & label)
-: owns_rcl_transition_handle_(true)
+Transition::Transition(
+  uint8_t id,
+  const std::string & label,
+  rcutils_allocator_t allocator)
+: allocator_(allocator),
+  owns_rcl_transition_handle_(true),
+  transition_handle_(nullptr)
 {
-  auto transition_handle = new rcl_lifecycle_transition_t;
+  auto transition_handle = reinterpret_cast<rcl_lifecycle_transition_t *>(
+    allocator_.allocate(sizeof(rcl_lifecycle_transition_t), allocator_.state));
+  if (!transition_handle) {
+    throw std::runtime_error("failed to allocate memory for rcl_lifecycle_transition_t");
+  }
   transition_handle->id = id;
-  transition_handle->label = label.c_str();
+  transition_handle->label = rcutils_strndup(
+    label.c_str(), label.size(), allocator_);
 
   transition_handle->start = nullptr;
   transition_handle->goal = nullptr;
@@ -36,54 +50,110 @@ Transition::Transition(uint8_t id, const std::string & label)
 
 Transition::Transition(
   uint8_t id, const std::string & label,
-  State && start, State && goal)
-: owns_rcl_transition_handle_(true)
+  State && start, State && goal,
+  rcutils_allocator_t allocator)
+: allocator_(allocator),
+  owns_rcl_transition_handle_(true),
+  transition_handle_(nullptr)
 {
-  auto transition_handle = new rcl_lifecycle_transition_t;
+  auto transition_handle = reinterpret_cast<rcl_lifecycle_transition_t *>(
+    allocator_.allocate(sizeof(rcl_lifecycle_transition_t), allocator_.state));
+  if (!transition_handle) {
+    throw std::runtime_error("failed to allocate memory for rcl_lifecycle_transition_t");
+  }
   transition_handle->id = id;
-  transition_handle->label = label.c_str();
+  transition_handle->label = rcutils_strndup(
+    label.c_str(), label.size(), allocator_);
 
-  auto start_state = new rcl_lifecycle_state_t;
+  auto start_state = reinterpret_cast<rcl_lifecycle_state_t *>(
+    allocator_.allocate(sizeof(rcl_lifecycle_state_t), allocator_.state));
+  if (!start_state) {
+    throw std::runtime_error("failed to allocate memory for rcl_lifecycle_state_t");
+  }
   start_state->id = start.id();
-  start_state->label = start.label().c_str();
+  start_state->label =
+    rcutils_strndup(start.label().c_str(), start.label().size(), allocator_);
 
-  auto goal_state = new rcl_lifecycle_state_t;
+  auto goal_state = reinterpret_cast<rcl_lifecycle_state_t *>(
+    allocator_.allocate(sizeof(rcl_lifecycle_state_t), allocator_.state));
+  if (!goal_state) {
+    throw std::runtime_error("failed to allocate memory for rcl_lifecycle_state_t");
+  }
   goal_state->id = goal.id();
-  goal_state->label = start.label().c_str();
+  goal_state->label =
+    rcutils_strndup(goal.label().c_str(), goal.label().size(), allocator_);
 
   transition_handle->start = start_state;
   transition_handle->goal = goal_state;
   transition_handle_ = transition_handle;
 }
 
-Transition::Transition(const rcl_lifecycle_transition_t * rcl_lifecycle_transition_handle)
-: owns_rcl_transition_handle_(false)
+Transition::Transition(
+  const rcl_lifecycle_transition_t * rcl_lifecycle_transition_handle,
+  rcutils_allocator_t allocator)
+: allocator_(allocator),
+  owns_rcl_transition_handle_(false),
+  transition_handle_(nullptr)
 {
-  transition_handle_ = rcl_lifecycle_transition_handle;
+  transition_handle_ = const_cast<rcl_lifecycle_transition_t *>(rcl_lifecycle_transition_handle);
 }
 
 Transition::~Transition()
 {
-  if (owns_rcl_transition_handle_) {
-    if (transition_handle_->start) {
-      delete transition_handle_->start;
-    }
-    if (transition_handle_->goal) {
-      delete transition_handle_->goal;
-    }
-    delete transition_handle_;
+    // nothing to free here
+  if (!transition_handle_) {
+    owns_rcl_transition_handle_ = false;
+    return;
   }
+
+  // can't free anything which is not owned
+  if (!owns_rcl_transition_handle_) {
+    transition_handle_ = nullptr;
+    return;
+  }
+
+  if (transition_handle_->start) {
+    if (transition_handle_->start->label) {
+      allocator_.deallocate(
+        const_cast<char *>(transition_handle_->start->label), allocator_.state);
+      transition_handle_->start->label = nullptr;
+    }
+    allocator_.deallocate(transition_handle_->start, allocator_.state);
+    transition_handle_->start = nullptr;
+  }
+  if (transition_handle_->goal) {
+    if (transition_handle_->goal->label) {
+      allocator_.deallocate(
+        const_cast<char *>(transition_handle_->goal->label), allocator_.state);
+      transition_handle_->goal->label = nullptr;
+    }
+    allocator_.deallocate(transition_handle_->goal, allocator_.state);
+    transition_handle_->goal = nullptr;
+  }
+  if (transition_handle_->label) {
+    allocator_.deallocate(
+      const_cast<char *>(transition_handle_->label), allocator_.state);
+    transition_handle_->label = nullptr;
+  }
+  allocator_.deallocate(transition_handle_, allocator_.state);
+  transition_handle_ = nullptr;
 }
 
 uint8_t
 Transition::id() const
 {
+  if (!transition_handle_) {
+    throw std::runtime_error("internal transition_handle is null");
+  }
   return transition_handle_->id;
 }
 
 std::string
 Transition::label() const
 {
+  if (!transition_handle_) {
+    throw std::runtime_error("internal transition_handle is null");
+  }
   return transition_handle_->label;
 }
 

--- a/rclcpp_lifecycle/test/test_state_wrapper.cpp
+++ b/rclcpp_lifecycle/test/test_state_wrapper.cpp
@@ -37,6 +37,13 @@ TEST_F(TestStateWrapper, wrapper) {
   }
 
   {
+    std::string state_name("my_state");
+    rclcpp_lifecycle::State state(1, state_name);
+    state_name = "not_my_state";
+    EXPECT_STREQ("my_state", state.label().c_str());
+  }
+
+  {
     rcl_lifecycle_state_t lc_state = {"my_c_state", 2, NULL, NULL, 0};
     rclcpp_lifecycle::State c_state(lc_state.id, lc_state.label);
     EXPECT_EQ(2, c_state.id());
@@ -59,8 +66,8 @@ TEST_F(TestStateWrapper, wrapper) {
     EXPECT_EQ(3, c_state.id());
     EXPECT_FALSE(c_state.label().empty());
     EXPECT_STREQ("my_c_state", c_state.label().c_str());
+    delete lc_state;
   }
-
 
   // introduces flakiness
   // unsupported behavior!

--- a/rclcpp_lifecycle/test/test_transition_wrapper.cpp
+++ b/rclcpp_lifecycle/test/test_transition_wrapper.cpp
@@ -1,0 +1,66 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+class TestTransitionWrapper : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+  }
+};
+
+TEST_F(TestTransitionWrapper, empty_transition) {
+  auto a = std::make_shared<rclcpp_lifecycle::Transition>(1, "my_transition");
+  EXPECT_NO_THROW(a.reset());
+}
+
+TEST_F(TestTransitionWrapper, wrapper) {
+
+  {
+    rclcpp_lifecycle::Transition t(12, "no_states_set");
+    EXPECT_EQ(12, t.id());
+    EXPECT_STREQ("no_states_set", t.label().c_str());
+  }
+
+  {
+    std::string transition_name = "no_states_set";
+    rclcpp_lifecycle::Transition t(12, transition_name);
+    transition_name = "not_no_states_set";
+    EXPECT_EQ(12, t.id());
+    EXPECT_STREQ("no_states_set", t.label().c_str());
+  }
+
+  {
+    rclcpp_lifecycle::State start_state(1, "start_state");
+    rclcpp_lifecycle::State goal_state(2, "goal_state");
+
+    rclcpp_lifecycle::Transition t(
+      12,
+      "from_start_to_goal",
+      std::move(start_state),
+      std::move(goal_state));
+
+    EXPECT_EQ(12, t.id());
+    EXPECT_FALSE(t.label().empty());
+    EXPECT_STREQ("from_start_to_goal", t.label().c_str());
+  }
+}

--- a/rclcpp_lifecycle/test/test_transition_wrapper.cpp
+++ b/rclcpp_lifecycle/test/test_transition_wrapper.cpp
@@ -34,7 +34,6 @@ TEST_F(TestTransitionWrapper, empty_transition) {
 }
 
 TEST_F(TestTransitionWrapper, wrapper) {
-
   {
     rclcpp_lifecycle::Transition t(12, "no_states_set");
     EXPECT_EQ(12, t.id());


### PR DESCRIPTION
Connects to https://github.com/ros2/rclcpp/issues/393

This is a redo of https://github.com/ros2/rclcpp/pull/395 split up into each individual issue, which is associated to it. This should help the review process.

Regarding https://github.com/ros2/rclcpp/pull/395#discussion_r154537015:
The `label` stays a `const char *` and get deallocated with a const cast. This is then the same practice as https://github.com/ros2/rmw_fastrtps/blob/master/rmw_fastrtps_cpp/src/rmw_node.cpp#L142
