### PR TITLE
remove dependency on rclpy from rclcpp_lifecycle

### DIFF
--- a/rclcpp_lifecycle/package.xml
+++ b/rclcpp_lifecycle/package.xml
@@ -18,7 +18,6 @@
   <exec_depend>lifecycle_msgs</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rcl_lifecycle</exec_depend>
-  <exec_depend>rclpy</exec_depend>
   <exec_depend>rmw_implementation</exec_depend>
   <exec_depend>rosidl_typesupport_cpp</exec_depend>
 


### PR DESCRIPTION
Not sure why it was there in the first place...

It has been there since the original commit adding lifecycle stuff.