### PR TITLE
Remove std::binary_function usage

### DIFF
--- a/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
@@ -262,7 +262,7 @@ private:
     std::hash<uint64_t>, std::equal_to<uint64_t>,
     RebindAlloc<std::pair<const uint64_t, SubscriptionBase::WeakPtr>>>;
 
-  struct strcmp_wrapper : public std::binary_function<const char *, const char *, bool>
+  struct strcmp_wrapper
   {
     bool
     operator()(const char * lhs, const char * rhs) const


### PR DESCRIPTION
This pull request removes an inherit of `std::binary_function` for the struct `strcmp_wrapper`, a C-style string comparator.

The struct `strcmp_wrapper` is used by the IDTopicMap typedef (line 276) which is a std::map, and std::map requires strcmp_wrapper to fulfill the [Compare named requirement](https://en.cppreference.com/w/cpp/named_req/Compare). The inherit of `std::binary_function` only defines 3 types: `first_argument_type`, `second_argument_type` and `result_type` (typedefs of types passed in argument), which is useless here because they are not part of the requirement.

 `std::binary_function` has been deprecated in C++11, removed in C++17. This change may seem useless, but this change enables us to compile C++17 ROS2 packages using rclcpp (or at least some of them), which may be useful.