### PR TITLE
pass AnyExecutable objects as reference to avoid memory allocation

### DIFF
--- a/rclcpp/include/rclcpp/any_executable.hpp
+++ b/rclcpp/include/rclcpp/any_executable.hpp
@@ -33,8 +33,6 @@ namespace executor
 
 struct AnyExecutable
 {
-  RCLCPP_SMART_PTR_DEFINITIONS(AnyExecutable)
-
   RCLCPP_PUBLIC
   AnyExecutable();
 

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -287,7 +287,7 @@ protected:
    */
   RCLCPP_PUBLIC
   void
-  execute_any_executable(AnyExecutable::SharedPtr any_exec);
+  execute_any_executable(AnyExecutable & any_exec);
 
   RCLCPP_PUBLIC
   static void
@@ -325,15 +325,17 @@ protected:
 
   RCLCPP_PUBLIC
   void
-  get_next_timer(AnyExecutable::SharedPtr any_exec);
+  get_next_timer(AnyExecutable & any_exec);
 
   RCLCPP_PUBLIC
-  AnyExecutable::SharedPtr
-  get_next_ready_executable();
+  bool
+  get_next_ready_executable(AnyExecutable & any_executable);
 
   RCLCPP_PUBLIC
-  AnyExecutable::SharedPtr
-  get_next_executable(std::chrono::nanoseconds timeout = std::chrono::nanoseconds(-1));
+  bool
+  get_next_executable(
+    AnyExecutable & any_executable,
+    std::chrono::nanoseconds timeout = std::chrono::nanoseconds(-1));
 
   /// Spinning state, used to prevent multi threaded calls to spin and to cancel blocking spins.
   std::atomic_bool spinning;

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -55,27 +55,23 @@ public:
   virtual void clear_handles() = 0;
   virtual void remove_null_handles(rcl_wait_set_t * wait_set) = 0;
 
-  /// Provide a newly initialized AnyExecutable object.
-  // \return Shared pointer to the fresh executable.
-  virtual rclcpp::executor::AnyExecutable::SharedPtr instantiate_next_executable() = 0;
-
   virtual void add_guard_condition(const rcl_guard_condition_t * guard_condition) = 0;
 
   virtual void remove_guard_condition(const rcl_guard_condition_t * guard_condition) = 0;
 
   virtual void
   get_next_subscription(
-    rclcpp::executor::AnyExecutable::SharedPtr any_exec,
+    rclcpp::executor::AnyExecutable & any_exec,
     const WeakNodeVector & weak_nodes) = 0;
 
   virtual void
   get_next_service(
-    rclcpp::executor::AnyExecutable::SharedPtr any_exec,
+    rclcpp::executor::AnyExecutable & any_exec,
     const WeakNodeVector & weak_nodes) = 0;
 
   virtual void
   get_next_client(
-    rclcpp::executor::AnyExecutable::SharedPtr any_exec,
+    rclcpp::executor::AnyExecutable & any_exec,
     const WeakNodeVector & weak_nodes) = 0;
 
   virtual rcl_allocator_t

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -222,9 +222,7 @@ Executor::spin_once(std::chrono::nanoseconds timeout)
   if (spinning.exchange(true)) {
     throw std::runtime_error("spin_once() called while already spinning");
   }
-  RCLCPP_SCOPE_EXIT({
-    this->spinning.store(false);
-  });
+  RCLCPP_SCOPE_EXIT(this->spinning.store(false); );
   AnyExecutable any_exec;
   if (get_next_executable(any_exec, timeout)) {
     execute_any_executable(any_exec);

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -69,13 +69,15 @@ void
 MultiThreadedExecutor::run(size_t)
 {
   while (rclcpp::ok() && spinning.load()) {
-    executor::AnyExecutable::SharedPtr any_exec;
+    executor::AnyExecutable any_exec;
     {
       std::lock_guard<std::mutex> wait_lock(wait_mutex_);
       if (!rclcpp::ok() || !spinning.load()) {
         return;
       }
-      any_exec = get_next_executable();
+      if (!get_next_executable(any_exec)) {
+        continue;
+      }
     }
     execute_any_executable(any_exec);
   }

--- a/rclcpp/src/rclcpp/executors/single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/single_threaded_executor.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rclcpp/any_executable.hpp"
 #include "rclcpp/scope_exit.hpp"
 
 using rclcpp::executors::SingleThreadedExecutor;
@@ -30,7 +31,9 @@ SingleThreadedExecutor::spin()
   }
   RCLCPP_SCOPE_EXIT(this->spinning.store(false); );
   while (rclcpp::ok() && spinning.load()) {
-    auto any_exec = get_next_executable();
-    execute_any_executable(any_exec);
+    rclcpp::executor::AnyExecutable any_executable;
+    if (get_next_executable(any_executable)) {
+      execute_any_executable(any_executable);
+    }
   }
 }


### PR DESCRIPTION
We've been trying to eliminate steady-state memory allocation, and this was identified as one of the easiest things we could change to avoid an unnecessary memory allocation and customization point.

CI:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4232)](http://ci.ros2.org/job/ci_linux/4232/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1271)](http://ci.ros2.org/job/ci_linux-aarch64/1271/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3502)](http://ci.ros2.org/job/ci_osx/3502/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4341)](http://ci.ros2.org/job/ci_windows/4341/)