### PR TITLE
Fixup timer

### DIFF
--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -49,7 +49,8 @@ public:
     rclcpp::Context::SharedPtr context);
 
   RCLCPP_PUBLIC
-  ~TimerBase();
+  virtual
+  ~TimerBase() = default;
 
   /// \throws anything rclcpp::exceptions::throw_from_rcl_error can throw
   RCLCPP_PUBLIC
@@ -139,10 +140,14 @@ public:
   }
 
   /// Default destructor.
-  virtual ~GenericTimer()
+  ~GenericTimer() override
   {
-    // Stop the timer from running.
-    cancel();
+    try {
+      // Stop the timer from running.
+      cancel();
+    } catch (std::exception & ex) {
+      RCUTILS_LOG_ERROR_NAMED("rclcpp", "Failed to cancel timer: %s", ex.what());
+    }
   }
 
   void

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -51,6 +51,7 @@ public:
   RCLCPP_PUBLIC
   ~TimerBase();
 
+  /// \throws anything rclcpp::exceptions::throw_from_rcl_error can throw
   RCLCPP_PUBLIC
   void
   cancel();
@@ -65,6 +66,7 @@ public:
   bool
   is_canceled();
 
+  /// \throws anything rclcpp::exceptions::throw_from_rcl_error can throw
   RCLCPP_PUBLIC
   void
   reset();
@@ -77,8 +79,11 @@ public:
   std::shared_ptr<const rcl_timer_t>
   get_timer_handle();
 
-  /// Check how long the timer has until its next scheduled callback.
-  /** \return A std::chrono::duration representing the relative time until the next callback. */
+  /**
+   * \brief Check how long the timer has until its next scheduled callback
+   * \return A std::chrono::duration representing the relative time until the next callback.
+   * \throws anything rclcpp::exceptions::throw_from_rcl_error can throw
+   */
   RCLCPP_PUBLIC
   std::chrono::nanoseconds
   time_until_trigger();
@@ -92,6 +97,7 @@ public:
    * This function expects its caller to immediately trigger the callback after this function,
    * since it maintains the last time the callback was triggered.
    * \return True if the timer needs to trigger.
+   * \throws anything rclcpp::exceptions::throw_from_rcl_error can throw
    */
   RCLCPP_PUBLIC
   bool is_ready();

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -46,7 +46,7 @@ public:
   explicit TimerBase(
     Clock::SharedPtr clock,
     std::chrono::nanoseconds period,
-    rclcpp::Context::SharedPtr context);
+    Context::SharedPtr context);
 
   RCLCPP_PUBLIC
   virtual
@@ -133,8 +133,7 @@ public:
    */
   explicit GenericTimer(
     Clock::SharedPtr clock, std::chrono::nanoseconds period, FunctorT && callback,
-    rclcpp::Context::SharedPtr context
-  )
+    Context::SharedPtr context)
   : TimerBase(clock, period, context), callback_(std::forward<FunctorT>(callback))
   {
   }
@@ -216,7 +215,7 @@ public:
   WallTimer(
     std::chrono::nanoseconds period,
     FunctorT && callback,
-    rclcpp::Context::SharedPtr context)
+    Context::SharedPtr context)
   : GenericTimer<FunctorT>(
       std::make_shared<Clock>(RCL_STEADY_TIME), period, std::move(callback), context)
   {}

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -18,24 +18,21 @@
 #include <chrono>
 #include <functional>
 #include <memory>
-#include <sstream>
-#include <thread>
 #include <type_traits>
+#include <stdexcept>
 #include <utility>
 
 #include "rclcpp/clock.hpp"
 #include "rclcpp/context.hpp"
+#include "rclcpp/exceptions.hpp"
 #include "rclcpp/function_traits.hpp"
 #include "rclcpp/macros.hpp"
-#include "rclcpp/rate.hpp"
 #include "rclcpp/utilities.hpp"
 #include "rclcpp/visibility_control.hpp"
 
-#include "rcl/error_handling.h"
 #include "rcl/timer.h"
 
-#include "rmw/error_handling.h"
-#include "rmw/rmw.h"
+#include "rcutils/logging_macros.h"
 
 namespace rclcpp
 {

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -18,8 +18,8 @@
 #include <chrono>
 #include <functional>
 #include <memory>
-#include <type_traits>
 #include <stdexcept>
+#include <type_traits>
 #include <utility>
 
 #include "rclcpp/clock.hpp"

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -153,12 +153,13 @@ public:
   void
   execute_callback() override
   {
-    rcl_ret_t ret = rcl_timer_call(timer_handle_.get());
+    const auto ret = rcl_timer_call(timer_handle_.get());
     if (ret == RCL_RET_TIMER_CANCELED) {
       return;
     }
     if (ret != RCL_RET_OK) {
-      throw std::runtime_error("Failed to notify timer that callback occurred");
+      exceptions::throw_from_rcl_error(ret,
+        "Failed to notify timer that callback occurred");
     }
     execute_callback_delegate<>();
   }

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -81,9 +81,9 @@ bool
 TimerBase::is_canceled()
 {
   bool is_canceled = false;
-  rcl_ret_t ret = rcl_timer_is_canceled(timer_handle_.get(), &is_canceled);
+  const auto ret = rcl_timer_is_canceled(timer_handle_.get(), &is_canceled);
   if (ret != RCL_RET_OK) {
-    rclcpp::exceptions::throw_from_rcl_error(ret, "Couldn't get timer cancelled state");
+    exceptions::throw_from_rcl_error(ret, "Couldn't get timer cancelled state");
   }
   return is_canceled;
 }

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -22,14 +22,17 @@
 
 #include "rcl/error_handling.h"
 
+namespace rclcpp
+{
+
 TimerBase::TimerBase(
-  rclcpp::Clock::SharedPtr clock,
+  Clock::SharedPtr clock,
   std::chrono::nanoseconds period,
-  rclcpp::Context::SharedPtr context)
+  Context::SharedPtr context)
 : clock_(clock), timer_handle_(nullptr)
 {
   if (nullptr == context) {
-    context = rclcpp::contexts::default_context::get_global_default_context();
+    context = contexts::default_context::get_global_default_context();
   }
 
   auto rcl_context = context->get_rcl_context();
@@ -108,10 +111,10 @@ TimerBase::time_until_trigger()
 {
   int64_t time_until_next_call = 0;
   const auto res = rcl_timer_get_time_until_next_call(timer_handle_.get(),
-                                                      &time_until_next_call);
+      &time_until_next_call);
   if (RCL_RET_OK != res) {
     exceptions::throw_from_rcl_error(res,
-            "Timer could not get time until next call");
+      "Timer could not get time until next call");
   }
   return std::chrono::nanoseconds(time_until_next_call);
 }
