### PR TITLE
Compile flag fixes

### DIFF
--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -49,32 +49,26 @@ namespace node_interfaces
 class NodeBaseInterface;
 }  // namespace node_interfaces
 
-class ClientBase
+class RCLCPP_PUBLIC ClientBase
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(ClientBase)
 
-  RCLCPP_PUBLIC
   ClientBase(
     rclcpp::node_interfaces::NodeBaseInterface * node_base,
     rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph);
 
-  RCLCPP_PUBLIC
   virtual ~ClientBase();
 
-  RCLCPP_PUBLIC
   const char *
   get_service_name() const;
 
-  RCLCPP_PUBLIC
   std::shared_ptr<rcl_client_t>
   get_client_handle();
 
-  RCLCPP_PUBLIC
   std::shared_ptr<const rcl_client_t>
   get_client_handle() const;
 
-  RCLCPP_PUBLIC
   bool
   service_is_ready() const;
 
@@ -96,15 +90,12 @@ public:
 protected:
   RCLCPP_DISABLE_COPY(ClientBase)
 
-  RCLCPP_PUBLIC
   bool
   wait_for_service_nanoseconds(std::chrono::nanoseconds timeout);
 
-  RCLCPP_PUBLIC
   rcl_node_t *
   get_rcl_node_handle();
 
-  RCLCPP_PUBLIC
   const rcl_node_t *
   get_rcl_node_handle() const;
 

--- a/rclcpp/include/rclcpp/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager.hpp
@@ -119,7 +119,7 @@ namespace intra_process_manager
  *
  * This class is neither CopyConstructable nor CopyAssignable.
  */
-class IntraProcessManager
+class RCLCPP_PUBLIC IntraProcessManager
 {
 private:
   RCLCPP_DISABLE_COPY(IntraProcessManager)
@@ -127,11 +127,9 @@ private:
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(IntraProcessManager)
 
-  RCLCPP_PUBLIC
   explicit IntraProcessManager(
     IntraProcessManagerImplBase::SharedPtr state = create_default_impl());
 
-  RCLCPP_PUBLIC
   virtual ~IntraProcessManager();
 
   /// Register a subscription with the manager, returns subscriptions unique id.
@@ -147,7 +145,6 @@ public:
    * \param subscription the Subscription to register.
    * \return an unsigned 64-bit integer which is the subscription's unique id.
    */
-  RCLCPP_PUBLIC
   uint64_t
   add_subscription(SubscriptionBase::SharedPtr subscription);
 
@@ -157,7 +154,6 @@ public:
    *
    * \param intra_process_subscription_id id of the subscription to remove.
    */
-  RCLCPP_PUBLIC
   void
   remove_subscription(uint64_t intra_process_subscription_id);
 
@@ -206,7 +202,6 @@ public:
    *
    * \param intra_process_publisher_id id of the publisher to remove.
    */
-  RCLCPP_PUBLIC
   void
   remove_publisher(uint64_t intra_process_publisher_id);
 
@@ -342,12 +337,10 @@ public:
   }
 
   /// Return true if the given rmw_gid_t matches any stored Publishers.
-  RCLCPP_PUBLIC
   bool
   matches_any_publishers(const rmw_gid_t * id) const;
 
 private:
-  RCLCPP_PUBLIC
   static uint64_t
   get_next_unique_id();
 

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -62,7 +62,7 @@ namespace rclcpp
 {
 
 /// Node is the single point of entry for creating publishers and subscribers.
-class Node : public std::enable_shared_from_this<Node>
+class RCLCPP_PUBLIC Node : public std::enable_shared_from_this<Node>
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(Node)
@@ -74,7 +74,6 @@ public:
    * \param[in] use_intra_process_comms True to use the optimized intra-process communication
    * pipeline to pass messages between nodes in the same process using shared memory.
    */
-  RCLCPP_PUBLIC
   explicit Node(
     const std::string & node_name,
     const std::string & namespace_ = "",
@@ -92,7 +91,6 @@ public:
    * \param[in] use_intra_process_comms True to use the optimized intra-process communication
    * pipeline to pass messages between nodes in the same process using shared memory.
    */
-  RCLCPP_PUBLIC
   Node(
     const std::string & node_name,
     const std::string & namespace_,
@@ -103,34 +101,28 @@ public:
     bool use_intra_process_comms = false,
     bool start_parameter_services = true);
 
-  RCLCPP_PUBLIC
   virtual ~Node();
 
   /// Get the name of the node.
   /** \return The name of the node. */
-  RCLCPP_PUBLIC
   const char *
   get_name() const;
 
   /// Get the namespace of the node.
   /** \return The namespace of the node. */
-  RCLCPP_PUBLIC
   const char *
   get_namespace() const;
 
   /// Get the logger of the node.
   /** \return The logger of the node. */
-  RCLCPP_PUBLIC
   rclcpp::Logger
   get_logger() const;
 
   /// Create and return a callback group.
-  RCLCPP_PUBLIC
   rclcpp::callback_group::CallbackGroup::SharedPtr
   create_callback_group(rclcpp::callback_group::CallbackGroupType group_type);
 
   /// Return the list of callback groups in the node.
-  RCLCPP_PUBLIC
   const std::vector<rclcpp::callback_group::CallbackGroup::WeakPtr> &
   get_callback_groups() const;
 
@@ -261,11 +253,9 @@ public:
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_services_default,
     rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr);
 
-  RCLCPP_PUBLIC
   std::vector<rcl_interfaces::msg::SetParametersResult>
   set_parameters(const std::vector<rclcpp::Parameter> & parameters);
 
-  RCLCPP_PUBLIC
   rcl_interfaces::msg::SetParametersResult
   set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters);
 
@@ -275,15 +265,12 @@ public:
     const std::string & name,
     const ParameterT & value);
 
-  RCLCPP_PUBLIC
   std::vector<rclcpp::Parameter>
   get_parameters(const std::vector<std::string> & names) const;
 
-  RCLCPP_PUBLIC
   rclcpp::Parameter
   get_parameter(const std::string & name) const;
 
