### PR TITLE
Add assignment of parameter-related fields in node options constructor

### DIFF
--- a/rclcpp/src/rclcpp/node_options.cpp
+++ b/rclcpp/src/rclcpp/node_options.cpp
@@ -68,7 +68,8 @@ NodeOptions::operator=(const NodeOptions & other)
     this->start_parameter_services_ = other.start_parameter_services_;
     this->allocator_ = other.allocator_;
     this->allow_undeclared_parameters_ = other.allow_undeclared_parameters_;
-    this->automatically_declare_initial_parameters_ = other.automatically_declare_initial_parameters_;
+    this->automatically_declare_initial_parameters_ =
+      other.automatically_declare_initial_parameters_;
   }
   return *this;
 }

--- a/rclcpp/src/rclcpp/node_options.cpp
+++ b/rclcpp/src/rclcpp/node_options.cpp
@@ -67,6 +67,8 @@ NodeOptions::operator=(const NodeOptions & other)
     this->use_intra_process_comms_ = other.use_intra_process_comms_;
     this->start_parameter_services_ = other.start_parameter_services_;
     this->allocator_ = other.allocator_;
+    this->allow_undeclared_parameters_ = other.allow_undeclared_parameters_;
+    this->automatically_declare_initial_parameters_ = other.automatically_declare_initial_parameters_;
   }
   return *this;
 }


### PR DESCRIPTION
The allow_undeclared_parameters and automatically_declare_initial_parameters fields of
the node options class were not assigned in the assignment operator, resulting in
an incorrect copy of the node options object, which also indirectly affects the
copy constructor.

Signed-off-by: Michael Jeronimo <michael.jeronimo@intel.com>