### PR TITLE
Wait for action server before sending goal

### DIFF
--- a/rclcpp_action/test/test_client.cpp
+++ b/rclcpp_action/test/test_client.cpp
@@ -47,6 +47,8 @@
 
 using namespace std::chrono_literals;
 
+const auto WAIT_FOR_SERVER_TIMEOUT = 10s;
+
 class TestClient : public ::testing::Test
 {
 protected:
@@ -269,6 +271,7 @@ TEST_F(TestClient, construction_and_destruction)
 TEST_F(TestClient, async_send_goal_but_ignore_feedback_and_result)
 {
   auto action_client = rclcpp_action::create_client<ActionType>(client_node, action_name);
+  ASSERT_TRUE(action_client->wait_for_action_server(WAIT_FOR_SERVER_TIMEOUT));
 
   ActionGoal bad_goal;
   bad_goal.order = -5;
@@ -290,6 +293,7 @@ TEST_F(TestClient, async_send_goal_but_ignore_feedback_and_result)
 TEST_F(TestClient, async_send_goal_and_ignore_feedback_but_wait_for_result)
 {
   auto action_client = rclcpp_action::create_client<ActionType>(client_node, action_name);
+  ASSERT_TRUE(action_client->wait_for_action_server(WAIT_FOR_SERVER_TIMEOUT));
 
   ActionGoal goal;
   goal.order = 5;
@@ -311,6 +315,7 @@ TEST_F(TestClient, async_send_goal_and_ignore_feedback_but_wait_for_result)
 TEST_F(TestClient, async_send_goal_with_feedback_and_result)
 {
   auto action_client = rclcpp_action::create_client<ActionType>(client_node, action_name);
+  ASSERT_TRUE(action_client->wait_for_action_server(WAIT_FOR_SERVER_TIMEOUT));
 
   ActionGoal goal;
   goal.order = 4;
@@ -342,6 +347,7 @@ TEST_F(TestClient, async_send_goal_with_feedback_and_result)
 TEST_F(TestClient, async_cancel_one_goal)
 {
   auto action_client = rclcpp_action::create_client<ActionType>(client_node, action_name);
+  ASSERT_TRUE(action_client->wait_for_action_server(WAIT_FOR_SERVER_TIMEOUT));
 
   ActionGoal goal;
   goal.order = 5;
@@ -359,6 +365,7 @@ TEST_F(TestClient, async_cancel_one_goal)
 TEST_F(TestClient, async_cancel_all_goals)
 {
   auto action_client = rclcpp_action::create_client<ActionType>(client_node, action_name);
+  ASSERT_TRUE(action_client->wait_for_action_server(WAIT_FOR_SERVER_TIMEOUT));
 
   ActionGoal goal;
   goal.order = 6;
@@ -393,6 +400,7 @@ TEST_F(TestClient, async_cancel_all_goals)
 TEST_F(TestClient, async_cancel_some_goals)
 {
   auto action_client = rclcpp_action::create_client<ActionType>(client_node, action_name);
+  ASSERT_TRUE(action_client->wait_for_action_server(WAIT_FOR_SERVER_TIMEOUT));
 
   ActionGoal goal;
   goal.order = 6;


### PR DESCRIPTION
Wait for discovery before trying to send goal. This is one of the failing tests in ros2/build_cop#166

See https://github.com/ros2/build_cop/issues/166#issuecomment-466365666

CI (testing only rclcpp)
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6262)](http://ci.ros2.org/job/ci_linux/6262/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2688)](http://ci.ros2.org/job/ci_linux-aarch64/2688/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5146)](http://ci.ros2.org/job/ci_osx/5146/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=6100)](http://ci.ros2.org/job/ci_windows/6100/)

~~In progress while CI runs~~ Ready for review