### PR TITLE
service for transition graph

### DIFF
--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -416,7 +416,7 @@ public:
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
   trigger_transition(
-    const Transition & transition, rcl_lifecycle_transition_key_t & cb_return_code);
+    const Transition & transition, LifecycleNodeInterface::CallbackReturn & cb_return_code);
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
@@ -425,7 +425,7 @@ public:
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
   trigger_transition(
-    uint8_t transition_id, rcl_lifecycle_transition_key_t & cb_return_code);
+    uint8_t transition_id, LifecycleNodeInterface::CallbackReturn & cb_return_code);
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
@@ -433,7 +433,7 @@ public:
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
-  configure(rcl_lifecycle_transition_key_t & cb_return_code);
+  configure(LifecycleNodeInterface::CallbackReturn & cb_return_code);
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
@@ -441,7 +441,7 @@ public:
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
-  cleanup(rcl_lifecycle_transition_key_t & cb_return_code);
+  cleanup(LifecycleNodeInterface::CallbackReturn & cb_return_code);
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
@@ -449,7 +449,7 @@ public:
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
-  activate(rcl_lifecycle_transition_key_t & cb_return_code);
+  activate(LifecycleNodeInterface::CallbackReturn & cb_return_code);
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
@@ -457,7 +457,7 @@ public:
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
-  deactivate(rcl_lifecycle_transition_key_t & cb_return_code);
+  deactivate(LifecycleNodeInterface::CallbackReturn & cb_return_code);
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
@@ -465,31 +465,31 @@ public:
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
-  shutdown(rcl_lifecycle_transition_key_t & cb_return_code);
+  shutdown(LifecycleNodeInterface::CallbackReturn & cb_return_code);
 
   RCLCPP_LIFECYCLE_PUBLIC
   bool
