### PR TITLE
Expose get_fully_qualified_name in Node API

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -115,6 +115,14 @@ public:
   const char *
   get_namespace() const;
 
+  /// Get the fully-qualified name of the node.
+  /**
+   * The fully-qualified name includes the local namespace and name of the node.
+   */
+  RCLCPP_PUBLIC
+  const char *
+  get_fully_qualified_name() const;
+
   /// Get the logger of the node.
   /** \return The logger of the node. */
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
@@ -58,6 +58,11 @@ public:
 
   RCLCPP_PUBLIC
   virtual
+  const char *
+  get_fully_qualified_name() const;
+
+  RCLCPP_PUBLIC
+  virtual
   rclcpp::Context::SharedPtr
   get_context();
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
@@ -56,6 +56,13 @@ public:
   const char *
   get_namespace() const = 0;
 
+  /// Return the fully qualified name of the node.
+  /** \return The fully qualified name of the node. */
+  RCLCPP_PUBLIC
+  virtual
+  const char *
+  get_fully_qualified_name() const = 0;
+
   /// Return the context of the node.
   /** \return SharedPtr to the node's context. */
   RCLCPP_PUBLIC

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -190,6 +190,12 @@ Node::get_namespace() const
   return node_base_->get_namespace();
 }
 
+const char *
+Node::get_fully_qualified_name() const
+{
+  return node_base_->get_fully_qualified_name();
+}
+
 rclcpp::Logger
 Node::get_logger() const
 {

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -161,6 +161,12 @@ NodeBase::get_namespace() const
   return rcl_node_get_namespace(node_handle_.get());
 }
 
+const char *
+NodeBase::get_fully_qualified_name() const
+{
+  return rcl_node_get_fully_qualified_name(node_handle_.get());
+}
+
 rclcpp::Context::SharedPtr
 NodeBase::get_context()
 {

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -57,21 +57,45 @@ TEST_F(TestNode, get_name_and_namespace) {
     auto node = std::make_shared<rclcpp::Node>("my_node", "/ns");
     EXPECT_STREQ("my_node", node->get_name());
     EXPECT_STREQ("/ns", node->get_namespace());
+    EXPECT_STREQ("/ns/my_node", node->get_fully_qualified_name());
+  }
+  {
+    auto options = rclcpp::NodeOptions()
+      .arguments({"__ns:=/another_ns"});
+    auto node = std::make_shared<rclcpp::Node>("my_node", "/ns", options);
+    EXPECT_STREQ("my_node", node->get_name());
+    EXPECT_STREQ("/another_ns", node->get_namespace());
+    EXPECT_STREQ("/another_ns/my_node", node->get_fully_qualified_name());
   }
   {
     auto node = std::make_shared<rclcpp::Node>("my_node", "ns");
     EXPECT_STREQ("my_node", node->get_name());
     EXPECT_STREQ("/ns", node->get_namespace());
+    EXPECT_STREQ("/ns/my_node", node->get_fully_qualified_name());
+  }
+  {
+    auto node = std::make_shared<rclcpp::Node>("my_node");
+    EXPECT_STREQ("my_node", node->get_name());
+    EXPECT_STREQ("/", node->get_namespace());
+    EXPECT_STREQ("/my_node", node->get_fully_qualified_name());
+  }
+  {
+    auto node = std::make_shared<rclcpp::Node>("my_node", "");
+    EXPECT_STREQ("my_node", node->get_name());
+    EXPECT_STREQ("/", node->get_namespace());
+    EXPECT_STREQ("/my_node", node->get_fully_qualified_name());
   }
   {
     auto node = std::make_shared<rclcpp::Node>("my_node", "/my/ns");
     EXPECT_STREQ("my_node", node->get_name());
     EXPECT_STREQ("/my/ns", node->get_namespace());
+    EXPECT_STREQ("/my/ns/my_node", node->get_fully_qualified_name());
   }
   {
     auto node = std::make_shared<rclcpp::Node>("my_node", "my/ns");
     EXPECT_STREQ("my_node", node->get_name());
     EXPECT_STREQ("/my/ns", node->get_namespace());
+    EXPECT_STREQ("/my/ns/my_node", node->get_fully_qualified_name());
   }
 }
 


### PR DESCRIPTION
This exposes `rcl_node_get_fully_qualified_name` (https://github.com/ros2/rcl/blob/99630cb66dc90644266e34ce6987c2b36b3a7602/rcl/include/rcl/node.h#L302) in the C++ API