### PR TITLE
Fix heap-use-after-free and memory leaks reported from test_node.cpp

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -493,10 +493,10 @@ NodeParameters::set_parameters_atomically(const std::vector<rclcpp::Parameter> &
     // assumption: the parameter to be undeclared should be in the parameter infos map
     assert(it != parameters_.end());
     if (it != parameters_.end()) {
-      // Remove it and update the parameter event message.
-      parameters_.erase(it);
+      // Update the parameter event message and remove it.
       parameter_event_msg.deleted_parameters.push_back(
         rclcpp::Parameter(it->first, it->second.value).to_parameter_msg());
+      parameters_.erase(it);
     }
   }
 

--- a/rclcpp/src/rclcpp/node_options.cpp
+++ b/rclcpp/src/rclcpp/node_options.cpp
@@ -44,6 +44,9 @@ rcl_node_options_t_destructor(rcl_node_options_t * node_options)
         "failed to finalize rcl node options: %s", rcl_get_error_string().str);
       rcl_reset_error();
     }
+
+    delete node_options;
+    node_options = nullptr;
   }
 }
 }  // namespace detail


### PR DESCRIPTION
Fix AddressSanitizer errors reported by test_node.cpp unit test.

#### This change fixes 2 errors reported by AddressSanitizer:
1. heap-use-after-free
```bash
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from TestNode
[ RUN      ] TestNode.set_parameter_undeclared_parameters_not_allowed

=================================================================
==16060==ERROR: AddressSanitizer: heap-use-after-free on address 0x614000006270 at pc 0x7f8ac7cc5733 bp 0x7ffef1b1ae50 sp 0x7ffef1b1a5f8
READ of size 11 at 0x614000006270 thread T0
    ...snip...

0x614000006270 is located 48 bytes inside of 416-byte region [0x614000006240,0x6140000063e0)
freed by thread T0 here:
    ...snip...

previously allocated by thread T0 here:
    ...snip...

SUMMARY: AddressSanitizer: heap-use-after-free (/usr/lib/x86_64-linux-gnu/libasan.so.4+0x79732) 
    ...snip...

==16060==ABORTING
```

2. Detected memory leaks
```bash
Running main() from /home/ANT.AMAZON.COM/prajaktg/ros2_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from TestNode
[ RUN      ] TestNode.set_parameter_undeclared_parameters_not_allowed
[       OK ] TestNode.set_parameter_undeclared_parameters_not_allowed (27 ms)
[----------] 1 test from TestNode (27 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (27 ms total)
[  PASSED  ] 1 test.

=================================================================
==17914==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 64 byte(s) in 1 object(s) allocated from:
    ...snip...

SUMMARY: AddressSanitizer: 64 byte(s) leaked in 1 allocation(s).
```

