### PR TITLE
Expose get_node_names API from node.

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -342,6 +342,10 @@ public:
   register_param_change_callback(CallbackT && callback);
 
   RCLCPP_PUBLIC
+  std::vector<std::string>
+  get_node_names() const;
+
+  RCLCPP_PUBLIC
   std::map<std::string, std::vector<std::string>>
   get_topic_names_and_types() const;
 

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -173,6 +173,12 @@ Node::list_parameters(
   return node_parameters_->list_parameters(prefixes, depth);
 }
 
+std::vector<std::string>
+Node::get_node_names() const
+{
+  return node_graph_->get_node_names();
+}
+
 std::map<std::string, std::vector<std::string>>
 Node::get_topic_names_and_types() const
 {

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -302,7 +302,7 @@ public:
 
   RCLCPP_LIFECYCLE_PUBLIC
   std::vector<std::string>
-  get_node_names(bool no_demangle = false) const;
+  get_node_names() const;
 
   RCLCPP_LIFECYCLE_PUBLIC
   std::map<std::string, std::vector<std::string>>

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -301,6 +301,10 @@ public:
   register_param_change_callback(CallbackT && callback);
 
   RCLCPP_LIFECYCLE_PUBLIC
+  std::vector<std::string>
+  get_node_names(bool no_demangle = false) const;
+
+  RCLCPP_LIFECYCLE_PUBLIC
   std::map<std::string, std::vector<std::string>>
   get_topic_names_and_types(bool no_demangle = false) const;
 

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -193,6 +193,12 @@ LifecycleNode::list_parameters(
   return node_parameters_->list_parameters(prefixes, depth);
 }
 
+std::vector<std::string>
+LifecycleNode::get_node_names(bool no_demangle) const
+{
+  return node_graph_->get_node_names(no_demangle);
+}
+
 std::map<std::string, std::vector<std::string>>
 LifecycleNode::get_topic_names_and_types(bool no_demangle) const
 {

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -194,9 +194,9 @@ LifecycleNode::list_parameters(
 }
 
 std::vector<std::string>
-LifecycleNode::get_node_names(bool no_demangle) const
+LifecycleNode::get_node_names() const
 {
-  return node_graph_->get_node_names(no_demangle);
+  return node_graph_->get_node_names();
 }
 
 std::map<std::string, std::vector<std::string>>


### PR DESCRIPTION
Exposing get_node_names API from node interfaces rather than node_graph ones. 