### PR TITLE
Fixup clock

### DIFF
--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -83,11 +83,11 @@ public:
 
   RCLCPP_PUBLIC
   rcl_clock_t *
-  get_clock_handle();
+  get_clock_handle() noexcept;
 
   RCLCPP_PUBLIC
   rcl_clock_type_t
-  get_clock_type();
+  get_clock_type() const noexcept;
 
   // Add a callback to invoke if the jump threshold is exceeded.
   /**

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -47,16 +47,36 @@ class Clock
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(Clock)
 
+  /// Default c'tor
+  /**
+   * Initializes the clock instance with the given clock_type.
+   *
+   * \param clock_type type of the clock.
+   * \throws anything rclcpp::exceptions::throw_from_rcl_error can throw.
+   */
   RCLCPP_PUBLIC
   explicit Clock(rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
 
   RCLCPP_PUBLIC
   ~Clock();
 
+  /**
+   * Returns current time from the time source specified by clock_type.
+   *
+   * \return current time.
+   * \throws anything rclcpp::exceptions::throw_from_rcl_error can throw.
+   */
   RCLCPP_PUBLIC
   Time
   now();
 
+  /**
+   * Returns the clock of the type `RCL_ROS_TIME` is active.
+   *
+   * \return true if the clock is active
+   * \throws anything rclcpp::exceptions::throw_from_rcl_error can throw if
+   * the current clock does not have the clock_type `RCL_ROS_TIME`.
+   */
   RCLCPP_PUBLIC
   bool
   ros_time_is_active();
@@ -73,6 +93,19 @@ public:
   /**
    * These callback functions must remain valid as long as the
    * returned shared pointer is valid.
+   *
+   * Function will register callbacks to the callback queue. On time jump all
+   * callbacks will be executed whose threshold is greater then the time jump;
+   * The logic will first call selected pre_callbacks and then all selected
+   * post_callbacks.
+   *
+   * Function is only applicable if the clock_type is `RCL_ROS_TIME`
+   *
+   * \param pre_callback. Must be non-throwing
+   * \param post_callback. Must be non-throwing.
+   * \param threshold. Callbacks will be triggered if the time jump is greater
+   * then the threshold.
+   * \throws anything rclcpp::exceptions::throw_from_rcl_error can throw.
    */
   RCLCPP_PUBLIC
   JumpHandler::SharedPtr

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -106,6 +106,7 @@ public:
    * \param threshold. Callbacks will be triggered if the time jump is greater
    * then the threshold.
    * \throws anything rclcpp::exceptions::throw_from_rcl_error can throw.
+   * \throws std::bad_alloc if the allocation of the JumpHandler fails.
    */
   RCLCPP_PUBLIC
   JumpHandler::SharedPtr

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -113,15 +113,12 @@ public:
    * \throws std::bad_alloc if the allocation of the JumpHandler fails.
    * \warning the instance of the clock must remain valid as long as any created
    * JumpHandler.
-   *
-   * Rationale: otherwise the custom deleter function would access
-   * an invalid memory of rcl_clock_ (clock.cpp:131).
    */
   RCLCPP_PUBLIC
   JumpHandler::SharedPtr
   create_jump_callback(
-    typename JumpHandler::pre_callback_t pre_callback,
-    typename JumpHandler::post_callback_t post_callback,
+    JumpHandler::pre_callback_t pre_callback,
+    JumpHandler::post_callback_t post_callback,
     const rcl_jump_threshold_t & threshold);
 
 private:

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -111,6 +111,11 @@ public:
    * then the threshold.
    * \throws anything rclcpp::exceptions::throw_from_rcl_error can throw.
    * \throws std::bad_alloc if the allocation of the JumpHandler fails.
+   * \warning the instance of the clock must remain valid as long as any created
+   * JumpHandler.
+   *
+   * Rationale: otherwise the custom deleter function would access
+   * an invalid memory of rcl_clock_ (clock.cpp:131).
    */
   RCLCPP_PUBLIC
   JumpHandler::SharedPtr

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -32,13 +32,17 @@ class JumpHandler
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(JumpHandler)
+
+  using pre_callback_t = std::function<void()>;
+  using post_callback_t = std::function<void(const rcl_time_jump_t &)>;
+
   JumpHandler(
-    std::function<void()> pre_callback,
-    std::function<void(const rcl_time_jump_t &)> post_callback,
+    pre_callback_t pre_callback,
+    post_callback_t post_callback,
     const rcl_jump_threshold_t & threshold);
 
-  std::function<void()> pre_callback;
-  std::function<void(const rcl_time_jump_t &)> post_callback;
+  pre_callback_t pre_callback;
+  post_callback_t post_callback;
   rcl_jump_threshold_t notice_threshold;
 };
 
@@ -111,8 +115,8 @@ public:
   RCLCPP_PUBLIC
   JumpHandler::SharedPtr
   create_jump_callback(
-    std::function<void()> pre_callback,
-    std::function<void(const rcl_time_jump_t &)> post_callback,
+    typename JumpHandler::pre_callback_t pre_callback,
+    typename JumpHandler::post_callback_t post_callback,
     const rcl_jump_threshold_t & threshold);
 
 private:

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -33,8 +33,8 @@ class JumpHandler
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(JumpHandler)
 
