### PR TITLE
Support jump handlers with only pre- or post-jump callback

### DIFF
--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -153,7 +153,9 @@ Clock::invoke_prejump_callbacks(
   const std::vector<JumpHandler::SharedPtr> & callbacks)
 {
   for (const auto cb : callbacks) {
-    cb->pre_callback();
+    if (cb->pre_callback != nullptr) {
+      cb->pre_callback();
+    }
   }
 }
 
@@ -163,7 +165,9 @@ Clock::invoke_postjump_callbacks(
   const TimeJump & jump)
 {
   for (auto cb : callbacks) {
-    cb->post_callback(jump);
+    if (cb->post_callback != nullptr) {
+      cb->post_callback(jump);
+    }
   }
 }
 


### PR DESCRIPTION
We are assuming both pre- and post-jump callback are set for a JumpHandler, which can lead to `bad_function_call` exceptions.

To me it seems reasonable that only one is provided and not the other, so I took the approach of checking before calling them, but if we think they should both be required and users have to put noops as appropriate, we can add a check to the constructor instead.