### PR TITLE
Replaced strncpy with memcpy

### DIFF
--- a/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
@@ -283,7 +283,7 @@ private:
   fixed_size_string(const char * str) const
   {
     FixedSizeString ret;
-    std::strncpy(ret.data(), str, ret.size());
+    std::memcpy(ret.data(), str, ret.size());
     return ret;
   }
 

--- a/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager_impl.hpp
@@ -30,8 +30,6 @@
 #include <unordered_map>
 #include <utility>
 
-#include "rcutils/snprintf.h"
-
 #include "rmw/validate_full_topic_name.h"
 
 #include "rclcpp/macros.hpp"
@@ -286,9 +284,11 @@ private:
   fixed_size_string(const char * str) const
   {
     FixedSizeString ret;
-    if (rcutils_snprintf(ret.data(), ret.size(), "%s", str) < 0) {
+    size_t size = std::strlen(str) + 1;
+    if (size > ret.size()) {
       throw std::runtime_error("failed to copy topic name");
     }
+    std::memcpy(ret.data(), str, size);
     return ret;
   }
   struct strcmp_wrapper


### PR DESCRIPTION
Solves [windows ci warning](https://ci.ros2.org/job/ci_windows/6441/warnings43Result/), as requested [here](https://github.com/ros2/rclcpp/pull/671#issuecomment-480141337).