### PR TITLE
use do { .. } while(0) around content of logging macros

### DIFF
--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -71,6 +71,9 @@ def is_supported_feature_combination(feature_combination):
 #else
 @[ for feature_combination in [fc for fc in feature_combinations if is_supported_feature_combination(fc)]]@
 @{suffix = get_suffix_from_features(feature_combination)}@
+// The RCLCPP_@(severity)@(suffix) macro is surrounded by do { .. } while (0)
+// to implement the standard C macro idiom to make the macro safe in all
+// contexts; see http://c-faq.com/cpp/multistmt.html for more information.
 /**
  * \def RCLCPP_@(severity)@(suffix)
  * Log a message with severity @(severity)@
@@ -90,18 +93,20 @@ def is_supported_feature_combination(feature_combination):
  * It also accepts a single argument of type std::string.
  */
 #define RCLCPP_@(severity)@(suffix)(logger, @(''.join([p + ', ' for p in get_macro_parameters(feature_combination).keys()]))...) \
-  static_assert( \
-    ::std::is_same<typename std::remove_reference<decltype(logger)>::type, \
-    typename ::rclcpp::Logger>::value, \
-    "First argument to logging macros must be an rclcpp::Logger"); \
-  RCUTILS_LOG_@(severity)@(suffix)_NAMED( \
+  do { \
+    static_assert( \
+      ::std::is_same<typename std::remove_reference<decltype(logger)>::type, \
+      typename ::rclcpp::Logger>::value, \
+      "First argument to logging macros must be an rclcpp::Logger"); \
+    RCUTILS_LOG_@(severity)@(suffix)_NAMED( \
 @{params = get_macro_parameters(feature_combination).keys()}@
 @[ if params]@
-@(''.join(['    ' + p + ', \\\n' for p in params]))@
+@(''.join(['      ' + p + ', \\\n' for p in params]))@
 @[ end if]@
-    logger.get_name(), \
-    rclcpp::get_c_string(RCLCPP_FIRST_ARG(__VA_ARGS__, "")), \
-      RCLCPP_ALL_BUT_FIRST_ARGS(__VA_ARGS__,""))
+      logger.get_name(), \
+      rclcpp::get_c_string(RCLCPP_FIRST_ARG(__VA_ARGS__, "")), \
+        RCLCPP_ALL_BUT_FIRST_ARGS(__VA_ARGS__,"")); \
+  } while (0)
 
 @[ end for]@
 #endif


### PR DESCRIPTION
Based on https://answers.ros.org/question/319004/rclcpp-logging-macros-not-a-single-expression/

Same as in [rcutils](https://github.com/ros2/rcutils/blob/9e1f5593763cfdc64f2e590dbafb0c316926f628/resource/logging_macros.h.em#L66-L75).

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6584)](http://ci.ros2.org/job/ci_linux/6584/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2922)](http://ci.ros2.org/job/ci_linux-aarch64/2922/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5401)](http://ci.ros2.org/job/ci_osx/5401/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=6404)](http://ci.ros2.org/job/ci_windows/6404/)