### PR TITLE
fix wrong use of constructor and hanging test

### DIFF
--- a/rclcpp/test/test_time_source.cpp
+++ b/rclcpp/test/test_time_source.cpp
@@ -348,14 +348,14 @@ TEST_F(TestTimeSource, parameter_activation) {
   EXPECT_TRUE(ros_clock->ros_time_is_active());
 
   set_use_sim_time_parameter(
-    node, rclcpp::ParameterValue(rclcpp::ParameterType::PARAMETER_NOT_SET));
+    node, rclcpp::ParameterValue());
   EXPECT_TRUE(ros_clock->ros_time_is_active());
 
   set_use_sim_time_parameter(node, rclcpp::ParameterValue(false));
   EXPECT_FALSE(ros_clock->ros_time_is_active());
 
   set_use_sim_time_parameter(
-    node, rclcpp::ParameterValue(rclcpp::ParameterType::PARAMETER_NOT_SET));
+    node, rclcpp::ParameterValue());
   EXPECT_FALSE(ros_clock->ros_time_is_active());
 
   // If the use_sim_time parameter is not explicitly set to True, this clock's use of sim time

--- a/rclcpp/test/test_time_source.cpp
+++ b/rclcpp/test/test_time_source.cpp
@@ -37,6 +37,11 @@ protected:
     rclcpp::init(0, nullptr);
   }
 
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
+
   void SetUp()
   {
     node = std::make_shared<rclcpp::Node>("my_node");


### PR DESCRIPTION
**First commit:** passing `rclcpp::ParameterType::PARAMETER_NOT_SET` to the `rclcpp::ParameterValue` constructor is wrong since it interprets the parameter as an integer value. This currently results in the test to print the following error message:

```
[ERROR] []: use_sim_time parameter set to something besides a bool
```

This happened in the Windows builds for an OpenSplice contribution: https://ci.ros2.org/job/ci_windows/5590/

Beside that error message the test still timed out.

**Second commit:** adds a call to `rclcpp::shutdown()` in the tests tear down function.

With these changes doesn't time out anymore and doesn't print any error message for invalid parameters anymore: https://ci.ros2.org/job/ci_windows/5596/