### PR TITLE
Add return code to CancelGoal service response

### DIFF
--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -357,7 +357,7 @@ ServerBase::execute_cancel_request_received()
 
   // If the user rejects all individual requests to cancel goals,
   // then we consider the top-level cancel request as rejected.
-  if (goals.size > 1u && 0u == response->goals_canceling.size()) {
+  if (goals.size >= 1u && 0u == response->goals_canceling.size()) {
     response->return_code = action_msgs::srv::CancelGoal::Response::ERROR_REJECTED;
   }
 

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -325,6 +325,9 @@ ServerBase::execute_cancel_request_received()
     pimpl_->action_server_.get(),
     &cancel_request,
     &cancel_response);
+  if (RCL_RET_OK != ret) {
+    rclcpp::exceptions::throw_from_rcl_error(ret);
+  }
 
   RCLCPP_SCOPE_EXIT({
     ret = rcl_action_cancel_response_fini(&cancel_response);

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -335,6 +335,7 @@ ServerBase::execute_cancel_request_received()
 
   auto response = std::make_shared<action_msgs::srv::CancelGoal::Response>();
 
+  response->return_code = cancel_response.msg.return_code;
   auto & goals = cancel_response.msg.goals_canceling;
   // For each canceled goal, call cancel callback
   for (size_t i = 0; i < goals.size; ++i) {
@@ -349,6 +350,12 @@ ServerBase::execute_cancel_request_received()
       cpp_info.stamp.nanosec = goal_info.stamp.nanosec;
       response->goals_canceling.push_back(cpp_info);
     }
+  }
+
+  // If the user rejects all individual requests to cancel goals,
+  // then we consider the top-level cancel request as rejected.
+  if (goals.size > 1u && 0u == response->goals_canceling.size()) {
+    response->return_code = action_msgs::srv::CancelGoal::Response::ERROR_REJECTED;
   }
 
   if (!response->goals_canceling.empty()) {

--- a/rclcpp_action/test/test_client.cpp
+++ b/rclcpp_action/test/test_client.cpp
@@ -480,17 +480,18 @@ TEST_F(TestClient, async_cancel_one_goal_with_callback)
   auto goal_handle = future_goal_handle.get();
   EXPECT_EQ(rclcpp_action::GoalStatus::STATUS_ACCEPTED, goal_handle->get_status());
 
-  bool cancel_callback_received = false;
+  bool cancel_response_received = false;
   auto future_cancel = action_client->async_cancel_goal(
     goal_handle,
-    [&cancel_callback_received, goal_handle](
+    [&cancel_response_received, goal_handle](
       ActionCancelGoalResponse::SharedPtr response) mutable
     {
       if (
         ActionCancelGoalResponse::ERROR_NONE == response->return_code &&
+        1ul == response->goals_canceling.size() &&
         goal_handle->get_goal_id() == response->goals_canceling[0].goal_id.uuid)
       {
-        cancel_callback_received = true;
+        cancel_response_received = true;
       }
     });
   dual_spin_until_future_complete(future_cancel);
@@ -498,7 +499,7 @@ TEST_F(TestClient, async_cancel_one_goal_with_callback)
   EXPECT_EQ(ActionCancelGoalResponse::ERROR_NONE, cancel_response->return_code);
   ASSERT_EQ(1ul, cancel_response->goals_canceling.size());
   EXPECT_EQ(goal_handle->get_goal_id(), cancel_response->goals_canceling[0].goal_id.uuid);
-  EXPECT_TRUE(cancel_callback_received);
+  EXPECT_TRUE(cancel_response_received);
 }
 
 TEST_F(TestClient, async_cancel_all_goals)


### PR DESCRIPTION
Refactored the callback signature for canceling one goal. Now it is the same as the other cancel methods.
This makes it easier to communicate the error code to the user.

Connects to https://github.com/ros2/rcl_interfaces/issues/63