-  RCLCPP_PUBLIC
   bool
   get_parameter(
     const std::string & name,
@@ -319,15 +306,12 @@ public:
     ParameterT & value,
     const ParameterT & alternative_value) const;
 
-  RCLCPP_PUBLIC
   std::vector<rcl_interfaces::msg::ParameterDescriptor>
   describe_parameters(const std::vector<std::string> & names) const;
 
-  RCLCPP_PUBLIC
   std::vector<uint8_t>
   get_parameter_types(const std::vector<std::string> & names) const;
 
-  RCLCPP_PUBLIC
   rcl_interfaces::msg::ListParametersResult
   list_parameters(const std::vector<std::string> & prefixes, uint64_t depth) const;
 
@@ -345,19 +329,15 @@ public:
   std::vector<std::string>
   get_node_names() const;
 
-  RCLCPP_PUBLIC
   std::map<std::string, std::vector<std::string>>
   get_topic_names_and_types() const;
 
-  RCLCPP_PUBLIC
   std::map<std::string, std::vector<std::string>>
   get_service_names_and_types() const;
 
-  RCLCPP_PUBLIC
   size_t
   count_publishers(const std::string & topic_name) const;
 
-  RCLCPP_PUBLIC
   size_t
   count_subscribers(const std::string & topic_name) const;
 
@@ -366,7 +346,6 @@ public:
    * The Event object is scoped and therefore to return the loan just let it go
    * out of scope.
    */
-  RCLCPP_PUBLIC
   rclcpp::Event::SharedPtr
   get_graph_event();
 
@@ -378,59 +357,48 @@ public:
    * \throws EventNotRegisteredError if the given event was not acquired with
    *   get_graph_event().
    */
-  RCLCPP_PUBLIC
   void
   wait_for_graph_change(
     rclcpp::Event::SharedPtr event,
     std::chrono::nanoseconds timeout);
 
-  RCLCPP_PUBLIC
   rclcpp::Clock::SharedPtr
   get_clock();
 
-  RCLCPP_PUBLIC
   Time
   now();
 
   /// Return the Node's internal NodeBaseInterface implementation.
-  RCLCPP_PUBLIC
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
   get_node_base_interface();
 
   /// Return the Node's internal NodeClockInterface implementation.
-  RCLCPP_PUBLIC
   rclcpp::node_interfaces::NodeClockInterface::SharedPtr
   get_node_clock_interface();
 
   /// Return the Node's internal NodeGraphInterface implementation.
-  RCLCPP_PUBLIC
   rclcpp::node_interfaces::NodeGraphInterface::SharedPtr
   get_node_graph_interface();
 
   /// Return the Node's internal NodeTimersInterface implementation.
-  RCLCPP_PUBLIC
   rclcpp::node_interfaces::NodeTimersInterface::SharedPtr
   get_node_timers_interface();
 
   /// Return the Node's internal NodeTopicsInterface implementation.
-  RCLCPP_PUBLIC
   rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr
   get_node_topics_interface();
 
   /// Return the Node's internal NodeServicesInterface implementation.
-  RCLCPP_PUBLIC
   rclcpp::node_interfaces::NodeServicesInterface::SharedPtr
   get_node_services_interface();
 
   /// Return the Node's internal NodeParametersInterface implementation.
-  RCLCPP_PUBLIC
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr
   get_node_parameters_interface();
 
 private:
   RCLCPP_DISABLE_COPY(Node)
 
-  RCLCPP_PUBLIC
   bool
   group_in_node(callback_group::CallbackGroup::SharedPtr group);
 

