### PR TITLE
Get node names and namespaces

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/node_graph.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph.hpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "rcl/guard_condition.h"

--- a/rclcpp/include/rclcpp/node_interfaces/node_graph.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph.hpp
@@ -71,6 +71,11 @@ public:
 
   RCLCPP_PUBLIC
   virtual
+  std::vector<std::pair<std::string, std::string>>
+  get_node_names_and_namespaces() const;
+
+  RCLCPP_PUBLIC
+  virtual
   size_t
   count_publishers(const std::string & topic_name) const;
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
@@ -66,6 +66,12 @@ public:
   std::vector<std::string>
   get_node_names() const = 0;
 
+  /// Return a vector of existing node names (string).
+  RCLCPP_PUBLIC
+  virtual
+  std::vector<std::pair<std::string, std::string>>
+  get_node_names_and_namespaces() const = 0;
+
   /// Return the number of publishers that are advertised on a given topic.
   RCLCPP_PUBLIC
   virtual

--- a/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
@@ -18,6 +18,7 @@
 #include <chrono>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "rcl/guard_condition.h"
@@ -66,7 +67,7 @@ public:
   std::vector<std::string>
   get_node_names() const = 0;
 
-  /// Return a vector of existing node names (string).
+  /// Return a vector of existing node names and namespaces (pair of string).
   RCLCPP_PUBLIC
   virtual
   std::vector<std::pair<std::string, std::string>>

--- a/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
@@ -16,6 +16,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "rcl/graph.h"


### PR DESCRIPTION
Add a new method to return a vector of pair to get both node names and namespaces.

Connects to ros2/rmw#142