### PR TITLE
[WIP] Exception Generator function for implementing "from_rcl_error"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+
+*.swp
+
+tags

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .DS_Store
+
+*.swp
+
+tags

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-.DS_Store
-
-*.swp
-tags

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
 
 *.swp
-
 tags

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
 .DS_Store
-
-*.swp
-
-tags

--- a/rclcpp/src/rclcpp/exceptions.cpp
+++ b/rclcpp/src/rclcpp/exceptions.cpp
@@ -46,31 +46,11 @@ throw_from_rcl_error(
   const rcl_error_state_t * error_state,
   void (* reset_error)())
 {
-  if (RCL_RET_OK == ret) {
-    throw std::invalid_argument("ret is RCL_RET_OK");
-  }
-  if (!error_state) {
-    error_state = rcl_get_error_state();
-  }
-  if (!error_state) {
-    throw std::runtime_error("rcl error state is not set");
-  }
-  std::string formated_prefix = prefix;
-  if (!prefix.empty()) {
-    formated_prefix += ": ";
-  }
-  RCLErrorBase base_exc(ret, error_state);
-  if (reset_error) {
-    reset_error();
-  }
-  switch (ret) {
-    case RCL_RET_BAD_ALLOC:
-      throw RCLBadAlloc(base_exc);
-    case RCL_RET_INVALID_ARGUMENT:
-      throw RCLInvalidArgument(base_exc, formated_prefix);
-    default:
-      throw RCLError(base_exc, formated_prefix);
-  }
+  // We expect this to either throw a standard error,
+  // or to generate an error pointer (which is caught
+  // in err, and immediately thrown)
+  auto err = from_rcl_error(rt, prefix, error_state, reset_error);
+  std::rethrow_exception(err);
 }
 
 std::exception_ptr

--- a/rclcpp/src/rclcpp/exceptions.cpp
+++ b/rclcpp/src/rclcpp/exceptions.cpp
@@ -89,9 +89,9 @@ throw_from_rcl_error(
     if (!error_state) {
       return std::make_exception_ptr(std::runtime_error("rcl error state is not set"));
     }
-    std::string formated_prefix = prefix;
+    std::string formatted_prefix = prefix;
     if (!prefix.empty()) {
-      formated_prefix += ": ";
+      formatted_prefix += ": ";
     }
     RCLErrorBase base_exc(ret, error_state);
     if (reset_error) {
@@ -101,9 +101,9 @@ throw_from_rcl_error(
       case RCL_RET_BAD_ALLOC:
         return std::make_exception_ptr(RCLBadAlloc(base_exc));
       case RCL_RET_INVALID_ARGUMENT:
-        return std::make_exception_ptr(RCLInvalidArgument(base_exc, formated_prefix));
+        return std::make_exception_ptr(RCLInvalidArgument(base_exc, formatted_prefix));
       default:
-        return std::make_exception_ptr(RCLError(base_exc, formated_prefix));
+        return std::make_exception_ptr(RCLError(base_exc, formatted_prefix));
     }
   }
 

--- a/rclcpp/src/rclcpp/exceptions.cpp
+++ b/rclcpp/src/rclcpp/exceptions.cpp
@@ -73,39 +73,39 @@ throw_from_rcl_error(
   }
 }
 
-  std::exception_ptr
-  from_rcl_error(
-    rcl_ret_t ret,
-    const std::string & prefix,
-    const rcl_error_state_t * error_state,
-    void (* reset_error)())
-  {
-    if (RCL_RET_OK == ret) {
-      return std::make_exception_ptr(std::invalid_argument("ret is RCL_RET_OK"));
-    }
-    if (!error_state) {
-      error_state = rcl_get_error_state();
-    }
-    if (!error_state) {
-      return std::make_exception_ptr(std::runtime_error("rcl error state is not set"));
-    }
-    std::string formatted_prefix = prefix;
-    if (!prefix.empty()) {
-      formatted_prefix += ": ";
-    }
-    RCLErrorBase base_exc(ret, error_state);
-    if (reset_error) {
-      reset_error();
-    }
-    switch (ret) {
-      case RCL_RET_BAD_ALLOC:
-        return std::make_exception_ptr(RCLBadAlloc(base_exc));
-      case RCL_RET_INVALID_ARGUMENT:
-        return std::make_exception_ptr(RCLInvalidArgument(base_exc, formatted_prefix));
-      default:
-        return std::make_exception_ptr(RCLError(base_exc, formatted_prefix));
-    }
+std::exception_ptr
+from_rcl_error(
+  rcl_ret_t ret,
+  const std::string & prefix,
+  const rcl_error_state_t * error_state,
+  void (* reset_error)())
+{
+  if (RCL_RET_OK == ret) {
+    throw std::invalid_argument("ret is RCL_RET_OK");
   }
+  if (!error_state) {
+    error_state = rcl_get_error_state();
+  }
+  if (!error_state) {
+    throw std::runtime_error("rcl error state is not set");
+  }
+  std::string formatted_prefix = prefix;
+  if (!prefix.empty()) {
+    formatted_prefix += ": ";
+  }
+  RCLErrorBase base_exc(ret, error_state);
+  if (reset_error) {
+    reset_error();
+  }
+  switch (ret) {
+    case RCL_RET_BAD_ALLOC:
+      return std::make_exception_ptr(RCLBadAlloc(base_exc));
+    case RCL_RET_INVALID_ARGUMENT:
+      return std::make_exception_ptr(RCLInvalidArgument(base_exc, formatted_prefix));
+    default:
+      return std::make_exception_ptr(RCLError(base_exc, formatted_prefix));
+  }
+}
 
 RCLErrorBase::RCLErrorBase(rcl_ret_t ret, const rcl_error_state_t * error_state)
 : ret(ret), message(error_state->message), file(error_state->file), line(error_state->line_number),

--- a/rclcpp/src/rclcpp/exceptions.cpp
+++ b/rclcpp/src/rclcpp/exceptions.cpp
@@ -73,6 +73,40 @@ throw_from_rcl_error(
   }
 }
 