--- a/rclcpp/include/rclcpp/parameter.hpp
+++ b/rclcpp/include/rclcpp/parameter.hpp
@@ -29,13 +29,11 @@ namespace rclcpp
 {
 
 /// Structure to store an arbitrary parameter with templated get/set methods.
-class Parameter
+class RCLCPP_PUBLIC Parameter
 {
 public:
-  RCLCPP_PUBLIC
   Parameter();
 
-  RCLCPP_PUBLIC
   Parameter(const std::string & name, const ParameterValue & value);
 
   template<typename ValueTypeT>
@@ -44,19 +42,15 @@ public:
   {
   }
 
-  RCLCPP_PUBLIC
   ParameterType
   get_type() const;
 
-  RCLCPP_PUBLIC
   std::string
   get_type_name() const;
 
-  RCLCPP_PUBLIC
   const std::string &
   get_name() const;
 
-  RCLCPP_PUBLIC
   rcl_interfaces::msg::ParameterValue
   get_value_message() const;
 
@@ -76,51 +70,39 @@ public:
     return value_.get<T>();
   }
 
-  RCLCPP_PUBLIC
   bool
   as_bool() const;
 
-  RCLCPP_PUBLIC
   int64_t
   as_int() const;
 
-  RCLCPP_PUBLIC
   double
   as_double() const;
 
-  RCLCPP_PUBLIC
   const std::string &
   as_string() const;
 
-  RCLCPP_PUBLIC
   const std::vector<uint8_t> &
   as_byte_array() const;
 
-  RCLCPP_PUBLIC
   const std::vector<bool> &
   as_bool_array() const;
 
-  RCLCPP_PUBLIC
   const std::vector<int64_t> &
   as_integer_array() const;
 
-  RCLCPP_PUBLIC
   const std::vector<double> &
   as_double_array() const;
 
-  RCLCPP_PUBLIC
   const std::vector<std::string> &
   as_string_array() const;
 
-  RCLCPP_PUBLIC
   static Parameter
   from_parameter_msg(const rcl_interfaces::msg::Parameter & parameter);
 
-  RCLCPP_PUBLIC
   rcl_interfaces::msg::Parameter
   to_parameter_msg() const;
 
-  RCLCPP_PUBLIC
   std::string
   value_to_string() const;
 

--- a/rclcpp/include/rclcpp/parameter_events_filter.hpp
+++ b/rclcpp/include/rclcpp/parameter_events_filter.hpp
@@ -31,7 +31,7 @@
 namespace rclcpp
 {
 
-class ParameterEventsFilter
+class RCLCPP_PUBLIC ParameterEventsFilter
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(ParameterEventsFilter)
@@ -54,7 +54,6 @@ public:
   *      {"foo", "bar"},
   *      {rclcpp::ParameterEventsFilter::EventType::NEW, rclcpp::ParameterEventsFilter::EventType::CHANGED});
   */
-  RCLCPP_PUBLIC
   ParameterEventsFilter(
     rcl_interfaces::msg::ParameterEvent::SharedPtr event,
     const std::vector<std::string> & names,
@@ -64,7 +63,6 @@ public:
   /**
    * \return A std::vector<EventPair> of all matching parameter changes in this event.
    */
-  RCLCPP_PUBLIC
   const std::vector<EventPair> & get_events() const;
 
 private:

--- a/rclcpp/include/rclcpp/parameter_service.hpp
+++ b/rclcpp/include/rclcpp/parameter_service.hpp
@@ -34,12 +34,11 @@
 namespace rclcpp
 {
 
-class ParameterService
+class RCLCPP_PUBLIC ParameterService
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(ParameterService)
 
-  RCLCPP_PUBLIC
   explicit ParameterService(
     const std::shared_ptr<node_interfaces::NodeBaseInterface> node_base,
     const std::shared_ptr<node_interfaces::NodeServicesInterface> node_services,

--- a/rclcpp/include/rclcpp/parameter_value.hpp
+++ b/rclcpp/include/rclcpp/parameter_value.hpp
@@ -67,65 +67,47 @@ public:
 };
 
 /// Store the type and value of a parameter.
-class ParameterValue
+class RCLCPP_PUBLIC ParameterValue
 {
 public:
   /// Construct a parameter value with type PARAMETER_NOT_SET.
-  RCLCPP_PUBLIC
   ParameterValue();
   /// Construct a parameter value from a message.
-  RCLCPP_PUBLIC
   explicit ParameterValue(const rcl_interfaces::msg::ParameterValue & value);
   /// Construct a parameter value with type PARAMETER_BOOL.
-  RCLCPP_PUBLIC
   explicit ParameterValue(const bool bool_value);
   /// Construct a parameter value with type PARAMETER_INTEGER.
-  RCLCPP_PUBLIC
   explicit ParameterValue(const int int_value);
   /// Construct a parameter value with type PARAMETER_INTEGER.
-  RCLCPP_PUBLIC
   explicit ParameterValue(const int64_t int_value);
   /// Construct a parameter value with type PARAMETER_DOUBLE.
-  RCLCPP_PUBLIC
   explicit ParameterValue(const float double_value);
   /// Construct a parameter value with type PARAMETER_DOUBLE.
-  RCLCPP_PUBLIC
   explicit ParameterValue(const double double_value);
   /// Construct a parameter value with type PARAMETER_STRING.
-  RCLCPP_PUBLIC
   explicit ParameterValue(const std::string & string_value);
   /// Construct a parameter value with type PARAMETER_STRING.
-  RCLCPP_PUBLIC
   explicit ParameterValue(const char * string_value);
   /// Construct a parameter value with type PARAMETER_BYTE_ARRAY.
-  RCLCPP_PUBLIC
   explicit ParameterValue(const std::vector<uint8_t> & byte_array_value);
   /// Construct a parameter value with type PARAMETER_BOOL_ARRAY.
-  RCLCPP_PUBLIC
   explicit ParameterValue(const std::vector<bool> & bool_array_value);
   /// Construct a parameter value with type PARAMETER_INTEGER_ARRAY.
-  RCLCPP_PUBLIC
   explicit ParameterValue(const std::vector<int> & int_array_value);
   /// Construct a parameter value with type PARAMETER_INTEGER_ARRAY.
-  RCLCPP_PUBLIC
   explicit ParameterValue(const std::vector<int64_t> & int_array_value);
   /// Construct a parameter value with type PARAMETER_DOUBLE_ARRAY.
-  RCLCPP_PUBLIC
   explicit ParameterValue(const std::vector<float> & double_array_value);
   /// Construct a parameter value with type PARAMETER_DOUBLE_ARRAY.
-  RCLCPP_PUBLIC
   explicit ParameterValue(const std::vector<double> & double_array_value);
   /// Construct a parameter value with type PARAMETER_STRING_ARRAY.
-  RCLCPP_PUBLIC
   explicit ParameterValue(const std::vector<std::string> & string_array_value);
 
   /// Return an enum indicating the type of the set value.
-  RCLCPP_PUBLIC
   ParameterType
   get_type() const;
 
   /// Return a message populated with the parameter value
-  RCLCPP_PUBLIC
   rcl_interfaces::msg::ParameterValue
   to_value_msg() const;
 

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -45,7 +45,7 @@ namespace node_interfaces
 class NodeTopicsInterface;
 }
 
-class PublisherBase
+class RCLCPP_PUBLIC PublisherBase
 {
   friend ::rclcpp::node_interfaces::NodeTopicsInterface;
 
@@ -61,49 +61,41 @@ public:
    * \param[in] type_support The type support structure for the type to be published.
    * \param[in] publisher_options QoS settings for this publisher.
    */
-  RCLCPP_PUBLIC
   PublisherBase(
     rclcpp::node_interfaces::NodeBaseInterface * node_base,
     const std::string & topic,
     const rosidl_message_type_support_t & type_support,
     const rcl_publisher_options_t & publisher_options);
 
-  RCLCPP_PUBLIC
   virtual ~PublisherBase();
 
   /// Get the topic that this publisher publishes on.
   /** \return The topic name. */
-  RCLCPP_PUBLIC
   const char *
   get_topic_name() const;
 
   /// Get the queue size for this publisher.
   /** \return The queue size. */
-  RCLCPP_PUBLIC
   size_t
   get_queue_size() const;
 
   /// Get the global identifier for this publisher (used in rmw and by DDS).
   /** \return The gid. */
-  RCLCPP_PUBLIC
   const rmw_gid_t &
   get_gid() const;
 
   /// Get the global identifier for this publisher used by intra-process communication.
   /** \return The intra-process gid. */
-  RCLCPP_PUBLIC
   const rmw_gid_t &
   get_intra_process_gid() const;
 
   /// Get the rcl publisher handle.
   /** \return The rcl publisher handle. */
-  RCLCPP_PUBLIC
   rcl_publisher_t *
   get_publisher_handle();
 
   /// Get the rcl publisher handle.
   /** \return The rcl publisher handle. */
-  RCLCPP_PUBLIC
   const rcl_publisher_t *
   get_publisher_handle() const;
 
@@ -113,7 +105,6 @@ public:
    * \param[in] gid Reference to a gid.
    * \return True if the publisher's gid matches the input.
    */
-  RCLCPP_PUBLIC
   bool
   operator==(const rmw_gid_t & gid) const;
 
@@ -123,14 +114,12 @@ public:
    * \param[in] gid A pointer to a gid.
    * \return True if this publisher's gid matches the input.
    */
-  RCLCPP_PUBLIC
   bool
   operator==(const rmw_gid_t * gid) const;
 
   using StoreMessageCallbackT = std::function<uint64_t(uint64_t, void *, const std::type_info &)>;
 
   /// Implementation utility function used to setup intra process publishing after creation.
-  RCLCPP_PUBLIC
   void
   setup_intra_process(
     uint64_t intra_process_publisher_id,

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -37,27 +37,22 @@
 namespace rclcpp
 {
 
-class ServiceBase
+class RCLCPP_PUBLIC ServiceBase
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(ServiceBase)
 
-  RCLCPP_PUBLIC
   explicit ServiceBase(
     std::shared_ptr<rcl_node_t> node_handle);
 
-  RCLCPP_PUBLIC
   virtual ~ServiceBase();
 
-  RCLCPP_PUBLIC
   const char *
   get_service_name();
 
-  RCLCPP_PUBLIC
   std::shared_ptr<rcl_service_t>
   get_service_handle();
 
-  RCLCPP_PUBLIC
   std::shared_ptr<const rcl_service_t>
   get_service_handle() const;
 
@@ -70,11 +65,9 @@ public:
 protected:
   RCLCPP_DISABLE_COPY(ServiceBase)
 
-  RCLCPP_PUBLIC
   rcl_node_t *
   get_rcl_node_handle();
 
-  RCLCPP_PUBLIC
   const rcl_node_t *
   get_rcl_node_handle() const;
 

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -48,7 +48,7 @@ class NodeTopicsInterface;
 
 /// Virtual base class for subscriptions. This pattern allows us to iterate over different template
 /// specializations of Subscription, among other things.
-class SubscriptionBase
+class RCLCPP_PUBLIC SubscriptionBase
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(SubscriptionBase)
@@ -60,7 +60,6 @@ public:
    * \param[in] topic_name Name of the topic to subscribe to.
    * \param[in] subscription_options options for the subscription.
    */
-  RCLCPP_PUBLIC
   SubscriptionBase(
     std::shared_ptr<rcl_node_t> node_handle,
     const rosidl_message_type_support_t & type_support_handle,
@@ -69,23 +68,18 @@ public:
     bool is_serialized = false);
 
   /// Default destructor.
-  RCLCPP_PUBLIC
   virtual ~SubscriptionBase();
 
   /// Get the topic that this subscription is subscribed on.
-  RCLCPP_PUBLIC
   const char *
   get_topic_name() const;
 
-  RCLCPP_PUBLIC
   std::shared_ptr<rcl_subscription_t>
   get_subscription_handle();
 
-  RCLCPP_PUBLIC
   const std::shared_ptr<rcl_subscription_t>
   get_subscription_handle() const;
 
-  RCLCPP_PUBLIC
   virtual const std::shared_ptr<rcl_subscription_t>
   get_intra_process_subscription_handle() const;
 

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -28,88 +28,67 @@ namespace rclcpp
 
 class Clock;
 
-class Time
+class RCLCPP_PUBLIC Time
 {
 public:
-  RCLCPP_PUBLIC
   Time(int32_t seconds, uint32_t nanoseconds, rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
 
-  RCLCPP_PUBLIC
   explicit Time(int64_t nanoseconds = 0, rcl_clock_type_t clock = RCL_SYSTEM_TIME);
 
-  RCLCPP_PUBLIC
   Time(const Time & rhs);
 
-  RCLCPP_PUBLIC
   Time(
     const builtin_interfaces::msg::Time & time_msg,
     rcl_clock_type_t ros_time = RCL_ROS_TIME);
 
-  RCLCPP_PUBLIC
   explicit Time(const rcl_time_point_t & time_point);
 
-  RCLCPP_PUBLIC
   virtual ~Time();
 
-  RCLCPP_PUBLIC
   operator builtin_interfaces::msg::Time() const;
 
-  RCLCPP_PUBLIC
   Time &
   operator=(const Time & rhs);
 
-  RCLCPP_PUBLIC
   Time &
   operator=(const builtin_interfaces::msg::Time & time_msg);
 
-  RCLCPP_PUBLIC
   bool
   operator==(const rclcpp::Time & rhs) const;
 
-  RCLCPP_PUBLIC
   bool
   operator!=(const rclcpp::Time & rhs) const;
 
-  RCLCPP_PUBLIC
   bool
   operator<(const rclcpp::Time & rhs) const;
 
-  RCLCPP_PUBLIC
   bool
   operator<=(const rclcpp::Time & rhs) const;
 
-  RCLCPP_PUBLIC
   bool
   operator>=(const rclcpp::Time & rhs) const;
 
-  RCLCPP_PUBLIC
   bool
   operator>(const rclcpp::Time & rhs) const;
 
-  RCLCPP_PUBLIC
   Time
   operator+(const rclcpp::Duration & rhs) const;
 
-  RCLCPP_PUBLIC
   Duration
   operator-(const rclcpp::Time & rhs) const;
 
-  RCLCPP_PUBLIC
   Time
   operator-(const rclcpp::Duration & rhs) const;
 
-  RCLCPP_PUBLIC
   rcl_time_point_value_t
   nanoseconds() const;
 
   /// \return the seconds since epoch as a floating point number.
   /// \warning Depending on sizeof(double) there could be significant precision loss.
   /// When an exact time is required use nanoseconds() instead.
-  RCLCPP_PUBLIC
   double
   seconds() const;
 
-  RCLCPP_PUBLIC
   rcl_clock_type_t
   get_clock_type() const;
 

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -33,39 +33,31 @@ namespace rclcpp
 {
 class Clock;
 
-class TimeSource
+class RCLCPP_PUBLIC TimeSource
 {
 public:
-  RCLCPP_PUBLIC
   explicit TimeSource(rclcpp::Node::SharedPtr node);
 
-  RCLCPP_PUBLIC
   TimeSource();
 
-  RCLCPP_PUBLIC
   void attachNode(rclcpp::Node::SharedPtr node);
 
-  RCLCPP_PUBLIC
   void attachNode(
     const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
     const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface,
     const rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_interface,
     const rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_interface);
 
-  RCLCPP_PUBLIC
   void detachNode();
 
   /// Attach a clock to the time source to be updated
   /**
    * \throws std::invalid_argument if node is nullptr
    */
-  RCLCPP_PUBLIC
   void attachClock(rclcpp::Clock::SharedPtr clock);
 
-  RCLCPP_PUBLIC
   void detachClock(rclcpp::Clock::SharedPtr clock);
 
-  RCLCPP_PUBLIC
   ~TimeSource();
 
 private:
@@ -95,6 +87,10 @@ private:
   // Callback for parameter updates
   void on_parameter_event(const rcl_interfaces::msg::ParameterEvent::SharedPtr event);
 
+  // Local storage of validity of ROS time
+  // This is needed when new clocks are added.
+  bool ros_time_active_;
+
   // An enum to hold the parameter state
   enum UseSimTimeParameterState {UNSET, SET_TRUE, SET_FALSE};
   UseSimTimeParameterState parameter_state_;
@@ -112,9 +108,6 @@ private:
     bool set_ros_time_enabled,
     rclcpp::Clock::SharedPtr clock);
 
-  // Local storage of validity of ROS time
-  // This is needed when new clocks are added.
-  bool ros_time_active_;
   // Last set message to be passed to newly registered clocks
   rosgraph_msgs::msg::Clock::SharedPtr last_msg_set_;
 

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -39,36 +39,29 @@
 namespace rclcpp
 {
 
-class TimerBase
+class RCLCPP_PUBLIC TimerBase
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(TimerBase)
 
-  RCLCPP_PUBLIC
   explicit TimerBase(Clock::SharedPtr clock, std::chrono::nanoseconds period);
 
-  RCLCPP_PUBLIC
   ~TimerBase();
 
-  RCLCPP_PUBLIC
   void
   cancel();
 
-  RCLCPP_PUBLIC
   void
   reset();
 
-  RCLCPP_PUBLIC
   virtual void
   execute_callback() = 0;
 
-  RCLCPP_PUBLIC
   std::shared_ptr<const rcl_timer_t>
   get_timer_handle();
 
   /// Check how long the timer has until its next scheduled callback.
   /** \return A std::chrono::duration representing the relative time until the next callback. */
-  RCLCPP_PUBLIC
   std::chrono::nanoseconds
   time_until_trigger();
 
@@ -82,7 +75,6 @@ public:
    * since it maintains the last time the callback was triggered.
    * \return True if the timer needs to trigger.
    */
-  RCLCPP_PUBLIC
   bool is_ready();
 
 protected:

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -37,8 +37,8 @@ JumpThreshold::is_exceeded(const TimeJump & jump)
   {
     return true;
   }
-  if ((uint64_t)jump.delta_.nanoseconds > min_forward_ ||
-    (uint64_t)jump.delta_.nanoseconds < min_backward_)
+  if ((static_cast<uint64_t>(jump.delta_.nanoseconds) > min_forward_) ||
+    (static_cast<uint64_t>(jump.delta_.nanoseconds) < min_backward_))
   {
     return true;
   }

--- a/rclcpp/src/rclcpp/duration.cpp
+++ b/rclcpp/src/rclcpp/duration.cpp
@@ -55,7 +55,8 @@ Duration::Duration(const Duration & rhs)
 Duration::Duration(
   const builtin_interfaces::msg::Duration & duration_msg)
 {
-  rcl_duration_.nanoseconds = RCL_S_TO_NS(static_cast<uint64_t>(duration_msg.sec));
+  rcl_duration_.nanoseconds =
+    static_cast<rcl_duration_value_t>(RCL_S_TO_NS(static_cast<uint64_t>(duration_msg.sec)));
   rcl_duration_.nanoseconds += duration_msg.nanosec;
 }
 
@@ -126,15 +127,15 @@ Duration::operator>(const rclcpp::Duration & rhs) const
 void
 bounds_check_duration_sum(int64_t lhsns, int64_t rhsns, uint64_t max)
 {
-  auto abs_lhs = (uint64_t)std::abs(lhsns);
-  auto abs_rhs = (uint64_t)std::abs(rhsns);
+  auto abs_lhs = static_cast<uint64_t>(std::abs(lhsns));
+  auto abs_rhs = static_cast<uint64_t>(std::abs(rhsns));
 
-  if (lhsns > 0 && rhsns > 0) {
-    if (abs_lhs + abs_rhs > (uint64_t) max) {
+  if ((lhsns > 0) && (rhsns > 0)) {
+    if ((abs_lhs + abs_rhs) > max) {
       throw std::overflow_error("addition leads to int64_t overflow");
     }
-  } else if (lhsns < 0 && rhsns < 0) {
-    if (abs_lhs + abs_rhs > (uint64_t) max) {
+  } else if ((lhsns < 0) && (rhsns < 0)) {
+    if ((abs_lhs + abs_rhs) > max) {
       throw std::underflow_error("addition leads to int64_t underflow");
     }
   }
@@ -154,15 +155,15 @@ Duration::operator+(const rclcpp::Duration & rhs) const
 void
 bounds_check_duration_difference(int64_t lhsns, int64_t rhsns, uint64_t max)
 {
-  auto abs_lhs = (uint64_t)std::abs(lhsns);
-  auto abs_rhs = (uint64_t)std::abs(rhsns);
+  auto abs_lhs = static_cast<uint64_t>(std::abs(lhsns));
+  auto abs_rhs = static_cast<uint64_t>(std::abs(rhsns));
 
-  if (lhsns > 0 && rhsns < 0) {
-    if (abs_lhs + abs_rhs > (uint64_t) max) {
+  if ((lhsns > 0) && (rhsns < 0)) {
+    if ((abs_lhs + abs_rhs) > max) {
       throw std::overflow_error("duration subtraction leads to int64_t overflow");
     }
-  } else if (lhsns < 0 && rhsns > 0) {
-    if (abs_lhs + abs_rhs > (uint64_t) max) {
+  } else if ((lhsns < 0) && (rhsns > 0)) {
+    if ((abs_lhs + abs_rhs) > max) {
       throw std::underflow_error("duration subtraction leads to int64_t underflow");
     }
   }
@@ -185,9 +186,11 @@ bounds_check_duration_scale(int64_t dns, double scale, uint64_t max)
 {
   auto abs_dns = static_cast<uint64_t>(std::abs(dns));
   auto abs_scale = std::abs(scale);
-
-  if (abs_scale > 1.0 && abs_dns > static_cast<uint64_t>(max / abs_scale)) {
-    if ((dns > 0 && scale > 0) || (dns < 0 && scale < 0)) {
+  long double max_ld = static_cast<long double>(max);
+  if ((abs_scale > 1.0) &&
+    (abs_dns > static_cast<uint64_t>(max_ld / static_cast<long double>(abs_scale))))
+  {
+    if (((dns > 0) && (scale > 0)) || ((dns < 0) && (scale < 0))) {
       throw std::overflow_error("duration scaling leads to int64_t overflow");
     } else {
       throw std::underflow_error("duration scaling leads to int64_t underflow");
@@ -205,7 +208,9 @@ Duration::operator*(double scale) const
     this->rcl_duration_.nanoseconds,
     scale,
     std::numeric_limits<rcl_duration_value_t>::max());
-  return Duration(static_cast<rcl_duration_value_t>(rcl_duration_.nanoseconds * scale));
+  long double scale_ld = static_cast<long double>(scale);
+  return Duration(static_cast<rcl_duration_value_t>(
+             static_cast<long double>(rcl_duration_.nanoseconds) * scale_ld));
 }
 
 rcl_duration_value_t

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -69,7 +69,7 @@ NodeBase::NodeBase(
   _dupenv_s(&ros_domain_id, &ros_domain_id_size, env_var);
 #endif
   if (ros_domain_id) {
-    uint32_t number = strtoul(ros_domain_id, NULL, 0);
+    uint32_t number = static_cast<uint32_t>(strtoul(ros_domain_id, NULL, 0));
     if (number == (std::numeric_limits<uint32_t>::max)()) {
       // Finalize the interrupt guard condition.
       finalize_notify_guard_condition();

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -146,7 +146,7 @@ AsyncParametersClient::get_parameters(
       auto & pvalues = cb_f.get()->values;
 
       for (auto & pvalue : pvalues) {
-        auto i = &pvalue - &pvalues[0];
+        size_t i = static_cast<size_t>(&pvalue - &pvalues[0]);
         rcl_interfaces::msg::Parameter parameter;
         parameter.name = request->names[i];
         parameter.value = pvalue;

--- a/rclcpp/src/rclcpp/parameter_value.cpp
+++ b/rclcpp/src/rclcpp/parameter_value.cpp
@@ -154,7 +154,7 @@ ParameterValue::ParameterValue(const int64_t int_value)
 
 ParameterValue::ParameterValue(const float double_value)
 {
-  value_.double_value = double_value;
+  value_.double_value = static_cast<double>(double_value);
   value_.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
 }
 

--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -96,9 +96,10 @@ set_signal_handler(int signal_value, signal_handler_t signal_handler)
     strerror_s(error_string, error_length, errno);
 #endif
     // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
-    throw std::runtime_error(
-      std::string("Failed to set SIGINT signal handler: (" + std::to_string(errno) + ")") +
-      error_string);
+    std::string error_message("Failed to set SIGINT signal handler: (");
+    error_message += std::to_string(errno) + ")";
+    error_message += error_string;
+    throw std::runtime_error(error_message);
     // *INDENT-ON*
   }
 
@@ -240,9 +241,9 @@ rclcpp::remove_ros_arguments(int argc, char const * const argv[])
   }
 
   std::vector<std::string> return_arguments;
-  return_arguments.resize(nonros_argc);
+  return_arguments.resize(static_cast<uint32_t>(nonros_argc));
 
-  for (int ii = 0; ii < nonros_argc; ++ii) {
+  for (uint32_t ii = 0U; ii < static_cast<uint32_t>(nonros_argc); ++ii) {
     return_arguments[ii] = std::string(nonros_argv[ii]);
   }
 

--- a/rclcpp/test/test_duration.cpp
+++ b/rclcpp/test/test_duration.cpp
@@ -47,15 +47,15 @@ TEST(TestDuration, operators) {
   EXPECT_FALSE(young == old);
 
   rclcpp::Duration add = old + young;
-  EXPECT_EQ(add.nanoseconds(), (rcl_duration_value_t)(old.nanoseconds() + young.nanoseconds()));
+  EXPECT_EQ(add.nanoseconds(), (old.nanoseconds() + young.nanoseconds()));
   EXPECT_EQ(add, old + young);
 
   rclcpp::Duration sub = young - old;
-  EXPECT_EQ(sub.nanoseconds(), (rcl_duration_value_t)(young.nanoseconds() - old.nanoseconds()));
+  EXPECT_EQ(sub.nanoseconds(), (young.nanoseconds() - old.nanoseconds()));
   EXPECT_EQ(sub, young - old);
 
   rclcpp::Duration scale = old * 3;
-  EXPECT_EQ(scale.nanoseconds(), (rcl_duration_value_t)(old.nanoseconds() * 3));
+  EXPECT_EQ(scale.nanoseconds(), (old.nanoseconds() * 3));
 
   rclcpp::Duration time = rclcpp::Duration(0, 0);
   rclcpp::Duration copy_constructor_duration(time);

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -121,7 +121,7 @@ TEST(TestTime, operators) {
   EXPECT_TRUE(young != old);
 
   rclcpp::Duration sub = young - old;
-  EXPECT_EQ(sub.nanoseconds(), (rcl_duration_value_t)(young.nanoseconds() - old.nanoseconds()));
+  EXPECT_EQ(sub.nanoseconds(), (young.nanoseconds() - old.nanoseconds()));
   EXPECT_EQ(sub, young - old);
 
   rclcpp::Time system_time(0, 0, RCL_SYSTEM_TIME);

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -64,7 +64,7 @@ namespace rclcpp_lifecycle
 /**
  * has lifecycle nodeinterface for configuring this node.
  */
-class LifecycleNode : public node_interfaces::LifecycleNodeInterface,
+class RCLCPP_LIFECYCLE_PUBLIC LifecycleNode : public node_interfaces::LifecycleNodeInterface,
   public std::enable_shared_from_this<LifecycleNode>
 {
 public:
@@ -77,7 +77,6 @@ public:
    * \param[in] use_intra_process_comms True to use the optimized intra-process communication
    * pipeline to pass messages between nodes in the same process using shared memory.
    */
-  RCLCPP_LIFECYCLE_PUBLIC
   explicit LifecycleNode(
     const std::string & node_name,
     const std::string & namespace_ = "",
@@ -95,7 +94,6 @@ public:
    * \param[in] use_intra_process_comms True to use the optimized intra-process communication
    * pipeline to pass messages between nodes in the same process using shared memory.
    */
-  RCLCPP_LIFECYCLE_PUBLIC
   LifecycleNode(
     const std::string & node_name,
     const std::string & namespace_,
@@ -106,34 +104,28 @@ public:
     bool use_intra_process_comms = false,
     bool start_parameter_services = true);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   virtual ~LifecycleNode();
 
   /// Get the name of the node.
   // \return The name of the node.
-  RCLCPP_LIFECYCLE_PUBLIC
   const char *
   get_name() const;
 
   /// Get the namespace of the node.
   // \return The namespace of the node.
-  RCLCPP_LIFECYCLE_PUBLIC
   const char *
   get_namespace() const;
 
   /// Get the logger of the node.
   /** \return The logger of the node. */
-  RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::Logger
   get_logger() const;
 
   /// Create and return a callback group.
-  RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::callback_group::CallbackGroup::SharedPtr
   create_callback_group(rclcpp::callback_group::CallbackGroupType group_type);
 
   /// Return the list of callback groups in the node.
-  RCLCPP_LIFECYCLE_PUBLIC
   const std::vector<rclcpp::callback_group::CallbackGroup::WeakPtr> &
   get_callback_groups() const;
 
@@ -253,23 +245,18 @@ public:
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_services_default,
     rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   std::vector<rcl_interfaces::msg::SetParametersResult>
   set_parameters(const std::vector<rclcpp::Parameter> & parameters);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   rcl_interfaces::msg::SetParametersResult
   set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   std::vector<rclcpp::Parameter>
   get_parameters(const std::vector<std::string> & names) const;
 
-  RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::Parameter
   get_parameter(const std::string & name) const;
 
-  RCLCPP_LIFECYCLE_PUBLIC
   bool
   get_parameter(
     const std::string & name,
@@ -279,15 +266,12 @@ public:
   bool
   get_parameter(const std::string & name, ParameterT & parameter) const;
 
-  RCLCPP_LIFECYCLE_PUBLIC
   std::vector<rcl_interfaces::msg::ParameterDescriptor>
   describe_parameters(const std::vector<std::string> & names) const;
 
-  RCLCPP_LIFECYCLE_PUBLIC
   std::vector<uint8_t>
   get_parameter_types(const std::vector<std::string> & names) const;
 
-  RCLCPP_LIFECYCLE_PUBLIC
   rcl_interfaces::msg::ListParametersResult
   list_parameters(const std::vector<std::string> & prefixes, uint64_t depth) const;
 
@@ -304,19 +288,15 @@ public:
   std::vector<std::string>
   get_node_names() const;
 
-  RCLCPP_LIFECYCLE_PUBLIC
   std::map<std::string, std::vector<std::string>>
   get_topic_names_and_types(bool no_demangle = false) const;
 
-  RCLCPP_LIFECYCLE_PUBLIC
   std::map<std::string, std::vector<std::string>>
   get_service_names_and_types() const;
 
-  RCLCPP_LIFECYCLE_PUBLIC
   size_t
   count_publishers(const std::string & topic_name) const;
 
-  RCLCPP_LIFECYCLE_PUBLIC
   size_t
   count_subscribers(const std::string & topic_name) const;
 
@@ -325,7 +305,6 @@ public:
    * The Event object is scoped and therefore to return the load just let it go
    * out of scope.
    */
-  RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::Event::SharedPtr
   get_graph_event();
 
@@ -336,67 +315,54 @@ public:
    * \throws EventNotRegisteredError if the given event was not acquired with
    *   get_graph_event().
    */
-  RCLCPP_LIFECYCLE_PUBLIC
   void
   wait_for_graph_change(
     rclcpp::Event::SharedPtr event,
     std::chrono::nanoseconds timeout);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::Clock::SharedPtr
   get_clock();
 
-  RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::Time
   now();
 
   /// Return the Node's internal NodeBaseInterface implementation.
-  RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
   get_node_base_interface();
 
   /// Return the Node's internal NodeClockInterface implementation.
-  RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::node_interfaces::NodeClockInterface::SharedPtr
   get_node_clock_interface();
 
   /// Return the Node's internal NodeGraphInterface implementation.
-  RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::node_interfaces::NodeGraphInterface::SharedPtr
   get_node_graph_interface();
 
   /// Return the Node's internal NodeTimersInterface implementation.
-  RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::node_interfaces::NodeTimersInterface::SharedPtr
   get_node_timers_interface();
 
   /// Return the Node's internal NodeTopicsInterface implementation.
-  RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr
   get_node_topics_interface();
 
   /// Return the Node's internal NodeServicesInterface implementation.
-  RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::node_interfaces::NodeServicesInterface::SharedPtr
   get_node_services_interface();
 
   /// Return the Node's internal NodeParametersInterface implementation.
-  RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr
   get_node_parameters_interface();
 
   //
   // LIFECYCLE COMPONENTS
   //
-  RCLCPP_LIFECYCLE_PUBLIC
   const State &
   get_current_state();
 
-  RCLCPP_LIFECYCLE_PUBLIC
   std::vector<State>
   get_available_states();
 
-  RCLCPP_LIFECYCLE_PUBLIC
   std::vector<Transition>
   get_available_transitions();
 
@@ -404,101 +370,78 @@ public:
   /*
    * return the new state after this transition
    */
-  RCLCPP_LIFECYCLE_PUBLIC
   const State &
   trigger_transition(const Transition & transition);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   const State &
   trigger_transition(
     const Transition & transition, rcl_lifecycle_transition_key_t & cb_return_code);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   const State &
   trigger_transition(uint8_t transition_id);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   const State &
   trigger_transition(
     uint8_t transition_id, rcl_lifecycle_transition_key_t & cb_return_code);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   const State &
   configure();
 
-  RCLCPP_LIFECYCLE_PUBLIC
   const State &
   configure(rcl_lifecycle_transition_key_t & cb_return_code);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   const State &
   cleanup();
 
-  RCLCPP_LIFECYCLE_PUBLIC
   const State &
   cleanup(rcl_lifecycle_transition_key_t & cb_return_code);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   const State &
   activate();
 
-  RCLCPP_LIFECYCLE_PUBLIC
   const State &
   activate(rcl_lifecycle_transition_key_t & cb_return_code);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   const State &
   deactivate();
 
-  RCLCPP_LIFECYCLE_PUBLIC
   const State &
   deactivate(rcl_lifecycle_transition_key_t & cb_return_code);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   const State &
   shutdown();
 
-  RCLCPP_LIFECYCLE_PUBLIC
   const State &
   shutdown(rcl_lifecycle_transition_key_t & cb_return_code);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   bool
   register_on_configure(std::function<rcl_lifecycle_transition_key_t(const State &)> fcn);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   bool
   register_on_cleanup(std::function<rcl_lifecycle_transition_key_t(const State &)> fcn);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   bool
   register_on_shutdown(std::function<rcl_lifecycle_transition_key_t(const State &)> fcn);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   bool
   register_on_activate(std::function<rcl_lifecycle_transition_key_t(const State &)> fcn);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   bool
   register_on_deactivate(std::function<rcl_lifecycle_transition_key_t(const State &)> fcn);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   bool
   register_on_error(std::function<rcl_lifecycle_transition_key_t(const State &)> fcn);
 
 protected:
-  RCLCPP_LIFECYCLE_PUBLIC
   void
   add_publisher_handle(std::shared_ptr<rclcpp_lifecycle::LifecyclePublisherInterface> pub);
 
-  RCLCPP_LIFECYCLE_PUBLIC
   void
   add_timer_handle(std::shared_ptr<rclcpp::TimerBase> timer);
 
 private:
   RCLCPP_DISABLE_COPY(LifecycleNode)
 
-  RCLCPP_LIFECYCLE_PUBLIC
   bool
   group_in_node(rclcpp::callback_group::CallbackGroup::SharedPtr group);
 

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -247,11 +247,11 @@ public:
     for (uint8_t i = 0; i < state_machine_.transition_map.transitions_size; ++i) {
       rcl_lifecycle_transition_t & rcl_transition = state_machine_.transition_map.transitions[i];
       lifecycle_msgs::msg::TransitionDescription trans_desc;
-      trans_desc.transition.id = rcl_transition.id;
+      trans_desc.transition.id = static_cast<uint8_t>(rcl_transition.id);
       trans_desc.transition.label = rcl_transition.label;
-      trans_desc.start_state.id = rcl_transition.start->id;
+      trans_desc.start_state.id = static_cast<uint8_t>(rcl_transition.start->id);
       trans_desc.start_state.label = rcl_transition.start->label;
-      trans_desc.goal_state.id = rcl_transition.goal->id;
+      trans_desc.goal_state.id = static_cast<uint8_t>(rcl_transition.goal->id);
       trans_desc.goal_state.label = rcl_transition.goal->label;
       resp->available_transitions.push_back(trans_desc);
     }
@@ -358,7 +358,7 @@ public:
     rcl_lifecycle_transition_key_t cb_success =
       lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
 
-    auto it = cb_map_.find(cb_id);
+    auto it = cb_map_.find(static_cast<uint8_t>(cb_id));
     if (it != cb_map_.end()) {
       auto callback = it->second;
       try {

--- a/rclcpp_lifecycle/src/state.cpp
+++ b/rclcpp_lifecycle/src/state.cpp
@@ -130,7 +130,7 @@ State::id() const
   if (!state_handle_) {
     throw std::runtime_error("Error in state! Internal state_handle is NULL.");
   }
-  return state_handle_->id;
+  return static_cast<uint8_t>(state_handle_->id);
 }
 
 std::string

--- a/rclcpp_lifecycle/src/transition.cpp
+++ b/rclcpp_lifecycle/src/transition.cpp
@@ -213,7 +213,7 @@ Transition::id() const
   if (!transition_handle_) {
     throw std::runtime_error("internal transition_handle is null");
   }
-  return transition_handle_->id;
+  return static_cast<uint8_t>(transition_handle_->id);
 }
 
 std::string


### PR DESCRIPTION
## Description
- Courtesy of @serge-nikulin 
- This PR fixes warning generated when building with:

```
-Wall
-Wextra
-pedantic
-Wcast-align
-Wunused
-Wconversion
-Wsign-conversion
-Wdouble-promotion
-fvisibility=hidden
```

- Related to ros2/rcl#276 and ros2/rcutils#114

connects to ros2/rcutils#114