### PR TITLE
Make sure timer is fini'd before clock

### DIFF
--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -36,7 +36,7 @@ TimerBase::TimerBase(rclcpp::Clock::SharedPtr clock, std::chrono::nanoseconds pe
         rcl_reset_error();
       }
       delete timer;
-      // Captured shared pointer by copy, reset to make sure timer is finialized before clock
+      // Captured shared pointer by copy, reset to make sure timer is finalized before clock
       clock.reset();
     });
 

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -27,7 +27,7 @@ TimerBase::TimerBase(rclcpp::Clock::SharedPtr clock, std::chrono::nanoseconds pe
   clock_ = clock;
 
   timer_handle_ = std::shared_ptr<rcl_timer_t>(
-    new rcl_timer_t, [ = ](rcl_timer_t * timer)
+    new rcl_timer_t, [ = ](rcl_timer_t * timer) mutable
     {
       if (rcl_timer_fini(timer) != RCL_RET_OK) {
         RCUTILS_LOG_ERROR_NAMED(
@@ -36,6 +36,8 @@ TimerBase::TimerBase(rclcpp::Clock::SharedPtr clock, std::chrono::nanoseconds pe
         rcl_reset_error();
       }
       delete timer;
+      // Captured shared pointer by copy, reset to make sure timer is finialized before clock
+      clock.reset();
     });
 
   *timer_handle_.get() = rcl_get_zero_initialized_timer();


### PR DESCRIPTION
This PR makes sure timers are finalized before clocks. Since a timer uses a clock, the clock must be valid longer than the timer.

I suspect this will fix the windows test failures in ros2/rcl#286. That PR adds a time jump callback to the clock in `rcl_timer_init()`, and removes it in `rcl_timer_fini()`. If the clock is finalized before the timer then the attempt to remove the jump callback results in trying to access an `rcl_clock_t` after it has been freed.

`TimerBase` already has a shared pointer to `Clock` for this purpose, but this is insufficient. `TimerBase::get_timer_handle()` [returns an `std::shared_ptr<rcl_timer_t>`](https://github.com/ros2/rclcpp/blob/8c6f38a0fa91749f1896b0ac462e9e90b5a31b17/rclcpp/include/rclcpp/timer.hpp#L65-L67) with a deleter that [calls `rcl_timer_fini()`](https://github.com/ros2/rclcpp/blob/8c6f38a0fa91749f1896b0ac462e9e90b5a31b17/rclcpp/src/rclcpp/timer.cpp#L29-L39). This handle can live longer than `TimerBase` in an [executor's memory strategy](https://github.com/ros2/rclcpp/blob/8c6f38a0fa91749f1896b0ac462e9e90b5a31b17/rclcpp/include/rclcpp/executor.hpp#L350). Specifically `AllocatorMemoryStrategy` keeps a [list of `std::shared_ptr<rcl_timer_t>`](https://github.com/ros2/rclcpp/blob/8c6f38a0fa91749f1896b0ac462e9e90b5a31b17/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp#L385). If the `NodeClock` and `TimerBase` are destroyed before an `Executor` then the clock is finalized before the timer handle which may result in a crash.

CI
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5150)](http://ci.ros2.org/job/ci_linux/5150/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1927)](http://ci.ros2.org/job/ci_linux-aarch64/1927/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4275)](http://ci.ros2.org/job/ci_osx/4275/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5130)](http://ci.ros2.org/job/ci_windows/5130/)

blocks ros2/rcl#286