### PR TITLE
Allow logger to be passed into macros as a reference

### DIFF
--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -85,7 +85,9 @@ def is_supported_feature_combination(feature_combination):
  * \param ... The format string, followed by the variable arguments for the format string
  */
 #define RCLCPP_@(severity)@(suffix)(logger, @(''.join([p + ', ' for p in get_macro_parameters(feature_combination).keys()]))...) \
-  static_assert(::std::is_same<std::remove_reference<decltype(logger)>::type, ::rclcpp::Logger>::value, "First argument to logging macros must be an rclcpp::Logger"); \
+  static_assert( \
+    ::std::is_same<std::remove_reference<decltype(logger)>::type, ::rclcpp::Logger>::value, \
+    "First argument to logging macros must be an rclcpp::Logger"); \
   RCUTILS_LOG_@(severity)@(suffix)_NAMED( \
 @{params = get_macro_parameters(feature_combination).keys()}@
 @[ if params]@

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -85,7 +85,7 @@ def is_supported_feature_combination(feature_combination):
  * \param ... The format string, followed by the variable arguments for the format string
  */
 #define RCLCPP_@(severity)@(suffix)(logger, @(''.join([p + ', ' for p in get_macro_parameters(feature_combination).keys()]))...) \
-  static_assert(::std::is_same<decltype(logger), ::rclcpp::Logger>::value, "First argument to logging macros must be an rclcpp::Logger"); \
+  static_assert(::std::is_same<std::remove_reference<decltype(logger)>::type, ::rclcpp::Logger>::value, "First argument to logging macros must be an rclcpp::Logger"); \
   RCUTILS_LOG_@(severity)@(suffix)_NAMED( \
 @{params = get_macro_parameters(feature_combination).keys()}@
 @[ if params]@


### PR DESCRIPTION
Otherwise when captured by a lambda as in https://github.com/ros2/demos/pull/205/files#diff-f3c8fd029db528b5408e0a785999636eR135 it does not pass the `rclcpp::Logger` type check because it is `rclcpp::Logger &`

CI windows including the logger usage in https://github.com/ros2/demos/pull/205: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3838)](http://ci.ros2.org/job/ci_windows/3838/) (`image_tools` testing passed)