### PR TITLE
Add CLI args to Node constructor

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -191,6 +191,16 @@ if(BUILD_TESTING)
     )
     target_link_libraries(test_node ${PROJECT_NAME})
   endif()
+  ament_add_gtest(test_node_global_args test/test_node_global_args.cpp)
+  if(TARGET test_node_global_args)
+    target_include_directories(test_node_global_args PUBLIC
+      ${rcl_interfaces_INCLUDE_DIRS}
+      ${rmw_INCLUDE_DIRS}
+      ${rosidl_generator_cpp_INCLUDE_DIRS}
+      ${rosidl_typesupport_cpp_INCLUDE_DIRS}
+    )
+    target_link_libraries(test_node_global_args ${PROJECT_NAME})
+  endif()
   ament_add_gtest(test_parameter_events_filter test/test_parameter_events_filter.cpp)
   if(TARGET test_parameter_events_filter)
     target_include_directories(test_parameter_events_filter PUBLIC

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -84,6 +84,9 @@ public:
    * \param[in] node_name Name of the node.
    * \param[in] namespace_ Namespace of the node.
    * \param[in] context The context for the node (usually represents the state of a process).
+   * \param[in] arguments Command line arguments that should apply only to this node.
+   * This can be used to provide remapping rules that only affect one instance.
+   * \param[in] use_global_arguments False to prevent node using arguments passed to the process.
    * \param[in] use_intra_process_comms True to use the optimized intra-process communication
    * pipeline to pass messages between nodes in the same process using shared memory.
    */
@@ -92,6 +95,8 @@ public:
     const std::string & node_name,
     const std::string & namespace_,
     rclcpp::Context::SharedPtr context,
+    const std::vector<std::string> & arguments,
+    bool use_global_arguments = true,
     bool use_intra_process_comms = false);
 
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
@@ -39,7 +39,9 @@ public:
   NodeBase(
     const std::string & node_name,
     const std::string & namespace_,
-    rclcpp::Context::SharedPtr context);
+    rclcpp::Context::SharedPtr context,
+    const std::vector<std::string> & arguments,
+    bool use_global_arguments);
 
   RCLCPP_PUBLIC
   virtual

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -43,6 +43,8 @@ Node::Node(
     node_name,
     namespace_,
     rclcpp::contexts::default_context::get_global_default_context(),
+    {},
+    true,
     use_intra_process_comms)
 {}
 
@@ -50,8 +52,11 @@ Node::Node(
   const std::string & node_name,
   const std::string & namespace_,
   rclcpp::Context::SharedPtr context,
+  const std::vector<std::string> & arguments,
+  bool use_global_arguments,
   bool use_intra_process_comms)
-: node_base_(new rclcpp::node_interfaces::NodeBase(node_name, namespace_, context)),
+: node_base_(new rclcpp::node_interfaces::NodeBase(
+      node_name, namespace_, context, arguments, use_global_arguments)),
   node_graph_(new rclcpp::node_interfaces::NodeGraph(node_base_.get())),
   node_logging_(new rclcpp::node_interfaces::NodeLogging(node_base_.get())),
   node_timers_(new rclcpp::node_interfaces::NodeTimers(node_base_.get())),

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -98,8 +98,12 @@ NodeBase::NodeBase(
     }
   }
   // TODO(sloretz) Pass an allocator to argument parsing
