### PR TITLE
Fini arguments passed to rcl_node_init()

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -118,10 +118,14 @@ NodeBase::NodeBase(
     // Finalize the interrupt guard condition.
     finalize_notify_guard_condition();
     // Finalize previously allocated node arguments
-    if (!rcl_arguments_fini(&options.arguments) == RCL_RET_OK) {
-      throw_from_rcl_error(RCL_RET_ERROR, "failed to deallocate node arguments");
+    if (RCL_RET_OK != rcl_arguments_fini(&options.arguments)) {
+      // Print message because exception will be thrown later in this code block
+      RCUTILS_LOG_ERROR_NAMED(
+        "rclcpp",
+        "Failed to fini arguments during error handling: %s", rcl_get_error_string_safe());
+      rcl_reset_error();
     }
-    
+
     if (ret == RCL_RET_NODE_INVALID_NAME) {
       rcl_reset_error();  // discard rcl_node_init error
       int validation_result;
@@ -187,6 +191,15 @@ NodeBase::NodeBase(
 
   // Indicate the notify_guard_condition is now valid.
   notify_guard_condition_is_valid_ = true;
+
+  // Finalize previously allocated node arguments
+  if (RCL_RET_OK != rcl_arguments_fini(&options.arguments)) {
+    // print message because throwing would prevent the destructor from being called
+    RCUTILS_LOG_ERROR_NAMED(
+      "rclcpp",
+      "Failed to fini arguments: %s", rcl_get_error_string_safe());
+    rcl_reset_error();
+  }
 }
 
 NodeBase::~NodeBase()

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -117,7 +117,11 @@ NodeBase::NodeBase(
   if (ret != RCL_RET_OK) {
     // Finalize the interrupt guard condition.
     finalize_notify_guard_condition();
-
+    // Finalize previously allocated node arguments
+    if (!rcl_arguments_fini(&options.arguments) == RCL_RET_OK) {
+      throw_from_rcl_error(RCL_RET_ERROR, "failed to deallocate node arguments");
+    }
+    
     if (ret == RCL_RET_NODE_INVALID_NAME) {
       rcl_reset_error();  // discard rcl_node_init error
       int validation_result;


### PR DESCRIPTION
Always finalize arguments because caller is responsible for freeing memory used by node options.

replaces ros2/rclcpp#467

connects to ros2/rcl#231