### PR TITLE
Adding a factory method to create a Duration from seconds

### DIFF
--- a/rclcpp/include/rclcpp/duration.hpp
+++ b/rclcpp/include/rclcpp/duration.hpp
@@ -28,10 +28,12 @@ class RCLCPP_PUBLIC Duration
 public:
   Duration(int32_t seconds, uint32_t nanoseconds);
 
+  // This constructor matches any numeric value - ints or floats
   explicit Duration(rcl_duration_value_t nanoseconds);
 
   explicit Duration(std::chrono::nanoseconds nanoseconds);
 
+  // This constructor matches any std::chrono value other than nanoseconds
   // intentionally not using explicit to create a conversion constructor
   template<class Rep, class Period>
   // cppcheck-suppress noExplicitConstructor

--- a/rclcpp/include/rclcpp/duration.hpp
+++ b/rclcpp/include/rclcpp/duration.hpp
@@ -94,6 +94,10 @@ public:
   double
   seconds() const;
 
+  // Create a duration object from a floating point number representing seconds
+  static Duration
+  from_seconds(double seconds);
+
   template<class DurationT>
   DurationT
   to_chrono() const

--- a/rclcpp/src/rclcpp/duration.cpp
+++ b/rclcpp/src/rclcpp/duration.cpp
@@ -233,4 +233,10 @@ Duration::to_rmw_time() const
   return result;
 }
 
+Duration
+Duration::from_seconds(double seconds)
+{
+  return Duration(static_cast<int64_t>(RCL_S_TO_NS(seconds)));
+}
+
 }  // namespace rclcpp

--- a/rclcpp/test/test_duration.cpp
+++ b/rclcpp/test/test_duration.cpp
@@ -136,3 +136,20 @@ TEST(TestDuration, maximum_duration) {
 
   EXPECT_EQ(max_duration, max);
 }
+
+static const int64_t HALF_SEC_IN_NS = 500 * 1000 * 1000;
+static const int64_t ONE_AND_HALF_SEC_IN_NS = 3 * HALF_SEC_IN_NS;
+
+TEST(TestDuration, from_seconds) {
+  EXPECT_EQ(rclcpp::Duration(0), rclcpp::Duration::from_seconds(0.0));
+  EXPECT_EQ(rclcpp::Duration(0), rclcpp::Duration::from_seconds(0));
+  EXPECT_EQ(rclcpp::Duration(1, HALF_SEC_IN_NS), rclcpp::Duration::from_seconds(1.5));
+  EXPECT_EQ(rclcpp::Duration(-ONE_AND_HALF_SEC_IN_NS), rclcpp::Duration::from_seconds(-1.5));
+}
+
+TEST(TestDuration, std_chrono_constructors) {
+  EXPECT_EQ(rclcpp::Duration(0), rclcpp::Duration(0.0s));
+  EXPECT_EQ(rclcpp::Duration(0), rclcpp::Duration(0s));
+  EXPECT_EQ(rclcpp::Duration(1, HALF_SEC_IN_NS), rclcpp::Duration(1.5s));
+  EXPECT_EQ(rclcpp::Duration(-1, 0), rclcpp::Duration(-1s));
+}


### PR DESCRIPTION
There are many places in the ROS codebase where a time duration is
specified as a floating point number of seconds. A factory function
to create a Duration object from these values makes the code a
bit simpler in many cases.

Sorry this change is based off the 0.5.1 tag. I was having trouble building
the tip of master. I will rebase this properly if you want to implement this
functionality this way.