### PR TITLE
Replace node constructor arguments with NodeOptions

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -47,6 +47,7 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/memory_strategies.cpp
   src/rclcpp/memory_strategy.cpp
   src/rclcpp/node.cpp
+  src/rclcpp/node_options.cpp
   src/rclcpp/node_interfaces/node_base.cpp
   src/rclcpp/node_interfaces/node_clock.cpp
   src/rclcpp/node_interfaces/node_graph.cpp

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -81,7 +81,7 @@ public:
   explicit Node(
     const std::string & node_name,
     const std::string & namespace_ = "",
-    bool use_intra_process_comms = false);
+    const NodeOptions & options = NodeOptions());
 
   /// Create a node based on the node name and a rclcpp::Context.
   /**
@@ -102,11 +102,7 @@ public:
     const std::string & node_name,
     const std::string & namespace_,
     rclcpp::Context::SharedPtr context,
-    const std::vector<std::string> & arguments,
-    const std::vector<Parameter> & initial_parameters,
-    bool use_global_arguments = true,
-    bool use_intra_process_comms = false,
-    bool start_parameter_services = true);
+    const NodeOptions & options);
 
   RCLCPP_PUBLIC
   virtual ~Node();

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -79,22 +79,19 @@ public:
   RCLCPP_PUBLIC
   explicit Node(
     const std::string & node_name,
-    const std::string & namespace_ = "",
-    const NodeOptions & options = NodeOptions());
+    const NodeOptions & options = NodeOptions::Builder().build());
 
-  /// Create a node based on the node name and a rclcpp::Context.
+  /// Create a new node with the specified name.
   /**
    * \param[in] node_name Name of the node.
    * \param[in] namespace_ Namespace of the node.
-   * \param[in] context The context for the node (usually represents the state of a process).
    * \param[in] options Additional options to control creation of the node.
    */
   RCLCPP_PUBLIC
-  Node(
+  explicit Node(
     const std::string & node_name,
     const std::string & namespace_,
-    rclcpp::Context::SharedPtr context,
-    const NodeOptions & options);
+    const NodeOptions & options = NodeOptions::Builder().build());
 
   RCLCPP_PUBLIC
   virtual ~Node();

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -74,8 +74,7 @@ public:
   /**
    * \param[in] node_name Name of the node.
    * \param[in] namespace_ Namespace of the node.
-   * \param[in] use_intra_process_comms True to use the optimized intra-process communication
-   * pipeline to pass messages between nodes in the same process using shared memory.
+   * \param[in] options Additional options to control creation of the node.
    */
   RCLCPP_PUBLIC
   explicit Node(
@@ -88,14 +87,7 @@ public:
    * \param[in] node_name Name of the node.
    * \param[in] namespace_ Namespace of the node.
    * \param[in] context The context for the node (usually represents the state of a process).
-   * \param[in] arguments Command line arguments that should apply only to this node.
-   * \param[in] initial_parameters a list of initial values for parameters on the node.
-   * This can be used to provide remapping rules that only affect one instance.
-   * \param[in] use_global_arguments False to prevent node using arguments passed to the process.
-   * \param[in] use_intra_process_comms True to use the optimized intra-process communication
-   * pipeline to pass messages between nodes in the same process using shared memory.
-   * \param[in] start_parameter_services True to setup ROS interfaces for accessing parameters
-   * in the node.
+   * \param[in] options Additional options to control creation of the node.
    */
   RCLCPP_PUBLIC
   Node(

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -78,7 +78,7 @@ public:
   RCLCPP_PUBLIC
   explicit Node(
     const std::string & node_name,
-    const NodeOptions & options = NodeOptions::Builder().build());
+    const NodeOptions & options = NodeOptions());
 
   /// Create a new node with the specified name.
   /**
@@ -90,7 +90,7 @@ public:
   explicit Node(
     const std::string & node_name,
     const std::string & namespace_,
-    const NodeOptions & options = NodeOptions::Builder().build());
+    const NodeOptions & options = NodeOptions());
 
   RCLCPP_PUBLIC
   virtual ~Node();

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -73,7 +73,6 @@ public:
   /// Create a new node with the specified name.
   /**
    * \param[in] node_name Name of the node.
-   * \param[in] namespace_ Namespace of the node.
    * \param[in] options Additional options to control creation of the node.
    */
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -41,6 +41,7 @@
 #include "rclcpp/logger.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/message_memory_strategy.hpp"
+#include "rclcpp/node_options.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/node_interfaces/node_clock_interface.hpp"
 #include "rclcpp/node_interfaces/node_graph_interface.hpp"

--- a/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
@@ -40,7 +40,6 @@ public:
   NodeBase(
     const std::string & node_name,
     const std::string & namespace_,
-    rclcpp::Context::SharedPtr context,
     const NodeOptions & options);
 
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
@@ -21,6 +21,7 @@
 
 #include "rclcpp/context.hpp"
 #include "rclcpp/macros.hpp"
+#include "rclcpp/node_options.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/visibility_control.hpp"
 
@@ -40,8 +41,7 @@ public:
     const std::string & node_name,
     const std::string & namespace_,
     rclcpp::Context::SharedPtr context,
-    const std::vector<std::string> & arguments,
-    bool use_global_arguments);
+    const NodeOptions & options);
 
   RCLCPP_PUBLIC
   virtual