@@ -121,3 +124,5 @@ TimerBase::get_timer_handle()
 {
   return timer_handle_;
 }
+
+}  // namespace rclcpp

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -66,8 +66,9 @@ TimerBase::TimerBase(
 void
 TimerBase::cancel()
 {
-  if (rcl_timer_cancel(timer_handle_.get()) != RCL_RET_OK) {
-    throw std::runtime_error(std::string("Couldn't cancel timer: ") + rcl_get_error_string().str);
+  const auto res = rcl_timer_cancel(timer_handle_.get());
+  if (RCL_RET_OK != res) {
+    exceptions::throw_from_rcl_error(res, "Couldn't cancel timer");
   }
 }
 
@@ -85,8 +86,9 @@ TimerBase::is_canceled()
 void
 TimerBase::reset()
 {
-  if (rcl_timer_reset(timer_handle_.get()) != RCL_RET_OK) {
-    throw std::runtime_error(std::string("Couldn't reset timer: ") + rcl_get_error_string().str);
+  const auto res = rcl_timer_reset(timer_handle_.get());
+  if (RCL_RET_OK != res) {
+    exceptions::throw_from_rcl_error(res, "Couldn't reset timer");
   }
 }
 
@@ -94,8 +96,9 @@ bool
 TimerBase::is_ready()
 {
   bool ready = false;
-  if (rcl_timer_is_ready(timer_handle_.get(), &ready) != RCL_RET_OK) {
-    throw std::runtime_error(std::string("Failed to check timer: ") + rcl_get_error_string().str);
+  const auto res = rcl_timer_is_ready(timer_handle_.get(), &ready);
+  if (RCL_RET_OK != res) {
+    exceptions::throw_from_rcl_error(res, "Failed to check timer");
   }
   return ready;
 }
@@ -104,12 +107,11 @@ std::chrono::nanoseconds
 TimerBase::time_until_trigger()
 {
   int64_t time_until_next_call = 0;
-  if (rcl_timer_get_time_until_next_call(timer_handle_.get(),
-    &time_until_next_call) != RCL_RET_OK)
-  {
-    throw std::runtime_error(
-            std::string("Timer could not get time until next call: ") +
-            rcl_get_error_string().str);
+  const auto res = rcl_timer_get_time_until_next_call(timer_handle_.get(),
+                                                      &time_until_next_call);
+  if (RCL_RET_OK != res) {
+    exceptions::throw_from_rcl_error(res,
+            "Timer could not get time until next call");
   }
   return std::chrono::nanoseconds(time_until_next_call);
 }

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -63,9 +63,6 @@ TimerBase::TimerBase(
   }
 }
 
-TimerBase::~TimerBase()
-{}
-
 void
 TimerBase::cancel()
 {

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -14,6 +14,8 @@
 
 #include "rclcpp/timer.hpp"
 
+#include <memory>
+
 #include "rclcpp/contexts/default_context.hpp"
 #include "rclcpp/exceptions.hpp"
 

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -38,7 +38,7 @@ TimerBase::TimerBase(
   auto rcl_context = context->get_rcl_context();
 
   timer_handle_ = std::shared_ptr<rcl_timer_t>(
-    new rcl_timer_t, [ = ](rcl_timer_t * timer) mutable
+    new rcl_timer_t, [ = ](rcl_timer_t * timer) mutable noexcept
     {
       if (rcl_timer_fini(timer) != RCL_RET_OK) {
         RCUTILS_LOG_ERROR_NAMED(

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -14,16 +14,13 @@
 
 #include "rclcpp/timer.hpp"
 
-#include <chrono>
-#include <string>
-#include <memory>
-
 #include "rclcpp/contexts/default_context.hpp"
 #include "rclcpp/exceptions.hpp"
 
 #include "rcutils/logging_macros.h"
 
-using rclcpp::TimerBase;
+
+#include "rcl/error_handling.h"
 
 TimerBase::TimerBase(
   rclcpp::Clock::SharedPtr clock,


### PR DESCRIPTION
Clean up minor issues in the timer.hpp/cpp

Most notably:
* possible exception in the d'tor of the GenericTimer
* missing virtual keywork in the d'tor of the BaseTimer
* move from custom exception raising to the generic interface of 'throw_from_rcl_error'

[!] Someone with the right permissions must trigger the ci