### PR TITLE
fix clang warning

### DIFF
--- a/rclcpp/test/test_intra_process_manager.cpp
+++ b/rclcpp/test/test_intra_process_manager.cpp
@@ -37,6 +37,9 @@ public:
   PublisherBase()
   : mock_topic_name(""), mock_queue_size(0) {}
 
+  virtual ~PublisherBase()
+  {}
+
   const char * get_topic_name() const
   {
     return mock_topic_name.c_str();


### PR DESCRIPTION
Fixes https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/55/warningsResult/

Linux `clang` build testing `rclcpp` before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7131)](https://ci.ros2.org/job/ci_linux/7131/)
Linux `clang` build testing `rclcpp` after: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7132)](https://ci.ros2.org/job/ci_linux/7132/)