--- a/rclcpp/include/rclcpp/node_options.hpp
+++ b/rclcpp/include/rclcpp/node_options.hpp
@@ -28,7 +28,7 @@
 namespace rclcpp
 {
 
-/// Encapsulation of options for initializing node.
+/// Encapsulation of options for node initialization.
 class NodeOptions
 {
 public:

--- a/rclcpp/include/rclcpp/node_options.hpp
+++ b/rclcpp/include/rclcpp/node_options.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 
 #include "rcl/node_options.h"
+#include "rclcpp/parameter.hpp"
 #include "rclcpp/visibility_control.hpp"
 
 namespace rclcpp
@@ -26,6 +27,7 @@ namespace rclcpp
 /// Encapsulation of options for initializing node.
 class NodeOptions
 {
+public:
   /// Constructor which allows you to specify the allocator used within the init options.
   RCLCPP_PUBLIC
   explicit NodeOptions(rcl_allocator_t allocator = rcl_get_default_allocator());
@@ -52,13 +54,36 @@ class NodeOptions
   const rcl_node_options_t *
   get_rcl_node_options() const;
 
+  /// Return the list of initial parameters
+  const std::vector<rclcpp::Parameter> & initial_parameters() const;
+  std::vector<rclcpp::Parameter> & initial_parameters();
+
+  const bool & use_global_arguments() const;
+  bool & use_global_arguments();
+
+  const bool & use_intra_process_comms() const;
+  bool & use_intra_process_comms();
+
+  const bool & start_parameter_services() const;
+  bool & start_parameter_services();
+
 protected:
   void
   finalize_node_options();
 
+  void
+  set_domain_id_from_env();
+
 private:
   std::unique_ptr<rcl_node_options_t>  node_options_;
+
+  std::vector<rclcpp::Parameter> initial_parameters_;
+
+  bool use_intra_process_comms_ {false};
+
+  bool start_parameter_services_ {true};
 };
 
 }  // namespace rclcpp
+
 #endif  // RCLCPP__NODEOPTIONS_HPP_

--- a/rclcpp/include/rclcpp/node_options.hpp
+++ b/rclcpp/include/rclcpp/node_options.hpp
@@ -125,6 +125,9 @@ public:
   use_global_arguments() const;
 
   /// Set the use_global_arguments flag, return this for parameter idiom.
+  /**
+   * This will cause the internal rcl_node_options_t struct to be invalidated.
+   */
   RCLCPP_PUBLIC
   NodeOptions &
   use_global_arguments(const bool & use_global_arguments);
@@ -151,14 +154,13 @@ public:
 
   /// Return the rcl_allocator_t to be used.
   RCLCPP_PUBLIC
-  rcl_allocator_t &
-  allocator();
-
-  RCLCPP_PUBLIC
   const rcl_allocator_t &
   allocator() const;
 
   /// Set the rcl_allocator_t to be used, may cause deallocation of existing rcl_node_options_t.
+  /**
+   * This will cause the internal rcl_node_options_t struct to be invalidated.
+   */
   RCLCPP_PUBLIC
   NodeOptions &
   allocator(rcl_allocator_t allocator);

--- a/rclcpp/include/rclcpp/node_options.hpp
+++ b/rclcpp/include/rclcpp/node_options.hpp
@@ -20,6 +20,8 @@
 #include <vector>
 
 #include "rcl/node_options.h"
+#include "rclcpp/context.hpp"
+#include "rclcpp/contexts/default_context.hpp"
 #include "rclcpp/parameter.hpp"
 #include "rclcpp/visibility_control.hpp"
 
@@ -30,27 +32,10 @@ namespace rclcpp
 class NodeOptions
 {
 public:
-  /// Create NodeOptions, optionally specifying the allocator to use.
-  /**
-   * \param[in] allocator allocator to use in construction of NodeOptions.
-   */
-  RCLCPP_PUBLIC
-  explicit NodeOptions(
-    rcl_allocator_t allocator = rcl_get_default_allocator());
+  // use this calss to construct NodeOptions.
+  class Builder;
 
-  /// Create NodeOptions, optionally specifying the allocator to use.
-  /**
-   * \param[in] arguments Command line arguments that should apply only to this node.
-   * \param[in] initial_parameters a list of initial values for parameters on the node.
-   * This can be used to provide remapping rules that only affect one instance.
-   * \param[in] allocator - allocator to use in construction of NodeOptions.
-   */
-  RCLCPP_PUBLIC
-  explicit NodeOptions(
-    const std::vector<std::string> & arguments,
-    const std::vector<rclcpp::Parameter> & initial_parameters = {},
-    rcl_allocator_t allocator = rcl_get_default_allocator());
-
+public:
   /// Copy constructor.
   RCLCPP_PUBLIC
   NodeOptions(const NodeOptions & other);
@@ -70,56 +55,123 @@ public:
   const rcl_node_options_t *
   get_rcl_node_options() const;
 
+  RCLCPP_PUBLIC
+  rclcpp::Context::SharedPtr
+  context() const;
+
   /// Return a reference to the list of initial parameters
   /**
    * Initial paramters is a list of initial values for parameters on the node.
-   * This can be used to provide remapping rules that only affect the node instance created with
-   * this NodeOptions instance.
    */
-  const std::vector<rclcpp::Parameter> & initial_parameters() const;
-  std::vector<rclcpp::Parameter> & initial_parameters();
+  RCLCPP_PUBLIC
+  const std::vector<rclcpp::Parameter> &
+  initial_parameters() const;
 
   /// Return a reference to the use_global_arguments flag
   /**
    * False to prevent node from using arguments passed to the process
    */
-  const bool & use_global_arguments() const;
-  bool & use_global_arguments();
+  RCLCPP_PUBLIC
+  const bool &
+  use_global_arguments() const;
 
   /// Return a reference to the use_intra_process_comms flag
   /**
    * True to use the optimized intra-process communication pipeline to pass messages bewteen nodes
    * in the same process using shared memory.
    */
-  const bool & use_intra_process_comms() const;
-  bool & use_intra_process_comms();
+  RCLCPP_PUBLIC
+  const bool &
+  use_intra_process_comms() const;
 
   /// Return a reference to the start_parameter_services flag
   /**
    * True to setup ROS interfaces for accessing parameters in the node.
    */
-  const bool & start_parameter_services() const;
-  bool & start_parameter_services();
+  RCLCPP_PUBLIC
+  const bool &
+  start_parameter_services() const;
 
 protected:
+  /// Create NodeOptions, optionally specifying the allocator to use.
+  /**
+   * \param[in] allocator allocator to use in construction of NodeOptions.
+   */
+  RCLCPP_PUBLIC
+  explicit NodeOptions(
+    rclcpp::Context::SharedPtr context,
+    const std::vector<std::string> & arguments,
+    const std::vector<rclcpp::Parameter> & initial_parameters,
+    bool use_global_arguments,
+    bool use_intra_process_comms,
+    bool start_parameter_services,
+    rcl_allocator_t allocator);
+
   /// Clean up internal rcl_node_options_t structure.
   void
   finalize_node_options();
 
   /// Retrieve the ROS_DOMAIN_ID environment variable and populate options.
-  void
-  set_domain_id_from_env();
+  size_t
+  get_domain_id_from_env() const;
 
 private:
   std::unique_ptr<rcl_node_options_t> node_options_;
 
+  rclcpp::Context::SharedPtr context_;
+
+  std::vector<std::string> arguments_;
+
   std::vector<rclcpp::Parameter> initial_parameters_;
 
-  /// True to use the optimized intra-process communication pipeline
+  bool use_intra_process_comms_;
+
+  bool start_parameter_services_;
+};
+
+class NodeOptions::Builder
+{
+public:
+  Builder() = default;
+
+  NodeOptions build();
+
+  Builder &
+  context(rclcpp::Context::SharedPtr context);
+
+  Builder &
+  arguments(const std::vector<std::string> & arguments);
+
+  Builder &
+  initial_parameters(const std::vector<rclcpp::Parameter> initial_parameters);
+
+  Builder &
+  use_global_arguments(bool use_global_arguments);
+
+  Builder &
+  use_intra_process_comms(bool use_intra_process_comms);
+
+  Builder &
+  start_parameter_services(bool start_parameter_services);
+
+  Builder &
+  allocator(rcl_allocator_t allocator);
+
+private:
+  rclcpp::Context::SharedPtr context_ {
+    rclcpp::contexts::default_context::get_global_default_context()};
+
+  std::vector<std::string> arguments_ {};
+
+  std::vector<rclcpp::Parameter> initial_parameters_ {};
+
+  bool use_global_arguments_ {true};
+
   bool use_intra_process_comms_ {false};
 
-  /// True to setup ROS interfaces for accessing parameters in the node.
   bool start_parameter_services_ {true};
+
+  rcl_allocator_t allocator_ {rcl_get_default_allocator()};
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/node_options.hpp
+++ b/rclcpp/include/rclcpp/node_options.hpp
@@ -1,0 +1,64 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__NODEOPTIONS_HPP_
+#define RCLCPP__NODEOPTIONS_HPP_
+
+#include <memory>
+
+#include "rcl/node_options.h"
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+
+/// Encapsulation of options for initializing node.
+class NodeOptions
+{
+  /// Constructor which allows you to specify the allocator used within the init options.
+  RCLCPP_PUBLIC
+  explicit NodeOptions(rcl_allocator_t allocator = rcl_get_default_allocator());
+
+  /// Constructor which is initialized by an existing node_options.
+  RCLCPP_PUBLIC
+  explicit NodeOptions(const rcl_node_options_t & node_options);
+
+  /// Copy constructor.
+  RCLCPP_PUBLIC
+  NodeOptions(const NodeOptions & other);
+
+  /// Assignment operator.
+  RCLCPP_PUBLIC
+  NodeOptions &
+  operator=(const NodeOptions & other);
+
+  RCLCPP_PUBLIC
+  virtual
+  ~NodeOptions();
+
+  /// Return the rcl node options.
+  RCLCPP_PUBLIC
+  const rcl_node_options_t *
+  get_rcl_node_options() const;
+
+protected:
+  void
+  finalize_node_options();
+
+private:
+  std::unique_ptr<rcl_node_options_t>  node_options_;
+};
+
+}  // namespace rclcpp
+#endif  // RCLCPP__NODEOPTIONS_HPP_

--- a/rclcpp/include/rclcpp/node_options.hpp
+++ b/rclcpp/include/rclcpp/node_options.hpp
@@ -50,44 +50,32 @@ public:
   virtual
   ~NodeOptions();
 
-  /// Return the rcl node options.
+  /// Return the rcl_node_options used by the node.
   RCLCPP_PUBLIC
   const rcl_node_options_t *
   get_rcl_node_options() const;
 
+  /// Return the context to be used by the node
   RCLCPP_PUBLIC
   rclcpp::Context::SharedPtr
   context() const;
 
   /// Return a reference to the list of initial parameters
-  /**
-   * Initial paramters is a list of initial values for parameters on the node.
-   */
   RCLCPP_PUBLIC
   const std::vector<rclcpp::Parameter> &
   initial_parameters() const;
 
   /// Return a reference to the use_global_arguments flag
-  /**
-   * False to prevent node from using arguments passed to the process
-   */
   RCLCPP_PUBLIC
   const bool &
   use_global_arguments() const;
 
   /// Return a reference to the use_intra_process_comms flag
-  /**
-   * True to use the optimized intra-process communication pipeline to pass messages bewteen nodes
-   * in the same process using shared memory.
-   */
   RCLCPP_PUBLIC
   const bool &
   use_intra_process_comms() const;
 
   /// Return a reference to the start_parameter_services flag
-  /**
-   * True to setup ROS interfaces for accessing parameters in the node.
-   */
   RCLCPP_PUBLIC
   const bool &
   start_parameter_services() const;
@@ -95,6 +83,15 @@ public:
 protected:
   /// Create NodeOptions, optionally specifying the allocator to use.
   /**
+   * \param[in] context The context for the node (usually represents the state of a process).
+   * \param[in] arguments Command line arguments that should apply only to this node.
+   * This can be used to provide remapping rules that only affect one instance.
+   * \param[in] initial_parameters a list of initial values for the parameters on the node.
+   * \param[in] use_global_arguments False to prevent node using arguments passed to the process.
+   * \param[in] use_intra_process_comms True to use the optimized intra-process communication
+   * pipeline to pass messages between nodes in the same process using shared memory.
+   * \param[in] start_parameter_services True to setup ROS interfaces for accessing parameters
+   * in the node.
    * \param[in] allocator allocator to use in construction of NodeOptions.
    */
   RCLCPP_PUBLIC
@@ -116,48 +113,98 @@ protected:
   get_domain_id_from_env() const;
 
 private:
+  /// Underlying rcl_node_options structure
   std::unique_ptr<rcl_node_options_t> node_options_;
 
+  /// The context for the node
   rclcpp::Context::SharedPtr context_;
 
-  std::vector<std::string> arguments_;
-
+  /// Initial parameters to set on the node
   std::vector<rclcpp::Parameter> initial_parameters_;
 
+  /// Use the optimized intra-process communication pipeline.
   bool use_intra_process_comms_;
 
+  /// Start ROS interfaces for accessing parameters in the node.
   bool start_parameter_services_;
 };
 
