### PR TITLE
Add virtual destructors to classes with virtual functions.

### DIFF
--- a/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
@@ -45,7 +45,7 @@ public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(IntraProcessManagerImplBase)
 
   IntraProcessManagerImplBase() = default;
-  ~IntraProcessManagerImplBase() = default;
+  virtual ~IntraProcessManagerImplBase() = default;
 
   virtual void
   add_subscription(uint64_t id, SubscriptionBase::SharedPtr subscription) = 0;

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -43,6 +43,8 @@ public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(MemoryStrategy)
   using WeakNodeVector = std::vector<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr>;
 
+  virtual ~MemoryStrategy() = default;
+
   virtual bool collect_entities(const WeakNodeVector & weak_nodes) = 0;
 
   virtual size_t number_of_ready_subscriptions() const = 0;

--- a/rclcpp/include/rclcpp/message_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/message_memory_strategy.hpp
@@ -71,6 +71,8 @@ public:
     rcutils_allocator_ = allocator::get_rcl_allocator<char, BufferAlloc>(*buffer_allocator_.get());
   }
 
+  virtual ~MessageMemoryStrategy() = default;
+
   /// Default factory method
   static SharedPtr create_default()
   {


### PR DESCRIPTION
This fixes the build on MacOS High Sierra and later, and
is the more correct thing to do anyway.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

fixes https://github.com/ros2/rclcpp/issues/563