+  if (arguments.size() > std::numeric_limits<int>::max()) {
+    throw_from_rcl_error(RCL_RET_INVALID_ARGUMENT, "Too many args");
+  }
   ret = rcl_parse_arguments(
-    arguments.size(), c_args.get(), rcl_get_default_allocator(), &(options.arguments));
+    static_cast<int>(arguments.size()), c_args.get(), rcl_get_default_allocator(),
+    &(options.arguments));
   if (RCL_RET_OK != ret) {
     finalize_notify_guard_condition();
     throw_from_rcl_error(ret, "failed to parse arguments");

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -16,6 +16,7 @@
 
 #include <string>
 #include <memory>
+#include <vector>
 
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/node.hpp"

--- a/rclcpp/test/test_node_global_args.cpp
+++ b/rclcpp/test/test_node_global_args.cpp
@@ -1,0 +1,62 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+#include <vector>
+
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+class TestNodeWithGlobalArgs : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    const char * const args[] = {"proc", "__node:=global_node_name"};
+    rclcpp::init(2, args);
+  }
+};
+
+TEST_F(TestNodeWithGlobalArgs, local_arguments_before_global) {
+  auto context = rclcpp::contexts::default_context::get_global_default_context();
+  const std::vector<std::string> arguments = {"__node:=local_arguments_test"};
+  const bool use_global_arguments = true;
+  const bool use_intra_process = false;
+  auto node = rclcpp::Node::make_shared(
+    "orig_name", "", context, arguments, use_global_arguments, use_intra_process);
+  EXPECT_STREQ("local_arguments_test", node->get_name());
+}
+
+TEST_F(TestNodeWithGlobalArgs, use_or_ignore_global_arguments) {
+  auto context = rclcpp::contexts::default_context::get_global_default_context();
+  const std::vector<std::string> arguments = {};
+  const bool use_intra_process = false;
+
+  {  // Don't use global args
+    const bool use_global_arguments = false;
+    auto node = rclcpp::Node::make_shared(
+      "orig_name", "", context, arguments, use_global_arguments, use_intra_process);
+    EXPECT_STREQ("orig_name", node->get_name());
+  }
+  {  // Do use global args
+    const bool use_global_arguments = true;
+    auto node = rclcpp::Node::make_shared(
+      "orig_name", "", context, arguments, use_global_arguments, use_intra_process);
+    EXPECT_STREQ("global_node_name", node->get_name());
+  }
+}

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -88,6 +88,9 @@ public:
    * \param[in] node_name Name of the node.
    * \param[in] node_name Namespace of the node.
    * \param[in] context The context for the node (usually represents the state of a process).
+   * \param[in] arguments Command line arguments that should apply only to this node.
+   * This can be used to provide remapping rules that only affect one instance.
+   * \param[in] use_global_arguments False to prevent node using arguments passed to the process.
    * \param[in] use_intra_process_comms True to use the optimized intra-process communication
    * pipeline to pass messages between nodes in the same process using shared memory.
    */
@@ -96,6 +99,8 @@ public:
     const std::string & node_name,
     const std::string & namespace_,
     rclcpp::Context::SharedPtr context,
+    const std::vector<std::string> & arguments,
+    bool use_global_arguments = true,
     bool use_intra_process_comms = false);
 
   RCLCPP_LIFECYCLE_PUBLIC

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -49,6 +49,8 @@ LifecycleNode::LifecycleNode(
     node_name,
     namespace_,
     rclcpp::contexts::default_context::get_global_default_context(),
+    {},
+    true,
     use_intra_process_comms)
 {}
 
@@ -56,8 +58,11 @@ LifecycleNode::LifecycleNode(
   const std::string & node_name,
   const std::string & namespace_,
   rclcpp::Context::SharedPtr context,
+  const std::vector<std::string> & arguments,
+  bool use_global_arguments,
   bool use_intra_process_comms)
-: node_base_(new rclcpp::node_interfaces::NodeBase(node_name, namespace_, context)),
+: node_base_(new rclcpp::node_interfaces::NodeBase(
+      node_name, namespace_, context, arguments, use_global_arguments)),
   node_graph_(new rclcpp::node_interfaces::NodeGraph(node_base_.get())),
   node_logging_(new rclcpp::node_interfaces::NodeLogging(node_base_.get())),
   node_timers_(new rclcpp::node_interfaces::NodeTimers(node_base_.get())),


### PR DESCRIPTION
This adds a parameter for command line arguments to `Node`, and a parameter to ignore global CLI arguments. I think roslaunch might need something like this to dynamically compose nodes without their arguments affecting other nodes, though I'm not sure if there is another strategy planned.


Kind of related to ros2/examples#200 and ros2/ros2#450