+/// Builder helper for creating NodeOptions instances
+/**
+ * The Builder object provides a mechanism for creating NodeOptions instances with particular
+ * default values overridden. It exposes all of the potential options for a Node instance.
+ */
 class NodeOptions::Builder
 {
 public:
+  /// Constructor
   Builder() = default;
 
+  /// Using the current state of the Builder, create a NodeOptions instance.
   NodeOptions build();
 
+  /// Set the context for the node instance to use
+  /**
+   * The context defaults to the global default context.
+   * \param[in] context The context for the node to use
+   */
   Builder &
   context(rclcpp::Context::SharedPtr context);
 
+  /// Set the local arguments for the node instance to use
+  /**
+   * Defaults to an empty set of arguments
+   * \param[in] arguments The list of arguments to be used
+   */
   Builder &
   arguments(const std::vector<std::string> & arguments);
 
+  /// Set the initial parameter values to set on the node instance
+  /**
+   * Defaults to an empty set of parameter values
+   * \param[in] initial_parameters a list of initial values for the parameters on the node.
+   */
   Builder &
   initial_parameters(const std::vector<rclcpp::Parameter> initial_parameters);
 
+  /// Set whether the node uses or ignores process-wide arguments
+  /**
+   * Defaults to true (uses global arguments)
+   * \param[in] use_global_arguments False to prevent node using arguments passed to the process.
+   */
   Builder &
   use_global_arguments(bool use_global_arguments);
 
+  /// Set whether the node uses the optimized intra-process pipeline.
+  /**
+   * Defaults to false (does not use shared memory intra-process communications)
+   * \param[in] use_intra_process_comms True to use the optimized intra-process communication
+   * pipeline to pass messages between nodes in the same process using shared memory.
+   */
   Builder &
   use_intra_process_comms(bool use_intra_process_comms);
 
+  /// Set whether the parameter services will be started on the node instance.
+  /**
+   * Defaults to true (parameter services will be started)
+   * \param[in] start_parameter_services True to setup ROS interfaces for accessing parameters
+   * in the node.
+   */
   Builder &
   start_parameter_services(bool start_parameter_services);
 
+  /// Set the allocator to be used by NodeOptions and the node instance
+  /**
+   * Defaults to the rcl_default_allocator.
+   * \param[in] allocator allocator to use in construction of NodeOptions.
+   */
   Builder &
   allocator(rcl_allocator_t allocator);
 
 private:
+  // IMPORTANT: if any of these default values are changed, please update the
+  // documentation on the corresponding Builder methods above to reflect the changes.
+
   rclcpp::Context::SharedPtr context_ {
     rclcpp::contexts::default_context::get_global_default_context()};
 

--- a/rclcpp/include/rclcpp/node_options.hpp
+++ b/rclcpp/include/rclcpp/node_options.hpp
@@ -30,19 +30,26 @@ namespace rclcpp
 class NodeOptions
 {
 public:
+  /// Create NodeOptions, optionally specifying the allocator to use.
+  /**
+   * \param[in] allocator allocator to use in construction of NodeOptions.
+   */
   RCLCPP_PUBLIC
   explicit NodeOptions(
     rcl_allocator_t allocator = rcl_get_default_allocator());
 
+  /// Create NodeOptions, optionally specifying the allocator to use.
+  /**
+   * \param[in] arguments Command line arguments that should apply only to this node.
+   * \param[in] initial_parameters a list of initial values for parameters on the node.
+   * This can be used to provide remapping rules that only affect one instance.
+   * \param[in] allocator - allocator to use in construction of NodeOptions.
+   */
   RCLCPP_PUBLIC
   explicit NodeOptions(
     const std::vector<std::string> & arguments,
     const std::vector<rclcpp::Parameter> & initial_parameters = {},
     rcl_allocator_t allocator = rcl_get_default_allocator());
-
-  /// Constructor which is initialized by an existing node_options.
-  RCLCPP_PUBLIC
-  explicit NodeOptions(const rcl_node_options_t & node_options);
 
   /// Copy constructor.
   RCLCPP_PUBLIC
@@ -53,6 +60,7 @@ public:
   NodeOptions &
   operator=(const NodeOptions & other);
 
+  /// Destructor
   RCLCPP_PUBLIC
   virtual
   ~NodeOptions();
@@ -62,23 +70,43 @@ public:
   const rcl_node_options_t *
   get_rcl_node_options() const;
 
-  /// Return the list of initial parameters
+  /// Return a reference to the list of initial parameters
+  /**
+   * Initial paramters is a list of initial values for parameters on the node.
+   * This can be used to provide remapping rules that only affect the node instance created with
+   * this NodeOptions instance.
+   */
   const std::vector<rclcpp::Parameter> & initial_parameters() const;
   std::vector<rclcpp::Parameter> & initial_parameters();
 
+  /// Return a reference to the use_global_arguments flag
+  /**
+   * False to prevent node from using arguments passed to the process
+   */
   const bool & use_global_arguments() const;
   bool & use_global_arguments();
 
+  /// Return a reference to the use_intra_process_comms flag
+  /**
+   * True to use the optimized intra-process communication pipeline to pass messages bewteen nodes
+   * in the same process using shared memory.
+   */
   const bool & use_intra_process_comms() const;
   bool & use_intra_process_comms();
 
+  /// Return a reference to the start_parameter_services flag
+  /**
+   * True to setup ROS interfaces for accessing parameters in the node.
+   */
   const bool & start_parameter_services() const;
   bool & start_parameter_services();
 
 protected:
+  /// Clean up internal rcl_node_options_t structure.
   void
   finalize_node_options();
 
+  /// Retrieve the ROS_DOMAIN_ID environment variable and populate options.
   void
   set_domain_id_from_env();
 
@@ -87,8 +115,10 @@ private:
 
   std::vector<rclcpp::Parameter> initial_parameters_;
 
+  /// True to use the optimized intra-process communication pipeline
   bool use_intra_process_comms_ {false};
 
+  /// True to setup ROS interfaces for accessing parameters in the node.
   bool start_parameter_services_ {true};
 };
 

--- a/rclcpp/include/rclcpp/node_options.hpp
+++ b/rclcpp/include/rclcpp/node_options.hpp
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RCLCPP__NODEOPTIONS_HPP_
-#define RCLCPP__NODEOPTIONS_HPP_
+#ifndef RCLCPP__NODE_OPTIONS_HPP_
+#define RCLCPP__NODE_OPTIONS_HPP_
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "rcl/node_options.h"
 #include "rclcpp/parameter.hpp"
@@ -28,9 +30,15 @@ namespace rclcpp
 class NodeOptions
 {
 public:
-  /// Constructor which allows you to specify the allocator used within the init options.
   RCLCPP_PUBLIC
-  explicit NodeOptions(rcl_allocator_t allocator = rcl_get_default_allocator());
+  explicit NodeOptions(
+    rcl_allocator_t allocator = rcl_get_default_allocator());
+
+  RCLCPP_PUBLIC
+  explicit NodeOptions(
+    const std::vector<std::string> & arguments,
+    const std::vector<rclcpp::Parameter> & initial_parameters = {},
+    rcl_allocator_t allocator = rcl_get_default_allocator());
 
   /// Constructor which is initialized by an existing node_options.
   RCLCPP_PUBLIC
@@ -75,7 +83,7 @@ protected:
   set_domain_id_from_env();
 
 private:
-  std::unique_ptr<rcl_node_options_t>  node_options_;
+  std::unique_ptr<rcl_node_options_t> node_options_;
 
   std::vector<rclcpp::Parameter> initial_parameters_;
 
@@ -86,4 +94,4 @@ private:
 
 }  // namespace rclcpp
 
-#endif  // RCLCPP__NODEOPTIONS_HPP_
+#endif  // RCLCPP__NODE_OPTIONS_HPP_

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -35,27 +35,25 @@
 #include "rclcpp/node_interfaces/node_waitables.hpp"
 
 using rclcpp::Node;
+using rclcpp::NodeOptions;
 using rclcpp::exceptions::throw_from_rcl_error;
 
 Node::Node(
   const std::string & node_name,
   const std::string & namespace_,
-  bool use_intra_process_comms)
+  const NodeOptions & options)
 : Node(
     node_name,
     namespace_,
     rclcpp::contexts::default_context::get_global_default_context(),
-    {},
-    {},
-    true,
-    use_intra_process_comms,
-    true)
+    options_)
 {}
 
 Node::Node(
   const std::string & node_name,
   const std::string & namespace_,
   rclcpp::Context::SharedPtr context,
+  const NodeOptions & options)
   const std::vector<std::string> & arguments,
   const std::vector<rclcpp::Parameter> & initial_parameters,
   bool use_global_arguments,

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -46,7 +46,7 @@ Node::Node(
     node_name,
     namespace_,
     rclcpp::contexts::default_context::get_global_default_context(),
-    options_)
+    options)
 {}
 
 Node::Node(
@@ -54,13 +54,8 @@ Node::Node(
   const std::string & namespace_,
   rclcpp::Context::SharedPtr context,
   const NodeOptions & options)
-  const std::vector<std::string> & arguments,
-  const std::vector<rclcpp::Parameter> & initial_parameters,
-  bool use_global_arguments,
-  bool use_intra_process_comms,
-  bool start_parameter_services)
 : node_base_(new rclcpp::node_interfaces::NodeBase(
-      node_name, namespace_, context, arguments, use_global_arguments)),
+      node_name, namespace_, context, options)),
   node_graph_(new rclcpp::node_interfaces::NodeGraph(node_base_.get())),
   node_logging_(new rclcpp::node_interfaces::NodeLogging(node_base_.get())),
   node_timers_(new rclcpp::node_interfaces::NodeTimers(node_base_.get())),
