### PR TITLE
Replace const char * with a std::array<char, TOPIC_NAME_LENGTH> as the key of IPM IDTopicMap

### DIFF
--- a/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
@@ -289,7 +289,7 @@ private:
     std::string,
     AllocSet,
     std::less<std::string>,
-    RebindAlloc<std::pair<const char * const, AllocSet>>>;
+    RebindAlloc<std::pair<const std::string, AllocSet>>>;
 
   SubscriptionMap subscriptions_;
 

--- a/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
@@ -16,6 +16,7 @@
 #define RCLCPP__INTRA_PROCESS_MANAGER_IMPL_HPP_
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <cstring>
 #include <functional>

--- a/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
@@ -285,18 +285,10 @@ private:
     std::hash<uint64_t>, std::equal_to<uint64_t>,
     RebindAlloc<std::pair<const uint64_t, SubscriptionBase::WeakPtr>>>;
 
-  struct strcmp_wrapper
-  {
-    bool
-    operator()(const char * lhs, const char * rhs) const
-    {
-      return std::strcmp(lhs, rhs) < 0;
-    }
-  };
   using IDTopicMap = std::map<
-    const char *,
+    std::string,
     AllocSet,
-    strcmp_wrapper,
+    std::less<std::string>,
     RebindAlloc<std::pair<const char * const, AllocSet>>>;
 
   SubscriptionMap subscriptions_;

--- a/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
@@ -281,8 +281,8 @@ private:
   FixedSizeString
   fixed_size_string(const char * str) const
   {
-    FixedSizeString ret = {0};
-    std::strncpy(ret.begin(), str, ret.size());
+    FixedSizeString ret;
+    std::strncpy(ret.data(), str, ret.size());
     return ret;
   }
 

--- a/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
@@ -98,7 +98,10 @@ public:
 private:
   char str_[RMW_TOPIC_MAX_NAME_LENGTH + 1];
 };
-bool operator<(const FixedSizeString & lhs, const FixedSizeString & rhs);
+
+RCLCPP_PUBLIC
+bool
+operator<(const FixedSizeString & lhs, const FixedSizeString & rhs);
 
 template<typename Allocator = std::allocator<void>>
 class IntraProcessManagerImpl : public IntraProcessManagerImplBase

--- a/rclcpp/src/rclcpp/intra_process_manager_impl.cpp
+++ b/rclcpp/src/rclcpp/intra_process_manager_impl.cpp
@@ -16,8 +16,28 @@
 
 #include <memory>
 
-rclcpp::intra_process_manager::IntraProcessManagerImplBase::SharedPtr
+using rclcpp::intra_process_manager::FixedSizeString;
+using rclcpp::intra_process_manager::IntraProcessManagerImplBase;
+
+IntraProcessManagerImplBase::SharedPtr
 rclcpp::intra_process_manager::create_default_impl()
 {
   return std::make_shared<IntraProcessManagerImpl<>>();
+}
+
+FixedSizeString::FixedSizeString(const char * str)
+{
+  std::strncpy(str_, str, RMW_TOPIC_MAX_NAME_LENGTH + 1);
+}
+
+const char * FixedSizeString::c_str() const
+{
+  return str_;
+}
+
+bool rclcpp::intra_process_manager::operator<(
+  const FixedSizeString & lhs,
+  const FixedSizeString & rhs)
+{
+  return std::strcmp(lhs.c_str(), rhs.c_str());
 }

--- a/rclcpp/src/rclcpp/intra_process_manager_impl.cpp
+++ b/rclcpp/src/rclcpp/intra_process_manager_impl.cpp
@@ -16,28 +16,8 @@
 
 #include <memory>
 
-using rclcpp::intra_process_manager::FixedSizeString;
-using rclcpp::intra_process_manager::IntraProcessManagerImplBase;
-
-IntraProcessManagerImplBase::SharedPtr
+rclcpp::intra_process_manager::IntraProcessManagerImplBase::SharedPtr
 rclcpp::intra_process_manager::create_default_impl()
 {
   return std::make_shared<IntraProcessManagerImpl<>>();
-}
-
-FixedSizeString::FixedSizeString(const char * str)
-{
-  std::strncpy(str_, str, RMW_TOPIC_MAX_NAME_LENGTH + 1);
-}
-
-const char * FixedSizeString::c_str() const
-{
-  return str_;
-}
-
-bool rclcpp::intra_process_manager::operator<(
-  const FixedSizeString & lhs,
-  const FixedSizeString & rhs)
-{
-  return std::strcmp(lhs.c_str(), rhs.c_str());
 }


### PR DESCRIPTION
Closes #668

## Changes

Replaces the `const char *` key in IDTopicMap with a std::array<char, TOPIC_NAME_LENGTH> key. A copy of the string is forced.

## Problem description

After some debugging, I realized what this random error was.
Sometimes, the topic name  wasn't found in the subscription_ids_by_topic_ map here:
https://github.com/ros2/rclcpp/blob/cb20529e5e218cde0106c59b12067a9ca9f43022/rclcpp/include/rclcpp/intra_process_manager_impl.hpp#L266-L270
And a 0 subscription count was returned.

The problem is that a `const char *` was used as a key, an the liveliness of that raw pointer was the liveliness of the subscription:
https://github.com/ros2/rclcpp/blob/cb20529e5e218cde0106c59b12067a9ca9f43022/rclcpp/include/rclcpp/intra_process_manager_impl.hpp#L98-L104
When another subscription was registered in the same topic, and the first subscription was already out of scope, it sometimes resulted in the correct behavior and sometimes failed silently. The OS usually not raise a segfault when accessing a recently freed block of memory, but data could be already corrupted at that moment.

## Bug reproduction

The error is not easy to reproduce. Here is the script I've used:
```bash
#!/bin/bash

set -e
mkdir -p logs_test_intra
for run in {1..50}; do
    echo "Starting test #" $run
    out=$(colcon test --packages-select rclcpp --ctest-arg -R test_publisher_subscription_count_api)
    echo "$out"
    substring="stderr"
    error_list=()
    if [ "${out/$substring}" != "$out" ]; then
        error_list+=($run)
    fi
    cp -L log/latest "logs_test_intra/test_${run}" -R
    echo
    echo "Finished test #" $run
    echo
    echo
done

echo ${error_list[*]}
```
Before I found one error per about 20 runs. I haven't found it again in 100 runs after this change.

## Closes 668

This is not syncing intra-process-subscription count and subscription count as requested in #668.
But it solves the bug, and syncing them is probably not a good idea as has been already discussed in the issue.