### PR TITLE
overload for node interfaces

### DIFF
--- a/rclcpp_action/include/rclcpp_action/create_client.hpp
+++ b/rclcpp_action/include/rclcpp_action/create_client.hpp
@@ -27,7 +27,13 @@ namespace rclcpp_action
 {
 /// Create an action client.
 /**
- * \param[in] node The action client will be added to this node.
+ * This function is equivalent to \sa create_client()` however is using the individual
+ * node interfaces to create the client.
+ *
+ * \param node_base_interface[in] The node base interface of the corresponding node.
+ * \param node_graph_interface[in] The node graph interface of the corresponding node.
+ * \param node_logging_interface[in] The node logging interface of the corresponding node.
+ * \param node_waitables_interface[in] The node waitables interface of the corresponding node.
  * \param[in] name The action name.
  * \param[in] group The action client will be added to this callback group.
  *   If `nullptr`, then the action client is added to the default callback group.
@@ -35,12 +41,15 @@ namespace rclcpp_action
 template<typename ActionT>
 typename Client<ActionT>::SharedPtr
 create_client(
-  rclcpp::Node::SharedPtr node,
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
+  rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_interface,
+  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface,
+  rclcpp::node_interfaces::NodeWaitablesInterface::SharedPtr node_waitables_interface,
   const std::string & name,
   rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr)
 {
   std::weak_ptr<rclcpp::node_interfaces::NodeWaitablesInterface> weak_node =
-    node->get_node_waitables_interface();
+    node_waitables_interface;
   std::weak_ptr<rclcpp::callback_group::CallbackGroup> weak_group = group;
   bool group_is_null = (nullptr == group.get());
 
@@ -71,14 +80,37 @@ create_client(
 
   std::shared_ptr<Client<ActionT>> action_client(
     new Client<ActionT>(
-      node->get_node_base_interface(),
-      node->get_node_graph_interface(),
-      node->get_node_logging_interface(),
+      node_base_interface,
+      node_graph_interface,
+      node_logging_interface,
       name),
     deleter);
 
-  node->get_node_waitables_interface()->add_waitable(action_client, group);
+  node_waitables_interface->add_waitable(action_client, group);
   return action_client;
+}
+
+/// Create an action client.
+/**
+ * \param[in] node The action client will be added to this node.
+ * \param[in] name The action name.
+ * \param[in] group The action client will be added to this callback group.
+ *   If `nullptr`, then the action client is added to the default callback group.
+ */
+template<typename ActionT>
+typename Client<ActionT>::SharedPtr
+create_client(
+  rclcpp::Node::SharedPtr node,
+  const std::string & name,
+  rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr)
+{
+  return create_client<ActionT>(
+    node->get_node_base_interface(),
+    node->get_node_graph_interface(),
+    node->get_node_logging_interface(),
+    node->get_node_waitables_interface(),
+    name,
+    group);
 }
 }  // namespace rclcpp_action
 