@@ -78,9 +73,9 @@ Node::Node(
       node_topics_,
       node_services_,
       node_clock_,
-      initial_parameters,
-      use_intra_process_comms,
-      start_parameter_services
+      options.initial_parameters(),
+      options.use_intra_process_comms(),
+      options.start_parameter_services()
     )),
   node_time_source_(new rclcpp::node_interfaces::NodeTimeSource(
       node_base_,
@@ -92,7 +87,7 @@ Node::Node(
       node_parameters_
     )),
   node_waitables_(new rclcpp::node_interfaces::NodeWaitables(node_base_.get())),
-  use_intra_process_comms_(use_intra_process_comms)
+  use_intra_process_comms_(options.use_intra_process_comms())
 {
 }
 

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -40,22 +40,17 @@ using rclcpp::exceptions::throw_from_rcl_error;
 
 Node::Node(
   const std::string & node_name,
-  const std::string & namespace_,
   const NodeOptions & options)
-: Node(
-    node_name,
-    namespace_,
-    rclcpp::contexts::default_context::get_global_default_context(),
-    options)
-{}
+: Node(node_name, "", options)
+{
+}
 
 Node::Node(
   const std::string & node_name,
   const std::string & namespace_,
-  rclcpp::Context::SharedPtr context,
   const NodeOptions & options)
 : node_base_(new rclcpp::node_interfaces::NodeBase(
-      node_name, namespace_, context, options)),
+      node_name, namespace_, options)),
   node_graph_(new rclcpp::node_interfaces::NodeGraph(node_base_.get())),
   node_logging_(new rclcpp::node_interfaces::NodeLogging(node_base_.get())),
   node_timers_(new rclcpp::node_interfaces::NodeTimers(node_base_.get())),

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -32,9 +32,8 @@ using rclcpp::node_interfaces::NodeBase;
 NodeBase::NodeBase(
   const std::string & node_name,
   const std::string & namespace_,
-  rclcpp::Context::SharedPtr context,
   const rclcpp::NodeOptions & options)
