### PR TITLE
Rename action state transitions

### DIFF
--- a/rclcpp_action/include/rclcpp_action/server.hpp
+++ b/rclcpp_action/include/rclcpp_action/server.hpp
@@ -360,7 +360,7 @@ protected:
       if (goal_handle) {
         resp = handle_cancel_(goal_handle);
         if (CancelResponse::ACCEPT == resp) {
-          goal_handle->_set_canceling();
+          goal_handle->_request_cancel();
         }
       }
     }

--- a/rclcpp_action/include/rclcpp_action/server.hpp
+++ b/rclcpp_action/include/rclcpp_action/server.hpp
@@ -360,7 +360,7 @@ protected:
       if (goal_handle) {
         resp = handle_cancel_(goal_handle);
         if (CancelResponse::ACCEPT == resp) {
-          goal_handle->_request_cancel();
+          goal_handle->_cancel_goal();
         }
       }
     }

--- a/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
+++ b/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
@@ -80,27 +80,27 @@ protected:
   /// \internal
   RCLCPP_ACTION_PUBLIC
   void
-  _set_aborted();
+  _abort();
 
   /// \internal
   RCLCPP_ACTION_PUBLIC
   void
-  _set_succeeded();
+  _succeed();
 
   /// \internal
   RCLCPP_ACTION_PUBLIC
   void
-  _set_canceling();
+  _request_cancel();
 
   /// \internal
   RCLCPP_ACTION_PUBLIC
   void
-  _set_canceled();
+  _cancel();
 
   /// \internal
   RCLCPP_ACTION_PUBLIC
   void
-  _set_executing();
+  _execute();
 
   /// Transition the goal to canceled state if it never reached a terminal state.
   /// \internal
@@ -165,9 +165,9 @@ public:
    * \param[in] result_msg the final result to send to clients.
    */
   void