-  register_on_configure(std::function<rcl_lifecycle_transition_key_t(const State &)> fcn);
+  register_on_configure(std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
 
   RCLCPP_LIFECYCLE_PUBLIC
   bool
-  register_on_cleanup(std::function<rcl_lifecycle_transition_key_t(const State &)> fcn);
+  register_on_cleanup(std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
 
   RCLCPP_LIFECYCLE_PUBLIC
   bool
-  register_on_shutdown(std::function<rcl_lifecycle_transition_key_t(const State &)> fcn);
+  register_on_shutdown(std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
 
   RCLCPP_LIFECYCLE_PUBLIC
   bool
-  register_on_activate(std::function<rcl_lifecycle_transition_key_t(const State &)> fcn);
+  register_on_activate(std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
 
   RCLCPP_LIFECYCLE_PUBLIC
   bool
-  register_on_deactivate(std::function<rcl_lifecycle_transition_key_t(const State &)> fcn);
+  register_on_deactivate(std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
 
   RCLCPP_LIFECYCLE_PUBLIC
   bool
-  register_on_error(std::function<rcl_lifecycle_transition_key_t(const State &)> fcn);
+  register_on_error(std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
 
 protected:
   RCLCPP_LIFECYCLE_PUBLIC

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
@@ -15,6 +15,8 @@
 #ifndef RCLCPP_LIFECYCLE__NODE_INTERFACES__LIFECYCLE_NODE_INTERFACE_HPP_
 #define RCLCPP_LIFECYCLE__NODE_INTERFACES__LIFECYCLE_NODE_INTERFACE_HPP_
 
+#include "lifecycle_msgs/msg/transition.hpp"
+
 #include "rcl_lifecycle/rcl_lifecycle.h"
 
 #include "rclcpp_lifecycle/state.hpp"
@@ -44,12 +46,19 @@ protected:
   LifecycleNodeInterface() {}
 
 public:
+  enum class CallbackReturn : uint8_t
+  {
+    SUCCESS = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS,
+    FAILURE = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE,
+    ERROR = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR
+  };
+
   /// Callback function for configure transition
   /*
    * \return true by default
    */
   RCLCPP_LIFECYCLE_PUBLIC
-  virtual rcl_lifecycle_transition_key_t
+  virtual CallbackReturn
   on_configure(const State & previous_state);
 
   /// Callback function for cleanup transition
@@ -57,7 +66,7 @@ public:
    * \return true by default
    */
   RCLCPP_LIFECYCLE_PUBLIC
-  virtual rcl_lifecycle_transition_key_t
+  virtual CallbackReturn
   on_cleanup(const State & previous_state);
 
   /// Callback function for shutdown transition
@@ -65,7 +74,7 @@ public:
    * \return true by default
    */
   RCLCPP_LIFECYCLE_PUBLIC
-  virtual rcl_lifecycle_transition_key_t
+  virtual CallbackReturn
   on_shutdown(const State & previous_state);
 
   /// Callback function for activate transition
@@ -73,7 +82,7 @@ public:
    * \return true by default
    */
   RCLCPP_LIFECYCLE_PUBLIC
-  virtual rcl_lifecycle_transition_key_t
+  virtual CallbackReturn
   on_activate(const State & previous_state);
 
   /// Callback function for deactivate transition
@@ -81,7 +90,7 @@ public:
    * \return true by default
    */
   RCLCPP_LIFECYCLE_PUBLIC
-  virtual rcl_lifecycle_transition_key_t
+  virtual CallbackReturn
   on_deactivate(const State & previous_state);
 
   /// Callback function for errorneous transition
@@ -89,7 +98,7 @@ public:
    * \return false by default
    */
   RCLCPP_LIFECYCLE_PUBLIC
-  virtual rcl_lifecycle_transition_key_t
+  virtual CallbackReturn
   on_error(const State & previous_state);
 };
 

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
@@ -15,7 +15,7 @@
 #ifndef RCLCPP_LIFECYCLE__NODE_INTERFACES__LIFECYCLE_NODE_INTERFACE_HPP_
 #define RCLCPP_LIFECYCLE__NODE_INTERFACES__LIFECYCLE_NODE_INTERFACE_HPP_
 
-#include "rcl_lifecycle/data_types.h"
+#include "rcl_lifecycle/rcl_lifecycle.h"
 
 #include "rclcpp_lifecycle/state.hpp"
 #include "rclcpp_lifecycle/visibility_control.h"

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -301,7 +301,7 @@ LifecycleNode::get_node_parameters_interface()
 ////
 bool
 LifecycleNode::register_on_configure(
-  std::function<rcl_lifecycle_transition_key_t(const State &)> fcn)
+  std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn)
 {
   return impl_->register_callback(
     lifecycle_msgs::msg::State::TRANSITION_STATE_CONFIGURING, fcn);
@@ -309,7 +309,7 @@ LifecycleNode::register_on_configure(
 
 bool
 LifecycleNode::register_on_cleanup(
-  std::function<rcl_lifecycle_transition_key_t(const State &)> fcn)
+  std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn)
 {
   return impl_->register_callback(
     lifecycle_msgs::msg::State::TRANSITION_STATE_CLEANINGUP, fcn);
@@ -317,7 +317,7 @@ LifecycleNode::register_on_cleanup(
 
 bool
 LifecycleNode::register_on_shutdown(
-  std::function<rcl_lifecycle_transition_key_t(const State &)> fcn)
+  std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn)
 {
   return impl_->register_callback(
     lifecycle_msgs::msg::State::TRANSITION_STATE_SHUTTINGDOWN, fcn);
@@ -325,7 +325,7 @@ LifecycleNode::register_on_shutdown(
 
 bool
 LifecycleNode::register_on_activate(
-  std::function<rcl_lifecycle_transition_key_t(const State &)> fcn)
+  std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn)
 {
   return impl_->register_callback(
     lifecycle_msgs::msg::State::TRANSITION_STATE_ACTIVATING, fcn);
@@ -333,7 +333,7 @@ LifecycleNode::register_on_activate(
 
 bool
 LifecycleNode::register_on_deactivate(
-  std::function<rcl_lifecycle_transition_key_t(const State &)> fcn)
+  std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn)
 {
   return impl_->register_callback(
     lifecycle_msgs::msg::State::TRANSITION_STATE_DEACTIVATING, fcn);
@@ -341,7 +341,7 @@ LifecycleNode::register_on_deactivate(
 
 bool
 LifecycleNode::register_on_error(
-  std::function<rcl_lifecycle_transition_key_t(const State &)> fcn)
+  std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn)
 {
   return impl_->register_callback(
     lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING, fcn);
@@ -373,7 +373,7 @@ LifecycleNode::trigger_transition(const Transition & transition)
 
 const State &
 LifecycleNode::trigger_transition(
-  const Transition & transition, rcl_lifecycle_transition_key_t & cb_return_code)
+  const Transition & transition, LifecycleNodeInterface::CallbackReturn & cb_return_code)
 {
   return trigger_transition(transition.id(), cb_return_code);
 }
@@ -386,7 +386,7 @@ LifecycleNode::trigger_transition(uint8_t transition_id)
 
 const State &
 LifecycleNode::trigger_transition(
-  uint8_t transition_id, rcl_lifecycle_transition_key_t & cb_return_code)
+  uint8_t transition_id, LifecycleNodeInterface::CallbackReturn & cb_return_code)
 {
   return impl_->trigger_transition(transition_id, cb_return_code);
 }
@@ -399,7 +399,7 @@ LifecycleNode::configure()
 }
 
 const State &
-LifecycleNode::configure(rcl_lifecycle_transition_key_t & cb_return_code)
+LifecycleNode::configure(LifecycleNodeInterface::CallbackReturn & cb_return_code)
 {
   return impl_->trigger_transition(
     lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE, cb_return_code);
@@ -413,7 +413,7 @@ LifecycleNode::cleanup()
 }
 
 const State &
-LifecycleNode::cleanup(rcl_lifecycle_transition_key_t & cb_return_code)
+LifecycleNode::cleanup(LifecycleNodeInterface::CallbackReturn & cb_return_code)
 {
   return impl_->trigger_transition(
     lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP, cb_return_code);
@@ -427,7 +427,7 @@ LifecycleNode::activate()
 }
 
 const State &
-LifecycleNode::activate(rcl_lifecycle_transition_key_t & cb_return_code)
+LifecycleNode::activate(LifecycleNodeInterface::CallbackReturn & cb_return_code)
 {
   return impl_->trigger_transition(
     lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE, cb_return_code);
@@ -441,7 +441,7 @@ LifecycleNode::deactivate()
 }
 
 const State &
-LifecycleNode::deactivate(rcl_lifecycle_transition_key_t & cb_return_code)
+LifecycleNode::deactivate(LifecycleNodeInterface::CallbackReturn & cb_return_code)
 {
   return impl_->trigger_transition(
     lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE, cb_return_code);
@@ -451,14 +451,14 @@ const State &
 LifecycleNode::shutdown()
 {
   return impl_->trigger_transition(
-    lifecycle_msgs::msg::Transition::TRANSITION_SHUTDOWN);
+    rcl_lifecycle_shutdown_label);
 }
 
 const State &
-LifecycleNode::shutdown(rcl_lifecycle_transition_key_t & cb_return_code)
+LifecycleNode::shutdown(LifecycleNodeInterface::CallbackReturn & cb_return_code)
 {
   return impl_->trigger_transition(
-    lifecycle_msgs::msg::Transition::TRANSITION_SHUTDOWN, cb_return_code);
+    rcl_lifecycle_shutdown_label, cb_return_code);
 }
 
 void

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -377,14 +377,14 @@ public:
     // error handling ?!
     // TODO(karsten1987): iterate over possible ret value
     if (cb_return_code == node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR) {
-      RCUTILS_LOG_WARN("Error occurred while doing error handling.")
+      RCUTILS_LOG_WARN("Error occurred while doing error handling.");
 
       auto error_cb_code = execute_callback(state_machine_.current_state->id, initial_state);
       auto error_cb_label = get_label_for_return_code(error_cb_code);
       if (rcl_lifecycle_trigger_transition_by_label(
           &state_machine_, error_cb_label, publish_update) != RCL_RET_OK)
       {
-        RCUTILS_LOG_ERROR("Failed to call cleanup on error state")
+        RCUTILS_LOG_ERROR("Failed to call cleanup on error state");
         return RCL_RET_ERROR;
       }
     }

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -95,6 +95,7 @@ public:
       rosidl_typesupport_cpp::get_service_type_support_handle<GetStateSrv>(),
       rosidl_typesupport_cpp::get_service_type_support_handle<GetAvailableStatesSrv>(),
       rosidl_typesupport_cpp::get_service_type_support_handle<GetAvailableTransitionsSrv>(),
+      rosidl_typesupport_cpp::get_service_type_support_handle<GetAvailableTransitionsSrv>(),
       true,
       &node_options->allocator);
     if (ret != RCL_RET_OK) {
@@ -163,6 +164,22 @@ public:
         std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_available_transitions_),
         nullptr);
     }
+
+    {  // get_transition_graph
+      auto cb = std::bind(&LifecycleNodeInterfaceImpl::on_get_transition_graph, this,
+          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+      rclcpp::AnyServiceCallback<GetAvailableTransitionsSrv> any_cb;
+      any_cb.set(std::move(cb));
+
+      srv_get_transition_graph_ =
+        std::make_shared<rclcpp::Service<GetAvailableTransitionsSrv>>(
+        node_base_interface_->get_shared_rcl_node_handle(),
+        &state_machine_.com_interface.srv_get_transition_graph,
+        any_cb);
+      node_services_interface_->add_service(
+        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_transition_graph_),
+        nullptr);
+    }
   }
 
   bool
@@ -192,7 +209,7 @@ public:
     // 1. return is the actual transition
     // 2. return is whether an error occurred or not
     resp->success =
-      (cb_return_code == lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS);
+      (cb_return_code.id == lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS);
   }
 
   void
@@ -244,8 +261,35 @@ public:
               "Can't get available transitions. State machine is not initialized.");
     }
 