+  std::exception_ptr
+  from_rcl_error(
+    rcl_ret_t ret,
+    const std::string & prefix,
+    const rcl_error_state_t * error_state,
+    void (* reset_error)())
+  {
+    if (RCL_RET_OK == ret) {
+      return std::make_exception_ptr(std::invalid_argument("ret is RCL_RET_OK"));
+    }
+    if (!error_state) {
+      error_state = rcl_get_error_state();
+    }
+    if (!error_state) {
+      return std::make_exception_ptr(std::runtime_error("rcl error state is not set"));
+    }
+    std::string formated_prefix = prefix;
+    if (!prefix.empty()) {
+      formated_prefix += ": ";
+    }
+    RCLErrorBase base_exc(ret, error_state);
+    if (reset_error) {
+      reset_error();
+    }
+    switch (ret) {
+      case RCL_RET_BAD_ALLOC:
+        return std::make_exception_ptr(RCLBadAlloc(base_exc));
+      case RCL_RET_INVALID_ARGUMENT:
+        return std::make_exception_ptr(RCLInvalidArgument(base_exc, formated_prefix));
+      default:
+        return std::make_exception_ptr(RCLError(base_exc, formated_prefix));
+    }
+  }
+
 RCLErrorBase::RCLErrorBase(rcl_ret_t ret, const rcl_error_state_t * error_state)
 : ret(ret), message(error_state->message), file(error_state->file), line(error_state->line_number),
   formatted_message(rcl_get_error_string().str)

--- a/rclcpp/src/rclcpp/exceptions.cpp
+++ b/rclcpp/src/rclcpp/exceptions.cpp
@@ -39,20 +39,6 @@ NameValidationError::format_error(
   return msg;
 }
 
-void
-throw_from_rcl_error(
-  rcl_ret_t ret,
-  const std::string & prefix,
-  const rcl_error_state_t * error_state,
-  void (* reset_error)())
-{
-  // We expect this to either throw a standard error,
-  // or to generate an error pointer (which is caught
-  // in err, and immediately thrown)
-  auto err = from_rcl_error(rt, prefix, error_state, reset_error);
-  std::rethrow_exception(err);
-}
-
 std::exception_ptr
 from_rcl_error(
   rcl_ret_t ret,
@@ -85,6 +71,20 @@ from_rcl_error(
     default:
       return std::make_exception_ptr(RCLError(base_exc, formatted_prefix));
   }
+}
+
+void
+throw_from_rcl_error(
+  rcl_ret_t ret,
+  const std::string & prefix,
+  const rcl_error_state_t * error_state,
+  void (* reset_error)())
+{
+  // We expect this to either throw a standard error,
+  // or to generate an error pointer (which is caught
+  // in err, and immediately thrown)
+  auto err = from_rcl_error(ret, prefix, error_state, reset_error);
+  std::rethrow_exception(err);
 }
 
 RCLErrorBase::RCLErrorBase(rcl_ret_t ret, const rcl_error_state_t * error_state)


### PR DESCRIPTION
The only way I found to send along exceptions was to make the function wrap the generated exception in a pointer. Which means that you'd have to use std::rethrow_exception instead of just a simple throw to use it.

Still, is this about what you were looking for? And do you have any specific areas that need this functionality?

Connects to issue #647 

Signed-off-by: Jacob Hassold <jhassold@dcscorp.com>

