### PR TITLE
Implement rclcpp::is_initialized()

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -386,6 +386,14 @@ if(BUILD_TESTING)
     target_link_libraries(test_utilities ${PROJECT_NAME})
   endif()
 
+  ament_add_gtest(test_init test/test_init.cpp
+    APPEND_LIBRARY_DIRS "${append_library_dirs}")
+  if(TARGET test_init)
+    ament_target_dependencies(test_init
+      "rcl")
+    target_link_libraries(test_init ${PROJECT_NAME})
+  endif()
+
   ament_add_gtest(test_multi_threaded_executor test/executors/test_multi_threaded_executor.cpp
     APPEND_LIBRARY_DIRS "${append_library_dirs}")
   if(TARGET test_multi_threaded_executor)

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -87,6 +87,12 @@ RCLCPP_PUBLIC
 bool
 ok();
 
+/// Returns true if init() has already been called.
+/** \return True if init() has been called, false otherwise. */
+RCLCPP_PUBLIC
+bool
+is_initialized();
+
 /// Notify the signal handler and rmw that rclcpp is shutting down.
 RCLCPP_PUBLIC
 void

--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -264,6 +264,12 @@ rclcpp::ok()
   return ::g_signal_status == 0;
 }
 
+bool
+rclcpp::is_initialized()
+{
+  return rcl_ok();
+}
+
 static std::mutex on_shutdown_mutex_;
 static std::vector<std::function<void(void)>> on_shutdown_callbacks_;
 

--- a/rclcpp/test/test_executor.cpp
+++ b/rclcpp/test/test_executor.cpp
@@ -28,7 +28,7 @@
 
 using namespace std::chrono_literals;
 
-class TestExcutors : public ::testing::Test
+class TestExecutors : public ::testing::Test
 {
 protected:
   static void SetUpTestCase()
@@ -50,7 +50,7 @@ protected:
 };
 
 // Make sure that executors detach from nodes when destructing
-TEST_F(TestExcutors, detachOnDestruction) {
+TEST_F(TestExecutors, detachOnDestruction) {
   {
     rclcpp::executors::SingleThreadedExecutor executor;
     executor.add_node(node);

--- a/rclcpp/test/test_init.cpp
+++ b/rclcpp/test/test_init.cpp
@@ -17,7 +17,6 @@
 #include "rclcpp/utilities.hpp"
 
 TEST(TestInit, is_initialized) {
-
   EXPECT_FALSE(rclcpp::is_initialized());
 
   rclcpp::init(0, nullptr);
@@ -28,4 +27,3 @@ TEST(TestInit, is_initialized) {
 
   EXPECT_TRUE(rclcpp::is_initialized());
 }
-

--- a/rclcpp/test/test_init.cpp
+++ b/rclcpp/test/test_init.cpp
@@ -1,0 +1,31 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rclcpp/utilities.hpp"
+
+TEST(TestInit, is_initialized) {
+
+  EXPECT_FALSE(rclcpp::is_initialized());
+
+  rclcpp::init(0, nullptr);
+
+  EXPECT_TRUE(rclcpp::is_initialized());
+
+  rclcpp::shutdown();
+
+  EXPECT_TRUE(rclcpp::is_initialized());
+}
+

--- a/rclcpp/test/test_utilities.cpp
+++ b/rclcpp/test/test_utilities.cpp
@@ -48,4 +48,6 @@ TEST(TestUtilities, init_with_args) {
 
   ASSERT_EQ(1u, other_args.size());
   ASSERT_EQ(std::string{"process_name"}, other_args[0]);
+
+  EXPECT_TRUE(rclcpp::is_initialized());
 }


### PR DESCRIPTION
Addresses https://github.com/ros2/rclcpp/issues/518.

* Named the function `is_initialized` instead of `isInitialized` because that seemed to be the style throughout the utilities
* It turns out that `rcl_ok` was already doing what was desired, so `rclcpp::is_initialized` is just a wrapper around that.
* Added new test file so it could run isolated