### PR TITLE
Add rclcpp::Time::seconds()

### DIFF
--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -100,6 +100,10 @@ public:
   ros_time_is_active();
 
   RCLCPP_PUBLIC
+  rcl_clock_t *
+  get_clock_handle();
+
+  RCLCPP_PUBLIC
   rcl_clock_type_t
   get_clock_type();
 

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -103,6 +103,8 @@ public:
   nanoseconds() const;
 
   /// \return the seconds since epoch as a floating point number.
+  /// \warning Depending on sizeof(double) there could be significant precision loss.
+  /// When an exact time is required use nanoseconds() instead.
   RCLCPP_PUBLIC
   double
   seconds() const;

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -102,6 +102,11 @@ public:
   rcl_time_point_value_t
   nanoseconds() const;
 
+  /// \return the seconds since epoch as a floating point number.
+  RCLCPP_PUBLIC
+  double
+  seconds() const;
+
   RCLCPP_PUBLIC
   rcl_clock_type_t
   get_clock_type() const;

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -23,6 +23,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "rclcpp/clock.hpp"
 #include "rclcpp/function_traits.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/rate.hpp"
@@ -44,7 +45,7 @@ public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(TimerBase)
 
   RCLCPP_PUBLIC
-  explicit TimerBase(std::chrono::nanoseconds period);
+  explicit TimerBase(Clock::SharedPtr clock, std::chrono::nanoseconds period);
 
   RCLCPP_PUBLIC
   ~TimerBase();
@@ -85,6 +86,7 @@ public:
   bool is_ready();
 
 protected:
+  Clock::SharedPtr clock_;
   std::shared_ptr<rcl_timer_t> timer_handle_;
 };
 
@@ -92,14 +94,12 @@ protected:
 using VoidCallbackType = std::function<void ()>;
 using TimerCallbackType = std::function<void (TimerBase &)>;
 
-/// Generic timer templated on the clock type. Periodically executes a user-specified callback.
+/// Generic timer. Periodically executes a user-specified callback.
 template<
   typename FunctorT,
-  class Clock,
   typename std::enable_if<
-    (rclcpp::function_traits::same_arguments<FunctorT, VoidCallbackType>::value ||
-    rclcpp::function_traits::same_arguments<FunctorT, TimerCallbackType>::value) &&
-    Clock::is_steady
+    rclcpp::function_traits::same_arguments<FunctorT, VoidCallbackType>::value ||
+    rclcpp::function_traits::same_arguments<FunctorT, TimerCallbackType>::value
   >::type * = nullptr
 >
 class GenericTimer : public TimerBase
@@ -109,11 +109,14 @@ public:
 
   /// Default constructor.
   /**
+   * \param[in] clock The clock providing the current time.
    * \param[in] period The interval at which the timer fires.
    * \param[in] callback User-specified callback function.
    */
-  GenericTimer(std::chrono::nanoseconds period, FunctorT && callback)
-  : TimerBase(period), callback_(std::forward<FunctorT>(callback))
+  explicit GenericTimer(
+    Clock::SharedPtr clock, std::chrono::nanoseconds period, FunctorT && callback
+  )
+  : TimerBase(clock, period), callback_(std::forward<FunctorT>(callback))
   {
   }
 
@@ -165,7 +168,7 @@ public:
   virtual bool
   is_steady()
   {
-    return Clock::is_steady;
+    return clock_->get_clock_type() == RCL_STEADY_TIME;
   }
 
 protected:
@@ -174,8 +177,26 @@ protected:
   FunctorT callback_;
 };
 
