### PR TITLE
Spin before checking if ros time is active

### DIFF
--- a/rclcpp/test/test_time_source.cpp
+++ b/rclcpp/test/test_time_source.cpp
@@ -50,7 +50,6 @@ protected:
   rclcpp::Node::SharedPtr node;
 };
 
-
 TEST_F(TestTimeSource, detachUnattached) {
   rclcpp::TimeSource ts;
 
@@ -344,9 +343,11 @@ TEST_F(TestTimeSource, parameter_activation) {
   for (auto & result : set_parameters_results) {
     EXPECT_TRUE(result.successful);
   }
+  // SyncParametersClient returns when parameters have been set on the node_parameters interface,
+  // but it doesn't mean the on_parameter_event subscription in TimeSource has been called.
+  // Spin some to handle that subscription.
   rclcpp::spin_some(node);
   EXPECT_TRUE(ros_clock->ros_time_is_active());
-
 
   set_parameters_results = parameters_client->set_parameters({
     rclcpp::parameter::ParameterVariant("use_sim_time", rclcpp::parameter::PARAMETER_NOT_SET)
@@ -354,6 +355,7 @@ TEST_F(TestTimeSource, parameter_activation) {
   for (auto & result : set_parameters_results) {
     EXPECT_TRUE(result.successful);
   }
+  rclcpp::spin_some(node);
   EXPECT_TRUE(ros_clock->ros_time_is_active());
 
   set_parameters_results = parameters_client->set_parameters({
@@ -362,6 +364,7 @@ TEST_F(TestTimeSource, parameter_activation) {
   for (auto & result : set_parameters_results) {
     EXPECT_TRUE(result.successful);
   }
+  rclcpp::spin_some(node);
   EXPECT_FALSE(ros_clock->ros_time_is_active());
 
   set_parameters_results = parameters_client->set_parameters({
@@ -370,5 +373,6 @@ TEST_F(TestTimeSource, parameter_activation) {
   for (auto & result : set_parameters_results) {
     EXPECT_TRUE(result.successful);
   }
+  rclcpp::spin_some(node);
   EXPECT_FALSE(ros_clock->ros_time_is_active());
 }


### PR DESCRIPTION
This is a fix for a possible cause of a test failure described by [this comment](https://github.com/ros2/rclcpp/pull/478#issuecomment-393228080).

During the test the `ros_clock->ros_time_is_active()` method is expected to return false, but sometimes it returns true. "Ros Time" on a clock is activated or deactivated in a subscription callback on the `parameter_events` topic. A `SyncParametersClient` calls `spin_node_until_future_complete` with an `std::shared_future` that completes when a response to a request to set parameters has been received. It looks like it is possible for the client response to be received before the `parameter_events` subscription callback is called.

Without this PR I see a test failure on my ubuntu xenial machine ~50% of the time using `--retest-until-fail 100`. With this PR `--retest-until-fail 1800` completed without failing.

I don't know why the change in #478 made this test flaky.

CI (only test rclcpp since only code change is in a test)
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4498)](http://ci.ros2.org/job/ci_linux/4498/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1423)](http://ci.ros2.org/job/ci_linux-aarch64/1423/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3685)](http://ci.ros2.org/job/ci_osx/3685/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4575)](http://ci.ros2.org/job/ci_windows/4575/)