### PR TITLE
Volatile is a keyword

### DIFF
--- a/rclcpp/include/rclcpp/qos.hpp
+++ b/rclcpp/include/rclcpp/qos.hpp
@@ -105,8 +105,11 @@ public:
   durability(rmw_qos_durability_policy_t durability);
 
   /// Set the durability setting to volatile.
+  /**
+    * Note that this cannot be named `volatile` because it is a C++ keyword.
+    */
   QoS &
-  volatile();
+  durability_volatile();
 
   /// Set the durability setting to transient local.
   QoS &

--- a/rclcpp/src/rclcpp/qos.cpp
+++ b/rclcpp/src/rclcpp/qos.cpp
@@ -120,7 +120,7 @@ QoS::durability(rmw_qos_durability_policy_t durability)
 }
 
 QoS &
-QoS::volatile()
+QoS::durability_volatile()
 {
   return this->durability(RMW_QOS_POLICY_DURABILITY_VOLATILE);
 }


### PR DESCRIPTION
I realize why the original was spelled wrong, volatile is a c++ keyword, so https://github.com/ros2/rclcpp/pull/724 was a bad change. Modify to not require learning a misspelling, and note why it can't have that name

So sorry about that @dirk-thomas, I was overeager and didn't verify the build properly.

Signed-off-by: Emerson Knapp <eknapp@amazon.com>