### PR TITLE
Throw nice errors when creating a publisher with intraprocess communication and incompatible qos policy

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
@@ -48,11 +48,11 @@ NodeTopics::create_publisher(
     auto ipm = context->get_sub_context<rclcpp::intra_process_manager::IntraProcessManager>();
     // Register the publisher with the intra process manager.
     if (publisher_options.qos.history == RMW_QOS_POLICY_HISTORY_KEEP_ALL) {
-      throw exceptions::InvalidParametersException(
+      throw std::invalid_argument(
               "intraprocess communication is not allowed with keep all history qos policy");
     }
     if (publisher_options.qos.depth == 0) {
-      throw exceptions::InvalidParametersException(
+      throw std::invalid_argument(
               "intraprocess communication is not allowed with a zero qos history depth value");
     }
     uint64_t intra_process_publisher_id = ipm->add_publisher(publisher);

--- a/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
@@ -47,6 +47,14 @@ NodeTopics::create_publisher(
     // Get the intra process manager instance for this context.
     auto ipm = context->get_sub_context<rclcpp::intra_process_manager::IntraProcessManager>();
     // Register the publisher with the intra process manager.
+    if (publisher_options.qos.history == RMW_QOS_POLICY_HISTORY_KEEP_ALL) {
+      throw exceptions::InvalidParametersException(
+              "intraprocess communication is not allowed with keep all history qos policy");
+    }
+    if (publisher_options.qos.depth == 0) {
+      throw exceptions::InvalidParametersException(
+              "intraprocess communication is not allowed with a zero qos history depth value");
+    }
     uint64_t intra_process_publisher_id = ipm->add_publisher(publisher);
     publisher->setup_intra_process(
       intra_process_publisher_id,

--- a/rclcpp/src/rclcpp/publisher_base.cpp
+++ b/rclcpp/src/rclcpp/publisher_base.cpp
@@ -265,7 +265,7 @@ PublisherBase::setup_intra_process(
 {
   // Intraprocess configuration is not allowed with "durability" qos policy non "volatile".
   if (this->get_actual_qos().durability != RMW_QOS_POLICY_DURABILITY_VOLATILE) {
-    throw exceptions::InvalidParametersException(
+    throw std::invalid_argument(
             "intraprocess communication is not allowed with durability qos policy non-volatile");
   }
   const char * topic_name = this->get_topic_name();


### PR DESCRIPTION
Closes #727.

I did't do the checking inside `setup_intra_process` because the mapped ring buffer is created before.

The other option, is to create the mapped ring buffer inside `setup_intra_process` method (call `ipm->add_publisher(publisher)` inside the function and stop taking `intra_process_publisher_id` as an argument). In this way all the errors because of incompatible qos settings with intra process comm are thrown from the same place.