### PR TITLE
Fix rosidl dependencies

### DIFF
--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcl_lifecycle REQUIRED)
+find_package(rosidl_typesupport_cpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
 
@@ -29,7 +30,9 @@ add_library(rclcpp_lifecycle
 ament_target_dependencies(rclcpp_lifecycle
   "rclcpp"
   "rcl_lifecycle"
-  "lifecycle_msgs")
+  "lifecycle_msgs"
+  "rosidl_typesupport_cpp"
+)
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/rclcpp_lifecycle/package.xml
+++ b/rclcpp_lifecycle/package.xml
@@ -8,12 +8,10 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
-  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <build_depend>rclcpp</build_depend>
   <build_depend>rcl_lifecycle</build_depend>
   <build_depend>rmw_implementation</build_depend>
-  <build_depend>rosidl_default_generators</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>lifecycle_msgs</build_depend>
 
@@ -21,7 +19,6 @@
   <exec_depend>rcl_lifecycle</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rmw_implementation</exec_depend>
-  <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>lifecycle_msgs</exec_depend>
 

--- a/rclcpp_lifecycle/package.xml
+++ b/rclcpp_lifecycle/package.xml
@@ -9,18 +9,20 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <build_depend>lifecycle_msgs</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rcl_lifecycle</build_depend>
   <build_depend>rmw_implementation</build_depend>
+  <build_depend>rosidl_typesupport_cpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>lifecycle_msgs</build_depend>
 
+  <exec_depend>lifecycle_msgs</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rcl_lifecycle</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rmw_implementation</exec_depend>
+  <exec_depend>rosidl_typesupport_cpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-  <exec_depend>lifecycle_msgs</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
This package does not generate any message so it doesnt need to depend on the generators, instead it should link against the libraries that provide the symbols it uses (in this case rosidl_typesupport_cpp)

Connects to ros2/demos#264