-: context_(context),
+: context_(options.context()),
   node_handle_(nullptr),
   default_callback_group_(nullptr),
   associated_with_executor_(false),
@@ -43,7 +42,7 @@ NodeBase::NodeBase(
   // Setup the guard condition that is notified when changes occur in the graph.
   rcl_guard_condition_options_t guard_condition_options = rcl_guard_condition_get_default_options();
   rcl_ret_t ret = rcl_guard_condition_init(
-    &notify_guard_condition_, context->get_rcl_context().get(), guard_condition_options);
+    &notify_guard_condition_, options.context()->get_rcl_context().get(), guard_condition_options);
   if (ret != RCL_RET_OK) {
     throw_from_rcl_error(ret, "failed to create interrupt guard condition");
   }
@@ -64,7 +63,7 @@ NodeBase::NodeBase(
   ret = rcl_node_init(
     rcl_node.get(),
     node_name.c_str(), namespace_.c_str(),
-    context->get_rcl_context().get(), options.get_rcl_node_options());
+    options.context()->get_rcl_context().get(), options.get_rcl_node_options());
   if (ret != RCL_RET_OK) {
     // Finalize the interrupt guard condition.
     finalize_notify_guard_condition();

--- a/rclcpp/src/rclcpp/node_options.cpp
+++ b/rclcpp/src/rclcpp/node_options.cpp
@@ -161,6 +161,7 @@ NodeOptions::use_global_arguments() const
 NodeOptions &
 NodeOptions::use_global_arguments(const bool & use_global_arguments)
 {
+  this->node_options_.reset();  // reset node options to make it be recreated on next access.
   this->use_global_arguments_ = use_global_arguments;
   return *this;
 }
@@ -191,12 +192,6 @@ NodeOptions::start_parameter_services(const bool & start_parameter_services)
   return *this;
 }
 
-rcl_allocator_t &
-NodeOptions::allocator()
-{
-  return this->allocator_;
-}
-
 const rcl_allocator_t &
 NodeOptions::allocator() const
 {
@@ -206,6 +201,7 @@ NodeOptions::allocator() const
 NodeOptions &
 NodeOptions::allocator(rcl_allocator_t allocator)
 {
+  this->node_options_.reset();  // reset node options to make it be recreated on next access.
   this->allocator_ = allocator;
   return *this;
 }

--- a/rclcpp/src/rclcpp/node_options.cpp
+++ b/rclcpp/src/rclcpp/node_options.cpp
@@ -1,0 +1,83 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/node_options.hpp"
+
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/logging.hpp"
+
+namespace rclcpp
+{
+
+NodeOptions::NodeOptions(rcl_allocator_t allocator)
+: node_options_(new rcl_node_options_t)
+{
+  *node_options_ = rcl_node_get_default_options();
+  node_options_->allocator = allocator;
+}
+
+NodeOptions::NodeOptions(const rcl_node_options_t & node_options)
+: node_options_(new rcl_node_options_t)
+{
+  *node_options_ = rcl_node_get_default_options();
+  rcl_ret_t ret = rcl_node_options_copy(&node_options, node_options_.get());
+  if(RCL_RET_OK != ret) {
+    rclcpp::exceptions::throw_from_rcl_error(ret, "failed to copy rcl node options");
+  }
+}
+
+NodeOptions::NodeOptions(const NodeOptions & other)
+: NodeOptions(*other.get_rcl_node_options())
+{}
+
+NodeOptions &
+NodeOptions::operator=(const NodeOptions & other)
+{
+  if (this != &other) {
+    this->finalize_node_options();
+    rcl_ret_t ret = rcl_node_options_copy(other.get_rcl_node_options(), node_options_.get());
+    if (RCL_RET_OK != ret) {
+      rclcpp::exceptions::throw_from_rcl_error(ret, "failed to copy rcl node options");
+    }
+  }
+  return *this;
+}
+
+NodeOptions::~NodeOptions()
+{
+  this->finalize_node_options();
+}
+
+void
+NodeOptions::finalize_node_options()
+{
+  if (node_options_) {
+    rcl_ret_t ret = rcl_node_options_fini(node_options_.get());
+    if (RCL_RET_OK != ret) {
+      RCLCPP_ERROR(
+          rclcpp::get_logger("rclcpp"),
+          "failed to finalize rcl node options: %s", rcl_get_error_string().str);
+      rcl_reset_error();
+    }
+  }
+}
+
+const rcl_node_options_t *
+NodeOptions::get_rcl_node_options() const
+{
+  return this->node_options_.get();
+}
+
+
+}  // namespace rclcpp

--- a/rclcpp/src/rclcpp/node_options.cpp
+++ b/rclcpp/src/rclcpp/node_options.cpp
@@ -66,19 +66,18 @@ NodeOptions::NodeOptions(
   initial_parameters_ = initial_parameters;
 }
 
-NodeOptions::NodeOptions(const rcl_node_options_t & node_options)
+NodeOptions::NodeOptions(const NodeOptions & other)
 : node_options_(new rcl_node_options_t)
 {
-  *node_options_ = rcl_node_get_default_options();
-  rcl_ret_t ret = rcl_node_options_copy(&node_options, node_options_.get());
+  rcl_ret_t ret = rcl_node_options_copy(other.get_rcl_node_options(), node_options_.get());
   if (RCL_RET_OK != ret) {
     rclcpp::exceptions::throw_from_rcl_error(ret, "failed to copy rcl node options");
   }
-}
 
-NodeOptions::NodeOptions(const NodeOptions & other)
-: NodeOptions(*other.get_rcl_node_options())
-{}
+  this->initial_parameters_ = other.initial_parameters();
+  this->use_intra_process_comms_ = other.use_intra_process_comms();
+  this->start_parameter_services_ = other.start_parameter_services();
+}
 
 NodeOptions &
 NodeOptions::operator=(const NodeOptions & other)
@@ -89,6 +88,10 @@ NodeOptions::operator=(const NodeOptions & other)
     if (RCL_RET_OK != ret) {
       rclcpp::exceptions::throw_from_rcl_error(ret, "failed to copy rcl node options");
     }
+
+    this->initial_parameters_ = other.initial_parameters();
+    this->use_intra_process_comms_ = other.use_intra_process_comms();
+    this->start_parameter_services_ = other.start_parameter_services();
   }
   return *this;
 }

