### PR TITLE
Added rclcpp_performance package

### DIFF
--- a/rclcpp_performance/CMakeLists.txt
+++ b/rclcpp_performance/CMakeLists.txt
@@ -39,7 +39,7 @@ ament_export_dependencies(rosidl_default_runtime)
 ament_package()
 
 install(
-  PROGRAMS scripts/posprocess_logging
+  PROGRAMS scripts/posprocess_logging scripts/performance_test
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/rclcpp_performance/CMakeLists.txt
+++ b/rclcpp_performance/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(rclcpp_performance)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+# find_package(ament_cmake_python REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+# ament_python_install_package(${PROJECT_NAME})
+
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/logs)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/MatchingPublisher.msg"
+  ADD_LINTER_TESTS
+)
+
+find_package(rclcpp REQUIRED)
+
+add_executable(communication_performance src/communication_performance.cpp)
+ament_target_dependencies(communication_performance
+  "rclcpp"
+  "rosidl_generator_cpp")
+rosidl_target_interfaces(communication_performance
+  ${PROJECT_NAME} "rosidl_typesupport_cpp")
+
+ament_export_dependencies(rosidl_default_runtime)
+# ament_export_dependencies(rclcpp)
+
+ament_package()
+
+install(
+  PROGRAMS scripts/posprocess_logging
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(
+  TARGETS communication_performance
+  DESTINATION lib/${PROJECT_NAME}
+)

--- a/rclcpp_performance/msg/MatchingPublisher.msg
+++ b/rclcpp_performance/msg/MatchingPublisher.msg
@@ -1,2 +1,3 @@
 uint64 publisher_id
 uint64 message_id
+uint8[] data

--- a/rclcpp_performance/msg/MatchingPublisher.msg
+++ b/rclcpp_performance/msg/MatchingPublisher.msg
@@ -1,0 +1,2 @@
+uint64 publisher_id
+uint64 message_id

--- a/rclcpp_performance/package.xml
+++ b/rclcpp_performance/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rclcpp_performance</name>
+  <version>0.6.2</version>
+  <description>A package containing rclcpp communication characterization tests.</description>
+  <maintainer email="ivanpauno@ekumenlabs.com">Ivan Paunovic</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <build_depend>rclcpp</build_depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rclcpp_performance/scripts/performance_test
+++ b/rclcpp_performance/scripts/performance_test
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+TEST_FOLDERS=(
+    "test_intra_shared_10ms_n100_m10000_l100000"
+    "test_inter_shared_10ms_n100_m10000_l100000"
+    "test_intra_unique_10ms_n100_m10000_l100000"
+    "test_inter_unique_10ms_n100_m10000_l100000"
+
+    "test_intra_shared_10ms_n10_m10000_l1000000"
+    "test_inter_shared_10ms_n10_m10000_l1000000"
+    "test_intra_unique_10ms_n10_m10000_l1000000"
+    "test_inter_unique_10ms_n10_m10000_l1000000"
+
+    "test_intra_shared_10ms_n1_m10000_l10000000"
+    "test_inter_shared_10ms_n1_m10000_l10000000"
+    "test_intra_unique_10ms_n1_m10000_l10000000"
+    "test_inter_unique_10ms_n1_m10000_l10000000"
+
+    # These tests below suffers of starvation
+    # "test_intra_shared_10ms_n5_m100_l10000000"
+    # "test_inter_shared_10ms_n5_m100_l10000000"
+)
+
+COMMAND_ARGUMENTS=(
+    "-p 10 -n 100 -m 10000 -l 100000 -intra"
+    "-p 10 -n 100 -m 10000 -l 100000"
+    "-p 10 -n 100 -m 10000 -l 100000 -intra -unique"
+    "-p 10 -n 100 -m 10000 -l 100000 -unique"
+
+    "-p 10 -n 10 -m 10000 -l 1000000 -intra"
+    "-p 10 -n 10 -m 10000 -l 1000000"
+    "-p 10 -n 10 -m 10000 -l 1000000 -intra -unique"
+    "-p 10 -n 10 -m 10000 -l 1000000 -unique"
+
+    "-p 10 -n 1 -m 10000 -l 10000000 -intra"
+    "-p 10 -n 1 -m 10000 -l 10000000"
+    "-p 10 -n 1 -m 10000 -l 10000000 -intra -unique"
+    "-p 10 -n 1 -m 10000 -l 10000000 -unique"
+
+    # "-p 10 -n 5 -m 10000 -l 10000000 -intra"
+    # "-p 10 -n 5 -m 10000 -l 10000000"
+)
+
+
+DESCRIPTION=(
+    "Intraprocess, shared publish, 100 pubs/subs, 10000 messages, 100000 bytes length, 10ms period."
+    "Interprocess, shared publish, 100 pubs/subs, 10000 messages, 100000 bytes length, 10ms period."
+    "Intraprocess, unique publish, 100 pubs/subs, 10000 messages, 100000 bytes length, 10ms period."
+    "Interprocess, unique publish, 100 pubs/subs, 10000 messages, 100000 bytes length, 10ms period."
+
+    "Intraprocess, shared publish, 10 pubs/subs, 10000 messages, 1000000 bytes length, 10ms period."
+    "Interprocess, shared publish, 10 pubs/subs, 10000 messages, 1000000 bytes length, 10ms period."
+    "Intraprocess, unique publish, 10 pubs/subs, 10000 messages, 1000000 bytes length, 10ms period."
+    "Interprocess, unique publish, 10 pubs/subs, 10000 messages, 1000000 bytes length, 10ms period."
+
+    "Intraprocess, shared publish, 1 pubs/subs, 10000 messages, 10000000 bytes length, 10ms period."
+    "Interprocess, shared publish, 1 pubs/subs, 10000 messages, 10000000 bytes length, 10ms period."
+    "Intraprocess, unique publish, 1 pubs/subs, 10000 messages, 10000000 bytes length, 10ms period."
+    "Interprocess, unique publish, 1 pubs/subs, 10000 messages, 10000000 bytes length, 10ms period."
+
+    # "Intraprocess, shared publish, 5 pubs/subs, 10000 messages, 10000000 bytes length, 10ms period."
+    # "Interprocess, shared publish, 5 pubs/subs, 10000 messages, 10000000 bytes length, 10ms period."
+)
+
+main()
+{
+    set -e
+    parse_arguments "$@"
+    if [[ $skip -eq 0 ]]; then
+        run_tests
+    fi
+    show_results
+}
+
+parse_arguments()
+{
+    set -e
+    out_dir="logs"
+    skip=0
+
+    while [[ $# > 0 ]]
+    do
+        key="$1"
+        case $key in
+            -d|--dir)
+                out_dir="$2"
+                shift # past argument
+            ;;
+            -s|--skip)
+                skip=1
+            ;;
+            -h|--help)
+                print_help
+            ;;
+            *)
+                print_help
+            ;;
+        esac
+        shift # past argument or value
+    done
+}
+
+print_help()
+{
+    echo "Usage: $0 -d OUTPUT_DIR [--skip]"
+    echo "The logs file will be generated inside OUTPUT_DIR"
+    echo "Options:"
+    echo -e "\t\t-s|--skip: Only posprocess and show results, skip running tests."
+    exit 0
+}
+
+run_tests()
+{
+    set -e
+    mkdir -p $out_dir
+    pushd $out_dir > /dev/null
+
+    i=0
+    for folder in "${TEST_FOLDERS[@]}"
+    do
+        echo -e "\e[34mRunning performance test with the following configuration:\e[39m"
+        echo -e "\e[34m\t\t${COMMAND_ARGUMENTS[i]}\e[39m"
+        mkdir -p $folder
+        ros2 run rclcpp_performance communication_performance -d $folder ${COMMAND_ARGUMENTS[i]}
+        i=$i+1
+        echo
+    done
+
+    popd
+}
+
+show_results()
+{
+    set -e
+    pushd $out_dir > /dev/null
+
+    echo -e "\e[34mThe generated data will be posprocessed an showed.\e[39m"
+    echo
+
+    i=0
+    for folder in "${TEST_FOLDERS[@]}"
+    do
+        echo "Next configuration to be posprocessed:"
+        echo -e "\t\t${COMMAND_ARGUMENTS[i]}"
+        read -p "Press enter to posprocess and plot the results."
+        echo
+        ros2 run rclcpp_performance posprocess_logging -d $folder
+        i=$i+1
+    done
+
+    popd
+}
+
+main "$@"