-  set_aborted(typename ActionT::Result::SharedPtr result_msg)
+  abort(typename ActionT::Result::SharedPtr result_msg)
   {
-    _set_aborted();
+    _abort();
     auto response = std::make_shared<typename ActionT::Impl::GetResultService::Response>();
     response->status = action_msgs::msg::GoalStatus::STATUS_ABORTED;
     response->result = *result_msg;
@@ -185,9 +185,9 @@ public:
    * \param[in] result_msg the final result to send to clients.
    */
   void
-  set_succeeded(typename ActionT::Result::SharedPtr result_msg)
+  succeed(typename ActionT::Result::SharedPtr result_msg)
   {
-    _set_succeeded();
+    _succeed();
     auto response = std::make_shared<typename ActionT::Impl::GetResultService::Response>();
     response->status = action_msgs::msg::GoalStatus::STATUS_SUCCEEDED;
     response->result = *result_msg;
@@ -205,9 +205,9 @@ public:
    * \param[in] result_msg the final result to send to clients.
    */
   void
-  set_canceled(typename ActionT::Result::SharedPtr result_msg)
+  cancel(typename ActionT::Result::SharedPtr result_msg)
   {
-    _set_canceled();
+    _cancel();
     auto response = std::make_shared<typename ActionT::Impl::GetResultService::Response>();
     response->status = action_msgs::msg::GoalStatus::STATUS_CANCELED;
     response->result = *result_msg;
@@ -221,9 +221,9 @@ public:
    * \throws rclcpp::exceptions::RCLError If the goal is in any state besides executing.
    */
   void
-  set_executing()
+  execute()
   {
-    _set_executing();
+    _execute();
     on_executing_(uuid_);
   }
 

--- a/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
+++ b/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
@@ -90,12 +90,12 @@ protected:
   /// \internal
   RCLCPP_ACTION_PUBLIC
   void
-  _request_cancel();
+  _cancel_goal();
 
   /// \internal
   RCLCPP_ACTION_PUBLIC
   void
-  _cancel();
+  _canceled();
 
   /// \internal
   RCLCPP_ACTION_PUBLIC
@@ -205,9 +205,9 @@ public:
    * \param[in] result_msg the final result to send to clients.
    */
   void
-  cancel(typename ActionT::Result::SharedPtr result_msg)
+  canceled(typename ActionT::Result::SharedPtr result_msg)
   {
-    _cancel();
+    _canceled();
     auto response = std::make_shared<typename ActionT::Impl::GetResultService::Response>();
     response->status = action_msgs::msg::GoalStatus::STATUS_CANCELED;
     response->result = *result_msg;

--- a/rclcpp_action/src/server_goal_handle.cpp
+++ b/rclcpp_action/src/server_goal_handle.cpp
@@ -78,20 +78,20 @@ ServerGoalHandleBase::_succeed()
 }
 
 void
-ServerGoalHandleBase::_request_cancel()
+ServerGoalHandleBase::_cancel_goal()
 {
   std::lock_guard<std::mutex> lock(rcl_handle_mutex_);
-  rcl_ret_t ret = rcl_action_update_goal_state(rcl_handle_.get(), GOAL_EVENT_REQUEST_CANCEL);
+  rcl_ret_t ret = rcl_action_update_goal_state(rcl_handle_.get(), GOAL_EVENT_CANCEL_GOAL);
   if (RCL_RET_OK != ret) {
     rclcpp::exceptions::throw_from_rcl_error(ret);
   }
 }
 
 void
-ServerGoalHandleBase::_cancel()
+ServerGoalHandleBase::_canceled()
 {
   std::lock_guard<std::mutex> lock(rcl_handle_mutex_);
-  rcl_ret_t ret = rcl_action_update_goal_state(rcl_handle_.get(), GOAL_EVENT_CANCEL);
+  rcl_ret_t ret = rcl_action_update_goal_state(rcl_handle_.get(), GOAL_EVENT_CANCELED);
   if (RCL_RET_OK != ret) {
     rclcpp::exceptions::throw_from_rcl_error(ret);
   }
@@ -116,7 +116,7 @@ ServerGoalHandleBase::try_canceling() noexcept
   const bool is_cancelable = rcl_action_goal_handle_is_cancelable(rcl_handle_.get());
   if (is_cancelable) {
     // Transition to CANCELING
-    ret = rcl_action_update_goal_state(rcl_handle_.get(), GOAL_EVENT_REQUEST_CANCEL);
+    ret = rcl_action_update_goal_state(rcl_handle_.get(), GOAL_EVENT_CANCEL_GOAL);
     if (RCL_RET_OK != ret) {
       return false;
     }
@@ -131,7 +131,7 @@ ServerGoalHandleBase::try_canceling() noexcept
 
   // If it's canceling, cancel it
   if (GOAL_STATE_CANCELING == state) {
-    ret = rcl_action_update_goal_state(rcl_handle_.get(), GOAL_EVENT_CANCEL);
+    ret = rcl_action_update_goal_state(rcl_handle_.get(), GOAL_EVENT_CANCELED);
     return RCL_RET_OK == ret;
   }
 

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -364,7 +364,7 @@ TEST_F(TestServer, publish_status_canceled)
   send_goal_request(node, uuid);
   send_cancel_request(node, uuid);
 
-  received_handle->cancel(std::make_shared<Fibonacci::Result>());
+  received_handle->canceled(std::make_shared<Fibonacci::Result>());
 
   // 10 seconds
   const size_t max_tries = 10 * 1000 / 100;

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -364,7 +364,7 @@ TEST_F(TestServer, publish_status_canceled)
   send_goal_request(node, uuid);
   send_cancel_request(node, uuid);
 
-  received_handle->set_canceled(std::make_shared<Fibonacci::Result>());
+  received_handle->cancel(std::make_shared<Fibonacci::Result>());
 
   // 10 seconds
   const size_t max_tries = 10 * 1000 / 100;
@@ -419,7 +419,7 @@ TEST_F(TestServer, publish_status_succeeded)
     });
 
   send_goal_request(node, uuid);
-  received_handle->set_succeeded(std::make_shared<Fibonacci::Result>());
+  received_handle->succeed(std::make_shared<Fibonacci::Result>());
 
   // 10 seconds
   const size_t max_tries = 10 * 1000 / 100;
@@ -474,7 +474,7 @@ TEST_F(TestServer, publish_status_aborted)
     });
 
   send_goal_request(node, uuid);
-  received_handle->set_aborted(std::make_shared<Fibonacci::Result>());
+  received_handle->abort(std::make_shared<Fibonacci::Result>());
 
   // 10 seconds
   const size_t max_tries = 10 * 1000 / 100;
@@ -592,7 +592,7 @@ TEST_F(TestServer, get_result)
   // Send a result
   auto result = std::make_shared<Fibonacci::Result>();
   result->sequence = {5, 8, 13, 21};
-  received_handle->set_succeeded(result);
+  received_handle->succeed(result);
 
   // Wait for the result request to be received
   ASSERT_EQ(rclcpp::executor::FutureReturnCode::SUCCESS,
@@ -637,6 +637,6 @@ TEST_F(TestServer, deferred_execution)
 
   EXPECT_TRUE(received_handle->is_active());
   EXPECT_FALSE(received_handle->is_executing());
-  received_handle->set_executing();
+  received_handle->execute();
   EXPECT_TRUE(received_handle->is_executing());
 }


### PR DESCRIPTION
Now using active verbs as described in the design doc:

http://design.ros2.org/articles/actions.html#goal-states

Connects to ros2/rcl#399.