After this commit, no sanitizer errors are reported
```bash
[==========] Running 30 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 30 tests from TestNode
[ RUN      ] TestNode.construction_and_destruction
[       OK ] TestNode.construction_and_destruction (52 ms)
[ RUN      ] TestNode.get_name_and_namespace
[       OK ] TestNode.get_name_and_namespace (521 ms)
[ RUN      ] TestNode.subnode_get_name_and_namespace
[       OK ] TestNode.subnode_get_name_and_namespace (215 ms)
[ RUN      ] TestNode.subnode_construction_and_destruction
[       OK ] TestNode.subnode_construction_and_destruction (292 ms)
[ RUN      ] TestNode.get_logger
[       OK ] TestNode.get_logger (180 ms)
[ RUN      ] TestNode.get_clock
[       OK ] TestNode.get_clock (39 ms)
[ RUN      ] TestNode.now
[       OK ] TestNode.now (38 ms)
[ RUN      ] TestNode.declare_parameter_with_no_initial_values
[       OK ] TestNode.declare_parameter_with_no_initial_values (39 ms)
[ RUN      ] TestNode.declare_parameter_with_initial_values
[       OK ] TestNode.declare_parameter_with_initial_values (39 ms)
[ RUN      ] TestNode.declare_parameters_with_no_initial_values
[       OK ] TestNode.declare_parameters_with_no_initial_values (40 ms)
[ RUN      ] TestNode.undeclare_parameter
[       OK ] TestNode.undeclare_parameter (39 ms)
[ RUN      ] TestNode.has_parameter
[       OK ] TestNode.has_parameter (38 ms)
[ RUN      ] TestNode.set_parameter_undeclared_parameters_not_allowed
[       OK ] TestNode.set_parameter_undeclared_parameters_not_allowed (40 ms)
[ RUN      ] TestNode.set_parameter_undeclared_parameters_allowed
[       OK ] TestNode.set_parameter_undeclared_parameters_allowed (39 ms)
[ RUN      ] TestNode.set_parameters_undeclared_parameters_not_allowed
[       OK ] TestNode.set_parameters_undeclared_parameters_not_allowed (41 ms)
[ RUN      ] TestNode.set_parameters_undeclared_parameters_allowed
[       OK ] TestNode.set_parameters_undeclared_parameters_allowed (39 ms)
[ RUN      ] TestNode.set_parameters_atomically_undeclared_parameters_not_allowed
[       OK ] TestNode.set_parameters_atomically_undeclared_parameters_not_allowed (40 ms)
[ RUN      ] TestNode.set_parameters_atomically_undeclared_parameters_allowed
[       OK ] TestNode.set_parameters_atomically_undeclared_parameters_allowed (39 ms)
[ RUN      ] TestNode.get_parameter_undeclared_parameters_not_allowed
[       OK ] TestNode.get_parameter_undeclared_parameters_not_allowed (38 ms)
[ RUN      ] TestNode.get_parameter_undeclared_parameters_allowed
[       OK ] TestNode.get_parameter_undeclared_parameters_allowed (38 ms)
[ RUN      ] TestNode.get_parameter_or_undeclared_parameters_not_allowed
[       OK ] TestNode.get_parameter_or_undeclared_parameters_not_allowed (39 ms)
[ RUN      ] TestNode.get_parameter_or_undeclared_parameters_allowed
[       OK ] TestNode.get_parameter_or_undeclared_parameters_allowed (38 ms)
[ RUN      ] TestNode.get_parameters_undeclared_parameters_not_allowed
[       OK ] TestNode.get_parameters_undeclared_parameters_not_allowed (81 ms)
[ RUN      ] TestNode.get_parameters_undeclared_parameters_allowed
[       OK ] TestNode.get_parameters_undeclared_parameters_allowed (39 ms)
[ RUN      ] TestNode.describe_parameter_undeclared_parameters_not_allowed
[       OK ] TestNode.describe_parameter_undeclared_parameters_not_allowed (39 ms)
[ RUN      ] TestNode.describe_parameter_undeclared_parameters_allowed
[       OK ] TestNode.describe_parameter_undeclared_parameters_allowed (37 ms)
[ RUN      ] TestNode.describe_parameters_undeclared_parameters_not_allowed
[       OK ] TestNode.describe_parameters_undeclared_parameters_not_allowed (39 ms)
[ RUN      ] TestNode.describe_parameters_undeclared_parameters_allowed
[       OK ] TestNode.describe_parameters_undeclared_parameters_allowed (39 ms)
[ RUN      ] TestNode.get_parameter_types_undeclared_parameters_not_allowed
[       OK ] TestNode.get_parameter_types_undeclared_parameters_not_allowed (39 ms)
[ RUN      ] TestNode.get_parameter_types_undeclared_parameters_allowed
[       OK ] TestNode.get_parameter_types_undeclared_parameters_allowed (39 ms)
[----------] 30 tests from TestNode (2275 ms total)

[----------] Global test environment tear-down
[==========] 30 tests from 1 test case ran. (2276 ms total)
[  PASSED  ] 30 tests.
```

Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>