--- a/rclcpp_performance/scripts/performance_test
+++ b/rclcpp_performance/scripts/performance_test
@@ -1,23 +1,23 @@
 #!/bin/bash
 
 TEST_FOLDERS=(
-    "test_intra_shared_10ms_n100_m10000_l100000"
-    "test_inter_shared_10ms_n100_m10000_l100000"
-    "test_intra_unique_10ms_n100_m10000_l100000"
-    "test_inter_unique_10ms_n100_m10000_l100000"
+    "test_intra_shared_10ms_n100_s1_m10000_l100000"
+    "test_inter_shared_10ms_n100_s1_m10000_l100000"
+    "test_intra_unique_10ms_n100_s1_m10000_l100000"
+    "test_inter_unique_10ms_n100_s1_m10000_l100000"
 
-    "test_intra_shared_10ms_n10_m10000_l1000000"
-    "test_inter_shared_10ms_n10_m10000_l1000000"
-    "test_intra_unique_10ms_n10_m10000_l1000000"
-    "test_inter_unique_10ms_n10_m10000_l1000000"
+    "test_intra_shared_10ms_n10_s1_m10000_l1000000"
+    "test_inter_shared_10ms_n10_s1_m10000_l1000000"
+    "test_intra_unique_10ms_n10_s1_m10000_l1000000"
+    "test_inter_unique_10ms_n10_s1_m10000_l1000000"
 
-    "test_intra_shared_10ms_n1_m10000_l10000000"
-    "test_inter_shared_10ms_n1_m10000_l10000000"
-    "test_intra_unique_10ms_n1_m10000_l10000000"
-    "test_inter_unique_10ms_n1_m10000_l10000000"
+    "test_intra_shared_10ms_n1_s1_m10000_l10000000"
+    "test_inter_shared_10ms_n1_s1_m10000_l10000000"
+    "test_intra_unique_10ms_n1_s1_m10000_l10000000"
+    "test_inter_unique_10ms_n1_s1_m10000_l10000000"
 
-    # "test_intra_shared_10ms_n5_m100_l10000000"
-    # "test_inter_shared_10ms_n5_m100_l10000000"
+    "test_intra_shared_10ms_n1_s50_m10000_l10000000"
+    "test_intra_unique_10ms_n1_s50_m10000_l10000000"
 )
 
 COMMAND_ARGUMENTS=(
@@ -36,8 +36,8 @@ COMMAND_ARGUMENTS=(
     "-p 10 -n 1 -m 10000 -l 10000000 -intra -unique"
     "-p 10 -n 1 -m 10000 -l 10000000 -unique"
 
-    # "-p 10 -n 5 -m 10000 -l 10000000 -intra"
-    # "-p 10 -n 5 -m 10000 -l 10000000"
+    "-p 10 -n 1 -s 50 -m 10000 -l 10000000 -intra"
+    "-p 10 -n 1 -s 50 -m 10000 -l 10000000 -intra -unique"
 )
 
 
@@ -57,8 +57,8 @@ DESCRIPTION=(
     "Intraprocess, unique publish, 1 pubs/subs, 10000 messages, 10000000 bytes length, 10ms period."
     "Interprocess, unique publish, 1 pubs/subs, 10000 messages, 10000000 bytes length, 10ms period."
 
-    # "Intraprocess, shared publish, 5 pubs/subs, 10000 messages, 10000000 bytes length, 10ms period."
-    # "Interprocess, shared publish, 5 pubs/subs, 10000 messages, 10000000 bytes length, 10ms period."
+    "Intraprocess, shared publish, 1 pubs, 50 subs per pub, 10000 messages, 10000000 bytes length, 10ms period."
+    "Intraprocess, unique publish, 1 pubs, 50 subs per pub, 10000 messages, 10000000 bytes length, 10ms period."
 )
 
 main()

--- a/rclcpp_performance/scripts/performance_test
+++ b/rclcpp_performance/scripts/performance_test
@@ -16,7 +16,6 @@ TEST_FOLDERS=(
     "test_intra_unique_10ms_n1_m10000_l10000000"
     "test_inter_unique_10ms_n1_m10000_l10000000"
 
-    # These tests below suffers of starvation
     # "test_intra_shared_10ms_n5_m100_l10000000"
     # "test_inter_shared_10ms_n5_m100_l10000000"
 )

--- a/rclcpp_performance/scripts/posprocess_logging
+++ b/rclcpp_performance/scripts/posprocess_logging
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Posprocess communication_performance logging.
+
+Calculates latency between publish and subscribe, and actual
+publishers and subscriptions rates.
+"""
+
+import argparse
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+import numpy as np
+
+
+def main():
+    """Do stuff."""
+    parser = argparse.ArgumentParser(description='Process logged data.')
+    parser.add_argument('-d', '--dir', nargs='?', default='./logs', const='./logs')
+
+    args = parser.parse_args()
+
+    path = Path(args.dir)
+    publishers = path.glob('publisher_*')
+    subscriptions = path.glob('subscription_*')
+    publishers_data = dict({})
+    for publisher in publishers:
+        publisher_id = int(str(publisher).partition('publisher_')[2])
+        csv_data = np.genfromtxt(
+            str(publisher),
+            dtype=(int, float),
+            delimiter=',')
+        publishers_data[publisher_id] = {row[0]: row[1] for row in csv_data}
+    subscription_data = dict({})
+    for subscription in subscriptions:
+        subscription_id = int(str(subscription).partition('subscription_')[2])
+        csv_data = np.genfromtxt(
+            str(subscription),
+            dtype=(int, int, float),
+            delimiter=',')
+        subscription_data[subscription_id] = dict({})
+        for row in csv_data:
+            try:
+                subscription_data[subscription_id][row[0]].update({row[1]: row[2]})
+            except:
+                subscription_data[subscription_id][row[0]] = {row[1]: row[2]}
+    plot_publishers_average_rate(publishers_data)
+    plot_subscriptions_average_rate(subscription_data)
+    plot_latencys(subscription_data, publishers_data)
+    plt.show()
+
+
+def plot_publishers_average_rate(data):
+    pub_rates = dict({})
+    for pub_id in sorted(data):
+        timestamps = np.array(list(data[pub_id].values()))
+        period = np.array([timestamps[i+1] - timestamps[i]
+                           for i in range(timestamps.size-1)])
+        pub_rates[pub_id] = np.average(period) / 1000
+    fig, ax = plt.subplots()
+    ax.plot(
+        np.array(list(pub_rates.keys())),
+        np.array(list(pub_rates.values())),
+        'ro',
+        marker='o')
+    fig.suptitle('Publishers average period')
+    fig.canvas.set_window_title('Publishers average period')
+
+
+def plot_subscriptions_average_rate(data):
+    sub_rates = dict({})
+    for sub_id in sorted(data):
+        for pub_id in sorted(data[sub_id]):
+            timestamps = np.array(list(data[sub_id][pub_id].values()))
+            period = np.array([timestamps[i+1] - timestamps[i]
+                               for i in range(timestamps.size-1)])
+            sub_rates[(sub_id, pub_id)] = np.average(period) / 1000
+    fig, ax = plt.subplots()
+    x = np.linspace(0, len(sub_rates)-1, len(sub_rates))
+    y = np.array(list(sub_rates.values()))
+    ax.plot(
+        x,
+        y,
+        'ro',
+        marker='o')
+    fig.suptitle('Subscriptions average period')
+    fig.canvas.set_window_title('Subscriptions average period')
+
+
+def plot_latencys(sub_data, pub_data):
+    av_latencys = dict({})
+    for sub_id in sorted(sub_data):
+        for pub_id in sorted(sub_data[sub_id]):
+            latencys = np.array([
+                sub_data[sub_id][pub_id][m_id] -
+                pub_data[pub_id][m_id]
+                for m_id in sub_data[sub_id][pub_id]]
+            )
+            av_latencys[(sub_id, pub_id)] = np.average(latencys) / 1000
+    fig, ax = plt.subplots()
+    x = np.linspace(0, len(av_latencys)-1, len(av_latencys))
+    y = np.array(list(av_latencys.values()))
+    ax.plot(x, y, marker='o')
+    fig.suptitle('Average latencys, between publish and subscribe')
+    fig.canvas.set_window_title('Average latencys, between publish and subscribe')
+
+
+if __name__ == '__main__':
+    main()

--- a/rclcpp_performance/scripts/posprocess_logging
+++ b/rclcpp_performance/scripts/posprocess_logging
@@ -61,13 +61,13 @@ def main():
                 subscription_data[subscription_id][row[0]].update({row[1]: row[2]})
             except:
                 subscription_data[subscription_id][row[0]] = {row[1]: row[2]}
-    plot_publishers_average_rate(publishers_data)
-    plot_subscriptions_average_rate(subscription_data)
+    plot_publishers_average_period(publishers_data)
+    plot_subscriptions_average_period(subscription_data)
     plot_latencys(subscription_data, publishers_data)
     plt.show()
 
 
-def plot_publishers_average_rate(data):
+def plot_publishers_average_period(data):
     pub_rates = dict({})
     for pub_id in sorted(data):
         timestamps = np.array(list(data[pub_id].values()))
@@ -75,6 +75,9 @@ def plot_publishers_average_rate(data):
                            for i in range(timestamps.size-1)])
         pub_rates[pub_id] = np.average(period) / 1000
     fig, ax = plt.subplots()
+    ax.ticklabel_format(useOffset=False)
+    ax.set_xlabel('publisherº')
+    ax.set_ylabel('ms')
     ax.plot(
         np.array(list(pub_rates.keys())),
         np.array(list(pub_rates.values())),
@@ -84,17 +87,20 @@ def plot_publishers_average_rate(data):
     fig.canvas.set_window_title('Publishers average period')
 
 
-def plot_subscriptions_average_rate(data):
-    sub_rates = dict({})
+def plot_subscriptions_average_period(data):
+    sub_periods = dict({})
     for sub_id in sorted(data):
         for pub_id in sorted(data[sub_id]):
             timestamps = np.array(list(data[sub_id][pub_id].values()))
             period = np.array([timestamps[i+1] - timestamps[i]
                                for i in range(timestamps.size-1)])
-            sub_rates[(sub_id, pub_id)] = np.average(period) / 1000
+            sub_periods[(sub_id, pub_id)] = np.average(period) / 1000
     fig, ax = plt.subplots()
-    x = np.linspace(0, len(sub_rates)-1, len(sub_rates))
-    y = np.array(list(sub_rates.values()))
+    x = np.linspace(0, len(sub_periods)-1, len(sub_periods))
+    y = np.array(list(sub_periods.values()))
+    ax.ticklabel_format(useOffset=False)
+    ax.set_xlabel('subscriptionº')
+    ax.set_ylabel('ms')
     ax.plot(
         x,
         y,
@@ -117,6 +123,9 @@ def plot_latencys(sub_data, pub_data):
     fig, ax = plt.subplots()
     x = np.linspace(0, len(av_latencys)-1, len(av_latencys))
     y = np.array(list(av_latencys.values()))
+    ax.ticklabel_format(useOffset=False)
+    ax.set_xlabel('pub/sub pairº')
+    ax.set_ylabel('ms')
     ax.plot(x, y, marker='o')
     fig.suptitle('Average latencys, between publish and subscribe')
     fig.canvas.set_window_title('Average latencys, between publish and subscribe')

--- a/rclcpp_performance/src/communication_performance.cpp
+++ b/rclcpp_performance/src/communication_performance.cpp
@@ -1,0 +1,295 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <cstdio>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <sstream>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rcutils/cmdline_parser.h"
+
+#include "rclcpp_performance/msg/matching_publisher.hpp"
+
+using PeriodT = std::chrono::milliseconds;
+using TimestampT = std::chrono::microseconds;
+
+class  PublisherConstantRate
+{
+public:
+  explicit PublisherConstantRate(
+    rclcpp::Node* node,
+    const std::string & topic_name,
+    uint64_t publisher_id,
+    std::string base_dir,
+    uint64_t number_of_messages_to_send,
+    PeriodT period,
+    bool use_unique_message,
+    rmw_qos_profile_t qos_profile = rmw_qos_profile_default) :
+  number_of_messages_to_send_(number_of_messages_to_send)
+  {
+    // Note(ivanpauno): msg type could be changed, to try the different publish methods.
+    shared_msg_ = std::make_shared<rclcpp_performance::msg::MatchingPublisher>();
+    shared_msg_->publisher_id = publisher_id;
+    shared_msg_->message_id = 0;
+
+    std::stringstream ss;
+
+    ss << base_dir << "/publisher_" << publisher_id << std::ends;
+    logging_file_.open(ss.str(), std::ios_base::trunc);
+    logging_file_.exceptions(std::ofstream::failbit | std::ofstream::badbit);
+
+    pub_ = node->create_publisher<rclcpp_performance::msg::MatchingPublisher>(
+        topic_name,
+        qos_profile);
+
+    // Use a timer to schedule periodic message publishing.
+    // The callback is different depending on the message type.
+    if (!use_unique_message) {
+      auto callback = [this]() -> void
+        {
+          if (this->number_of_messages_to_send_) {
+            this->logging_file_ << this->shared_msg_->message_id << ", "
+            << std::chrono::duration_cast<TimestampT>(
+                std::chrono::system_clock::now().time_since_epoch()).count()
+              << std::endl;
+            this->pub_->publish(this->shared_msg_);
+            this->shared_msg_->message_id++;
+          } else {
+            this->timer_->cancel();
+            this->st_number_of_publishers_--;
+          }
+          this->number_of_messages_to_send_--;
+        };
+      timer_ = node->create_wall_timer(period, callback);
+    } else {
+      auto callback = [this]() -> void
+        {
+          if (this->number_of_messages_to_send_) {
+            // First create a shared message and copy the data.
+            // Then log and publish.
+            rclcpp_performance::msg::MatchingPublisher::UniquePtr unique_msg =
+              std::make_unique<rclcpp_performance::msg::MatchingPublisher>();
+            unique_msg->publisher_id = this->shared_msg_->publisher_id;
+            unique_msg->message_id = this->shared_msg_->message_id;
+            this->logging_file_ << unique_msg->message_id << ", "
+            << std::chrono::duration_cast<TimestampT>(
+                std::chrono::system_clock::now().time_since_epoch()).count()
+              << std::endl;
+            this->pub_->publish(unique_msg);
+            this->shared_msg_->message_id++;
+          } else {
+            this->timer_->cancel();
+            this->st_number_of_publishers_--;
+          }
+          this->number_of_messages_to_send_--;
+        };
+      timer_ = node->create_wall_timer(period, callback);
+    }
+
+    // Increment static counting
+    PublisherConstantRate::st_number_of_publishers_++;
+  }
+
+  static uint64_t get_number_of_publishers() {
+    return st_number_of_publishers_;
+  }
+
+private:
+  rclcpp_performance::msg::MatchingPublisher::SharedPtr shared_msg_;
+  rclcpp::Publisher<rclcpp_performance::msg::MatchingPublisher>::SharedPtr pub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+
+  std::ofstream logging_file_;
+  uint64_t number_of_messages_to_send_;
+
+  static uint64_t st_number_of_publishers_;
+};
+
+uint64_t PublisherConstantRate::st_number_of_publishers_ = 0;
+
+class SubscriptionLogger
+{
+public:
+  explicit SubscriptionLogger(
+    rclcpp::Node* node,
+    const std::string & topic_name,
+    uint64_t subscription_id,
+    std::string base_dir,
+    rmw_qos_profile_t qos_profile = rmw_qos_profile_default
+    )
+  {
+    std::stringstream ss;
+    ss << base_dir << "/subscription_" << subscription_id << std::ends;
+
+    logging_file_.open(ss.str(), std::ios_base::trunc);
+    logging_file_.exceptions(std::ofstream::failbit | std::ofstream::badbit);
+
+    auto callback = [this](const rclcpp_performance::msg::MatchingPublisher::SharedPtr msg) -> void
+      { 
+        this->logging_file_ << msg->publisher_id << ", "
+          << msg->message_id << ", "
+          << std::chrono::duration_cast<TimestampT>(
+            std::chrono::system_clock::now().time_since_epoch()).count()
+          << std::endl;
+      };
+
+    sub_ = node->create_subscription<rclcpp_performance::msg::MatchingPublisher>(
+      topic_name,
+      callback,
+      qos_profile);
+  }
+
+private:
+  rclcpp::Subscription<rclcpp_performance::msg::MatchingPublisher>::SharedPtr sub_;
+  std::ofstream logging_file_;
+};
+
+class ShutdownHook
+{
+public:
+  ShutdownHook(
+    rclcpp::Node* node,
+    PeriodT period = PeriodT(10000))
+  {
+    auto callback = [this]() -> void
+      {
+        uint64_t number_of_publishers =
+          PublisherConstantRate::get_number_of_publishers();
+        printf(
+          "Checking shutdown, %lu publishers are still alive\n",
+          number_of_publishers);
+        if (!number_of_publishers) {
+          this->timer_->cancel();
+          rclcpp::shutdown();
+          printf("Done!\n");
+        }
+      };
+    timer_ = node->create_wall_timer(period, callback);
+  }
+
+private:
+  rclcpp::TimerBase::SharedPtr timer_;
+};
+
+class PerformanceTestNode : public rclcpp::Node
+{
+public:
+  explicit PerformanceTestNode(
+    std::string node_name,
+    rclcpp::NodeOptions node_options,
+    std::string base_dir,
+    uint64_t number_of_pub_sub,
+    uint64_t number_of_messages,
+    PeriodT publish_period,
+    bool use_unique_message) :
+  Node(node_name, node_options)
+  {
+    // Create Publishers and Subscriptions, and match one to the other.
+    for (uint64_t i = 0; i < number_of_pub_sub; i++) {
+      std::stringstream ss;
+      ss << "topic_" << i << std::ends;
+      std::shared_ptr<SubscriptionLogger> sub =
+        std::make_shared<SubscriptionLogger>(
+          this,
+          ss.str(),
+          i,
+          base_dir);
+      subscriptions_.push_back(sub);
+      std::shared_ptr<PublisherConstantRate> pub =
+        std::make_shared<PublisherConstantRate>(
+          this,
+          ss.str(),
+          i,
+          base_dir,
+          number_of_messages,
+          publish_period,
+          use_unique_message);
+      publishers_.push_back(pub);
+    }
+    shutdown_hook_ = std::make_shared<ShutdownHook>(this);
+  }
+private:
+  std::vector<std::shared_ptr<PublisherConstantRate>> publishers_;
+  std::vector<std::shared_ptr<SubscriptionLogger>> subscriptions_;
+  std::shared_ptr<ShutdownHook> shutdown_hook_;
+};
+
+int main(int argc, char ** argv)
+{
+  std::string base_dir = "logs/";
+  PeriodT period = PeriodT(100);
+  uint64_t number_of_messages = 1000;
+  uint64_t number_of_publishers = 100;
+  rclcpp::NodeOptions node_options;
+  bool use_unique_message = false;
+
+  rclcpp::init(argc, argv);
+
+  char * cli_option = rcutils_cli_get_option(argv, argv + argc, "-d");
+  if (nullptr != cli_option) {
+    base_dir = std::string(cli_option);
+  }
+  printf("Output directory: %s\n", base_dir.c_str());
+
+  cli_option = rcutils_cli_get_option(argv, argv + argc, "-p");
+  if (nullptr != cli_option) {
+    uint64_t p;
+    std::istringstream iss(cli_option);
+    iss >> p;
+    period = PeriodT(p);
+  }
+
+  cli_option = rcutils_cli_get_option(argv, argv + argc, "-m");
+  if (nullptr != cli_option) {
+    std::istringstream iss(cli_option);
+    iss >> number_of_messages;
+  }
+
+  cli_option = rcutils_cli_get_option(argv, argv + argc, "-n");
+  if (nullptr != cli_option) {
+    std::istringstream iss(cli_option);
+    iss >> number_of_publishers;
+  }
+
+  bool option = rcutils_cli_option_exist(argv, argv + argc, "-intra");
+  if (option) {
+    node_options.use_intra_process_comms(true);
+  }
+
+  option = rcutils_cli_option_exist(argv, argv + argc, "-unique");
+  if (option) {
+    use_unique_message = true;
+  }
+
+  // TODO(ivanpauno): Add directory error checking
+
+  auto node = std::make_shared<PerformanceTestNode>(
+    "communication_performance",
+    node_options,
+    base_dir,
+    number_of_publishers, //number of publishers/subscriptions
+    number_of_messages, // number of messages to be send
+    period, // Publish period
+    use_unique_message); //use unique message or shared
+
+  rclcpp::spin(node);
+  // Shutdown is called internally by the node,
+  // when the test ends.
+  // Repeated here in case signal was sent.
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
This targets the first task of https://github.com/ros2/rclcpp/issues/634

This package adds three executables:
1. Script for running some predefined tests, and then do the post-processing and plotting of all of them.
   Example usage: ros2 run  rclcpp_performance performance_test -d output_dir [--skip]
   - output_dir: Directory where the logging files will be created.
   - -s|--skip: Don't run the tests again, only post-process and plot results.

2. communication_performance: Which logs the timestamps.
   Example usage: ros2 run communication_performance [-d output_dir] [-p publish_period_ms] [-m M][-n N][-unique] [-intra]
   - output_dir: directory where the log files will be created (it should be created before running). Default: ./logs
   - -p publish_period_ms: Publish period in ms. Default: 100ms
   - -m M: Number of messages that will be published by each publisher before exiting. Default: 1000
   - -n N: Number of publisher/subscriber pairs created. Defualt: 100.
   - -unique: If option exists, the publish method taking an unique_ptr reference is used. If not, shared_ptr publish method is used.
   - -intra: Set intra process comm.

3. posprocess_logging: Plot results.
Example usage: ros2 run posprocess_logging -d output_dir
Where output_dir contains the logged file.
It plots three things:
   - The measured average publish period of each publisher.
   - The measured average publish period of each subscriber.
   - The measured latencys of each publish-subscriber pair.
In all the cases, y axes is in ms and x axes is the result of one of the parts (one publisher, one subscriber, or one publisher-subscriber pair).

My results:
https://docs.google.com/document/d/1YRpWajYvXF_RA7nIH3Qe8RFUyVJwJoxVTSpQFJKN18U/edit?usp=sharing
Old results (https://github.com/ros2/rclcpp/pull/636/commits/841e206942eed33d7396eeacdf042ecd53d3143e):
https://docs.google.com/document/d/11RBqAjcjQ4FBYkwfVtudOaHJSP_wz_TW9AGneo1_ePE/edit?usp=sharing

TODO:
- It needs a general cleaning, and add some error handling.