### PR TITLE
Avoid race that triggers timer too often

### DIFF
--- a/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
@@ -78,7 +78,6 @@ private:
   size_t number_of_threads_;
   bool yield_before_execute_;
 
-  std::mutex scheduled_timers_mutex_;
   std::set<TimerBase::SharedPtr> scheduled_timers_;
 };
 

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -82,7 +82,6 @@ MultiThreadedExecutor::run(size_t)
       }
       if (any_exec.timer) {
         // Guard against multiple threads getting the same timer.
-        std::lock_guard<std::mutex> lock(scheduled_timers_mutex_);
         if (scheduled_timers_.count(any_exec.timer) != 0) {
           continue;
         }
@@ -96,7 +95,7 @@ MultiThreadedExecutor::run(size_t)
     execute_any_executable(any_exec);
 
     if (any_exec.timer) {
-      std::lock_guard<std::mutex> lock(scheduled_timers_mutex_);
+      std::lock_guard<std::mutex> wait_lock(wait_mutex_);
       auto it = scheduled_timers_.find(any_exec.timer);
       if (it != scheduled_timers_.end()) {
         scheduled_timers_.erase(it);


### PR DESCRIPTION
We are experiencing sporadic failures of `TestMultiThreadedExecutor.timer_over_take` in our CI, where the measured time difference between two timer executions is close to zero.

Looking at the code there is a subtle opportunity for a race condition in `rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp`:
```c
      ...
      if (!get_next_executable(any_exec)) {                                                                                                                                                    
        continue;                                                                                                                                                                              
      }  
                                                                                                                                                                                      
      /* 
        IMAGINE OR INSERT A SHORT FEW MILLISECOND SLEEP HERE 
      */

      if (any_exec.timer) {                                                                                                                                                                    
        // Guard against multiple threads getting the same timer.                                                                                                                              
        std::lock_guard<std::mutex> lock(scheduled_timers_mutex_);                                                                                                                             
        if (scheduled_timers_.count(any_exec.timer) != 0) {                                                                                                                                    
          continue;                                                                                                                                                                            
        }                                                                                                                                                                                      
        scheduled_timers_.insert(any_exec.timer);                                                                                                                                              
      }
      ...                                                                                                                                                                                      
```

The race condition is triggered if:
- a thread gets an already scheduled timer
- acquiring the second lock_guard is slightly delayed

In this case a previously fetched and scheduled timer handle could be removed from the list of scheduled timers by the thread that first got the timer before the delayed check. This results in a second execution of the timer callback.

For me replacing the above comment with 
```
std::this_thread::sleep_for(std::chrono::milliseconds(5));
```
causes the test to always fail.

To mitigate, `get_next_executable` and `if (scheduled_timers_.count ... )` have to be protected by one `lock_guard`. This pull request takes this requirement into account and removes the now redundant second `lock_guard`.