### PR TITLE
Correctly clean up arguments structure.

### DIFF
--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -252,7 +252,7 @@ rclcpp::remove_ros_arguments(int argc, char const * const argv[])
 
   ret = rcl_arguments_fini(&parsed_args);
   if (RCL_RET_OK != ret) {
-    exceptions::throw_from_rcl_error(ret, "failed to cleanup parsed arguments, leaking memory: ");
+    exceptions::throw_from_rcl_error(ret, "failed to cleanup parsed arguments, leaking memory");
   }
 
   return return_arguments;

--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -210,16 +210,7 @@ rclcpp::remove_ros_arguments(int argc, char const * const argv[])
 
   ret = rcl_parse_arguments(argc, argv, alloc, &parsed_args);
   if (RCL_RET_OK != ret) {
-    // Not using throw_from_rcl_error, because we may need to append deallocation failures.
-    exceptions::RCLErrorBase base_exec(ret, rcl_get_error_state());
-    rcl_reset_error();
-    if (RCL_RET_OK != rcl_arguments_fini(&parsed_args)) {
-      base_exec.formatted_message += std::string(
-        ", failed also to cleanup parsed arguments, leaking memory: ") +
-        rcl_get_error_string_safe();
-      rcl_reset_error();
-    }
-    throw base_exec;
+    exceptions::throw_from_rcl_error(ret, "failed to parse arguments");
   }
 
   int nonros_argc = 0;

--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -204,7 +204,7 @@ std::vector<std::string>
 rclcpp::remove_ros_arguments(int argc, char const * const argv[])
 {
   rcl_allocator_t alloc = rcl_get_default_allocator();
-  rcl_arguments_t parsed_args;
+  rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
 
   rcl_ret_t ret;
 

--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -210,7 +210,16 @@ rclcpp::remove_ros_arguments(int argc, char const * const argv[])
 
   ret = rcl_parse_arguments(argc, argv, alloc, &parsed_args);
   if (RCL_RET_OK != ret) {
-    exceptions::throw_from_rcl_error(ret, "Failed to parse arguments");
+    // Not using throw_from_rcl_error, because we may need to append deallocation failures.
+    exceptions::RCLErrorBase base_exec(ret, rcl_get_error_state());
+    rcl_reset_error();
+    if (RCL_RET_OK != rcl_arguments_fini(&parsed_args)) {
+      base_exec.formatted_message += std::string(
+        ", failed also to cleanup parsed arguments, leaking memory: ") +
+        rcl_get_error_string_safe();
+      rcl_reset_error();
+    }
+    throw base_exec;
   }
 
   int nonros_argc = 0;
@@ -224,10 +233,19 @@ rclcpp::remove_ros_arguments(int argc, char const * const argv[])
     &nonros_argv);
 
   if (RCL_RET_OK != ret) {
+    // Not using throw_from_rcl_error, because we may need to append deallocation failures.
+    exceptions::RCLErrorBase base_exec(ret, rcl_get_error_state());
+    rcl_reset_error();
     if (NULL != nonros_argv) {
       alloc.deallocate(nonros_argv, alloc.state);
     }
-    exceptions::throw_from_rcl_error(ret, "Failed to remove ROS arguments: ");
+    if (RCL_RET_OK != rcl_arguments_fini(&parsed_args)) {
+      base_exec.formatted_message += std::string(
+        ", failed also to cleanup parsed arguments, leaking memory: ") +
+        rcl_get_error_string_safe();
+      rcl_reset_error();
+    }
+    throw base_exec;
   }
 
   std::vector<std::string> return_arguments;
@@ -239,6 +257,11 @@ rclcpp::remove_ros_arguments(int argc, char const * const argv[])
 
   if (NULL != nonros_argv) {
     alloc.deallocate(nonros_argv, alloc.state);
+  }
+
+  ret = rcl_arguments_fini(&parsed_args);
+  if (RCL_RET_OK != ret) {
+    exceptions::throw_from_rcl_error(ret, "failed to cleanup parsed arguments, leaking memory: ");
   }
 
   return return_arguments;

--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -225,18 +225,18 @@ rclcpp::remove_ros_arguments(int argc, char const * const argv[])
 
   if (RCL_RET_OK != ret) {
     // Not using throw_from_rcl_error, because we may need to append deallocation failures.
-    exceptions::RCLErrorBase base_exec(ret, rcl_get_error_state());
+    exceptions::RCLErrorBase base_exc(ret, rcl_get_error_state());
     rcl_reset_error();
     if (NULL != nonros_argv) {
       alloc.deallocate(nonros_argv, alloc.state);
     }
     if (RCL_RET_OK != rcl_arguments_fini(&parsed_args)) {
-      base_exec.formatted_message += std::string(
+      base_exc.formatted_message += std::string(
         ", failed also to cleanup parsed arguments, leaking memory: ") +
         rcl_get_error_string_safe();
       rcl_reset_error();
     }
-    throw base_exec;
+    throw exceptions::RCLError(base_exc, "");
   }
 
   std::vector<std::string> return_arguments;


### PR DESCRIPTION
Clean up the arguments structure, which was previously leaking.

Connects to ros2/rclcpp#458