--- a/rclcpp/src/rclcpp/node_options.cpp
+++ b/rclcpp/src/rclcpp/node_options.cpp
@@ -14,18 +14,56 @@
 
 #include "rclcpp/node_options.hpp"
 
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/logging.hpp"
+
+using rclcpp::exceptions::throw_from_rcl_error;
 
 namespace rclcpp
 {
 
 NodeOptions::NodeOptions(rcl_allocator_t allocator)
+: NodeOptions({}, {}, allocator)
+{
+}
+
+NodeOptions::NodeOptions(
+  const std::vector<std::string> & arguments,
+  const std::vector<rclcpp::Parameter> & initial_parameters,
+  rcl_allocator_t allocator)
 : node_options_(new rcl_node_options_t)
 {
   *node_options_ = rcl_node_get_default_options();
   node_options_->allocator = allocator;
   set_domain_id_from_env();
+
+  std::unique_ptr<const char *[]> c_args;
+  if (!arguments.empty()) {
+    c_args.reset(new const char *[arguments.size()]);
+    for (std::size_t i = 0; i < arguments.size(); ++i) {
+      c_args[i] = arguments[i].c_str();
+    }
+  }
+
+  if (arguments.size() > std::numeric_limits<int>::max()) {
+    throw_from_rcl_error(RCL_RET_INVALID_ARGUMENT, "Too many args");
+  }
+
+  // TODO(sloretz) Pass an allocator to argument parsing
+  rmw_ret_t ret = rcl_parse_arguments(
+    static_cast<int>(arguments.size()), c_args.get(), allocator,
+    &(this->node_options_->arguments));
+
+  if (RCL_RET_OK != ret) {
+    throw_from_rcl_error(ret, "failed to parse arguments");
+  }
+
+  initial_parameters_ = initial_parameters;
 }
 
 NodeOptions::NodeOptions(const rcl_node_options_t & node_options)
@@ -33,7 +71,7 @@ NodeOptions::NodeOptions(const rcl_node_options_t & node_options)
 {
   *node_options_ = rcl_node_get_default_options();
   rcl_ret_t ret = rcl_node_options_copy(&node_options, node_options_.get());
-  if(RCL_RET_OK != ret) {
+  if (RCL_RET_OK != ret) {
     rclcpp::exceptions::throw_from_rcl_error(ret, "failed to copy rcl node options");
   }
 }
@@ -149,8 +187,8 @@ NodeOptions::finalize_node_options()
     rcl_ret_t ret = rcl_node_options_fini(node_options_.get());
     if (RCL_RET_OK != ret) {
       RCLCPP_ERROR(
-          rclcpp::get_logger("rclcpp"),
-          "failed to finalize rcl node options: %s", rcl_get_error_string().str);
+        rclcpp::get_logger("rclcpp"),
+        "failed to finalize rcl node options: %s", rcl_get_error_string().str);
       rcl_reset_error();
     }
   }

--- a/rclcpp/src/rclcpp/node_options.cpp
+++ b/rclcpp/src/rclcpp/node_options.cpp
@@ -206,6 +206,8 @@ NodeOptions::allocator(rcl_allocator_t allocator)
   return *this;
 }
 
+// TODO(wjwwood): reuse rcutils_get_env() to avoid code duplication.
+//   See also: https://github.com/ros2/rcl/issues/119
 size_t
 NodeOptions::get_domain_id_from_env() const
 {

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -31,6 +31,10 @@ protected:
   }
 };
 
+TEST_F(TestNode, node_options) {
+  auto node_options = rclcpp::NodeOptions();
+}
+
 /*
    Testing node construction and destruction.
  */

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -32,7 +32,11 @@ protected:
 };
 
 TEST_F(TestNode, node_options) {
-  auto node_options = rclcpp::NodeOptions();
+  ASSERT_NO_THROW({
+    auto options = rclcpp::NodeOptions();
+    rclcpp::NodeOptions options2 = options;
+    rclcpp::NodeOptions options3(options2);
+  });
 }
 
 /*

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -31,14 +31,6 @@ protected:
   }
 };
 
-TEST_F(TestNode, node_options) {
-  ASSERT_NO_THROW({
-    auto options = rclcpp::NodeOptions();
-    rclcpp::NodeOptions options2 = options;
-    rclcpp::NodeOptions options3(options2);
-  });
-}
-
 /*
    Testing node construction and destruction.
  */

--- a/rclcpp/test/test_node_global_args.cpp
+++ b/rclcpp/test/test_node_global_args.cpp
@@ -20,6 +20,7 @@
 
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/node.hpp"
+#include "rclcpp/node_options.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 class TestNodeWithGlobalArgs : public ::testing::Test
@@ -34,31 +35,29 @@ protected:
 
 TEST_F(TestNodeWithGlobalArgs, local_arguments_before_global) {
   auto context = rclcpp::contexts::default_context::get_global_default_context();
-  const std::vector<std::string> arguments = {"__node:=local_arguments_test"};
-  const std::vector<rclcpp::Parameter> initial_values = {};
-  const bool use_global_arguments = true;
-  const bool use_intra_process = false;
+
+  rclcpp::NodeOptions node_options({"__node:=local_arguments_test"});
+
   auto node = rclcpp::Node::make_shared(
-    "orig_name", "", context, arguments, initial_values, use_global_arguments, use_intra_process);
+    "orig_name", "", context, node_options);
   EXPECT_STREQ("local_arguments_test", node->get_name());
 }
 
 TEST_F(TestNodeWithGlobalArgs, use_or_ignore_global_arguments) {
   auto context = rclcpp::contexts::default_context::get_global_default_context();
-  const std::vector<std::string> arguments = {};
-  const std::vector<rclcpp::Parameter> initial_values = {};
-  const bool use_intra_process = false;
 
   {  // Don't use global args
-    const bool use_global_arguments = false;
-    auto node = rclcpp::Node::make_shared(
-      "orig_name", "", context, arguments, initial_values, use_global_arguments, use_intra_process);
+    rclcpp::NodeOptions node_options;
+    node_options.use_global_arguments() = false;
+
+    auto node = rclcpp::Node::make_shared("orig_name", "", context, node_options);
     EXPECT_STREQ("orig_name", node->get_name());
   }
   {  // Do use global args
-    const bool use_global_arguments = true;
-    auto node = rclcpp::Node::make_shared(
-      "orig_name", "", context, arguments, initial_values, use_global_arguments, use_intra_process);
+    rclcpp::NodeOptions node_options;
+    node_options.use_global_arguments() = true;
+
+    auto node = rclcpp::Node::make_shared("orig_name", "", context, node_options);
     EXPECT_STREQ("global_node_name", node->get_name());
   }
 }

