### PR TITLE
Fix cpplint on xenial

### DIFF
--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -135,10 +135,10 @@ Clock::create_jump_callback(
 
   // *INDENT-OFF*
   // create shared_ptr that removes the callback automatically when all copies are destructed
-  return rclcpp::JumpHandler::SharedPtr(handler, [this](rclcpp::JumpHandler * handler) noexcept {
+  return rclcpp::JumpHandler::SharedPtr(handler, [this](rclcpp::JumpHandler * jhandler) noexcept {
     rcl_ret_t ret = rcl_clock_remove_jump_callback(&rcl_clock_, rclcpp::Clock::on_time_jump,
-        handler);
-    delete handler;
+        jhandler);
+    delete jhandler;
     if (RCL_RET_OK != ret) {
       RCUTILS_LOG_ERROR("Failed to remove time jump callback");
     }

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -130,15 +130,16 @@ Clock::create_jump_callback(
       rclcpp::Clock::on_time_jump, handler);
   if (RCL_RET_OK != ret) {
     delete handler;
+    handler = NULL;
     rclcpp::exceptions::throw_from_rcl_error(ret, "Failed to add time jump callback");
   }
 
   // *INDENT-OFF*
   // create shared_ptr that removes the callback automatically when all copies are destructed
-  return rclcpp::JumpHandler::SharedPtr(handler, [this](rclcpp::JumpHandler * jhandler) noexcept {
+  return rclcpp::JumpHandler::SharedPtr(handler, [this](rclcpp::JumpHandler * handler) noexcept {
     rcl_ret_t ret = rcl_clock_remove_jump_callback(&rcl_clock_, rclcpp::Clock::on_time_jump,
-        jhandler);
-    delete jhandler;
+        handler);
+    delete handler;
     if (RCL_RET_OK != ret) {
       RCUTILS_LOG_ERROR("Failed to remove time jump callback");
     }

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -140,6 +140,7 @@ Clock::create_jump_callback(
     rcl_ret_t ret = rcl_clock_remove_jump_callback(&rcl_clock_, rclcpp::Clock::on_time_jump,
         handler);
     delete handler;
+    handler = NULL;
     if (RCL_RET_OK != ret) {
       RCUTILS_LOG_ERROR("Failed to remove time jump callback");
     }


### PR DESCRIPTION
It looks like there is a false positive cpplint violation on xenial (ros2/build_cop#147).

I'm guessing it either had an issue with the same variable name being used in the shared pointer deleter, or it didn't recognize execution stops at `throw_from_rcl_error` above.

First attempt: change variable name in lambda.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5182)](http://ci.ros2.org/job/ci_linux/5182/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1954)](http://ci.ros2.org/job/ci_linux-aarch64/1954/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4306)](http://ci.ros2.org/job/ci_osx/4306/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5162)](http://ci.ros2.org/job/ci_windows/5162/)

connects to ros2/build_cop#147