+    for (uint8_t i = 0; i < state_machine_.current_state->valid_transition_size; ++i) {
+      auto transition_key = state_machine_.current_state->valid_transition_keys[i];
+      lifecycle_msgs::msg::TransitionDescription trans_desc;
+      trans_desc.transition.id = transition_key.id;
+      trans_desc.transition.label = transition_key.label;
+      auto rcl_transition = state_machine_.current_state->valid_transitions[i];
+      trans_desc.start_state.id = rcl_transition.start->id;
+      trans_desc.start_state.label = rcl_transition.start->label;
+      trans_desc.goal_state.id = rcl_transition.goal->id;
+      trans_desc.goal_state.label = rcl_transition.goal->label;
+      resp->available_transitions.push_back(trans_desc);
+    }
+  }
+
+  void
+  on_get_transition_graph(
+    const std::shared_ptr<rmw_request_id_t> header,
+    const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
+    std::shared_ptr<GetAvailableTransitionsSrv::Response> resp)
+  {
+    (void)header;
+    (void)req;
+    if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
+      throw std::runtime_error(
+              "Can't get available transitions. State machine is not initialized.");
+    }
+
     for (uint8_t i = 0; i < state_machine_.transition_map.transitions_size; ++i) {
-      rcl_lifecycle_transition_t & rcl_transition = state_machine_.transition_map.transitions[i];
+      auto rcl_transition = state_machine_.transition_map.transitions[i];
       lifecycle_msgs::msg::TransitionDescription trans_desc;
       trans_desc.transition.id = rcl_transition.id;
       trans_desc.transition.label = rcl_transition.label;
@@ -303,7 +347,7 @@ public:
 
     uint8_t transition_id = lifecycle_transition;
     if (rcl_lifecycle_trigger_transition(
-        &state_machine_, transition_id, publish_update) != RCL_RET_OK)
+        &state_machine_, {transition_id, ""}, publish_update) != RCL_RET_OK)
     {
       RCUTILS_LOG_ERROR("Unable to start transition %u from current state %s: %s",
         transition_id, state_machine_.current_state->label, rcl_get_error_string_safe());
@@ -327,7 +371,7 @@ public:
       RCUTILS_LOG_WARN("Error occurred while doing error handling.");
       rcl_lifecycle_transition_key_t error_resolved = execute_callback(
         state_machine_.current_state->id, initial_state);
-      if (error_resolved == lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS) {
+      if (error_resolved.id == lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS) {
         // We call cleanup on the error state
         if (rcl_lifecycle_trigger_transition(
             &state_machine_, error_resolved, publish_update) != RCL_RET_OK)
@@ -355,8 +399,7 @@ public:
   execute_callback(unsigned int cb_id, const State & previous_state)
   {
     // in case no callback was attached, we forward directly
-    rcl_lifecycle_transition_key_t cb_success =
-      lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+    rcl_lifecycle_transition_key_t cb_success = RCL_LIFECYCLE_TRANSITION_KEY_CALLBACK_SUCCESS;
 
     auto it = cb_map_.find(cb_id);
     if (it != cb_map_.end()) {
@@ -371,7 +414,7 @@ public:
         // RCUTILS_LOG_ERROR("Original error msg: %s\n", e.what());
         // maybe directly go for error handling here
         // and pass exception along with it
-        cb_success = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR;
+        cb_success = RCL_LIFECYCLE_TRANSITION_KEY_CALLBACK_ERROR;
       }
     }
     return cb_success;
@@ -419,6 +462,8 @@ public:
     std::shared_ptr<rclcpp::Service<GetAvailableStatesSrv>>;
   using GetAvailableTransitionsSrvPtr =
     std::shared_ptr<rclcpp::Service<GetAvailableTransitionsSrv>>;
+  using GetTransitionGraphSrvPtr =
+    std::shared_ptr<rclcpp::Service<GetAvailableTransitionsSrv>>;
 
   NodeBasePtr node_base_interface_;
   NodeServicesPtr node_services_interface_;
@@ -426,6 +471,7 @@ public:
   GetStateSrvPtr srv_get_state_;
   GetAvailableStatesSrvPtr srv_get_available_states_;
   GetAvailableTransitionsSrvPtr srv_get_available_transitions_;
+  GetTransitionGraphSrvPtr srv_get_transition_graph_;
 
   // to controllable things
   std::vector<std::weak_ptr<rclcpp_lifecycle::LifecyclePublisherInterface>> weak_pubs_;

--- a/rclcpp_lifecycle/src/node_interfaces/lifecycle_node_interface.cpp
+++ b/rclcpp_lifecycle/src/node_interfaces/lifecycle_node_interface.cpp
@@ -12,48 +12,49 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lifecycle_msgs/msg/transition.hpp"
-
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+
+#include "rcl_lifecycle/rcl_lifecycle.h"
 
 namespace rclcpp_lifecycle
 {
 namespace node_interfaces
 {
+
 rcl_lifecycle_transition_key_t
 LifecycleNodeInterface::on_configure(const State &)
 {
-  return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+  return RCL_LIFECYCLE_TRANSITION_KEY_CALLBACK_SUCCESS;
 }
 
 rcl_lifecycle_transition_key_t
 LifecycleNodeInterface::on_cleanup(const State &)
 {
-  return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+  return RCL_LIFECYCLE_TRANSITION_KEY_CALLBACK_SUCCESS;
 }
 
 rcl_lifecycle_transition_key_t
 LifecycleNodeInterface::on_shutdown(const State &)
 {
-  return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+  return RCL_LIFECYCLE_TRANSITION_KEY_CALLBACK_SUCCESS;
 }
 
 rcl_lifecycle_transition_key_t
 LifecycleNodeInterface::on_activate(const State &)
 {
-  return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+  return RCL_LIFECYCLE_TRANSITION_KEY_CALLBACK_SUCCESS;
 }
 
 rcl_lifecycle_transition_key_t
 LifecycleNodeInterface::on_deactivate(const State &)
 {
-  return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+  return RCL_LIFECYCLE_TRANSITION_KEY_CALLBACK_SUCCESS;
 }
 
 rcl_lifecycle_transition_key_t
 LifecycleNodeInterface::on_error(const State &)
 {
-  return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE;
+  return RCL_LIFECYCLE_TRANSITION_KEY_CALLBACK_SUCCESS;
 }
 
 }  // namespace node_interfaces

--- a/rclcpp_lifecycle/src/node_interfaces/lifecycle_node_interface.cpp
+++ b/rclcpp_lifecycle/src/node_interfaces/lifecycle_node_interface.cpp
@@ -21,40 +21,40 @@ namespace rclcpp_lifecycle
 namespace node_interfaces
 {
 
-rcl_lifecycle_transition_key_t
+LifecycleNodeInterface::CallbackReturn
 LifecycleNodeInterface::on_configure(const State &)
 {
-  return RCL_LIFECYCLE_TRANSITION_KEY_CALLBACK_SUCCESS;
+  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
-rcl_lifecycle_transition_key_t
+LifecycleNodeInterface::CallbackReturn
 LifecycleNodeInterface::on_cleanup(const State &)
 {
-  return RCL_LIFECYCLE_TRANSITION_KEY_CALLBACK_SUCCESS;
+  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
-rcl_lifecycle_transition_key_t
+LifecycleNodeInterface::CallbackReturn
 LifecycleNodeInterface::on_shutdown(const State &)
 {
-  return RCL_LIFECYCLE_TRANSITION_KEY_CALLBACK_SUCCESS;
+  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
-rcl_lifecycle_transition_key_t
+LifecycleNodeInterface::CallbackReturn
 LifecycleNodeInterface::on_activate(const State &)
 {
-  return RCL_LIFECYCLE_TRANSITION_KEY_CALLBACK_SUCCESS;
+  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
-rcl_lifecycle_transition_key_t
+LifecycleNodeInterface::CallbackReturn
 LifecycleNodeInterface::on_deactivate(const State &)
 {
-  return RCL_LIFECYCLE_TRANSITION_KEY_CALLBACK_SUCCESS;
+  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
-rcl_lifecycle_transition_key_t
+LifecycleNodeInterface::CallbackReturn
 LifecycleNodeInterface::on_error(const State &)
 {
-  return RCL_LIFECYCLE_TRANSITION_KEY_CALLBACK_SUCCESS;
+  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
 }  // namespace node_interfaces

--- a/rclcpp_lifecycle/test/test_callback_exceptions.cpp
+++ b/rclcpp_lifecycle/test/test_callback_exceptions.cpp
@@ -46,18 +46,18 @@ public:
   size_t number_of_callbacks = 0;
 
 protected:
-  rcl_lifecycle_transition_key_t
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_configure(const rclcpp_lifecycle::State &)
   {
     ++number_of_callbacks;
     throw std::runtime_error("custom exception raised in configure callback");
   }
 
-  rcl_lifecycle_transition_key_t
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_error(const rclcpp_lifecycle::State &)
   {
     ++number_of_callbacks;
-    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 };
 
@@ -68,18 +68,17 @@ TEST_F(TestCallbackExceptions, positive_on_error) {
   EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->trigger_transition(
       rclcpp_lifecycle::Transition(Transition::TRANSITION_CONFIGURE)).id());
   // check if all callbacks were successfully overwritten
-  EXPECT_EQ(static_cast<size_t>(2), test_node->number_of_callbacks);
+  EXPECT_EQ(2u, test_node->number_of_callbacks);
 }
 
 TEST_F(TestCallbackExceptions, positive_on_error_with_code) {
   auto test_node = std::make_shared<PositiveCallbackExceptionNode>("testnode");
 
   EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
-  rcl_lifecycle_transition_key_t ret = {
-    lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""
-  };
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn ret =
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   test_node->configure(ret);
-  EXPECT_EQ(lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR, ret.id);
+  EXPECT_EQ(rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR, ret);
 }
 
 class NegativeCallbackExceptionNode : public rclcpp_lifecycle::LifecycleNode
@@ -92,18 +91,18 @@ public:
   size_t number_of_callbacks = 0;
 
 protected:
-  rcl_lifecycle_transition_key_t
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_configure(const rclcpp_lifecycle::State &)
   {
     ++number_of_callbacks;
     throw std::runtime_error("custom exception raised in configure callback");
   }
 
-  rcl_lifecycle_transition_key_t
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_error(const rclcpp_lifecycle::State &)
   {
     ++number_of_callbacks;
-    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE, ""};
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
   }
 };
 
@@ -114,14 +113,14 @@ TEST_F(TestCallbackExceptions, negative_on_error) {
   EXPECT_EQ(State::PRIMARY_STATE_FINALIZED, test_node->trigger_transition(
       rclcpp_lifecycle::Transition(Transition::TRANSITION_CONFIGURE)).id());
   // check if all callbacks were successfully overwritten
-  EXPECT_EQ(static_cast<size_t>(2), test_node->number_of_callbacks);
+  EXPECT_EQ(2u, test_node->number_of_callbacks);
 }
 
 TEST_F(TestCallbackExceptions, negative_on_error_with_code) {
   auto test_node = std::make_shared<NegativeCallbackExceptionNode>("testnode");
 
   EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
-  rcl_lifecycle_transition_key_t ret;
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn ret;
   test_node->configure(ret);
-  EXPECT_EQ(lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR, ret.id);
+  EXPECT_EQ(rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR, ret);
 }

--- a/rclcpp_lifecycle/test/test_callback_exceptions.cpp
+++ b/rclcpp_lifecycle/test/test_callback_exceptions.cpp
@@ -57,7 +57,7 @@ protected:
   on_error(const rclcpp_lifecycle::State &)
   {
     ++number_of_callbacks;
-    return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
   }
 };
 
@@ -75,9 +75,11 @@ TEST_F(TestCallbackExceptions, positive_on_error_with_code) {
   auto test_node = std::make_shared<PositiveCallbackExceptionNode>("testnode");
 
   EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
-  rcl_lifecycle_transition_key_t ret = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+  rcl_lifecycle_transition_key_t ret = {
+    lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""
+  };
   test_node->configure(ret);
-  EXPECT_EQ(lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR, ret);
+  EXPECT_EQ(lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR, ret.id);
 }
 
 class NegativeCallbackExceptionNode : public rclcpp_lifecycle::LifecycleNode
@@ -101,7 +103,7 @@ protected:
   on_error(const rclcpp_lifecycle::State &)
   {
     ++number_of_callbacks;
-    return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE;
+    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE, ""};
   }
 };
 
@@ -119,7 +121,7 @@ TEST_F(TestCallbackExceptions, negative_on_error_with_code) {
   auto test_node = std::make_shared<NegativeCallbackExceptionNode>("testnode");
 
   EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
-  rcl_lifecycle_transition_key_t ret = RCL_RET_OK;
+  rcl_lifecycle_transition_key_t ret;
   test_node->configure(ret);
-  EXPECT_EQ(lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR, ret);
+  EXPECT_EQ(lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR, ret.id);
 }

--- a/rclcpp_lifecycle/test/test_register_custom_callbacks.cpp
+++ b/rclcpp_lifecycle/test/test_register_custom_callbacks.cpp
@@ -46,91 +46,91 @@ public:
   size_t number_of_callbacks = 0;
 
 protected:
-  rcl_lifecycle_transition_key_t
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_configure(const rclcpp_lifecycle::State &)
   {
     ADD_FAILURE();
     ++number_of_callbacks;
-    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 
-  rcl_lifecycle_transition_key_t
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_activate(const rclcpp_lifecycle::State &)
   {
     ADD_FAILURE();
     ++number_of_callbacks;
-    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 
-  rcl_lifecycle_transition_key_t
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_deactivate(const rclcpp_lifecycle::State &)
   {
     ADD_FAILURE();
     ++number_of_callbacks;
-    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 
-  rcl_lifecycle_transition_key_t
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_cleanup(const rclcpp_lifecycle::State &)
   {
     ADD_FAILURE();
     ++number_of_callbacks;
-    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 
-  rcl_lifecycle_transition_key_t
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_shutdown(const rclcpp_lifecycle::State &)
   {
     ADD_FAILURE();
     ++number_of_callbacks;
-    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 
   // Custom callbacks
 
 public:
-  rcl_lifecycle_transition_key_t
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_custom_configure(const rclcpp_lifecycle::State & previous_state)
   {
     EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, previous_state.id());
     EXPECT_EQ(State::TRANSITION_STATE_CONFIGURING, get_current_state().id());
     ++number_of_callbacks;
-    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 
-  rcl_lifecycle_transition_key_t
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_custom_activate(const rclcpp_lifecycle::State & previous_state)
   {
     EXPECT_EQ(State::PRIMARY_STATE_INACTIVE, previous_state.id());
     EXPECT_EQ(State::TRANSITION_STATE_ACTIVATING, get_current_state().id());
     ++number_of_callbacks;
-    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 
-  rcl_lifecycle_transition_key_t
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_custom_deactivate(const rclcpp_lifecycle::State & previous_state)
   {
     EXPECT_EQ(State::PRIMARY_STATE_ACTIVE, previous_state.id());
     EXPECT_EQ(State::TRANSITION_STATE_DEACTIVATING, get_current_state().id());
     ++number_of_callbacks;
-    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 
-  rcl_lifecycle_transition_key_t
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_custom_cleanup(const rclcpp_lifecycle::State & previous_state)
   {
     EXPECT_EQ(State::PRIMARY_STATE_INACTIVE, previous_state.id());
     EXPECT_EQ(State::TRANSITION_STATE_CLEANINGUP, get_current_state().id());
     ++number_of_callbacks;
-    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 
-  rcl_lifecycle_transition_key_t
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_custom_shutdown(const rclcpp_lifecycle::State &)
   {
     EXPECT_EQ(State::TRANSITION_STATE_SHUTTINGDOWN, get_current_state().id());
     ++number_of_callbacks;
-    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 };
 
@@ -158,8 +158,8 @@ TEST_F(TestRegisterCustomCallbacks, custom_callbacks) {
   EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->trigger_transition(
       rclcpp_lifecycle::Transition(Transition::TRANSITION_CLEANUP)).id());
   EXPECT_EQ(State::PRIMARY_STATE_FINALIZED, test_node->trigger_transition(
-      rclcpp_lifecycle::Transition(Transition::TRANSITION_SHUTDOWN)).id());
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_UNCONFIGURED_SHUTDOWN)).id());
 
   // check if all callbacks were successfully overwritten
-  EXPECT_EQ(static_cast<size_t>(5), test_node->number_of_callbacks);
+  EXPECT_EQ(5u, test_node->number_of_callbacks);
 }

--- a/rclcpp_lifecycle/test/test_register_custom_callbacks.cpp
+++ b/rclcpp_lifecycle/test/test_register_custom_callbacks.cpp
@@ -51,7 +51,7 @@ protected:
   {
     ADD_FAILURE();
     ++number_of_callbacks;
-    return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
   }
 
   rcl_lifecycle_transition_key_t
@@ -59,7 +59,7 @@ protected:
   {
     ADD_FAILURE();
     ++number_of_callbacks;
-    return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
   }
 
   rcl_lifecycle_transition_key_t
@@ -67,7 +67,7 @@ protected:
   {
     ADD_FAILURE();
     ++number_of_callbacks;
-    return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
   }
 
   rcl_lifecycle_transition_key_t
@@ -75,7 +75,7 @@ protected:
   {
     ADD_FAILURE();
     ++number_of_callbacks;
-    return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
   }
 
   rcl_lifecycle_transition_key_t
@@ -83,7 +83,7 @@ protected:
   {
     ADD_FAILURE();
     ++number_of_callbacks;
-    return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
   }
 
   // Custom callbacks
@@ -95,7 +95,7 @@ public:
     EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, previous_state.id());
     EXPECT_EQ(State::TRANSITION_STATE_CONFIGURING, get_current_state().id());
     ++number_of_callbacks;
-    return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
   }
 
   rcl_lifecycle_transition_key_t
@@ -104,7 +104,7 @@ public:
     EXPECT_EQ(State::PRIMARY_STATE_INACTIVE, previous_state.id());
     EXPECT_EQ(State::TRANSITION_STATE_ACTIVATING, get_current_state().id());
     ++number_of_callbacks;
-    return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
   }
 
   rcl_lifecycle_transition_key_t
@@ -113,7 +113,7 @@ public:
     EXPECT_EQ(State::PRIMARY_STATE_ACTIVE, previous_state.id());
     EXPECT_EQ(State::TRANSITION_STATE_DEACTIVATING, get_current_state().id());
     ++number_of_callbacks;
-    return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
   }
 
   rcl_lifecycle_transition_key_t
@@ -122,7 +122,7 @@ public:
     EXPECT_EQ(State::PRIMARY_STATE_INACTIVE, previous_state.id());
     EXPECT_EQ(State::TRANSITION_STATE_CLEANINGUP, get_current_state().id());
     ++number_of_callbacks;
-    return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
   }
 
   rcl_lifecycle_transition_key_t
@@ -130,7 +130,7 @@ public:
   {
     EXPECT_EQ(State::TRANSITION_STATE_SHUTTINGDOWN, get_current_state().id());
     ++number_of_callbacks;
-    return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
+    return {lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS, ""};
   }
 };
 

--- a/rclcpp_lifecycle/test/test_state_wrapper.cpp
+++ b/rclcpp_lifecycle/test/test_state_wrapper.cpp
@@ -44,7 +44,7 @@ TEST_F(TestStateWrapper, wrapper) {
   }
 
   {
-    rcl_lifecycle_state_t lc_state = {"my_c_state", 2, NULL, NULL, 0};
+    rcl_lifecycle_state_t lc_state = {"my_c_state", 2, NULL, 0};
     rclcpp_lifecycle::State c_state(lc_state.id, lc_state.label);
     EXPECT_EQ(2, c_state.id());
     EXPECT_FALSE(c_state.label().empty());
@@ -52,7 +52,7 @@ TEST_F(TestStateWrapper, wrapper) {
   }
 
   {
-    rcl_lifecycle_state_t lc_state = {"my_c_state", 2, NULL, NULL, 0};
+    rcl_lifecycle_state_t lc_state = {"my_c_state", 2, NULL, 0};
     rclcpp_lifecycle::State c_state(&lc_state);
     EXPECT_EQ(2, c_state.id());
     EXPECT_FALSE(c_state.label().empty());
@@ -61,7 +61,7 @@ TEST_F(TestStateWrapper, wrapper) {
 
   {
     rcl_lifecycle_state_t * lc_state =
-      new rcl_lifecycle_state_t {"my_c_state", 3, NULL, NULL, 0};
+      new rcl_lifecycle_state_t {"my_c_state", 3, NULL, 0};
     rclcpp_lifecycle::State c_state(lc_state->id, lc_state->label);
     EXPECT_EQ(3, c_state.id());
     EXPECT_FALSE(c_state.label().empty());
@@ -107,12 +107,12 @@ TEST_F(TestStateWrapper, assignment_operator) {
 TEST_F(TestStateWrapper, assignment_operator2) {
   // Non-owning State
   rcl_lifecycle_state_t * lc_state1 =
-    new rcl_lifecycle_state_t{"my_c_state1", 1, NULL, NULL, 0};
+    new rcl_lifecycle_state_t{"my_c_state1", 1, NULL, 0};
   auto non_owning_state1 = std::make_shared<rclcpp_lifecycle::State>(lc_state1);
 
   // Non-owning State
   rcl_lifecycle_state_t * lc_state2 =
-    new rcl_lifecycle_state_t{"my_c_state2", 2, NULL, NULL, 0};
+    new rcl_lifecycle_state_t{"my_c_state2", 2, NULL, 0};
   auto non_owning_state2 = std::make_shared<rclcpp_lifecycle::State>(lc_state2);
 
   *non_owning_state2 = *non_owning_state1;
@@ -130,7 +130,7 @@ TEST_F(TestStateWrapper, assignment_operator2) {
 TEST_F(TestStateWrapper, assignment_operator3) {
   // Non-owning State
   rcl_lifecycle_state_t * lc_state1 =
-    new rcl_lifecycle_state_t{"my_c_state1", 1, NULL, NULL, 0};
+    new rcl_lifecycle_state_t{"my_c_state1", 1, NULL, 0};
   auto non_owning_state1 = std::make_shared<rclcpp_lifecycle::State>(lc_state1);
 
   // owning State
@@ -150,7 +150,7 @@ TEST_F(TestStateWrapper, assignment_operator3) {
 TEST_F(TestStateWrapper, assignment_operator4) {
   // Non-owning State
   rcl_lifecycle_state_t * lc_state1 =
-    new rcl_lifecycle_state_t{"my_c_state1", 1, NULL, NULL, 0};
+    new rcl_lifecycle_state_t{"my_c_state1", 1, NULL, 0};
   auto non_owning_state1 = std::make_shared<rclcpp_lifecycle::State>(lc_state1);
 
   // owning State


### PR DESCRIPTION
fixes https://github.com/ros2/rclcpp/issues/550

The biggest change (this will break existing API) here is that a `rcl_lifecycle_transition_key_t` now is a struct has thus has `label` and `id`. This label will then be presented when calling `get_available_transitions`. There is a second service introduced called `get_transition_graph` which yields all available transitions within the state machine. This is then helpful when introspecting the state machine.

I am not feeling a hundred percent convinced that the naming here is perfect, so I'd ask for feedback between the following separation:

* Transition: A unique transition within the state machine is labeled as i.e. `configure_to_shutdown` or `configure_to_configuring`.
* Key: A transition key is used here to trigger the change of state, i.e. `configure` or `shutdown` and one key can be used to trigger different individual transitions. The example here could be `shutdown` which can be used to trigger `configure_to_shutdown` or `inactive_to_shutdown`.

Any feedback on naming here?  