### PR TITLE
Use ament_cmake_ros

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -98,7 +98,6 @@ add_library(${PROJECT_NAME}
 ament_target_dependencies(${PROJECT_NAME}
   "builtin_interfaces"
   "rcl"
-  "rmw"
   "rosidl_generator_cpp"
   "rosidl_typesupport_cpp")
 
@@ -117,7 +116,6 @@ install(
 ament_export_dependencies(ament_cmake)
 ament_export_dependencies(builtin_interfaces)
 ament_export_dependencies(rcl)
-ament_export_dependencies(rmw)
 ament_export_dependencies(rosidl_generator_cpp)
 ament_export_dependencies(rosidl_typesupport_c)
 ament_export_dependencies(rosidl_typesupport_cpp)

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rclcpp)
 
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rcl REQUIRED)
 find_package(rcl_interfaces REQUIRED)
@@ -93,11 +93,12 @@ list(APPEND ${PROJECT_NAME}_SRCS
   include/rclcpp/logging.hpp)
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/include")
 
-add_library(${PROJECT_NAME} SHARED
+add_library(${PROJECT_NAME}
   ${${PROJECT_NAME}_SRCS})
 ament_target_dependencies(${PROJECT_NAME}
   "builtin_interfaces"
   "rcl"
+  "rmw"
   "rosidl_generator_cpp"
   "rosidl_typesupport_cpp")
 
@@ -116,6 +117,7 @@ install(
 ament_export_dependencies(ament_cmake)
 ament_export_dependencies(builtin_interfaces)
 ament_export_dependencies(rcl)
+ament_export_dependencies(rmw)
 ament_export_dependencies(rosidl_generator_cpp)
 ament_export_dependencies(rosidl_typesupport_c)
 ament_export_dependencies(rosidl_typesupport_cpp)

--- a/rclcpp/package.xml
+++ b/rclcpp/package.xml
@@ -25,7 +25,7 @@
   <depend>rcl</depend>
   <depend>rmw_implementation</depend>
 
-  <exec_depend>ament_cmake_ros</exec_depend>
+  <exec_depend>ament_cmake</exec_depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>

--- a/rclcpp/package.xml
+++ b/rclcpp/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <build_export_depend>rmw</build_export_depend>
 
@@ -25,7 +25,7 @@
   <depend>rcl</depend>
   <depend>rmw_implementation</depend>
 
-  <exec_depend>ament_cmake</exec_depend>
+  <exec_depend>ament_cmake_ros</exec_depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>

--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -10,7 +10,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcl_lifecycle REQUIRED)
 find_package(std_msgs REQUIRED)
@@ -20,7 +20,6 @@ include_directories(include)
 
 ### CPP High level library
 add_library(rclcpp_lifecycle
-  SHARED
   src/lifecycle_node.cpp
   src/node_interfaces/lifecycle_node_interface.cpp
   src/state.cpp

--- a/rclcpp_lifecycle/package.xml
+++ b/rclcpp_lifecycle/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="karsten@osrfoundation.org">Karsten Knese</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <build_depend>rclcpp</build_depend>


### PR DESCRIPTION
Revival of https://github.com/ros2/rclcpp/pull/390

- removed `rmw` dependency addition that seemed unrelated
- updated to include `rclcpp_lifecycle`
- [removed](https://github.com/ros2/rclcpp/commit/a346c90e92e08b9a1a10207613b94d170aeada90) the change from `exec_depend`ing on `ament_cmake` to `ament_cmake_ros` because from [this PR]() I inferred the dependency is for `normalize_path` from `ament_cmake` itself.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3978)](http://ci.ros2.org/job/ci_linux/3978/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1091)](http://ci.ros2.org/job/ci_linux-aarch64/1091/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3315)](http://ci.ros2.org/job/ci_osx/3315/) (unrelated linter errors)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4080)](http://ci.ros2.org/job/ci_windows/4080/) (unrelated linter errors)