### PR TITLE
Check QoS policy when configuring intraprocess, skip interprocess publish when possible

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -64,6 +64,17 @@
 namespace rclcpp
 {
 
+/// Used as argument in create_publisher and create_subscriber.
+enum class IntraprocessSetting
+{
+  /// Explicitly enable intraprocess comm at publisher/subscription level.
+  ENABLE,
+  /// Explicitly disable intraprocess comm at publisher/subscription level.
+  DISABLE,
+  /// Take intraprocess configuration from the node.
+  DEFAULT_FROM_NODE
+};
+
 /// Node is the single point of entry for creating publishers and subscribers.
 class Node : public std::enable_shared_from_this<Node>
 {
@@ -152,7 +163,8 @@ public:
   std::shared_ptr<PublisherT>
   create_publisher(
     const std::string & topic_name, size_t qos_history_depth,
-    std::shared_ptr<Alloc> allocator = nullptr);
+    std::shared_ptr<Alloc> allocator = nullptr,
+    IntraprocessSetting use_intra_process_comm = IntraprocessSetting::DEFAULT_FROM_NODE);
 
   /// Create and return a Publisher.
   /**
@@ -168,7 +180,8 @@ public:
   create_publisher(
     const std::string & topic_name,
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_default,
-    std::shared_ptr<Alloc> allocator = nullptr);
+    std::shared_ptr<Alloc> allocator = nullptr,
+    IntraprocessSetting use_intra_process_comm = IntraprocessSetting::DEFAULT_FROM_NODE);
 
   /// Create and return a Subscription.
   /**
@@ -201,7 +214,8 @@ public:
     typename rclcpp::message_memory_strategy::MessageMemoryStrategy<
       typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, Alloc>::SharedPtr
     msg_mem_strat = nullptr,
-    std::shared_ptr<Alloc> allocator = nullptr);
+    std::shared_ptr<Alloc> allocator = nullptr,
+    IntraprocessSetting use_intra_process_comm = IntraprocessSetting::DEFAULT_FROM_NODE);
 
   /// Create and return a Subscription.
   /**
@@ -234,7 +248,8 @@ public:
     typename rclcpp::message_memory_strategy::MessageMemoryStrategy<
       typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, Alloc>::SharedPtr
     msg_mem_strat = nullptr,
-    std::shared_ptr<Alloc> allocator = nullptr);
+    std::shared_ptr<Alloc> allocator = nullptr,
+    IntraprocessSetting use_intra_process_comm = IntraprocessSetting::DEFAULT_FROM_NODE);
 
   /// Create a timer.
   /**

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -55,14 +55,16 @@ template<typename MessageT, typename Alloc, typename PublisherT>
 std::shared_ptr<PublisherT>
 Node::create_publisher(
   const std::string & topic_name, size_t qos_history_depth,
-  std::shared_ptr<Alloc> allocator)
+  std::shared_ptr<Alloc> allocator,
+  IntraprocessSetting use_intra_process_comm)
 {
   if (!allocator) {
     allocator = std::make_shared<Alloc>();
   }
   rmw_qos_profile_t qos = rmw_qos_profile_default;
   qos.depth = qos_history_depth;
-  return this->create_publisher<MessageT, Alloc, PublisherT>(topic_name, qos, allocator);
+  return this->create_publisher<MessageT, Alloc, PublisherT>(topic_name, qos,
+           allocator, use_intra_process_comm);
 }
 
 RCLCPP_LOCAL
@@ -81,17 +83,30 @@ template<typename MessageT, typename Alloc, typename PublisherT>
 std::shared_ptr<PublisherT>
 Node::create_publisher(
   const std::string & topic_name, const rmw_qos_profile_t & qos_profile,
-  std::shared_ptr<Alloc> allocator)
+  std::shared_ptr<Alloc> allocator, IntraprocessSetting use_intra_process_comm)
 {
   if (!allocator) {
     allocator = std::make_shared<Alloc>();
+  }
+
+  bool use_intra_process;
+  switch (use_intra_process_comm) {
+    case IntraprocessSetting::ENABLE:
+      use_intra_process = true;
+      break;
+    case IntraprocessSetting::DISABLE:
+      use_intra_process = false;
+      break;
+    default:  // IntraprocessSetting::DEFAULT_FROM_NODE
+      use_intra_process = this->get_node_options().use_intra_process_comms();
+      break;
   }
 
   return rclcpp::create_publisher<MessageT, Alloc, PublisherT>(
     this->node_topics_.get(),
     extend_name_with_sub_namespace(topic_name, this->get_sub_namespace()),
     qos_profile,
-    this->get_node_options().use_intra_process_comms(),
+    use_intra_process,
     allocator);
 }
 
@@ -110,7 +125,8 @@ Node::create_subscription(
   typename rclcpp::message_memory_strategy::MessageMemoryStrategy<
     typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, Alloc>::SharedPtr
   msg_mem_strat,
-  std::shared_ptr<Alloc> allocator)
+  std::shared_ptr<Alloc> allocator,
+  IntraprocessSetting use_intra_process_comm)
 {
   using CallbackMessageT = typename rclcpp::subscription_traits::has_message_type<CallbackT>::type;
 
@@ -123,6 +139,19 @@ Node::create_subscription(
     msg_mem_strat = MessageMemoryStrategy<CallbackMessageT, Alloc>::create_default();
   }
 
+  bool use_intra_process;
+  switch (use_intra_process_comm) {
+    case IntraprocessSetting::ENABLE:
+      use_intra_process = true;
+      break;
+    case IntraprocessSetting::DISABLE:
+      use_intra_process = false;
+      break;
+    default:  // IntraprocessSetting::DEFAULT_FROM_NODE
+      use_intra_process = this->get_node_options().use_intra_process_comms();
+      break;
+  }
+
   return rclcpp::create_subscription<MessageT, CallbackT, Alloc, CallbackMessageT, SubscriptionT>(
     this->node_topics_.get(),
     extend_name_with_sub_namespace(topic_name, this->get_sub_namespace()),
@@ -130,7 +159,7 @@ Node::create_subscription(
     qos_profile,
     group,
     ignore_local_publications,
-    this->get_node_options().use_intra_process_comms(),
+    use_intra_process,
     msg_mem_strat,
     allocator);
 }
@@ -150,7 +179,8 @@ Node::create_subscription(
   typename rclcpp::message_memory_strategy::MessageMemoryStrategy<
     typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, Alloc>::SharedPtr
   msg_mem_strat,
-  std::shared_ptr<Alloc> allocator)
+  std::shared_ptr<Alloc> allocator,
+  IntraprocessSetting use_intra_process_comm)
 {
   rmw_qos_profile_t qos = rmw_qos_profile_default;
   qos.depth = qos_history_depth;
@@ -162,7 +192,8 @@ Node::create_subscription(
     group,
     ignore_local_publications,
     msg_mem_strat,
-    allocator);
+    allocator,
+    use_intra_process_comm);
 }
 
 template<typename DurationRepT, typename DurationT, typename CallbackT>

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -228,7 +228,9 @@ public:
   virtual void
   publish(std::unique_ptr<MessageT, MessageDeleter> & msg)
   {
-    this->do_inter_process_publish(msg.get());
+    if (!use_intra_process_ || get_subscription_count() > get_intra_process_subscription_count()) {
+      this->do_inter_process_publish(msg.get());
+    }
     if (store_intra_process_message_) {
       // Take the pointer from the unique_msg, release it and pass as a void *
       // to the ipm. The ipm should then capture it again as a unique_ptr of

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -181,7 +181,7 @@ protected:
 
   using IntraProcessManagerWeakPtr =
     std::weak_ptr<rclcpp::intra_process_manager::IntraProcessManager>;
-  bool use_intra_process_;
+  bool intra_process_is_enabled_;
   IntraProcessManagerWeakPtr weak_ipm_;
   uint64_t intra_process_publisher_id_;
   StoreMessageCallbackT store_intra_process_message_;
@@ -228,7 +228,9 @@ public:
   virtual void
   publish(std::unique_ptr<MessageT, MessageDeleter> & msg)
   {
-    if (!use_intra_process_ || get_subscription_count() > get_intra_process_subscription_count()) {
+    bool inter_process_subscriptions_exist =
+      get_subscription_count() > get_intra_process_subscription_count();
+    if (!intra_process_is_enabled_ || inter_process_subscriptions_exist) {
       this->do_inter_process_publish(msg.get());
     }
     if (store_intra_process_message_) {

--- a/rclcpp/src/rclcpp/publisher.cpp
+++ b/rclcpp/src/rclcpp/publisher.cpp
@@ -254,7 +254,7 @@ PublisherBase::setup_intra_process(
   if (intra_process_options.qos.durability != RMW_QOS_POLICY_DURABILITY_VOLATILE) {
     RCLCPP_WARN(
       rclcpp::get_logger("rclcpp"),
-      "Enabled intraprocess communication with incompatible QoS policy.");
+      "Skipping intraprocess communication with incompatible QoS policy.");
     return;
   }
   const char * topic_name = this->get_topic_name();

--- a/rclcpp/src/rclcpp/publisher.cpp
+++ b/rclcpp/src/rclcpp/publisher.cpp
@@ -244,18 +244,12 @@ PublisherBase::setup_intra_process(
   IntraProcessManagerSharedPtr ipm,
   const rcl_publisher_options_t & intra_process_options)
 {
-  // Skip intraprocess configuration if the "durability" qos policy is not "volatile".
-  // TODO(ivanpauno):
-  //    RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT is for FastRTPS and Connext also
-  //    equal to "volatile". It would be good to add a
-  //    is_durability_policy_volatile(rcl_publisher_options_t options)
-  //    method to rcl, and corresponging methods in rmw and the rmw vendor
-  //    implementations, which will also checks if "system_default" is "volatile" or not.
-  if (intra_process_options.qos.durability != RMW_QOS_POLICY_DURABILITY_VOLATILE) {
-    RCLCPP_WARN(
-      rclcpp::get_logger("rclcpp"),
-      "Skipping intraprocess communication with incompatible QoS policy.");
-    return;
+  // Intraprocess configuration is only available with "volatile"
+  // durability qos policy.
+  if (this->get_actual_qos().durability != RMW_QOS_POLICY_DURABILITY_VOLATILE) {
+    throw std::runtime_error(
+            "Intraprocess communication is not allowed"
+            " with any qos policy different than volatile.");
   }
   const char * topic_name = this->get_topic_name();
   if (!topic_name) {

--- a/rclcpp/src/rclcpp/publisher.cpp
+++ b/rclcpp/src/rclcpp/publisher.cpp
@@ -245,6 +245,19 @@ PublisherBase::setup_intra_process(
   IntraProcessManagerSharedPtr ipm,
   const rcl_publisher_options_t & intra_process_options)
 {
+  // Skip intraprocess configuration if the "durability" qos policy is not "volatile".
+  // TODO(ivanpauno):
+  //    RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT is for FastRTPS and Connext also
+  //    equal to "volatile". It would be good to add a
+  //    is_durability_policy_volatile(rcl_publisher_options_t options)
+  //    method to rcl, and corresponging methods in rmw and the rmw vendor
+  //    implementations, which will also checks if "system_default" is "volatile" or not.
+  if (intra_process_options.qos.durability != RMW_QOS_POLICY_DURABILITY_VOLATILE) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("rclcpp"),
+      "Enabled intraprocess communication with incompatible QoS policy.");
+    return;
+  }
   const char * topic_name = this->get_topic_name();
   if (!topic_name) {
     throw std::runtime_error("failed to get topic name");


### PR DESCRIPTION
This is part of the intraprocess comm improvement (https://github.com/ros2/ros2/issues/649, https://docs.google.com/document/d/1dM8O34GM-SbFps1vd1rocPMAg_7O9_-OG4NF4axOz7E/edit#)

As the current and proposed IPM doesn't complain with a non-volatile 'Durability' QoS policy, intraprocess comm shouldn't be configured in those cases. 
- Advantage: Solves compliance issues with QoS policies.
  e.g.: If a publisher and subscriber in the same process had been configured with QoS policy  
  'durability=transient_local" and "history=keep_last", a late subscriber would receive the last message 
  published, as this was not supported by the intra process manager.
- Disadvantage: Intraprocess comm is not supported in those cases.

Previously, interprocess publish was always done. Now, it is skipped when only having intraprocess subscriptions.
- Advantage: Less publish-to-subscribe latency, cpu usage, memory usage when the topic is only used for intraprocess comm.
- Disadvantage: Probably, the time it takes to recognize a interprocess subscription done just before the publishing is longer than before. 
   e.g.:    Process B subscribes to topic /topic.
              Process A publishes to topic /topic just after process B subscriber.
              Since maybe the count updating time it's not the same as how the publish method checks its subscribers, a message is not received when before it was.  
           (This hasn't been checked, it's only a possible drawback of this change)