### PR TITLE
Implement callbacks for liveliness and deadline QoS events

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -65,6 +65,7 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/parameter_map.cpp
   src/rclcpp/parameter_service.cpp
   src/rclcpp/publisher.cpp
+  src/rclcpp/qos_event.cpp
   src/rclcpp/service.cpp
   src/rclcpp/signal_handler.cpp
   src/rclcpp/subscription.cpp

--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -22,6 +22,7 @@
 
 #include "rclcpp/client.hpp"
 #include "rclcpp/service.hpp"
+#include "rclcpp/publisher.hpp"
 #include "rclcpp/subscription.hpp"
 #include "rclcpp/timer.hpp"
 #include "rclcpp/visibility_control.hpp"
@@ -91,6 +92,10 @@ public:
 
 protected:
   RCLCPP_DISABLE_COPY(CallbackGroup)
+
+  RCLCPP_PUBLIC
+  void
+  add_publisher(const rclcpp::PublisherBase::SharedPtr publisher_ptr);
 
   RCLCPP_PUBLIC
   void

--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -21,8 +21,8 @@
 #include <vector>
 
 #include "rclcpp/client.hpp"
-#include "rclcpp/service.hpp"
 #include "rclcpp/publisher.hpp"
+#include "rclcpp/service.hpp"
 #include "rclcpp/subscription.hpp"
 #include "rclcpp/timer.hpp"
 #include "rclcpp/visibility_control.hpp"

