### PR TITLE
Add rcl_node_get_fully_qualified_name (ros2/rcl#255)

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -121,18 +121,7 @@ NodeParameters::NodeParameters(
   get_yaml_paths(&(options->arguments));
 
   // Get fully qualified node name post-remapping to use to find node's params in yaml files
-  const std::string node_name = node_base->get_name();
-  const std::string node_namespace = node_base->get_namespace();
-  if (0u == node_namespace.size() || 0u == node_name.size()) {
-    // Should never happen
-    throw std::runtime_error("Node name and namespace were not set");
-  }
-
-  if ('/' == node_namespace.at(node_namespace.size() - 1)) {
-    combined_name_ = node_namespace + node_name;
-  } else {
-    combined_name_ = node_namespace + '/' + node_name;
-  }
+  combined_name_ = node_base->get_fully_qualified_name();
 
   // TODO(sloretz) use rcl to parse yaml when circular dependency is solved
   // See https://github.com/ros2/rcl/issues/252


### PR DESCRIPTION
Follow up to ros2/rcl#255

Rebased from #615 

Most of the content was duplicated in #662 this catches one other improvement from @rarvolt 

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6861)](http://ci.ros2.org/job/ci_linux/6861/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3151)](http://ci.ros2.org/job/ci_linux-aarch64/3151/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5638)](http://ci.ros2.org/job/ci_osx/5638/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=6680)](http://ci.ros2.org/job/ci_windows/6680/)