### PR TITLE
nothing uses std_msgs anymore

### DIFF
--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -14,7 +14,6 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcl_lifecycle REQUIRED)
 find_package(rosidl_typesupport_cpp REQUIRED)
-find_package(std_msgs REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
 
 include_directories(include)

--- a/rclcpp_lifecycle/package.xml
+++ b/rclcpp_lifecycle/package.xml
@@ -14,7 +14,6 @@
   <build_depend>rcl_lifecycle</build_depend>
   <build_depend>rmw_implementation</build_depend>
   <build_depend>rosidl_typesupport_cpp</build_depend>
-  <build_depend>std_msgs</build_depend>
 
   <exec_depend>lifecycle_msgs</exec_depend>
   <exec_depend>rclcpp</exec_depend>
@@ -22,7 +21,6 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rmw_implementation</exec_depend>
   <exec_depend>rosidl_typesupport_cpp</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
To be backported in bouncy https://github.com/ros2/ros2/issues/537

Allows to release the `rclcpp` repo without needing to release `common_interfaces` first

Connects to https://github.com/ros2/rcl/pull/270
CI at https://github.com/ros2/rcl/pull/270#issue-201414918