### PR TITLE
remove use of uninitialized CMake var

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -247,8 +247,7 @@ if(BUILD_TESTING)
     )
     target_link_libraries(test_publisher ${PROJECT_NAME})
   endif()
-  ament_add_gtest(test_rate test/test_rate.cpp
-    ENV RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation})
+  ament_add_gtest(test_rate test/test_rate.cpp)
   if(TARGET test_rate)
     target_include_directories(test_rate PUBLIC
       ${rcl_interfaces_INCLUDE_DIRS}
@@ -260,8 +259,7 @@ if(BUILD_TESTING)
       ${PROJECT_NAME}
     )
   endif()
-  ament_add_gtest(test_serialized_message_allocator test/test_serialized_message_allocator.cpp
-    ENV RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation})
+  ament_add_gtest(test_serialized_message_allocator test/test_serialized_message_allocator.cpp)
   if(TARGET test_serialized_message_allocator)
     target_include_directories(test_serialized_message_allocator PUBLIC
       ${test_msgs_INCLUDE_DIRS}


### PR DESCRIPTION
When building with `--warn-uninitialized` the variable is being flagged so it can be safely removed.