--- a/rclcpp/test/test_node_global_args.cpp
+++ b/rclcpp/test/test_node_global_args.cpp
@@ -34,9 +34,8 @@ protected:
 };
 
 TEST_F(TestNodeWithGlobalArgs, local_arguments_before_global) {
-  auto options = rclcpp::NodeOptions::Builder()
-    .arguments({"__node:=local_arguments_test"})
-    .build();
+  auto options = rclcpp::NodeOptions()
+    .arguments({"__node:=local_arguments_test"});
 
   auto node = rclcpp::Node::make_shared("orig_name", options);
   EXPECT_STREQ("local_arguments_test", node->get_name());
@@ -44,17 +43,15 @@ TEST_F(TestNodeWithGlobalArgs, local_arguments_before_global) {
 
 TEST_F(TestNodeWithGlobalArgs, use_or_ignore_global_arguments) {
   {  // Don't use global args
-    auto options = rclcpp::NodeOptions::Builder()
-      .use_global_arguments(false)
-      .build();
+    auto options = rclcpp::NodeOptions()
+      .use_global_arguments(false);
 
     auto node = rclcpp::Node::make_shared("orig_name", options);
     EXPECT_STREQ("orig_name", node->get_name());
   }
   {  // Do use global args
-    auto options = rclcpp::NodeOptions::Builder()
-      .use_global_arguments(true)
-      .build();
+    auto options = rclcpp::NodeOptions()
+      .use_global_arguments(true);
 
     auto node = rclcpp::Node::make_shared("orig_name", options);
     EXPECT_STREQ("global_node_name", node->get_name());

--- a/rclcpp/test/test_node_global_args.cpp
+++ b/rclcpp/test/test_node_global_args.cpp
@@ -34,30 +34,29 @@ protected:
 };
 
 TEST_F(TestNodeWithGlobalArgs, local_arguments_before_global) {
-  auto context = rclcpp::contexts::default_context::get_global_default_context();
+  auto options = rclcpp::NodeOptions::Builder()
+    .arguments({"__node:=local_arguments_test"})
+    .build();
 
-  rclcpp::NodeOptions node_options({"__node:=local_arguments_test"});
-
-  auto node = rclcpp::Node::make_shared(
-    "orig_name", "", context, node_options);
+  auto node = rclcpp::Node::make_shared("orig_name", options);
   EXPECT_STREQ("local_arguments_test", node->get_name());
 }
 
 TEST_F(TestNodeWithGlobalArgs, use_or_ignore_global_arguments) {
-  auto context = rclcpp::contexts::default_context::get_global_default_context();
-
   {  // Don't use global args
-    rclcpp::NodeOptions node_options;
-    node_options.use_global_arguments() = false;
+    auto options = rclcpp::NodeOptions::Builder()
+      .use_global_arguments(false)
+      .build();
 
-    auto node = rclcpp::Node::make_shared("orig_name", "", context, node_options);
+    auto node = rclcpp::Node::make_shared("orig_name", options);
     EXPECT_STREQ("orig_name", node->get_name());
   }
   {  // Do use global args
-    rclcpp::NodeOptions node_options;
-    node_options.use_global_arguments() = true;
+    auto options = rclcpp::NodeOptions::Builder()
+      .use_global_arguments(true)
+      .build();
 
-    auto node = rclcpp::Node::make_shared("orig_name", "", context, node_options);
+    auto node = rclcpp::Node::make_shared("orig_name", options);
     EXPECT_STREQ("global_node_name", node->get_name());
   }
 }

--- a/rclcpp/test/test_node_initial_parameters.cpp
+++ b/rclcpp/test/test_node_initial_parameters.cpp
@@ -36,30 +36,30 @@ protected:
 };
 
 TEST_F(TestNodeWithInitialValues, no_initial_values) {
-  auto context = rclcpp::contexts::default_context::get_global_default_context();
+  auto options = rclcpp::NodeOptions::Builder()
+    .use_intra_process_comms(false)
+    .use_global_arguments(false)
+    .build();
 
-  rclcpp::NodeOptions node_options;
-  node_options.use_intra_process_comms() = false;
-  node_options.use_global_arguments() = false;
-
-  auto node = rclcpp::Node::make_shared("node_name", "", context, node_options);
+  auto node = rclcpp::Node::make_shared("node_name", options);
   auto list_params_result = node->list_parameters({}, 0);
   EXPECT_EQ(0u, list_params_result.names.size());
 }
 
 TEST_F(TestNodeWithInitialValues, multiple_initial_values) {
-  auto context = rclcpp::contexts::default_context::get_global_default_context();
-
-  rclcpp::NodeOptions node_options({}, {
+  auto parameters = std::vector<rclcpp::Parameter>({
     rclcpp::Parameter("foo", true),
     rclcpp::Parameter("bar", "hello world"),
     rclcpp::Parameter("baz", std::vector<double>{3.14, 2.718})
   });
 
-  node_options.use_global_arguments() = false;
-  node_options.use_intra_process_comms() = false;
+  auto options = rclcpp::NodeOptions::Builder()
+    .initial_parameters(parameters)
+    .use_global_arguments(false)
+    .use_intra_process_comms(false)
+    .build();
 
-  auto node = rclcpp::Node::make_shared("node_name", "", context, node_options);
+  auto node = rclcpp::Node::make_shared("node_name", options);
   auto list_params_result = node->list_parameters({}, 0);
   EXPECT_EQ(3u, list_params_result.names.size());
   EXPECT_TRUE(node->get_parameter("foo").get_value<bool>());

--- a/rclcpp/test/test_node_initial_parameters.cpp
+++ b/rclcpp/test/test_node_initial_parameters.cpp
@@ -37,28 +37,29 @@ protected:
 
 TEST_F(TestNodeWithInitialValues, no_initial_values) {
   auto context = rclcpp::contexts::default_context::get_global_default_context();
-  const std::vector<std::string> arguments = {};
-  const std::vector<rclcpp::Parameter> initial_values = {};
-  const bool use_global_arguments = false;
-  const bool use_intra_process = false;
-  auto node = rclcpp::Node::make_shared(
-    "node_name", "", context, arguments, initial_values, use_global_arguments, use_intra_process);
+
+  rclcpp::NodeOptions node_options;
+  node_options.use_intra_process_comms() = false;
+  node_options.use_global_arguments() = false;
+
+  auto node = rclcpp::Node::make_shared("node_name", "", context, node_options);
   auto list_params_result = node->list_parameters({}, 0);
   EXPECT_EQ(0u, list_params_result.names.size());
 }
 
 TEST_F(TestNodeWithInitialValues, multiple_initial_values) {
   auto context = rclcpp::contexts::default_context::get_global_default_context();
-  const std::vector<std::string> arguments = {};
-  const std::vector<rclcpp::Parameter> initial_values = {
+
+  rclcpp::NodeOptions node_options({}, {
     rclcpp::Parameter("foo", true),
     rclcpp::Parameter("bar", "hello world"),
     rclcpp::Parameter("baz", std::vector<double>{3.14, 2.718})
-  };
-  const bool use_global_arguments = false;
-  const bool use_intra_process = false;
-  auto node = rclcpp::Node::make_shared(
-    "node_name", "", context, arguments, initial_values, use_global_arguments, use_intra_process);
+  });
+
+  node_options.use_global_arguments() = false;
+  node_options.use_intra_process_comms() = false;
+
+  auto node = rclcpp::Node::make_shared("node_name", "", context, node_options);
   auto list_params_result = node->list_parameters({}, 0);
   EXPECT_EQ(3u, list_params_result.names.size());
   EXPECT_TRUE(node->get_parameter("foo").get_value<bool>());

--- a/rclcpp/test/test_node_initial_parameters.cpp
+++ b/rclcpp/test/test_node_initial_parameters.cpp
@@ -36,10 +36,9 @@ protected:
 };
 
 TEST_F(TestNodeWithInitialValues, no_initial_values) {
-  auto options = rclcpp::NodeOptions::Builder()
+  auto options = rclcpp::NodeOptions()
     .use_intra_process_comms(false)
-    .use_global_arguments(false)
-    .build();
+    .use_global_arguments(false);
 
   auto node = rclcpp::Node::make_shared("node_name", options);
   auto list_params_result = node->list_parameters({}, 0);
@@ -53,11 +52,10 @@ TEST_F(TestNodeWithInitialValues, multiple_initial_values) {
     rclcpp::Parameter("baz", std::vector<double>{3.14, 2.718})
   });
 
-  auto options = rclcpp::NodeOptions::Builder()
+  auto options = rclcpp::NodeOptions()
     .initial_parameters(parameters)
     .use_global_arguments(false)
-    .use_intra_process_comms(false)
-    .build();
+    .use_intra_process_comms(false);
 
   auto node = rclcpp::Node::make_shared("node_name", options);
   auto list_params_result = node->list_parameters({}, 0);

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -36,6 +36,7 @@
 #include "rclcpp/logger.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/message_memory_strategy.hpp"
+#include "rclcpp/node_options.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/node_interfaces/node_clock_interface.hpp"
 #include "rclcpp/node_interfaces/node_graph_interface.hpp"
@@ -75,39 +76,27 @@ public:
   /**
    * \param[in] node_name Name of the node.
    * \param[in] namespace_ Namespace of the node.
-   * \param[in] use_intra_process_comms True to use the optimized intra-process communication
-   * pipeline to pass messages between nodes in the same process using shared memory.
+   * \param[in] options Additional options to control creation of the node.
    */
   RCLCPP_LIFECYCLE_PUBLIC
   explicit LifecycleNode(
     const std::string & node_name,
     const std::string & namespace_ = "",
-    bool use_intra_process_comms = false);
+    const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
   /// Create a node based on the node name and a rclcpp::Context.
   /**
    * \param[in] node_name Name of the node.
    * \param[in] namespace_ Namespace of the node.
    * \param[in] context The context for the node (usually represents the state of a process).
-   * \param[in] arguments Command line arguments that should apply only to this node.
-   * \param[in] initial_parameters a list of initial values for parameters on the node.
-   * This can be used to provide remapping rules that only affect one instance.
-   * \param[in] use_global_arguments False to prevent node using arguments passed to the process.
-   * \param[in] use_intra_process_comms True to use the optimized intra-process communication
-   * pipeline to pass messages between nodes in the same process using shared memory.
-   * \param[in] start_parameter_services True to setup ROS interfaces for accessing parameters
-   * in the node.
+   * \param[in] options Additional options to control creation of the node.
    */
   RCLCPP_LIFECYCLE_PUBLIC
   LifecycleNode(
     const std::string & node_name,
     const std::string & namespace_,
     rclcpp::Context::SharedPtr context,
-    const std::vector<std::string> & arguments,
-    const std::vector<rclcpp::Parameter> & initial_parameters,
-    bool use_global_arguments = true,
-    bool use_intra_process_comms = false,
-    bool start_parameter_services = true);
+    const rclcpp::NodeOptions & options);
 
   RCLCPP_LIFECYCLE_PUBLIC
   virtual ~LifecycleNode();

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -81,7 +81,7 @@ public:
   RCLCPP_LIFECYCLE_PUBLIC
   explicit LifecycleNode(
     const std::string & node_name,
-    const rclcpp::NodeOptions & options = rclcpp::NodeOptions::Builder().build());
+    const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
   /// Create a node based on the node name and a rclcpp::Context.
   /**

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -81,8 +81,7 @@ public:
   RCLCPP_LIFECYCLE_PUBLIC
   explicit LifecycleNode(
     const std::string & node_name,
-    const std::string & namespace_ = "",
-    const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+    const rclcpp::NodeOptions & options = rclcpp::NodeOptions::Builder().build());
 
   /// Create a node based on the node name and a rclcpp::Context.
   /**
@@ -95,7 +94,6 @@ public:
   LifecycleNode(
     const std::string & node_name,
     const std::string & namespace_,
-    rclcpp::Context::SharedPtr context,
     const rclcpp::NodeOptions & options);
 
   RCLCPP_LIFECYCLE_PUBLIC

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -46,29 +46,21 @@ namespace rclcpp_lifecycle
 LifecycleNode::LifecycleNode(
   const std::string & node_name,
   const std::string & namespace_,
-  bool use_intra_process_comms)
+  const rclcpp::NodeOptions & options)
 : LifecycleNode(
     node_name,
     namespace_,
     rclcpp::contexts::default_context::get_global_default_context(),
-    {},
-    {},
-    true,
-    use_intra_process_comms,
-    true)
+    options)
 {}
 
 LifecycleNode::LifecycleNode(
   const std::string & node_name,
   const std::string & namespace_,
   rclcpp::Context::SharedPtr context,
-  const std::vector<std::string> & arguments,
-  const std::vector<rclcpp::Parameter> & initial_parameters,
-  bool use_global_arguments,
-  bool use_intra_process_comms,
-  bool start_parameter_services)
+  const rclcpp::NodeOptions & options)
 : node_base_(new rclcpp::node_interfaces::NodeBase(
-      node_name, namespace_, context, arguments, use_global_arguments)),
+      node_name, namespace_, context, options)),
   node_graph_(new rclcpp::node_interfaces::NodeGraph(node_base_.get())),
   node_logging_(new rclcpp::node_interfaces::NodeLogging(node_base_.get())),
   node_timers_(new rclcpp::node_interfaces::NodeTimers(node_base_.get())),
@@ -86,12 +78,12 @@ LifecycleNode::LifecycleNode(
       node_topics_,
       node_services_,
       node_clock_,
-      initial_parameters,
-      use_intra_process_comms,
-      start_parameter_services
+      options.initial_parameters(),
+      options.use_intra_process_comms(),
+      options.start_parameter_services()
     )),
   node_waitables_(new rclcpp::node_interfaces::NodeWaitables(node_base_.get())),
-  use_intra_process_comms_(use_intra_process_comms),
+  use_intra_process_comms_(options.use_intra_process_comms()),
   impl_(new LifecycleNodeInterfaceImpl(node_base_, node_services_))
 {
   impl_->init();

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -45,22 +45,19 @@ namespace rclcpp_lifecycle
 
 LifecycleNode::LifecycleNode(
   const std::string & node_name,
-  const std::string & namespace_,
   const rclcpp::NodeOptions & options)
 : LifecycleNode(
     node_name,
-    namespace_,
-    rclcpp::contexts::default_context::get_global_default_context(),
+    "",
     options)
 {}
 
 LifecycleNode::LifecycleNode(
   const std::string & node_name,
   const std::string & namespace_,
-  rclcpp::Context::SharedPtr context,
   const rclcpp::NodeOptions & options)
 : node_base_(new rclcpp::node_interfaces::NodeBase(
-      node_name, namespace_, context, options)),
+      node_name, namespace_, options)),
   node_graph_(new rclcpp::node_interfaces::NodeGraph(node_base_.get())),
   node_logging_(new rclcpp::node_interfaces::NodeLogging(node_base_.get())),
   node_timers_(new rclcpp::node_interfaces::NodeTimers(node_base_.get())),


### PR DESCRIPTION
Creates a NodeOptions object to pass all of the necessary options to the node constructor.

Connects to #492 