### PR TITLE
Remove incorrect exception on sec < 0

### DIFF
--- a/rclcpp/src/rclcpp/duration.cpp
+++ b/rclcpp/src/rclcpp/duration.cpp
@@ -88,9 +88,6 @@ Duration::operator=(const Duration & rhs)
 Duration &
 Duration::operator=(const builtin_interfaces::msg::Duration & duration_msg)
 {
-  if (duration_msg.sec < 0) {
-    throw std::runtime_error("cannot store a negative duration point in rclcpp::Duration");
-  }
   rcl_duration_.nanoseconds = RCL_S_TO_NS(static_cast<int64_t>(duration_msg.sec));
   rcl_duration_.nanoseconds += duration_msg.nanosec;
   return *this;

--- a/rclcpp/test/test_duration.cpp
+++ b/rclcpp/test/test_duration.cpp
@@ -101,12 +101,15 @@ TEST(TestDuration, overflows) {
 TEST(TestDuration, negative_duration) {
   rclcpp::Duration assignable_duration = rclcpp::Duration(0) - rclcpp::Duration(5, 0);
 
-  EXPECT_EQ(-5000000000, assignable_duration.nanoseconds());
+  // Since number is smaller than -INT_MAX, must explicitly set the type for windows.
+  const int64_t expected_value_1 = -5000000000;
+  EXPECT_EQ(expected_value_1, assignable_duration.nanoseconds());
 
   builtin_interfaces::msg::Duration duration_msg;
   duration_msg.sec = -4;
   duration_msg.nanosec = 250000000;
 
   assignable_duration = duration_msg;
-  EXPECT_EQ(-3750000000, assignable_duration.nanoseconds());
+  const int64_t expected_value_2 = -3750000000;
+  EXPECT_EQ(expected_value_2, assignable_duration.nanoseconds());
 }

--- a/rclcpp/test/test_duration.cpp
+++ b/rclcpp/test/test_duration.cpp
@@ -97,3 +97,16 @@ TEST(TestDuration, overflows) {
   EXPECT_THROW(base_d_neg * (-4), std::overflow_error);
   EXPECT_THROW(base_d_neg * 4, std::underflow_error);
 }
+
+TEST(TestDuration, negative_duration) {
+  rclcpp::Duration assignable_duration = rclcpp::Duration(0) - rclcpp::Duration(5, 0);
+
+  EXPECT_EQ(-5000000000, assignable_duration.nanoseconds());
+
+  builtin_interfaces::msg::Duration duration_msg;
+  duration_msg.sec = -4;
+  duration_msg.nanosec = -500000000;
+
+  assignable_duration = duration_msg;
+  EXPECT_EQ(-4500000000, assignable_duration.nanoseconds());
+}

--- a/rclcpp/test/test_duration.cpp
+++ b/rclcpp/test/test_duration.cpp
@@ -101,15 +101,22 @@ TEST(TestDuration, overflows) {
 TEST(TestDuration, negative_duration) {
   rclcpp::Duration assignable_duration = rclcpp::Duration(0) - rclcpp::Duration(5, 0);
 
-  // Since number is smaller than -INT_MAX, must explicitly set the type for windows.
-  const int64_t expected_value_1 = -5000000000;
-  EXPECT_EQ(expected_value_1, assignable_duration.nanoseconds());
+  {
+    // avoid windows converting a literal number less than -INT_MAX to unsigned int C4146
+    int64_t expected_value = -5000;
+    expected_value *= 1000 * 1000;
+    EXPECT_EQ(expected_value, assignable_duration.nanoseconds());
+  }
 
-  builtin_interfaces::msg::Duration duration_msg;
-  duration_msg.sec = -4;
-  duration_msg.nanosec = 250000000;
+  {
+    builtin_interfaces::msg::Duration duration_msg;
+    duration_msg.sec = -4;
+    duration_msg.nanosec = 250000000;
 
-  assignable_duration = duration_msg;
-  const int64_t expected_value_2 = -3750000000;
-  EXPECT_EQ(expected_value_2, assignable_duration.nanoseconds());
+    assignable_duration = duration_msg;
+    // avoid windows converting a literal number less than -INT_MAX to unsigned int C4146
+    int64_t expected_value = -3750;
+    expected_value *= 1000 * 1000;
+    EXPECT_EQ(expected_value, assignable_duration.nanoseconds());
+  }
 }

--- a/rclcpp/test/test_duration.cpp
+++ b/rclcpp/test/test_duration.cpp
@@ -105,8 +105,8 @@ TEST(TestDuration, negative_duration) {
 
   builtin_interfaces::msg::Duration duration_msg;
   duration_msg.sec = -4;
-  duration_msg.nanosec = -500000000;
+  duration_msg.nanosec = 250000000;
 
   assignable_duration = duration_msg;
-  EXPECT_EQ(-4500000000, assignable_duration.nanoseconds());
+  EXPECT_EQ(-3750000000, assignable_duration.nanoseconds());
 }


### PR DESCRIPTION
Discussion in #525 

This removes a thrown exception that appears to be a copy/paste error from `rclcpp::Time`.

~~Requires ros2/rcl_interfaces#38~~