### PR TITLE
logging, remove_const before comparison

### DIFF
--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -95,7 +95,7 @@ def is_supported_feature_combination(feature_combination):
 #define RCLCPP_@(severity)@(suffix)(logger, @(''.join([p + ', ' for p in get_macro_parameters(feature_combination).keys()]))...) \
   do { \
     static_assert( \
-      ::std::is_same<typename std::remove_reference<std::remove_cv<decltype(logger)>::type>::type, \
+      ::std::is_same<typename std::remove_reference<typename std::remove_cv<decltype(logger)>::type>::type, \
       typename ::rclcpp::Logger>::value, \
       "First argument to logging macros must be an rclcpp::Logger"); \
     RCUTILS_LOG_@(severity)@(suffix)_NAMED( \

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -95,7 +95,7 @@ def is_supported_feature_combination(feature_combination):
 #define RCLCPP_@(severity)@(suffix)(logger, @(''.join([p + ', ' for p in get_macro_parameters(feature_combination).keys()]))...) \
   do { \
     static_assert( \
-      ::std::is_same<typename std::remove_reference<std::remove_const<decltype(logger)>::type>::type, \
+      ::std::is_same<typename std::remove_reference<std::remove_cv<decltype(logger)>::type>::type, \
       typename ::rclcpp::Logger>::value, \
       "First argument to logging macros must be an rclcpp::Logger"); \
     RCUTILS_LOG_@(severity)@(suffix)_NAMED( \

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -95,7 +95,7 @@ def is_supported_feature_combination(feature_combination):
 #define RCLCPP_@(severity)@(suffix)(logger, @(''.join([p + ', ' for p in get_macro_parameters(feature_combination).keys()]))...) \
   do { \
     static_assert( \
-      ::std::is_same<typename std::remove_reference<decltype(logger)>::type, \
+      ::std::is_same<typename std::remove_reference<std::remove_const<decltype(logger)>::type>::type, \
       typename ::rclcpp::Logger>::value, \
       "First argument to logging macros must be an rclcpp::Logger"); \
     RCUTILS_LOG_@(severity)@(suffix)_NAMED( \


### PR DESCRIPTION
This change removes the const value from the logger before
comparing with std::is_same.