### PR TITLE
Workaround for wait_for_service lasting the full timeout with connext

### DIFF
--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -133,7 +133,7 @@ ClientBase::wait_for_service_nanoseconds(std::chrono::nanoseconds timeout)
     if (!rclcpp::ok()) {
       return false;
     }
-    // Limit each wait to 1ms to workaround an issue specific to the Connext RMW implementation.
+    // Limit each wait to 100ms to workaround an issue specific to the Connext RMW implementation.
     // A race condition means that graph changes for services becoming available may trigger the
     // wait set to wake up, but then not be reported as ready immediately after the wake up
     // (see https://github.com/ros2/rmw_connext/issues/201)
@@ -141,7 +141,7 @@ ClientBase::wait_for_service_nanoseconds(std::chrono::nanoseconds timeout)
     // has been reached, despite the service being available, so we artificially limit the wait
     // time to limit the delay.
     node_ptr->wait_for_graph_change(
-      event, std::min(time_to_wait, std::chrono::nanoseconds(1000000)));
+      event, std::min(time_to_wait, std::chrono::nanoseconds(RCL_MS_TO_NS(100))));
     // Because of the aforementioned race condition, we check if the service is ready even if the
     // graph event wasn't triggered.
     event->check_and_clear();

--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -14,6 +14,7 @@
 
 #include "rclcpp/client.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <cstdio>
 #include <memory>
@@ -132,12 +133,18 @@ ClientBase::wait_for_service_nanoseconds(std::chrono::nanoseconds timeout)
     if (!rclcpp::ok()) {
       return false;
     }
-    node_ptr->wait_for_graph_change(event, time_to_wait);
-    event->check_and_clear();  // reset the event
-
-    // always check if the service is ready, even if the graph event wasn't triggered
-    // this is needed to avoid a race condition that is specific to the Connext RMW implementation
+    // Limit each wait to 1ms to workaround an issue specific to the Connext RMW implementation.
+    // A race condition means that graph changes for services becoming available may trigger the
+    // wait set to wake up, but then not be reported as ready immediately after the wake up
     // (see https://github.com/ros2/rmw_connext/issues/201)
+    // If no other graph events occur, the wait set will not be triggered again until the timeout
+    // has been reached, despite the service being available, so we artificially limit the wait
+    // time to limit the delay.
+    node_ptr->wait_for_graph_change(
+      event, std::min(time_to_wait, std::chrono::nanoseconds(1000000)));
+    // Because of the aforementioned race condition, we check if the service is ready even if the
+    // graph event wasn't triggered.
+    event->check_and_clear();
     if (this->service_is_ready()) {
       return true;
     }


### PR DESCRIPTION
Fixes https://github.com/ros2/rmw_connext/issues/280

We already have a workaround in the implementation of `wait_for_service_nanoseconds` to accommodate a race condition in connext between when the graph condition is triggered and when the service is reported as being available (https://github.com/ros2/rclcpp/pull/262).

While that workaround works, it can be slow if there are no other graph events coincidentally happening at the same time. Currently, when we are hit by that race condition, we get stuck waiting the full duration of the remaining `time_to_wait` before the wait set wakes up again and we notice the service is now available.

This PR changes the behaviour to put a max wait in the `wait_for_graph_change` so that in the event we are hit by the race condition, we recover from it in a limited amount of time (I chose 100ms arbitrarily).

I didn't find where the race condition is coming from yet. I have an idea which I'll put on https://github.com/ros2/rmw_connext/issues/201

This adds overhead of graph wakeups and `service_is_ready` checks. We can only add that if connext is being used if we think it's worthwhile.

Standard CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4448)](http://ci.ros2.org/job/ci_linux/4448/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1383)](http://ci.ros2.org/job/ci_linux-aarch64/1383/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3630)](http://ci.ros2.org/job/ci_osx/3630/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4513)](http://ci.ros2.org/job/ci_windows/4513/)

CI repeating `test_client_scope_cpp` 100 times [with its timeout lowered from 60s to 10s](https://github.com/ros2/system_tests/commit/e798ee8976b922656f547148b8e3702ccaac7458): [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4447)](https://ci.ros2.org/job/ci_linux/4447/) (used to be regularly [flaky with a 30s timeout](https://github.com/ros2/system_tests/pull/259/files))