### PR TITLE
Get parameters that aren't set

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -49,16 +49,35 @@ public:
   set_parameters_atomically(
     const std::vector<rclcpp::Parameter> & parameters) = 0;
 
+  /// Return descriptions of parameters given their names.
+  /*
+   * \param[in] names a list of parameter names to check.
+   * \return the list of parameters that were found.
+   * Any parameter not found is omitted from the returned list.
+   */
   RCLCPP_PUBLIC
   virtual
   std::vector<rclcpp::Parameter>
   get_parameters(const std::vector<std::string> & names) const = 0;
 
+  /// Return the description of one parameter given a name.
+  /*
+   * \param[in] name the name of the parameter to look for.
+   * \return the parameter if it exists on the node.
+   * \throws std::out_of_range if the parameter does not exist on the node.
+   */
   RCLCPP_PUBLIC
   virtual
   rclcpp::Parameter
   get_parameter(const std::string & name) const = 0;
 
+  /// Return the description of one parameter given a name.
+  /*
+   * \param[in] name the name of the parameter to look for.
+   * \param[out] parameter the description if parameter exists on the node.
+   * \return true if the parameter exists on the node, or
+   * \return false if the parameter does not exist.
+   */
   RCLCPP_PUBLIC
   virtual
   bool

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -49,7 +49,7 @@ public:
   set_parameters_atomically(
     const std::vector<rclcpp::Parameter> & parameters) = 0;
 
-  /// Return descriptions of parameters given their names.
+  /// Get descriptions of parameters given their names.
   /*
    * \param[in] names a list of parameter names to check.
    * \return the list of parameters that were found.
@@ -60,7 +60,7 @@ public:
   std::vector<rclcpp::Parameter>
   get_parameters(const std::vector<std::string> & names) const = 0;
 
-  /// Return the description of one parameter given a name.
+  /// Get the description of one parameter given a name.
   /*
    * \param[in] name the name of the parameter to look for.
    * \return the parameter if it exists on the node.
@@ -71,7 +71,7 @@ public:
   rclcpp::Parameter
   get_parameter(const std::string & name) const = 0;
 
-  /// Return the description of one parameter given a name.
+  /// Get the description of one parameter given a name.
   /*
    * \param[in] name the name of the parameter to look for.
    * \param[out] parameter the description if parameter exists on the node.

--- a/rclcpp/src/rclcpp/parameter_service.cpp
+++ b/rclcpp/src/rclcpp/parameter_service.cpp
@@ -39,9 +39,12 @@ ParameterService::ParameterService(
       const std::shared_ptr<rcl_interfaces::srv::GetParameters::Request> request,
       std::shared_ptr<rcl_interfaces::srv::GetParameters::Response> response)
     {
-      auto values = node_params->get_parameters(request->names);
-      for (auto & pvariant : values) {
-        response->values.push_back(pvariant.get_value_message());
+      for (const auto & name : request->names) {
+        // Default construct param to NOT_SET
+        rclcpp::Parameter param;
+        node_params->get_parameter(name, param);
+        // push back NOT_SET when get_parameter() call fails
+        response->values.push_back(param.get_value_message());
       }
     },
     qos_profile, nullptr);


### PR DESCRIPTION
Parameters that are queried but don't exist on the node should return a value with type NOT_SET to comply with the service definition in `rcl_interfaces`.

This PR only changes the behavior of the `get_parameters` service. The C++ API doesn't have the same problem (it returns both the name and the value of the parameter), so this PR adds documentation to it instead.

Fixes ros2/rclcpp#490
connects to ros2/rclcpp#490