### PR TITLE
Guard against ParameterNotDeclaredException in parameter service callbacks

### DIFF
--- a/rclcpp/src/rclcpp/parameter_service.cpp
+++ b/rclcpp/src/rclcpp/parameter_service.cpp
@@ -82,7 +82,8 @@ ParameterService::ParameterService(
       auto result = rcl_interfaces::msg::SetParametersResult();
       for (auto & p : request->parameters) {
         try {
-          result = node_params->set_parameters({rclcpp::Parameter::from_parameter_msg(p)})[0];
+          result = node_params->set_parameters_atomically(
+            {rclcpp::Parameter::from_parameter_msg(p)});
         } catch (const rclcpp::exceptions::ParameterNotDeclaredException & ex) {
           RCLCPP_WARN(rclcpp::get_logger("rclcpp"), "Failed to set parameter: %s", ex.what());
           result.successful = false;

--- a/rclcpp/src/rclcpp/parameter_service.cpp
+++ b/rclcpp/src/rclcpp/parameter_service.cpp
@@ -114,7 +114,7 @@ ParameterService::ParameterService(
         RCLCPP_WARN(
           rclcpp::get_logger("rclcpp"), "Failed to set parameters atomically: %s", ex.what());
         response->result.successful = false;
-        response->result.reason = "One or more parameters was not declared before setting";
+        response->result.reason = "One or more parameters wer not declared before setting";
       }
     },
     qos_profile, nullptr);


### PR DESCRIPTION
Fixes #705.

If the set_parameters() call fails, it's nice to be able to return a partial result.
Since there is no convenient method to obtain a partial result, we call set_parameters()
once for each parameter.