-template<typename CallbackType>
-using WallTimer = GenericTimer<CallbackType, std::chrono::steady_clock>;
+template<
+  typename FunctorT,
+  typename std::enable_if<
+    rclcpp::function_traits::same_arguments<FunctorT, VoidCallbackType>::value ||
+    rclcpp::function_traits::same_arguments<FunctorT, TimerCallbackType>::value
+  >::type * = nullptr
+>
+class WallTimer : public GenericTimer<FunctorT>
+{
+public:
+  RCLCPP_SMART_PTR_DEFINITIONS(WallTimer)
+
+  explicit WallTimer(std::chrono::nanoseconds period, FunctorT && callback)
+  : GenericTimer<FunctorT>(
+      std::make_shared<Clock>(RCL_STEADY_TIME), period, std::move(callback))
+  {}
+
+protected:
+  RCLCPP_DISABLE_COPY(WallTimer)
+};
 
 }  // namespace rclcpp
 

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -77,7 +77,7 @@ Clock::now()
 {
   Time now(0, 0, rcl_clock_.type);
 
-  auto ret = rcl_clock_get_now(&rcl_clock_, &now.rcl_time_);
+  auto ret = rcl_clock_get_now(&rcl_clock_, &now.rcl_time_.nanoseconds);
   if (ret != RCL_RET_OK) {
     rclcpp::exceptions::throw_from_rcl_error(
       ret, "could not get current time stamp");
@@ -101,6 +101,12 @@ Clock::ros_time_is_active()
       ret, "Failed to check ros_time_override_status");
   }
   return is_enabled;
+}
+
+rcl_clock_t *
+Clock::get_clock_handle()
+{
+  return &rcl_clock_;
 }
 
 rcl_clock_type_t

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -227,6 +227,12 @@ Time::nanoseconds() const
   return rcl_time_.nanoseconds;
 }
 
+double
+Time::seconds() const
+{
+  return std::chrono::duration<double>(std::chrono::nanoseconds(rcl_time_.nanoseconds)).count();
+}
+
 rcl_clock_type_t
 Time::get_clock_type() const
 {

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -65,7 +65,7 @@ void TimeSource::attachNode(
   node_services_ = node_services_interface;
   // TODO(tfoote): Update QOS
 
-  const std::string & topic_name = "/clock";
+  const std::string topic_name = "/clock";
 
   rclcpp::callback_group::CallbackGroup::SharedPtr group;
   using rclcpp::message_memory_strategy::MessageMemoryStrategy;

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -22,8 +22,10 @@
 
 using rclcpp::TimerBase;
 
-TimerBase::TimerBase(std::chrono::nanoseconds period)
+TimerBase::TimerBase(rclcpp::Clock::SharedPtr clock, std::chrono::nanoseconds period)
 {
+  clock_ = clock;
+
   timer_handle_ = std::shared_ptr<rcl_timer_t>(
     new rcl_timer_t, [ = ](rcl_timer_t * timer)
     {
@@ -38,8 +40,9 @@ TimerBase::TimerBase(std::chrono::nanoseconds period)
 
   *timer_handle_.get() = rcl_get_zero_initialized_timer();
 
+  rcl_clock_t * clock_handle = clock_->get_clock_handle();
   if (rcl_timer_init(
-      timer_handle_.get(), period.count(), nullptr,
+      timer_handle_.get(), clock_handle, period.count(), nullptr,
       rcl_get_default_allocator()) != RCL_RET_OK)
   {
     RCUTILS_LOG_ERROR_NAMED(

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -244,3 +244,9 @@ TEST(TestTime, overflows) {
   rclcpp::Time two_time(2);
   EXPECT_NO_THROW(one_time - two_time);
 }
+
+TEST(TestTime, seconds) {
+  EXPECT_DOUBLE_EQ(0.0, rclcpp::Time(0, 0).seconds());
+  EXPECT_DOUBLE_EQ(4.5, rclcpp::Time(4, 500000000).seconds());
+  EXPECT_DOUBLE_EQ(2.5, rclcpp::Time(0, 2500000000).seconds());
+}


### PR DESCRIPTION
~~(edit) ros2/rclcpp#482~~ Edit oops, this doesn't fix 482.  That ticket is about duration types.

This adds `seconds()` which returns the seconds since epoch as a double.

Connects to ros2/geometry2#67