### PR TITLE
fix wait for service memory leak

### DIFF
--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -109,7 +109,6 @@ ClientBase::wait_for_service_nanoseconds(std::chrono::nanoseconds timeout)
   if (!node_ptr) {
     throw InvalidNodeError();
   }
-  auto event = node_ptr->get_graph_event();
   // check to see if the server is ready immediately
   if (this->service_is_ready()) {
     return true;
@@ -118,6 +117,7 @@ ClientBase::wait_for_service_nanoseconds(std::chrono::nanoseconds timeout)
     // check was non-blocking, return immediately
     return false;
   }
+  auto event = node_ptr->get_graph_event();
   // update the time even on the first loop to account for time spent in the first call
   // to this->server_is_ready()
   std::chrono::nanoseconds time_to_wait = timeout - (std::chrono::steady_clock::now() - start);


### PR DESCRIPTION
when call wait_for_service in a loop, the get graph event will leak memory.
we fix it by, when service is ok, there's no need to create a new one.