--- a/rclcpp/include/rclcpp/create_publisher.hpp
+++ b/rclcpp/include/rclcpp/create_publisher.hpp
@@ -31,6 +31,8 @@ create_publisher(
   rclcpp::node_interfaces::NodeTopicsInterface * node_topics,
   const std::string & topic_name,
   const rmw_qos_profile_t & qos_profile,
+  const PublisherEventCallbacks & event_callbacks,
+  rclcpp::callback_group::CallbackGroup::SharedPtr group,
   bool use_intra_process_comms,
   std::shared_ptr<AllocatorT> allocator)
 {
@@ -39,10 +41,12 @@ create_publisher(
 
   auto pub = node_topics->create_publisher(
     topic_name,
-    rclcpp::create_publisher_factory<MessageT, AllocatorT, PublisherT>(allocator),
+    rclcpp::create_publisher_factory<MessageT, AllocatorT, PublisherT>(event_callbacks, allocator),
     publisher_options,
     use_intra_process_comms);
-  node_topics->add_publisher(pub);
+
+  node_topics->add_publisher(pub, group);
+
   return std::dynamic_pointer_cast<PublisherT>(pub);
 }
 

--- a/rclcpp/include/rclcpp/create_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_subscription.hpp
@@ -38,6 +38,7 @@ create_subscription(
   const std::string & topic_name,
   CallbackT && callback,
   const rmw_qos_profile_t & qos_profile,
+  const SubscriptionEventCallbacks & event_callbacks,
   rclcpp::callback_group::CallbackGroup::SharedPtr group,
   bool ignore_local_publications,
   bool use_intra_process_comms,
@@ -52,7 +53,10 @@ create_subscription(
 
   auto factory = rclcpp::create_subscription_factory
     <MessageT, CallbackT, AllocatorT, CallbackMessageT, SubscriptionT>(
-    std::forward<CallbackT>(callback), msg_mem_strat, allocator);
+    std::forward<CallbackT>(callback),
+    event_callbacks,
+    msg_mem_strat,
+    allocator);
 
   auto sub = node_topics->create_subscription(
     topic_name,

--- a/rclcpp/include/rclcpp/exceptions.hpp
+++ b/rclcpp/include/rclcpp/exceptions.hpp
@@ -111,9 +111,8 @@ public:
  * \throws RCLErrorBase some child class exception based on ret
  */
 RCLCPP_PUBLIC
-[[noreturn]]
 void
-throw_from_rcl_error(
+throw_from_rcl_error [[noreturn]] (
   rcl_ret_t ret,
   const std::string & prefix = "",
   const rcl_error_state_t * error_state = nullptr,

--- a/rclcpp/include/rclcpp/exceptions.hpp
+++ b/rclcpp/include/rclcpp/exceptions.hpp
@@ -111,6 +111,7 @@ public:
  * \throws RCLErrorBase some child class exception based on ret
  */
 RCLCPP_PUBLIC
+[[noreturn]]
 void
 throw_from_rcl_error(
   rcl_ret_t ret,

--- a/rclcpp/include/rclcpp/exceptions.hpp
+++ b/rclcpp/include/rclcpp/exceptions.hpp
@@ -110,6 +110,7 @@ public:
  * \throws std::runtime_error if the rcl_get_error_state returns 0
  * \throws RCLErrorBase some child class exception based on ret
  */
+/* *INDENT-OFF* */  // Uncrustify cannot yet understand [[noreturn]] properly
 RCLCPP_PUBLIC
 void
 throw_from_rcl_error [[noreturn]] (
@@ -117,6 +118,7 @@ throw_from_rcl_error [[noreturn]] (
   const std::string & prefix = "",
   const rcl_error_state_t * error_state = nullptr,
   void (* reset_error)() = rcl_reset_error);
+/* *INDENT-ON* */
 
 class RCLErrorBase
 {

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -51,6 +51,7 @@ public:
   virtual size_t number_of_ready_subscriptions() const = 0;
   virtual size_t number_of_ready_services() const = 0;
   virtual size_t number_of_ready_clients() const = 0;
+  virtual size_t number_of_ready_events() const = 0;
   virtual size_t number_of_ready_timers() const = 0;
   virtual size_t number_of_guard_conditions() const = 0;
   virtual size_t number_of_waitables() const = 0;

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -1120,13 +1120,16 @@ public:
   const NodeOptions &
   get_node_options() const;
 
-  /// Manually assert that this Node is alive (for RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE)
+  /// Manually assert that this Node is alive (for RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE).
   /**
    * If the rmw Liveliness policy is set to RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE, the creator
    * of this node may manually call `assert_liveliness` at some point in time to signal to the rest
    * of the system that this Node is still alive.
+   *
+   * \return `true` if the liveliness was asserted successfully, otherwise `false`
    */
   RCLCPP_PUBLIC
+  RCUTILS_WARN_UNUSED
   bool
   assert_liveliness() const;
 

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -1120,6 +1120,16 @@ public:
   const NodeOptions &
   get_node_options() const;
 
+  /// Manually assert that this Node is alive (for RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE)
+  /**
+   * If the rmw Liveliness policy is set to RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE, the creator
+   * of this node may manually call `assert_liveliness` at some point in time to signal to the rest
+   * of the system that this Node is still alive.
+   */
+  RCLCPP_PUBLIC
+  bool
+  assert_liveliness() const;
+
 protected:
   /// Construct a sub-node, which will extend the namespace of all entities created with it.
   /**

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -97,6 +97,8 @@ Node::create_publisher(
     this->node_topics_.get(),
     extend_name_with_sub_namespace(topic_name, this->get_sub_namespace()),
     qos_profile,
+    options.event_callbacks,
+    options.callback_group,
     use_intra_process,
     allocator);
 }
@@ -181,6 +183,7 @@ Node::create_subscription(
     extend_name_with_sub_namespace(topic_name, this->get_sub_namespace()),
     std::forward<CallbackT>(callback),
     qos_profile,
+    options.event_callbacks,
     options.callback_group,
     options.ignore_local_publications,
     use_intra_process,

--- a/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
@@ -88,6 +88,11 @@ public:
 
   RCLCPP_PUBLIC
   virtual
+  bool
+  assert_liveliness() const;
+
+  RCLCPP_PUBLIC
+  virtual
   rclcpp::callback_group::CallbackGroup::SharedPtr
   create_callback_group(rclcpp::callback_group::CallbackGroupType group_type);
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
@@ -102,7 +102,7 @@ public:
   std::shared_ptr<const rcl_node_t>
   get_shared_rcl_node_handle() const = 0;
 
-  /// Manually assert that this Node is alive (for RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE)
+  /// Manually assert that this Node is alive (for RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE).
   RCLCPP_PUBLIC
   virtual
   bool

--- a/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
@@ -102,6 +102,12 @@ public:
   std::shared_ptr<const rcl_node_t>
   get_shared_rcl_node_handle() const = 0;
 
+  /// Manually assert that this Node is alive (for RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE)
+  RCLCPP_PUBLIC
+  virtual
+  bool
+  assert_liveliness() const = 0;
+
   /// Create and return a callback group.
   RCLCPP_PUBLIC
   virtual

--- a/rclcpp/include/rclcpp/node_interfaces/node_topics.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_topics.hpp
@@ -58,7 +58,8 @@ public:
   virtual
   void
   add_publisher(
-    rclcpp::PublisherBase::SharedPtr publisher);
+    rclcpp::PublisherBase::SharedPtr publisher,
+    rclcpp::callback_group::CallbackGroup::SharedPtr callback_group);
 
   RCLCPP_PUBLIC
   virtual

--- a/rclcpp/include/rclcpp/node_interfaces/node_topics_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_topics_interface.hpp
@@ -57,7 +57,8 @@ public:
   virtual
   void
   add_publisher(
-    rclcpp::PublisherBase::SharedPtr publisher) = 0;
+    rclcpp::PublisherBase::SharedPtr publisher,
+    rclcpp::callback_group::CallbackGroup::SharedPtr callback_group) = 0;
 
   RCLCPP_PUBLIC
   virtual

--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -127,6 +127,7 @@ public:
       "parameter_events",
       std::forward<CallbackT>(callback),
       rmw_qos_profile_default,
+      SubscriptionEventCallbacks(),
       nullptr,  // group,
       false,  // ignore_local_publications,
       false,  // use_intra_process_comms_,

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -21,9 +21,9 @@
 #include <functional>
 #include <iostream>
 #include <memory>
-#include <vector>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "rcl/error_handling.h"
 #include "rcl/publisher.h"
@@ -43,8 +43,8 @@ namespace rclcpp
 
 namespace node_interfaces
 {
-// NOTE(emersonknapp) Forward declaration avoids including node_base_interface.hpp which causes
-// circular inclusion from callback_group.hpp
+// Forward declaration avoids including node_base_interface.hpp
+// which causes circular inclusion from callback_group.hpp
 class NodeBaseInterface;
 // Forward declaration is used for friend statement.
 class NodeTopicsInterface;
@@ -121,8 +121,10 @@ public:
   const rcl_publisher_t *
   get_publisher_handle() const;
 
+  /// Get all the QoS event handlers associated with this publisher.
+  /** \return The vector of QoS event handlers. */
   RCLCPP_PUBLIC
-  const std::vector<std::shared_ptr<QOSEventHandlerBase>> &
+  const std::vector<std::shared_ptr<rclcpp::QOSEventHandlerBase>> &
   get_event_handlers() const;
 
   /// Get subscription count
@@ -137,13 +139,16 @@ public:
   size_t
   get_intra_process_subscription_count() const;
 
-  /// Manually assert that this Publisher is alive (for RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC)
+  /// Manually assert that this Publisher is alive (for RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC).
   /**
    * If the rmw Liveliness policy is set to RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC, the creator
    * of this publisher may manually call `assert_liveliness` at some point in time to signal to the
    * rest of the system that this Node is still alive.
+   *
+   * \return `true` if the liveliness was asserted successfully, otherwise `false`
    */
   RCLCPP_PUBLIC
+  RCUTILS_WARN_UNUSED
   bool
   assert_liveliness() const;
 
@@ -214,7 +219,7 @@ protected:
   rcl_publisher_t publisher_handle_ = rcl_get_zero_initialized_publisher();
   rcl_publisher_t intra_process_publisher_handle_ = rcl_get_zero_initialized_publisher();
 
-  std::vector<std::shared_ptr<QOSEventHandlerBase>> event_handlers_;
+  std::vector<std::shared_ptr<rclcpp::QOSEventHandlerBase>> event_handlers_;
 
   using IntraProcessManagerWeakPtr =
     std::weak_ptr<rclcpp::intra_process_manager::IntraProcessManager>;

--- a/rclcpp/include/rclcpp/publisher_factory.hpp
+++ b/rclcpp/include/rclcpp/publisher_factory.hpp
@@ -91,8 +91,12 @@ create_publisher_factory(
       auto message_alloc = std::make_shared<typename PublisherT::MessageAlloc>(*allocator.get());
       publisher_options.allocator = allocator::get_rcl_allocator<MessageT>(*message_alloc.get());
 
-      return std::make_shared<PublisherT>(node_base, topic_name, publisher_options,
-        event_callbacks, message_alloc);
+      return std::make_shared<PublisherT>(
+        node_base,
+        topic_name,
+        publisher_options,
+        event_callbacks,
+        message_alloc);
     };
 
   // function to add a publisher to the intra process manager

--- a/rclcpp/include/rclcpp/publisher_factory.hpp
+++ b/rclcpp/include/rclcpp/publisher_factory.hpp
@@ -75,13 +75,15 @@ struct PublisherFactory
 /// Return a PublisherFactory with functions setup for creating a PublisherT<MessageT, Alloc>.
 template<typename MessageT, typename Alloc, typename PublisherT>
 PublisherFactory
-create_publisher_factory(std::shared_ptr<Alloc> allocator)
+create_publisher_factory(
+  const PublisherEventCallbacks & event_callbacks,
+  std::shared_ptr<Alloc> allocator)
 {
   PublisherFactory factory;
 
   // factory function that creates a MessageT specific PublisherT
   factory.create_typed_publisher =
-    [allocator](
+    [event_callbacks, allocator](
     rclcpp::node_interfaces::NodeBaseInterface * node_base,
     const std::string & topic_name,
     rcl_publisher_options_t & publisher_options) -> std::shared_ptr<PublisherT>
@@ -89,7 +91,8 @@ create_publisher_factory(std::shared_ptr<Alloc> allocator)
       auto message_alloc = std::make_shared<typename PublisherT::MessageAlloc>(*allocator.get());
       publisher_options.allocator = allocator::get_rcl_allocator<MessageT>(*message_alloc.get());
 
-      return std::make_shared<PublisherT>(node_base, topic_name, publisher_options, message_alloc);
+      return std::make_shared<PublisherT>(node_base, topic_name, publisher_options,
+               event_callbacks, message_alloc);
     };
 
   // function to add a publisher to the intra process manager

--- a/rclcpp/include/rclcpp/publisher_factory.hpp
+++ b/rclcpp/include/rclcpp/publisher_factory.hpp
@@ -92,7 +92,7 @@ create_publisher_factory(
       publisher_options.allocator = allocator::get_rcl_allocator<MessageT>(*message_alloc.get());
 
       return std::make_shared<PublisherT>(node_base, topic_name, publisher_options,
-               event_callbacks, message_alloc);
+        event_callbacks, message_alloc);
     };
 
   // function to add a publisher to the intra process manager

--- a/rclcpp/include/rclcpp/publisher_options.hpp
+++ b/rclcpp/include/rclcpp/publisher_options.hpp
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+#include "rclcpp/qos_event.hpp"
+#include "rclcpp/callback_group.hpp"
 #include "rclcpp/intra_process_setting.hpp"
 #include "rclcpp/visibility_control.hpp"
 
@@ -29,10 +31,12 @@ namespace rclcpp
 template<typename Allocator>
 struct PublisherOptionsWithAllocator
 {
+  PublisherEventCallbacks event_callbacks;
   /// The quality of service profile to pass on to the rmw implementation.
   rmw_qos_profile_t qos_profile = rmw_qos_profile_default;
+  rclcpp::callback_group::CallbackGroup::SharedPtr callback_group;
   /// Optional custom allocator.
-  std::shared_ptr<Allocator> allocator = nullptr;
+  std::shared_ptr<Allocator> allocator;
   /// Setting to explicitly set intraprocess communications.
   IntraProcessSetting use_intra_process_comm = IntraProcessSetting::NodeDefault;
 };

--- a/rclcpp/include/rclcpp/publisher_options.hpp
+++ b/rclcpp/include/rclcpp/publisher_options.hpp
@@ -19,9 +19,9 @@
 #include <string>
 #include <vector>
 
-#include "rclcpp/qos_event.hpp"
 #include "rclcpp/callback_group.hpp"
 #include "rclcpp/intra_process_setting.hpp"
+#include "rclcpp/qos_event.hpp"
 #include "rclcpp/visibility_control.hpp"
 
 namespace rclcpp

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -56,17 +56,21 @@ struct SubscriptionEventCallbacks
 class QOSEventHandlerBase : public Waitable
 {
 public:
+  RCLCPP_PUBLIC
   virtual ~QOSEventHandlerBase();
 
   /// Get the number of ready events
+  RCLCPP_PUBLIC
   size_t
   get_number_of_ready_events() override;
 
   /// Add the Waitable to a wait set.
+  RCLCPP_PUBLIC
   bool
   add_to_wait_set(rcl_wait_set_t * wait_set) override;
 
   /// Check if the Waitable is ready.
+  RCLCPP_PUBLIC
   bool
   is_ready(rcl_wait_set_t * wait_set) override;
 

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Open Source Robotics Foundation, Inc.
+// Copyright 2019 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,10 +21,9 @@
 
 #include "rcutils/logging_macros.h"
 
-#include "rclcpp/waitable.hpp"
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/function_traits.hpp"
-
+#include "rclcpp/waitable.hpp"
 
 namespace rclcpp
 {
@@ -39,14 +38,14 @@ using QOSDeadlineOfferedCallbackType = std::function<void (QOSDeadlineOfferedInf
 using QOSLivelinessChangedCallbackType = std::function<void (QOSLivelinessChangedInfo &)>;
 using QOSLivelinessLostCallbackType = std::function<void (QOSLivelinessLostInfo &)>;
 
-/// Contains callbacks for various types of events a Publisher can receive from the middleware
+/// Contains callbacks for various types of events a Publisher can receive from the middleware.
 struct PublisherEventCallbacks
 {
   QOSDeadlineOfferedCallbackType deadline_callback;
   QOSLivelinessLostCallbackType liveliness_callback;
 };
 
-/// Contains callbacks for non-message events that a Subscriber can receive from the middleware
+/// Contains callbacks for non-message events that a Subscription can receive from the middleware.
 struct SubscriptionEventCallbacks
 {
   QOSDeadlineRequestedCallbackType deadline_callback;
@@ -78,7 +77,6 @@ protected:
   rcl_event_t event_handle_;
   size_t wait_set_event_index_;
 };
-
 
 template<typename EventCallbackT>
 class QOSEventHandler : public QOSEventHandlerBase

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -1,0 +1,124 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__QOS_EVENT_HPP_
+#define RCLCPP__QOS_EVENT_HPP_
+
+#include <functional>
+
+#include "rcl/error_handling.h"
+
+#include "rcutils/logging_macros.h"
+
+#include "rclcpp/waitable.hpp"
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/function_traits.hpp"
+
+
+namespace rclcpp
+{
+
+using QOSDeadlineRequestedInfo = rmw_requested_deadline_missed_status_t;
+using QOSDeadlineOfferedInfo = rmw_offered_deadline_missed_status_t;
+using QOSLivelinessChangedInfo = rmw_liveliness_changed_status_t;
+using QOSLivelinessLostInfo = rmw_liveliness_lost_status_t;
+
+using QOSDeadlineRequestedCallbackType = std::function<void (QOSDeadlineRequestedInfo &)>;
+using QOSDeadlineOfferedCallbackType = std::function<void (QOSDeadlineOfferedInfo &)>;
+using QOSLivelinessChangedCallbackType = std::function<void (QOSLivelinessChangedInfo &)>;
+using QOSLivelinessLostCallbackType = std::function<void (QOSLivelinessLostInfo &)>;
+
+/// Contains callbacks for various types of events a Publisher can receive from the middleware
+struct PublisherEventCallbacks
+{
+  QOSDeadlineOfferedCallbackType deadline_callback;
+  QOSLivelinessLostCallbackType liveliness_callback;
+};
+
+/// Contains callbacks for non-message events that a Subscriber can receive from the middleware
+struct SubscriptionEventCallbacks
+{
+  QOSDeadlineRequestedCallbackType deadline_callback;
+  QOSLivelinessChangedCallbackType liveliness_callback;
+};
+
+class QOSEventHandlerBase : public Waitable
+{
+public:
+  virtual ~QOSEventHandlerBase();
+
+  /// Get the number of ready events
+  size_t
+  get_number_of_ready_events() override;
+
+  /// Add the Waitable to a wait set.
+  bool
+  add_to_wait_set(rcl_wait_set_t * wait_set) override;
+
+  /// Check if the Waitable is ready.
+  bool
+  is_ready(rcl_wait_set_t * wait_set) override;
+
+protected:
+  rcl_event_t event_handle_;
+  size_t wait_set_event_index_;
+};
+
+
+template<typename EventCallbackT>
+class QOSEventHandler : public QOSEventHandlerBase
+{
+public:
+  template<typename InitFuncT, typename ParentHandleT, typename EventTypeEnum>
+  QOSEventHandler(
+    const EventCallbackT & callback,
+    InitFuncT init_func,
+    ParentHandleT parent_handle,
+    EventTypeEnum event_type)
+  : event_callback_(callback)
+  {
+    event_handle_ = rcl_get_zero_initialized_event();
+    rcl_ret_t ret = init_func(&event_handle_, parent_handle, event_type);
+    if (ret != RCL_RET_OK) {
+      rclcpp::exceptions::throw_from_rcl_error(ret, "could not create event");
+    }
+  }
+
+  /// Execute any entities of the Waitable that are ready.
+  void
+  execute() override
+  {
+    EventCallbackInfoT callback_info;
+
+    rcl_ret_t ret = rcl_take_event(&event_handle_, &callback_info);
+    if (ret != RCL_RET_OK) {
+      RCUTILS_LOG_ERROR_NAMED(
+        "rclcpp",
+        "Couldn't take event info: %s", rcl_get_error_string().str);
+      return;
+    }
+
+    event_callback_(callback_info);
+  }
+
+private:
+  using EventCallbackInfoT = typename std::remove_reference<typename
+      rclcpp::function_traits::function_traits<EventCallbackT>::template argument_type<0>>::type;
+
+  EventCallbackT event_callback_;
+};
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__QOS_EVENT_HPP_

--- a/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
@@ -430,6 +430,15 @@ public:
     return number_of_services;
   }
 
+  size_t number_of_ready_events() const
+  {
+    size_t number_of_events = 0;
+    for (auto waitable : waitable_handles_) {
+      number_of_events += waitable->get_number_of_ready_events();
+    }
+    return number_of_events;
+  }
+
   size_t number_of_ready_clients() const
   {
     size_t number_of_clients = client_handles_.size();

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -21,9 +21,9 @@
 #include <functional>
 #include <iostream>
 #include <memory>
-#include <vector>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "rcl/error_handling.h"
 #include "rcl/subscription.h"
@@ -102,8 +102,10 @@ public:
   virtual const std::shared_ptr<rcl_subscription_t>
   get_intra_process_subscription_handle() const;
 
+  /// Get all the QoS event handlers associated with this subscription.
+  /** \return The vector of QoS event handlers. */
   RCLCPP_PUBLIC
-  const std::vector<std::shared_ptr<QOSEventHandlerBase>> &
+  const std::vector<std::shared_ptr<rclcpp::QOSEventHandlerBase>> &
   get_event_handlers() const;
 
   /// Borrow a new message.
@@ -175,7 +177,7 @@ protected:
   size_t wait_set_subscription_index_;
   bool subscription_ready_;
 
-  std::vector<std::shared_ptr<QOSEventHandlerBase>> event_handlers_;
+  std::vector<std::shared_ptr<rclcpp::QOSEventHandlerBase>> event_handlers_;
 
   bool use_intra_process_;
   std::shared_ptr<rcl_subscription_t> intra_process_subscription_handle_;

--- a/rclcpp/include/rclcpp/subscription_factory.hpp
+++ b/rclcpp/include/rclcpp/subscription_factory.hpp
@@ -75,6 +75,7 @@ template<
 SubscriptionFactory
 create_subscription_factory(
   CallbackT && callback,
+  const SubscriptionEventCallbacks & event_callbacks,
   typename rclcpp::message_memory_strategy::MessageMemoryStrategy<
     CallbackMessageT, Alloc>::SharedPtr
   msg_mem_strat,
@@ -91,7 +92,7 @@ create_subscription_factory(
 
   // factory function that creates a MessageT specific SubscriptionT
   factory.create_typed_subscription =
-    [allocator, msg_mem_strat, any_subscription_callback, message_alloc](
+    [allocator, msg_mem_strat, any_subscription_callback, event_callbacks, message_alloc](
     rclcpp::node_interfaces::NodeBaseInterface * node_base,
     const std::string & topic_name,
     rcl_subscription_options_t & subscription_options
@@ -109,6 +110,7 @@ create_subscription_factory(
         topic_name,
         subscription_options,
         any_subscription_callback,
+        event_callbacks,
         msg_mem_strat);
       auto sub_base_ptr = std::dynamic_pointer_cast<SubscriptionBase>(sub);
       return sub_base_ptr;

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+#include "rclcpp/qos_event.hpp"
+#include "rclcpp/callback_group.hpp"
 #include "rclcpp/intra_process_setting.hpp"
 #include "rclcpp/visibility_control.hpp"
 
@@ -29,14 +31,15 @@ namespace rclcpp
 template<typename Allocator>
 struct SubscriptionOptionsWithAllocator
 {
+  SubscriptionEventCallbacks event_callbacks;
   /// The quality of service profile to pass on to the rmw implementation.
   rmw_qos_profile_t qos_profile = rmw_qos_profile_default;
   /// True to ignore local publications.
   bool ignore_local_publications = false;
   /// The callback group for this subscription. NULL to use the default callback group.
-  rclcpp::callback_group::CallbackGroup::SharedPtr callback_group = nullptr;
+  rclcpp::callback_group::CallbackGroup::SharedPtr callback_group;
   /// Optional custom allocator.
-  std::shared_ptr<Allocator> allocator = nullptr;
+  std::shared_ptr<Allocator> allocator;
   /// Setting to explicitly set intraprocess communications.
   IntraProcessSetting use_intra_process_comm = IntraProcessSetting::NodeDefault;
 };

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -19,9 +19,9 @@
 #include <string>
 #include <vector>
 
-#include "rclcpp/qos_event.hpp"
 #include "rclcpp/callback_group.hpp"
 #include "rclcpp/intra_process_setting.hpp"
+#include "rclcpp/qos_event.hpp"
 #include "rclcpp/visibility_control.hpp"
 
 namespace rclcpp

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -61,6 +61,17 @@ public:
   size_t
   get_number_of_ready_clients();
 
+  /// Get the number of ready events
+  /**
+   * Returns a value of 0 by default.
+   * This should be overridden if the Waitable contains one or more events.
+   * \return The number of events associated with the Waitable.
+   */
+  RCLCPP_PUBLIC
+  virtual
+  size_t
+  get_number_of_ready_events();
+
   /// Get the number of ready services
   /**
    * Returns a value of 0 by default.

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -99,6 +99,7 @@ public:
   /**
    * \param[in] wait_set A handle to the wait set to add the Waitable to.
    * \return `true` if the Waitable is added successfully, `false` otherwise.
+   * \throws rclcpp::execptions::RCLError from rcl_wait_set_add_*()
    */
   RCLCPP_PUBLIC
   virtual

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -61,7 +61,7 @@ Executor::Executor(const ExecutorArgs & args)
   context_ = args.context;
 
   ret = rcl_wait_set_init(&wait_set_, 0, 2, 0, 0, 0, 0,
-      context_->get_rcl_context().get(), allocator);
+    context_->get_rcl_context().get(), allocator);
   if (RCL_RET_OK != ret) {
     RCUTILS_LOG_ERROR_NAMED(
       "rclcpp",

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -60,7 +60,8 @@ Executor::Executor(const ExecutorArgs & args)
   // Store the context for later use.
   context_ = args.context;
 
-  ret = rcl_wait_set_init(&wait_set_, 0, 2, 0, 0, 0, context_->get_rcl_context().get(), allocator);
+  ret = rcl_wait_set_init(&wait_set_, 0, 2, 0, 0, 0, 0,
+      context_->get_rcl_context().get(), allocator);
   if (RCL_RET_OK != ret) {
     RCUTILS_LOG_ERROR_NAMED(
       "rclcpp",
@@ -434,7 +435,8 @@ Executor::wait_for_work(std::chrono::nanoseconds timeout)
   rcl_ret_t ret = rcl_wait_set_resize(
     &wait_set_, memory_strategy_->number_of_ready_subscriptions(),
     memory_strategy_->number_of_guard_conditions(), memory_strategy_->number_of_ready_timers(),
-    memory_strategy_->number_of_ready_clients(), memory_strategy_->number_of_ready_services());
+    memory_strategy_->number_of_ready_clients(), memory_strategy_->number_of_ready_services(),
+    memory_strategy_->number_of_ready_events());
   if (RCL_RET_OK != ret) {
     throw std::runtime_error(
             std::string("Couldn't resize the wait set : ") + rcl_get_error_string().str);

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -60,8 +60,11 @@ Executor::Executor(const ExecutorArgs & args)
   // Store the context for later use.
   context_ = args.context;
 
-  ret = rcl_wait_set_init(&wait_set_, 0, 2, 0, 0, 0, 0,
-    context_->get_rcl_context().get(), allocator);
+  ret = rcl_wait_set_init(
+    &wait_set_,
+    0, 2, 0, 0, 0, 0,
+    context_->get_rcl_context().get(),
+    allocator);
   if (RCL_RET_OK != ret) {
     RCUTILS_LOG_ERROR_NAMED(
       "rclcpp",

--- a/rclcpp/src/rclcpp/graph_listener.cpp
+++ b/rclcpp/src/rclcpp/graph_listener.cpp
@@ -79,6 +79,7 @@ GraphListener::start_if_not_started()
       0,  // number_of_timers
       0,  // number_of_clients
       0,  // number_of_services
+      0,  // number_of_events
       this->parent_context_->get_rcl_context().get(),
       rcl_get_default_allocator());
     if (RCL_RET_OK != ret) {
@@ -145,7 +146,7 @@ GraphListener::run_loop()
     const size_t node_graph_interfaces_size = node_graph_interfaces_.size();
     // Add 2 for the interrupt and shutdown guard conditions
     if (wait_set_.size_of_guard_conditions < (node_graph_interfaces_size + 2)) {
-      ret = rcl_wait_set_resize(&wait_set_, 0, node_graph_interfaces_size + 2, 0, 0, 0);
+      ret = rcl_wait_set_resize(&wait_set_, 0, node_graph_interfaces_size + 2, 0, 0, 0, 0);
       if (RCL_RET_OK != ret) {
         throw_from_rcl_error(ret, "failed to resize wait set");
       }

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -470,3 +470,9 @@ Node::get_node_options() const
 {
   return this->node_options_;
 }
+
+bool
+Node::assert_liveliness() const
+{
+  return node_base_->assert_liveliness();
+}

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -197,6 +197,12 @@ NodeBase::get_shared_rcl_node_handle() const
   return node_handle_;
 }
 
+bool
+NodeBase::assert_liveliness() const
+{
+  return RCL_RET_OK == rcl_node_assert_liveliness(get_rcl_node_handle());
+}
+
 rclcpp::callback_group::CallbackGroup::SharedPtr
 NodeBase::create_callback_group(rclcpp::callback_group::CallbackGroupType group_type)
 {

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -75,6 +75,8 @@ NodeParameters::NodeParameters(
       node_topics.get(),
       "parameter_events",
       parameter_event_qos_profile,
+      PublisherEventCallbacks(),
+      nullptr,
       use_intra_process,
       allocator);
   }

--- a/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
@@ -64,11 +64,22 @@ NodeTopics::create_publisher(
 
 void
 NodeTopics::add_publisher(
-  rclcpp::PublisherBase::SharedPtr publisher)
+  rclcpp::PublisherBase::SharedPtr publisher,
+  rclcpp::callback_group::CallbackGroup::SharedPtr callback_group)
 {
-  // The publisher is not added to a callback group or anthing like that for now.
-  // It may be stored within the NodeTopics class or the NodeBase class in the future.
-  (void)publisher;
+  // Assign to a group.
+  if (callback_group) {
+    if (!node_base_->callback_group_in_node(callback_group)) {
+      throw std::runtime_error("Cannot create publisher, callback group not in node.");
+    }
+  } else {
+    callback_group = node_base_->get_default_callback_group();
+  }
+
+  for (auto & publisher_event : publisher->get_event_handlers()) {
+    callback_group->add_waitable(publisher_event);
+  }
+
   // Notify the executor that a new publisher was created using the parent Node.
   {
     auto notify_guard_condition_lock = node_base_->acquire_notify_guard_condition_lock();
@@ -114,9 +125,13 @@ NodeTopics::add_subscription(
       // TODO(jacquelinekay): use custom exception
       throw std::runtime_error("Cannot create subscription, callback group not in node.");
     }
-    callback_group->add_subscription(subscription);
   } else {
-    node_base_->get_default_callback_group()->add_subscription(subscription);
+    callback_group = node_base_->get_default_callback_group();
+  }
+
+  callback_group->add_subscription(subscription);
+  for (auto & subscription_event : subscription->get_event_handlers()) {
+    callback_group->add_waitable(subscription_event);
   }
 
   // Notify the executor that a new subscription was created using the parent Node.

--- a/rclcpp/src/rclcpp/publisher.cpp
+++ b/rclcpp/src/rclcpp/publisher.cpp
@@ -20,9 +20,9 @@
 #include <iostream>
 #include <memory>
 #include <mutex>
-#include <vector>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "rcl_interfaces/msg/intra_process_message.hpp"
 #include "rcutils/logging_macros.h"
@@ -31,10 +31,10 @@
 #include "rclcpp/allocator/allocator_common.hpp"
 #include "rclcpp/allocator/allocator_deleter.hpp"
 #include "rclcpp/exceptions.hpp"
+#include "rclcpp/expand_topic_or_service_name.hpp"
 #include "rclcpp/intra_process_manager.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/node.hpp"
-#include "rclcpp/expand_topic_or_service_name.hpp"
 
 using rclcpp::PublisherBase;
 

--- a/rclcpp/src/rclcpp/publisher.cpp
+++ b/rclcpp/src/rclcpp/publisher.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <memory>
 #include <mutex>
+#include <vector>
 #include <sstream>
 #include <string>
 
@@ -81,6 +82,9 @@ PublisherBase::PublisherBase(
 
 PublisherBase::~PublisherBase()
 {
+  // must fini the events before fini-ing the publisher
+  event_handlers_.clear();
+
   if (rcl_publisher_fini(&intra_process_publisher_handle_, rcl_node_handle_.get()) != RCL_RET_OK) {
     RCUTILS_LOG_ERROR_NAMED(
       "rclcpp",
@@ -154,6 +158,12 @@ PublisherBase::get_publisher_handle() const
   return &publisher_handle_;
 }
 
+const std::vector<std::shared_ptr<rclcpp::QOSEventHandlerBase>> &
+PublisherBase::get_event_handlers() const
+{
+  return event_handlers_;
+}
+
 size_t
 PublisherBase::get_subscription_count() const
 {
@@ -206,6 +216,12 @@ PublisherBase::get_actual_qos() const
     throw std::runtime_error(msg);
   }
   return *qos;
+}
+
+bool
+PublisherBase::assert_liveliness() const
+{
+  return RCL_RET_OK == rcl_publisher_assert_liveliness(&publisher_handle_);
 }
 
 bool

--- a/rclcpp/src/rclcpp/qos_event.cpp
+++ b/rclcpp/src/rclcpp/qos_event.cpp
@@ -1,0 +1,59 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/qos_event.hpp"
+
+
+namespace rclcpp
+{
+
+QOSEventHandlerBase::~QOSEventHandlerBase()
+{
+  if (rcl_event_fini(&event_handle_) != RCL_RET_OK) {
+    RCUTILS_LOG_ERROR_NAMED(
+      "rclcpp",
+      "Error in destruction of rcl event handle: %s", rcl_get_error_string().str);
+    rcl_reset_error();
+  }
+}
+
+/// Get the number of ready events
+size_t
+QOSEventHandlerBase::get_number_of_ready_events()
+{
+  return 1;
+}
+
+/// Add the Waitable to a wait set.
+bool
+QOSEventHandlerBase::add_to_wait_set(rcl_wait_set_t * wait_set)
+{
+  if (rcl_wait_set_add_event(wait_set, &event_handle_, &wait_set_event_index_) != RCL_RET_OK) {
+    RCUTILS_LOG_ERROR_NAMED(
+      "rclcpp",
+      "Couldn't add event to wait set: %s", rcl_get_error_string().str);
+    return false;
+  }
+
+  return true;
+}
+
+/// Check if the Waitable is ready.
+bool
+QOSEventHandlerBase::is_ready(rcl_wait_set_t * wait_set)
+{
+  return wait_set->events[wait_set_event_index_] == &event_handle_;
+}
+
+}  // namespace rclcpp

--- a/rclcpp/src/rclcpp/qos_event.cpp
+++ b/rclcpp/src/rclcpp/qos_event.cpp
@@ -38,13 +38,11 @@ QOSEventHandlerBase::get_number_of_ready_events()
 bool
 QOSEventHandlerBase::add_to_wait_set(rcl_wait_set_t * wait_set)
 {
-  if (rcl_wait_set_add_event(wait_set, &event_handle_, &wait_set_event_index_) != RCL_RET_OK) {
-    RCUTILS_LOG_ERROR_NAMED(
-      "rclcpp",
-      "Couldn't add event to wait set: %s", rcl_get_error_string().str);
+  rcl_ret_t ret = rcl_wait_set_add_event(wait_set, &event_handle_, &wait_set_event_index_);
+  if (RCL_RET_OK != ret) {
+    exceptions::throw_from_rcl_error(ret, "Couldn't add event to wait set");
     return false;
   }
-
   return true;
 }
 

--- a/rclcpp/src/rclcpp/qos_event.cpp
+++ b/rclcpp/src/rclcpp/qos_event.cpp
@@ -41,7 +41,6 @@ QOSEventHandlerBase::add_to_wait_set(rcl_wait_set_t * wait_set)
   rcl_ret_t ret = rcl_wait_set_add_event(wait_set, &event_handle_, &wait_set_event_index_);
   if (RCL_RET_OK != ret) {
     exceptions::throw_from_rcl_error(ret, "Couldn't add event to wait set");
-    return false;
   }
   return true;
 }

--- a/rclcpp/src/rclcpp/qos_event.cpp
+++ b/rclcpp/src/rclcpp/qos_event.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Open Source Robotics Foundation, Inc.
+// Copyright 2019 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 
 #include "rclcpp/qos_event.hpp"
 
-
 namespace rclcpp
 {
 
@@ -28,7 +27,7 @@ QOSEventHandlerBase::~QOSEventHandlerBase()
   }
 }
 
-/// Get the number of ready events
+/// Get the number of ready events.
 size_t
 QOSEventHandlerBase::get_number_of_ready_events()
 {

--- a/rclcpp/src/rclcpp/subscription.cpp
+++ b/rclcpp/src/rclcpp/subscription.cpp
@@ -17,6 +17,7 @@
 #include <cstdio>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/expand_topic_or_service_name.hpp"
@@ -119,6 +120,12 @@ const std::shared_ptr<rcl_subscription_t>
 SubscriptionBase::get_intra_process_subscription_handle() const
 {
   return intra_process_subscription_handle_;
+}
+
+const std::vector<std::shared_ptr<rclcpp::QOSEventHandlerBase>> &
+SubscriptionBase::get_event_handlers() const
+{
+  return event_handlers_;
 }
 
 const rosidl_message_type_support_t &

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -223,6 +223,7 @@ void TimeSource::create_clock_sub()
     topic_name,
     std::move(cb),
     rmw_qos_profile_default,
+    rclcpp::SubscriptionEventCallbacks(),
     group,
     false,
     false,

--- a/rclcpp/src/rclcpp/waitable.cpp
+++ b/rclcpp/src/rclcpp/waitable.cpp
@@ -35,6 +35,12 @@ Waitable::get_number_of_ready_clients()
 }
 
 size_t
+Waitable::get_number_of_ready_events()
+{
+  return 0u;
+}
+
+size_t
 Waitable::get_number_of_ready_services()
 {
   return 0u;

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
@@ -23,10 +23,12 @@
 
 #include "rclcpp/contexts/default_context.hpp"
 #include "rclcpp/intra_process_manager.hpp"
+#include "rclcpp/event.hpp"
 #include "rclcpp/parameter.hpp"
 #include "rclcpp/create_publisher.hpp"
 #include "rclcpp/create_service.hpp"
 #include "rclcpp/create_subscription.hpp"
+#include "rclcpp/subscription_options.hpp"
 #include "rclcpp/type_support_decl.hpp"
 
 #include "lifecycle_publisher.hpp"
@@ -65,6 +67,8 @@ LifecycleNode::create_publisher(
     this->node_topics_.get(),
     topic_name,
     qos_profile,
+    rclcpp::PublisherEventCallbacks(),
+    nullptr,
     use_intra_process_comms_,
     allocator);
 }
@@ -99,6 +103,7 @@ LifecycleNode::create_subscription(
     topic_name,
     std::forward<CallbackT>(callback),
     qos_profile,
+    rclcpp::SubscriptionEventCallbacks(),
     group,
     ignore_local_publications,
     use_intra_process_comms_,
@@ -128,6 +133,7 @@ LifecycleNode::create_subscription(
     topic_name,
     std::forward<CallbackT>(callback),
     qos,
+    rclcpp::SubscriptionEventCallbacks(),
     group,
     ignore_local_publications,
     msg_mem_strat,

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_publisher.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_publisher.hpp
@@ -61,9 +61,10 @@ public:
     rclcpp::node_interfaces::NodeBaseInterface * node_base,
     const std::string & topic,
     const rcl_publisher_options_t & publisher_options,
+    const rclcpp::PublisherEventCallbacks event_callbacks,
     std::shared_ptr<MessageAlloc> allocator)
   : rclcpp::Publisher<MessageT, Alloc>(
-      node_base, topic, publisher_options, allocator),
+      node_base, topic, publisher_options, event_callbacks, allocator),
     enabled_(false),
     logger_(rclcpp::get_logger("LifecyclePublisher"))
   {


### PR DESCRIPTION
This PR adds the ability for a client application to specify callback functions that are called when liveliness and/or deadline events occur. The client application will also be able to manually `assert_liveliness()` of a specific node or publisher.

Connects to ros2/rmw#171