-  using pre_callback_t = std::function<void()>;
-  using post_callback_t = std::function<void(const rcl_time_jump_t &)>;
+  using pre_callback_t = std::function<void ()>;
+  using post_callback_t = std::function<void (const rcl_time_jump_t &)>;
 
   JumpHandler(
     pre_callback_t pre_callback,

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -16,9 +16,6 @@
 #define RCLCPP__CLOCK_HPP_
 
 #include <functional>
-#include <memory>
-#include <mutex>
-#include <vector>
 
 #include "rclcpp/macros.hpp"
 #include "rclcpp/time.hpp"

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -78,7 +78,7 @@ Clock::ros_time_is_active()
     return false;
   }
 
-  bool is_enabled;
+  bool is_enabled = false;
   auto ret = rcl_is_enabled_ros_time_override(&rcl_clock_, &is_enabled);
   if (ret != RCL_RET_OK) {
     rclcpp::exceptions::throw_from_rcl_error(

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -112,8 +112,7 @@ Clock::create_jump_callback(
   // Allocate a new jump handler
   JumpHandler::UniquePtr handler(new JumpHandler(pre_callback, post_callback, threshold));
   if (nullptr == handler) {
-    exceptions::throw_from_rcl_error(RCL_RET_BAD_ALLOC,
-      "Failed to allocate jump handler");
+    throw std::bad_alloc{};
   }
 
   // Try to add the jump callback to the clock

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -96,7 +96,7 @@ Clock::on_time_jump(
   void * user_data)
 {
   const auto * handler = static_cast<JumpHandler *>(user_data);
-  if (!handler) {
+  if (nullptr == handler) {
     return;
   }
   if (before_jump && handler->pre_callback) {
@@ -127,7 +127,7 @@ Clock::create_jump_callback(
 
   // *INDENT-OFF*
   // create shared_ptr that removes the callback automatically when all copies are destructed
-  // TODO(dorezyuk) UB, if the clock leafs scope before the JumpHandler
+  // TODO(dorezyuk) UB, if the clock leaves scope before the JumpHandler
   return JumpHandler::SharedPtr(handler.release(), [this](JumpHandler * handler) noexcept {
     rcl_ret_t ret = rcl_clock_remove_jump_callback(&rcl_clock_, Clock::on_time_jump,
         handler);

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -108,8 +108,8 @@ Clock::on_time_jump(
 
 JumpHandler::SharedPtr
 Clock::create_jump_callback(
-  typename JumpHandler::pre_callback_t pre_callback,
-  typename JumpHandler::post_callback_t post_callback,
+  JumpHandler::pre_callback_t pre_callback,
+  JumpHandler::post_callback_t post_callback,
   const rcl_jump_threshold_t & threshold)
 {
   // Allocate a new jump handler

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -14,14 +14,6 @@
 
 #include "rclcpp/clock.hpp"
 
-#include <memory>
-#include <utility>
-#include <vector>
-
-#include "builtin_interfaces/msg/time.hpp"
-
-#include "rcl/time.h"
-
 #include "rclcpp/exceptions.hpp"
 
 #include "rcutils/logging_macros.h"

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -95,7 +95,10 @@ Clock::on_time_jump(
   bool before_jump,
   void * user_data)
 {
-  JumpHandler * handler = static_cast<JumpHandler *>(user_data);
+  const auto * handler = static_cast<JumpHandler *>(user_data);
+  if (!handler) {
+    return;
+  }
   if (before_jump && handler->pre_callback) {
     handler->pre_callback();
   } else if (!before_jump && handler->post_callback) {

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -22,8 +22,8 @@ namespace rclcpp
 {
 
 JumpHandler::JumpHandler(
-  std::function<void()> pre_callback,
-  std::function<void(const rcl_time_jump_t &)> post_callback,
+  pre_callback_t pre_callback,
+  post_callback_t post_callback,
   const rcl_jump_threshold_t & threshold)
 : pre_callback(pre_callback),
   post_callback(post_callback),
@@ -108,8 +108,8 @@ Clock::on_time_jump(
 
 JumpHandler::SharedPtr
 Clock::create_jump_callback(
-  std::function<void()> pre_callback,
-  std::function<void(const rcl_time_jump_t &)> post_callback,
+  typename JumpHandler::pre_callback_t pre_callback,
+  typename JumpHandler::post_callback_t post_callback,
   const rcl_jump_threshold_t & threshold)
 {
   // Allocate a new jump handler

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -80,13 +80,13 @@ Clock::ros_time_is_active()
 }
 
 rcl_clock_t *
-Clock::get_clock_handle()
+Clock::get_clock_handle() noexcept
 {
   return &rcl_clock_;
 }
 
 rcl_clock_type_t
-Clock::get_clock_type()
+Clock::get_clock_type() const noexcept
 {
   return rcl_clock_.type;
 }

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -127,6 +127,7 @@ Clock::create_jump_callback(
 
   // *INDENT-OFF*
   // create shared_ptr that removes the callback automatically when all copies are destructed
+  // TODO(dorezyuk) UB, if the clock leafs scope before the JumpHandler
   return JumpHandler::SharedPtr(handler.release(), [this](JumpHandler * handler) noexcept {
     rcl_ret_t ret = rcl_clock_remove_jump_callback(&rcl_clock_, Clock::on_time_jump,
         handler);


### PR DESCRIPTION
PR contains
* fix uninitalized bool in clock.cpp
* fix missing nullptr check after static_cast in clock.cpp
* add documentation, most notably for exceptions
* add warning for possible UB when clock leaves scope before of its JumpHandlers