--- a/rclcpp_action/include/rclcpp_action/create_server.hpp
+++ b/rclcpp_action/include/rclcpp_action/create_server.hpp
@@ -31,13 +31,19 @@
 
 namespace rclcpp_action
 {
+
 /// Create an action server.
 /**
  * All provided callback functions must be non-blocking.
+ * This function is equivalent to \sa create_server()` however is using the individual
+ * node interfaces to create the server.
  *
  * \sa Server::Server() for more information.
  *
- * \param node[in] The action server will be added to this node.
+ * \param node_base_interface[in] The node base interface of the corresponding node.
+ * \param node_clock_interface[in] The node clock interface of the corresponding node.
+ * \param node_logging_interface[in] The node logging interface of the corresponding node.
+ * \param node_waitables_interface[in] The node waitables interface of the corresponding node.
  * \param name[in] The action name.
  * \param[in] handle_goal A callback that decides if a goal should be accepted or rejected.
  * \param[in] handle_cancel A callback that decides if a goal should be attempted to be canceled.
@@ -51,7 +57,10 @@ namespace rclcpp_action
 template<typename ActionT>
 typename Server<ActionT>::SharedPtr
 create_server(
-  rclcpp::Node::SharedPtr node,
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
+  rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_interface,
+  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface,
+  rclcpp::node_interfaces::NodeWaitablesInterface::SharedPtr node_waitables_interface,
   const std::string & name,
   typename Server<ActionT>::GoalCallback handle_goal,
   typename Server<ActionT>::CancelCallback handle_cancel,
@@ -60,7 +69,7 @@ create_server(
   rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr)
 {
   std::weak_ptr<rclcpp::node_interfaces::NodeWaitablesInterface> weak_node =
-    node->get_node_waitables_interface();
+    node_waitables_interface;
   std::weak_ptr<rclcpp::callback_group::CallbackGroup> weak_group = group;
   bool group_is_null = (nullptr == group.get());
 
@@ -90,17 +99,58 @@ create_server(
     };
 
   std::shared_ptr<Server<ActionT>> action_server(new Server<ActionT>(
-      node->get_node_base_interface(),
-      node->get_node_clock_interface(),
-      node->get_node_logging_interface(),
+      node_base_interface,
+      node_clock_interface,
+      node_logging_interface,
       name,
       options,
       handle_goal,
       handle_cancel,
       handle_accepted), deleter);
 
-  node->get_node_waitables_interface()->add_waitable(action_server, group);
+  node_waitables_interface->add_waitable(action_server, group);
   return action_server;
+}
+
+/// Create an action server.
+/**
+ * All provided callback functions must be non-blocking.
+ *
+ * \sa Server::Server() for more information.
+ *
+ * \param node[in] The action server will be added to this node.
+ * \param name[in] The action name.
+ * \param[in] handle_goal A callback that decides if a goal should be accepted or rejected.
+ * \param[in] handle_cancel A callback that decides if a goal should be attempted to be canceled.
+ *  The return from this callback only indicates if the server will try to cancel a goal.
+ *  It does not indicate if the goal was actually canceled.
+ * \param[in] handle_accepted A callback that is called to give the user a handle to the goal.
+ * \param[in] options options to pass to the underlying `rcl_action_server_t`.
+ * \param group[in] The action server will be added to this callback group.
+ *   If `nullptr`, then the action server is added to the default callback group.
+ */
+template<typename ActionT>
+typename Server<ActionT>::SharedPtr
+create_server(
+  rclcpp::Node::SharedPtr node,
+  const std::string & name,
+  typename Server<ActionT>::GoalCallback handle_goal,
+  typename Server<ActionT>::CancelCallback handle_cancel,
+  typename Server<ActionT>::AcceptedCallback handle_accepted,
+  const rcl_action_server_options_t & options = rcl_action_server_get_default_options(),
+  rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr)
+{
+  return create_server<ActionT>(
+    node->get_node_base_interface(),
+    node->get_node_clock_interface(),
+    node->get_node_logging_interface(),
+    node->get_node_waitables_interface(),
+    name,
+    handle_goal,
+    handle_cancel,
+    handle_accepted,
+    options,
+    group);
 }
 }  // namespace rclcpp_action
 #endif  // RCLCPP_ACTION__CREATE_SERVER_HPP_

--- a/rclcpp_action/include/rclcpp_action/create_server.hpp
+++ b/rclcpp_action/include/rclcpp_action/create_server.hpp
@@ -31,7 +31,6 @@
 
 namespace rclcpp_action
 {
-
 /// Create an action server.
 /**
  * All provided callback functions must be non-blocking.


### PR DESCRIPTION
fixes ros2/rclcpp#699

This PR allows to create an action server within a constructor inheriting from node and therefore composition of these nodes.

Signed-off-by: Karsten Knese <karsten@openrobotics.org>