### PR TITLE
Options-struct interfaces for creating publishers/subscribers (pre-QoS, standalone)

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -248,6 +248,15 @@ if(BUILD_TESTING)
     )
     target_link_libraries(test_publisher ${PROJECT_NAME})
   endif()
+  ament_add_gtest(test_pub_sub_option_interface test/test_pub_sub_option_interface.cpp)
+  if(TARGET test_pub_sub_option_interface)
+    ament_target_dependencies(test_pub_sub_option_interface
+      test_msgs
+    )
+    target_link_libraries(test_pub_sub_option_interface
+      ${PROJECT_NAME}
+    )
+  endif()
   ament_add_gtest(test_publisher_subscription_count_api test/test_publisher_subscription_count_api.cpp)
   if(TARGET test_publisher_subscription_count_api)
     ament_target_dependencies(test_publisher_subscription_count_api

--- a/rclcpp/include/rclcpp/intra_process_setting.hpp
+++ b/rclcpp/include/rclcpp/intra_process_setting.hpp
@@ -1,0 +1,34 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__INTRA_PROCESS_SETTING_HPP_
+#define RCLCPP__INTRA_PROCESS_SETTING_HPP_
+
+namespace rclcpp
+{
+
+/// Used as argument in create_publisher and create_subscriber.
+enum class IntraProcessSetting
+{
+  /// Explicitly enable intraprocess comm at publisher/subscription level.
+  Enable,
+  /// Explicitly disable intraprocess comm at publisher/subscription level.
+  Disable,
+  /// Take intraprocess configuration from the node.
+  NodeDefault
+};
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__INTRA_PROCESS_SETTING_HPP_

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -169,6 +169,7 @@ public:
   template<
     typename MessageT, typename Alloc = std::allocator<void>,
     typename PublisherT = ::rclcpp::Publisher<MessageT, Alloc>>
+  // cppcheck-suppress syntaxError // bug in cppcheck 1.82 for [[deprecated]] on templated function
   [[deprecated(
     "use the create_publisher(const std::string &, size_t, const PublisherOptions<Alloc> & = "
     "PublisherOptions<Alloc>()) signature instead")]]

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -150,13 +150,14 @@ public:
    */
   template<
     typename MessageT,
-    typename Alloc = std::allocator<void>,
-    typename PublisherT = ::rclcpp::Publisher<MessageT, Alloc>>
+    typename AllocatorT = std::allocator<void>,
+    typename PublisherT = ::rclcpp::Publisher<MessageT, AllocatorT>>
   std::shared_ptr<PublisherT>
   create_publisher(
     const std::string & topic_name,
     size_t qos_history_depth,
-    const PublisherOptions<Alloc> & options = PublisherOptions<Alloc>());
+    const PublisherOptionsWithAllocator<AllocatorT> &
+    options = PublisherOptionsWithAllocator<AllocatorT>());
 
   /// Create and return a Publisher.
   /**
@@ -211,17 +212,19 @@ public:
   template<
     typename MessageT,
     typename CallbackT,
-    typename Alloc = std::allocator<void>,
+    typename AllocatorT = std::allocator<void>,
     typename SubscriptionT = rclcpp::Subscription<
-      typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, Alloc>>
+      typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, AllocatorT>>
   std::shared_ptr<SubscriptionT>
   create_subscription(
     const std::string & topic_name,
     CallbackT && callback,
     size_t qos_history_depth,
-    const SubscriptionOptions<Alloc> & options = SubscriptionOptions<Alloc>(),
+    const SubscriptionOptionsWithAllocator<AllocatorT> &
+    options = SubscriptionOptionsWithAllocator<AllocatorT>(),
     typename rclcpp::message_memory_strategy::MessageMemoryStrategy<
-      typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, Alloc>::SharedPtr
+      typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, AllocatorT
+    >::SharedPtr
     msg_mem_strat = nullptr);
 
   /// Create and return a Subscription.

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -171,8 +171,9 @@ public:
   [[deprecated]]
   std::shared_ptr<PublisherT>
   create_publisher(
-    const std::string & topic_name, size_t qos_history_depth,
-    std::shared_ptr<Alloc> allocator = nullptr,
+    const std::string & topic_name,
+    size_t qos_history_depth,
+    std::shared_ptr<Alloc> allocator,
     IntraProcessSetting use_intra_process_comm = IntraProcessSetting::NodeDefault);
 
   /// Create and return a Publisher.
@@ -284,7 +285,7 @@ public:
     const std::string & topic_name,
     CallbackT && callback,
     size_t qos_history_depth,
-    rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr,
+    rclcpp::callback_group::CallbackGroup::SharedPtr group,
     bool ignore_local_publications = false,
     typename rclcpp::message_memory_strategy::MessageMemoryStrategy<
       typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, Alloc>::SharedPtr

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -168,7 +168,9 @@ public:
   template<
     typename MessageT, typename Alloc = std::allocator<void>,
     typename PublisherT = ::rclcpp::Publisher<MessageT, Alloc>>
-  [[deprecated]]
+  [[deprecated(
+    "use the create_publisher(const std::string &, size_t, const PublisherOptions<Alloc> & = "
+    "PublisherOptions<Alloc>()) signature instead")]]
   std::shared_ptr<PublisherT>
   create_publisher(
     const std::string & topic_name,
@@ -186,7 +188,6 @@ public:
   template<
     typename MessageT, typename Alloc = std::allocator<void>,
     typename PublisherT = ::rclcpp::Publisher<MessageT, Alloc>>
-  [[deprecated]]
   std::shared_ptr<PublisherT>
   create_publisher(
     const std::string & topic_name,
@@ -244,7 +245,6 @@ public:
     typename Alloc = std::allocator<void>,
     typename SubscriptionT = rclcpp::Subscription<
       typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, Alloc>>
-  [[deprecated]]
   std::shared_ptr<SubscriptionT>
   create_subscription(
     const std::string & topic_name,
@@ -279,7 +279,9 @@ public:
     typename Alloc = std::allocator<void>,
     typename SubscriptionT = rclcpp::Subscription<
       typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, Alloc>>
-  [[deprecated]]
+  [[deprecated(
+    "use the create_subscription(const std::string &, CallbackT &&, size_t, "
+    "const SubscriptionOptions<Alloc> & = SubscriptionOptions<Alloc>(), ...) signature instead")]]
   std::shared_ptr<SubscriptionT>
   create_subscription(
     const std::string & topic_name,

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -115,7 +115,6 @@ Node::create_publisher(
     topic_name, qos_history_depth, pub_options);
 }
 
-
 template<typename MessageT, typename Alloc, typename PublisherT>
 std::shared_ptr<PublisherT>
 Node::create_publisher(
@@ -216,7 +215,6 @@ Node::create_subscription(
   return this->create_subscription<MessageT, CallbackT, Alloc, SubscriptionT>(
     topic_name, std::forward<CallbackT>(callback), qos_profile.depth, sub_options, msg_mem_strat);
 }
-
 
 template<
   typename MessageT,

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -63,16 +63,16 @@ extend_name_with_sub_namespace(const std::string & name, const std::string & sub
   return name_with_sub_namespace;
 }
 
-template<typename MessageT, typename Alloc, typename PublisherT>
+template<typename MessageT, typename AllocatorT, typename PublisherT>
 std::shared_ptr<PublisherT>
 Node::create_publisher(
   const std::string & topic_name,
   size_t qos_history_depth,
-  const PublisherOptions<Alloc> & options)
+  const PublisherOptionsWithAllocator<AllocatorT> & options)
 {
-  std::shared_ptr<Alloc> allocator = options.allocator;
+  std::shared_ptr<AllocatorT> allocator = options.allocator;
   if (!allocator) {
-    allocator = std::make_shared<Alloc>();
+    allocator = std::make_shared<AllocatorT>();
   }
   rmw_qos_profile_t qos_profile = options.qos_profile;
   qos_profile.depth = qos_history_depth;
@@ -93,7 +93,7 @@ Node::create_publisher(
       break;
   }
 
-  return rclcpp::create_publisher<MessageT, Alloc, PublisherT>(
+  return rclcpp::create_publisher<MessageT, AllocatorT, PublisherT>(
     this->node_topics_.get(),
     extend_name_with_sub_namespace(topic_name, this->get_sub_namespace()),
     qos_profile,
@@ -108,7 +108,7 @@ Node::create_publisher(
   std::shared_ptr<Alloc> allocator,
   IntraProcessSetting use_intra_process_comm)
 {
-  PublisherOptions<Alloc> pub_options;
+  PublisherOptionsWithAllocator<Alloc> pub_options;
   pub_options.allocator = allocator;
   pub_options.use_intra_process_comm = use_intra_process_comm;
   return this->create_publisher<MessageT, Alloc, PublisherT>(
@@ -121,7 +121,7 @@ Node::create_publisher(
   const std::string & topic_name, const rmw_qos_profile_t & qos_profile,
   std::shared_ptr<Alloc> allocator, IntraProcessSetting use_intra_process_comm)
 {
-  PublisherOptions<Alloc> pub_options;
+  PublisherOptionsWithAllocator<Alloc> pub_options;
   pub_options.qos_profile = qos_profile;
   pub_options.allocator = allocator;
   pub_options.use_intra_process_comm = use_intra_process_comm;
@@ -132,23 +132,23 @@ Node::create_publisher(
 template<
   typename MessageT,
   typename CallbackT,
-  typename Alloc,
+  typename AllocatorT,
   typename SubscriptionT>
 std::shared_ptr<SubscriptionT>
 Node::create_subscription(
   const std::string & topic_name,
   CallbackT && callback,
   size_t qos_history_depth,
-  const SubscriptionOptions<Alloc> & options,
+  const SubscriptionOptionsWithAllocator<AllocatorT> & options,
   typename rclcpp::message_memory_strategy::MessageMemoryStrategy<
-    typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, Alloc>::SharedPtr
+    typename rclcpp::subscription_traits::has_message_type<CallbackT>::type, AllocatorT>::SharedPtr
   msg_mem_strat)
 {
   using CallbackMessageT = typename rclcpp::subscription_traits::has_message_type<CallbackT>::type;
 
-  std::shared_ptr<Alloc> allocator = options.allocator;
+  std::shared_ptr<AllocatorT> allocator = options.allocator;
   if (!allocator) {
-    allocator = std::make_shared<Alloc>();
+    allocator = std::make_shared<AllocatorT>();
   }
 
   rmw_qos_profile_t qos_profile = options.qos_profile;
@@ -156,7 +156,7 @@ Node::create_subscription(
 
   if (!msg_mem_strat) {
     using rclcpp::message_memory_strategy::MessageMemoryStrategy;
-    msg_mem_strat = MessageMemoryStrategy<CallbackMessageT, Alloc>::create_default();
+    msg_mem_strat = MessageMemoryStrategy<CallbackMessageT, AllocatorT>::create_default();
   }
 
   bool use_intra_process;
@@ -175,7 +175,8 @@ Node::create_subscription(
       break;
   }
 
-  return rclcpp::create_subscription<MessageT, CallbackT, Alloc, CallbackMessageT, SubscriptionT>(
+  return rclcpp::create_subscription<
+    MessageT, CallbackT, AllocatorT, CallbackMessageT, SubscriptionT>(
     this->node_topics_.get(),
     extend_name_with_sub_namespace(topic_name, this->get_sub_namespace()),
     std::forward<CallbackT>(callback),
@@ -205,7 +206,7 @@ Node::create_subscription(
   std::shared_ptr<Alloc> allocator,
   IntraProcessSetting use_intra_process_comm)
 {
-  SubscriptionOptions<Alloc> sub_options;
+  SubscriptionOptionsWithAllocator<Alloc> sub_options;
   sub_options.qos_profile = qos_profile;
   sub_options.callback_group = group;
   sub_options.ignore_local_publications = ignore_local_publications;
@@ -234,7 +235,7 @@ Node::create_subscription(
   std::shared_ptr<Alloc> allocator,
   IntraProcessSetting use_intra_process_comm)
 {
-  SubscriptionOptions<Alloc> sub_options;
+  SubscriptionOptionsWithAllocator<Alloc> sub_options;
   sub_options.callback_group = group;
   sub_options.ignore_local_publications = ignore_local_publications;
   sub_options.allocator = allocator;

--- a/rclcpp/include/rclcpp/publisher_options.hpp
+++ b/rclcpp/include/rclcpp/publisher_options.hpp
@@ -1,0 +1,39 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__PUBLISHER_OPTIONS_HPP_
+#define RCLCPP__PUBLISHER_OPTIONS_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/intra_process_setting.hpp"
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+
+/// Structure containing optional configuration for Publishers.
+template<typename Alloc = std::allocator<void>>
+struct PublisherOptions
+{
+  rmw_qos_profile_t qos_profile = rmw_qos_profile_default;
+  std::shared_ptr<Alloc> allocator = nullptr;
+  IntraProcessSetting use_intra_process_comm = IntraProcessSetting::NodeDefault;
+};
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__PUBLISHER_OPTIONS_HPP_

--- a/rclcpp/include/rclcpp/publisher_options.hpp
+++ b/rclcpp/include/rclcpp/publisher_options.hpp
@@ -29,8 +29,11 @@ namespace rclcpp
 template<typename Alloc = std::allocator<void>>
 struct PublisherOptions
 {
+  /// The quality of service profile to pass on to the rmw implementation.
   rmw_qos_profile_t qos_profile = rmw_qos_profile_default;
+  /// Optional custom allocator.
   std::shared_ptr<Alloc> allocator = nullptr;
+  /// Setting to explicitly set intraprocess communications.
   IntraProcessSetting use_intra_process_comm = IntraProcessSetting::NodeDefault;
 };
 

--- a/rclcpp/include/rclcpp/publisher_options.hpp
+++ b/rclcpp/include/rclcpp/publisher_options.hpp
@@ -26,16 +26,18 @@ namespace rclcpp
 {
 
 /// Structure containing optional configuration for Publishers.
-template<typename Alloc = std::allocator<void>>
-struct PublisherOptions
+template<typename Allocator>
+struct PublisherOptionsWithAllocator
 {
   /// The quality of service profile to pass on to the rmw implementation.
   rmw_qos_profile_t qos_profile = rmw_qos_profile_default;
   /// Optional custom allocator.
-  std::shared_ptr<Alloc> allocator = nullptr;
+  std::shared_ptr<Allocator> allocator = nullptr;
   /// Setting to explicitly set intraprocess communications.
   IntraProcessSetting use_intra_process_comm = IntraProcessSetting::NodeDefault;
 };
+
+using PublisherOptions = PublisherOptionsWithAllocator<std::allocator<void>>;
 
 }  // namespace rclcpp
 

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -1,0 +1,41 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__SUBSCRIPTION_OPTIONS_HPP_
+#define RCLCPP__SUBSCRIPTION_OPTIONS_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/intra_process_setting.hpp"
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+
+/// Structure containing optional configuration for Subscriptions.
+template<typename Alloc = std::allocator<void>>
+struct SubscriptionOptions
+{
+  rmw_qos_profile_t qos_profile = rmw_qos_profile_default;
+  bool ignore_local_publications = false;
+  rclcpp::callback_group::CallbackGroup::SharedPtr callback_group = nullptr;
+  std::shared_ptr<Alloc> allocator = nullptr;
+  IntraProcessSetting use_intra_process_comm = IntraProcessSetting::NodeDefault;
+};
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__SUBSCRIPTION_OPTIONS_HPP_

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -26,8 +26,8 @@ namespace rclcpp
 {
 
 /// Structure containing optional configuration for Subscriptions.
-template<typename Alloc = std::allocator<void>>
-struct SubscriptionOptions
+template<typename Allocator>
+struct SubscriptionOptionsWithAllocator
 {
   /// The quality of service profile to pass on to the rmw implementation.
   rmw_qos_profile_t qos_profile = rmw_qos_profile_default;
@@ -36,10 +36,12 @@ struct SubscriptionOptions
   /// The callback group for this subscription. NULL to use the default callback group.
   rclcpp::callback_group::CallbackGroup::SharedPtr callback_group = nullptr;
   /// Optional custom allocator.
-  std::shared_ptr<Alloc> allocator = nullptr;
+  std::shared_ptr<Allocator> allocator = nullptr;
   /// Setting to explicitly set intraprocess communications.
   IntraProcessSetting use_intra_process_comm = IntraProcessSetting::NodeDefault;
 };
+
+using SubscriptionOptions = SubscriptionOptionsWithAllocator<std::allocator<void>>;
 
 }  // namespace rclcpp
 

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -29,10 +29,15 @@ namespace rclcpp
 template<typename Alloc = std::allocator<void>>
 struct SubscriptionOptions
 {
+  /// The quality of service profile to pass on to the rmw implementation.
   rmw_qos_profile_t qos_profile = rmw_qos_profile_default;
+  /// True to ignore local publications.
   bool ignore_local_publications = false;
+  /// The callback group for this subscription. NULL to use the default callback group.
   rclcpp::callback_group::CallbackGroup::SharedPtr callback_group = nullptr;
+  /// Optional custom allocator.
   std::shared_ptr<Alloc> allocator = nullptr;
+  /// Setting to explicitly set intraprocess communications.
   IntraProcessSetting use_intra_process_comm = IntraProcessSetting::NodeDefault;
 };
 

--- a/rclcpp/test/test_pub_sub_option_interface.cpp
+++ b/rclcpp/test/test_pub_sub_option_interface.cpp
@@ -42,8 +42,8 @@ protected:
 };
 
 TEST_F(TestPubSubOptionAPI, check_for_ambiguous) {
-  rclcpp::PublisherOptions<> pub_options;
-  rclcpp::SubscriptionOptions<> sub_options;
+  rclcpp::PublisherOptions pub_options;
+  rclcpp::SubscriptionOptions sub_options;
 
   auto topic_only_pub = node->create_publisher<test_msgs::msg::Empty>(
     "topic_only");

--- a/rclcpp/test/test_pub_sub_option_interface.cpp
+++ b/rclcpp/test/test_pub_sub_option_interface.cpp
@@ -1,0 +1,57 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "test_msgs/msg/empty.hpp"
+
+class TestPublisher : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void SetUp()
+  {
+    node = std::make_shared<rclcpp::Node>("my_node", "/ns");
+  }
+
+  void TearDown()
+  {
+    node.reset();
+  }
+
+  rclcpp::Node::SharedPtr node;
+};
+
+/*
+   Testing construction and destruction.
+ */
+TEST_F(TestPublisher, construction_and_destruction) {
+  rclcpp::PublisherOptions<> pub_options;
+  auto publisher = node->create_publisher<test_msgs::msg::Empty>("topic", 5, pub_options);
+
+  rclcpp::SubscriptionOptions<> sub_options;
+  auto subscription = node->create_subscription<test_msgs::msg::Empty>(
+    "topic",
+    [](std::shared_ptr<test_msgs::msg::Empty> test_msg) {(void) test_msg;},
+    5,
+    sub_options);
+}

--- a/rclcpp/test/test_pub_sub_option_interface.cpp
+++ b/rclcpp/test/test_pub_sub_option_interface.cpp
@@ -20,7 +20,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "test_msgs/msg/empty.hpp"
 
-class TestPublisher : public ::testing::Test
+class TestPubSubOptionAPI : public ::testing::Test
 {
 protected:
   static void SetUpTestCase()
@@ -41,17 +41,30 @@ protected:
   rclcpp::Node::SharedPtr node;
 };
 
-/*
-   Testing construction and destruction.
- */
-TEST_F(TestPublisher, construction_and_destruction) {
+TEST_F(TestPubSubOptionAPI, check_for_ambiguous) {
   rclcpp::PublisherOptions<> pub_options;
-  auto publisher = node->create_publisher<test_msgs::msg::Empty>("topic", 5, pub_options);
-
   rclcpp::SubscriptionOptions<> sub_options;
-  auto subscription = node->create_subscription<test_msgs::msg::Empty>(
-    "topic",
+
+  auto topic_only_pub = node->create_publisher<test_msgs::msg::Empty>(
+    "topic_only");
+  auto topic_depth_pub = node->create_publisher<test_msgs::msg::Empty>(
+    "topic_depth",
+    10);
+  auto all_options_pub = node->create_publisher<test_msgs::msg::Empty>(
+    "topic_options",
+    10,
+    pub_options);
+
+  auto topic_only_sub = node->create_subscription<test_msgs::msg::Empty>(
+    "topic_only",
+    [](std::shared_ptr<test_msgs::msg::Empty> test_msg) {(void) test_msg;});
+  auto topic_depth_sub = node->create_subscription<test_msgs::msg::Empty>(
+    "topic_depth",
     [](std::shared_ptr<test_msgs::msg::Empty> test_msg) {(void) test_msg;},
-    5,
+    10);
+  auto all_options_sub = node->create_subscription<test_msgs::msg::Empty>(
+    "topic_options",
+    [](std::shared_ptr<test_msgs::msg::Empty> test_msg) {(void) test_msg;},
+    10,
     sub_options);
 }

--- a/rclcpp/test/test_pub_sub_option_interface.cpp
+++ b/rclcpp/test/test_pub_sub_option_interface.cpp
@@ -57,14 +57,14 @@ TEST_F(TestPubSubOptionAPI, check_for_ambiguous) {
 
   auto topic_only_sub = node->create_subscription<test_msgs::msg::Empty>(
     "topic_only",
-    [](std::shared_ptr<test_msgs::msg::Empty> test_msg) {(void) test_msg;});
+    [](std::shared_ptr<test_msgs::msg::Empty>) {});
   auto topic_depth_sub = node->create_subscription<test_msgs::msg::Empty>(
     "topic_depth",
-    [](std::shared_ptr<test_msgs::msg::Empty> test_msg) {(void) test_msg;},
+    [](std::shared_ptr<test_msgs::msg::Empty>) {},
     10);
   auto all_options_sub = node->create_subscription<test_msgs::msg::Empty>(
     "topic_options",
-    [](std::shared_ptr<test_msgs::msg::Empty> test_msg) {(void) test_msg;},
+    [](std::shared_ptr<test_msgs::msg::Empty>) {},
     10,
     sub_options);
 }


### PR DESCRIPTION
Adds new PublisherOptions and SubscriptionOptions classes, with new Publisher and Subscriber constructors to accept them.

QoS event callbacks will be put into these Options structs - so this is the only API change needed for QoS event callbacks.

Signed-off-by: Emerson Knapp <eknapp@amazon.com>