### PR TITLE
Enforce parameter ranges

### DIFF
--- a/rclcpp/include/rclcpp/exceptions.hpp
+++ b/rclcpp/include/rclcpp/exceptions.hpp
@@ -198,13 +198,6 @@ class InvalidParameterValueException : public std::runtime_error
   using std::runtime_error::runtime_error;
 };
 
-/// Thrown if passed parameter description is invalid.
-class InvalidParameterDescriptionException : public std::runtime_error
-{
-  // Inherit constructors from runtime_error.
-  using std::runtime_error::runtime_error;
-};
-
 /// Thrown if parameter is already declared.
 class ParameterAlreadyDeclaredException : public std::runtime_error
 {

--- a/rclcpp/include/rclcpp/exceptions.hpp
+++ b/rclcpp/include/rclcpp/exceptions.hpp
@@ -198,6 +198,13 @@ class InvalidParameterValueException : public std::runtime_error
   using std::runtime_error::runtime_error;
 };
 
+/// Thrown if passed parameter description is invalid.
+class InvalidParameterDescriptionException : public std::runtime_error
+{
+  // Inherit constructors from runtime_error.
+  using std::runtime_error::runtime_error;
+};
+
 /// Thrown if parameter is already declared.
 class ParameterAlreadyDeclaredException : public std::runtime_error
 {

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -191,7 +191,7 @@ __lockless_has_parameter(
 // see https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
 RCLCPP_LOCAL
 bool
-__are_doubles_equal(double x, double y, int ulp = 100)
+__are_doubles_equal(double x, double y, size_t ulp = 100)
 {
   return std::abs(x - y) <= std::numeric_limits<double>::epsilon() * std::abs(x + y) * ulp;
 }

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -263,7 +263,6 @@ __check_parameter_value_in_range(
   return result;
 }
 
-
 // Return true if parameter values comply with the descriptors in parameter_infos.
 RCLCPP_LOCAL
 rcl_interfaces::msg::SetParametersResult

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -260,8 +260,6 @@ __check_parameters(
   for (const rclcpp::Parameter & parameter : parameters) {
     const rcl_interfaces::msg::ParameterDescriptor & descriptor =
       parameter_infos[parameter.get_name()].descriptor;
-    result = descriptor.type == parameter.get_type() ||
-      descriptor.type == rclcpp::PARAMETER_NOT_SET;
     result = result && __check_parameter_value_in_range(
       descriptor,
       parameter.get_parameter_value());
@@ -295,8 +293,7 @@ __set_parameters_atomically_common(
   if (result.successful) {
     for (size_t i = 0; i < parameters.size(); ++i) {
       const std::string & name = parameters[i].get_name();
-      // TODO(ivanpauno): Why updating the descriptor name in each set?
-      // Maybe, set the correct name when declare parameter is call, and delete it here.
+      parameter_infos[name].descriptor.type = parameters[i].get_type();
       parameter_infos[name].descriptor.name = parameters[i].get_name();
       parameter_infos[name].value = parameters[i].get_parameter_value();
     }

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -252,7 +252,7 @@ __check_parameter_value_in_range(
     if (fp_range.step == 0.0) {
       return result;
     }
-    long rounded_div = std::lround((v - fp_range.from_value) / fp_range.step);
+    double rounded_div = std::round((v - fp_range.from_value) / fp_range.step);
     if (__are_doubles_equal(v, fp_range.from_value + rounded_div * fp_range.step)) {
       return result;
     }

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -313,8 +313,8 @@ __set_parameters_atomically_common(
   if (result.successful) {
     for (size_t i = 0; i < parameters.size(); ++i) {
       const std::string & name = parameters[i].get_name();
-      parameter_infos[name].descriptor.type = parameters[i].get_type();
       parameter_infos[name].descriptor.name = parameters[i].get_name();
+      parameter_infos[name].descriptor.type = parameters[i].get_type();
       parameter_infos[name].value = parameters[i].get_parameter_value();
     }
   }

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -197,12 +197,15 @@ __are_doubles_equal(double x, double y, int ulp = ULP)
   return std::abs(x - y) <= std::numeric_limits<double>::epsilon() * std::abs(x + y) * ulp;
 }
 
-#define FORMAT_REASON(reason, name, range_type) \
-  { \
-    std::ostringstream ss; \
-    ss << "Parameter {" << name << "} doesn't comply with " << range_type << " range."; \
-    reason = ss.str(); \
-  }
+RCLCPP_LOCAL
+inline
+void
+format_reason(std::string & reason, const std::string & name, const char * range_type)
+{
+  std::ostringstream ss;
+  ss << "Parameter {" << name << "} doesn't comply with " << range_type << " range.";
+  reason = ss.str();
+}
 
 RCLCPP_LOCAL
 rcl_interfaces::msg::SetParametersResult
@@ -217,7 +220,7 @@ __check_parameter_value_in_range(
     auto integer_range = descriptor.integer_range.at(0);
     if ((v < integer_range.from_value) || (v > integer_range.to_value)) {
       result.successful = false;
-      FORMAT_REASON(result.reason, descriptor.name, "integer")
+      format_reason(result.reason, descriptor.name, "integer");
       return result;
     }
     if (v == integer_range.from_value || v == integer_range.to_value) {
@@ -230,7 +233,7 @@ __check_parameter_value_in_range(
       return result;
     }
     result.successful = false;
-    FORMAT_REASON(result.reason, descriptor.name, "integer")
+    format_reason(result.reason, descriptor.name, "integer");
     return result;
   }
 
@@ -244,7 +247,7 @@ __check_parameter_value_in_range(
     }
     if ((v < fp_range.from_value) || (v > fp_range.to_value)) {
       result.successful = false;
-      FORMAT_REASON(result.reason, descriptor.name, "floating point")
+      format_reason(result.reason, descriptor.name, "floating point");
       return result;
     }
     if (fp_range.step == 0.0) {
@@ -255,7 +258,7 @@ __check_parameter_value_in_range(
       return result;
     }
     result.successful = false;
-    FORMAT_REASON(result.reason, descriptor.name, "floating point")
+    format_reason(result.reason, descriptor.name, "floating point");
     return result;
   }
   return result;

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -217,12 +217,12 @@ __check_parameter_value_in_range(
   if (!descriptor.integer_range.empty() && value.get_type() == rclcpp::PARAMETER_INTEGER) {
     int64_t v = value.get<int64_t>();
     auto integer_range = descriptor.integer_range.at(0);
+    if (v == integer_range.from_value || v == integer_range.to_value) {
+      return result;
+    }
     if ((v < integer_range.from_value) || (v > integer_range.to_value)) {
       result.successful = false;
       format_reason(result.reason, descriptor.name, "integer");
-      return result;
-    }
-    if (v == integer_range.from_value || v == integer_range.to_value) {
       return result;
     }
     if (integer_range.step == 0) {

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -189,10 +189,9 @@ __lockless_has_parameter(
 }
 
 // see https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
-#define ULP 100
 RCLCPP_LOCAL
 bool
-__are_doubles_equal(double x, double y, int ulp = ULP)
+__are_doubles_equal(double x, double y, int ulp = 100)
 {
   return std::abs(x - y) <= std::numeric_limits<double>::epsilon() * std::abs(x + y) * ulp;
 }

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -252,7 +252,7 @@ __check_parameter_value_in_range(
     if (fp_range.step == 0.0) {
       return result;
     }
-    int rounded_div = std::round((v - fp_range.from_value) / fp_range.step);
+    long rounded_div = std::lround((v - fp_range.from_value) / fp_range.step);
     if (__are_doubles_equal(v, fp_range.from_value + rounded_div * fp_range.step)) {
       return result;
     }

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -730,7 +730,9 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     integer_range.from_value = 10;
     integer_range.to_value = 18;
     integer_range.step = 2;
-    ASSERT_THROW(node->declare_parameter(name, 42, descriptor), rclcpp::exceptions::InvalidParameterValueException);
+    ASSERT_THROW(
+      node->declare_parameter(name, 42, descriptor),
+      rclcpp::exceptions::InvalidParameterValueException);
   }
   {
     // setting a parameter with floating point range descriptor

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -1450,13 +1450,13 @@ TEST_F(TestNode, describe_parameter_undeclared_parameters_not_allowed) {
     {
       auto result = node->describe_parameter(name1);
       EXPECT_EQ(result.name, name1);
-      EXPECT_EQ(result.type, rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER);
+      EXPECT_EQ(result.type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
       EXPECT_FALSE(result.read_only);
     }
     {
       auto result = node->describe_parameter(name2);
       EXPECT_EQ(result.name, name2);
-      EXPECT_EQ(result.type, rcl_interfaces::msg::ParameterType::PARAMETER_STRING);
+      EXPECT_EQ(result.type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
       EXPECT_TRUE(result.read_only);
     }
   }
@@ -1490,13 +1490,13 @@ TEST_F(TestNode, describe_parameter_undeclared_parameters_allowed) {
     {
       auto result = node->describe_parameter(name1);
       EXPECT_EQ(result.name, name1);
-      EXPECT_EQ(result.type, rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER);
+      EXPECT_EQ(result.type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
       EXPECT_FALSE(result.read_only);
     }
     {
       auto result = node->describe_parameter(name2);
       EXPECT_EQ(result.name, name2);
-      EXPECT_EQ(result.type, rcl_interfaces::msg::ParameterType::PARAMETER_STRING);
+      EXPECT_EQ(result.type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
       EXPECT_TRUE(result.read_only);
     }
   }
@@ -1533,11 +1533,11 @@ TEST_F(TestNode, describe_parameters_undeclared_parameters_not_allowed) {
     EXPECT_EQ(results.size(), 2u);
 
     EXPECT_EQ(results[0].name, name1);
-    EXPECT_EQ(results[0].type, rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER);
+    EXPECT_EQ(results[0].type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
     EXPECT_FALSE(results[0].read_only);
 
     EXPECT_EQ(results[1].name, name2);
-    EXPECT_EQ(results[1].type, rcl_interfaces::msg::ParameterType::PARAMETER_STRING);
+    EXPECT_EQ(results[1].type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
     EXPECT_TRUE(results[1].read_only);
   }
   {
@@ -1578,15 +1578,15 @@ TEST_F(TestNode, describe_parameters_undeclared_parameters_not_allowed) {
     EXPECT_EQ(results.size(), 3u);
 
     EXPECT_EQ(results[0].name, name2);
-    EXPECT_EQ(results[0].type, rcl_interfaces::msg::ParameterType::PARAMETER_STRING);
+    EXPECT_EQ(results[0].type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
     EXPECT_TRUE(results[0].read_only);
 
     EXPECT_EQ(results[1].name, name1);
-    EXPECT_EQ(results[1].type, rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER);
+    EXPECT_EQ(results[1].type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
     EXPECT_FALSE(results[1].read_only);
 
     EXPECT_EQ(results[2].name, name2);
-    EXPECT_EQ(results[2].type, rcl_interfaces::msg::ParameterType::PARAMETER_STRING);
+    EXPECT_EQ(results[2].type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
     EXPECT_TRUE(results[2].read_only);
   }
 }
@@ -1611,11 +1611,11 @@ TEST_F(TestNode, describe_parameters_undeclared_parameters_allowed) {
     EXPECT_EQ(results.size(), 2u);
 
     EXPECT_EQ(results[0].name, name1);
-    EXPECT_EQ(results[0].type, rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER);
+    EXPECT_EQ(results[0].type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
     EXPECT_FALSE(results[0].read_only);
 
     EXPECT_EQ(results[1].name, name2);
-    EXPECT_EQ(results[1].type, rcl_interfaces::msg::ParameterType::PARAMETER_STRING);
+    EXPECT_EQ(results[1].type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
     EXPECT_TRUE(results[1].read_only);
   }
   {

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -699,7 +699,6 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     // setting a parameter with integer range descriptor
     auto name = "parameter"_unq;
     rcl_interfaces::msg::ParameterDescriptor descriptor;
-    descriptor.type = rclcpp::PARAMETER_INTEGER;
     descriptor.integer_range.resize(1);
     auto & integer_range = descriptor.integer_range.at(0);
     integer_range.from_value = 10;
@@ -726,7 +725,6 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     // setting a parameter with integer range descriptor and wrong default value will throw
     auto name = "parameter"_unq;
     rcl_interfaces::msg::ParameterDescriptor descriptor;
-    descriptor.type = rclcpp::PARAMETER_INTEGER;
     descriptor.integer_range.resize(1);
     auto & integer_range = descriptor.integer_range.at(0);
     integer_range.from_value = 10;
@@ -735,10 +733,9 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     ASSERT_THROW(node->declare_parameter(name, 42, descriptor), rclcpp::exceptions::InvalidParameterValueException);
   }
   {
-    // setting a parameter with floatin point range descriptor
+    // setting a parameter with floating point range descriptor
     auto name = "parameter"_unq;
     rcl_interfaces::msg::ParameterDescriptor descriptor;
-    descriptor.type = rclcpp::PARAMETER_DOUBLE;
     descriptor.floating_point_range.resize(1);
     auto & floating_point_range = descriptor.floating_point_range.at(0);
     floating_point_range.from_value = 10.0;
@@ -762,8 +759,8 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     EXPECT_EQ(node->get_parameter(name).get_value<double>(), 11.0);
   }
   {
-    // setting a parameter with a different type will fail if
-    // it has a descriptor specifying a type
+    // setting a parameter with a different type is still possible
+    // when having a descriptor specifying a type (type is a status, not a constraint).
     auto name = "parameter"_unq;
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.type = rclcpp::PARAMETER_INTEGER;
@@ -773,12 +770,11 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER);
     EXPECT_EQ(value.get_value<int64_t>(), 42);
 
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, "asd")).successful);
-
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, "asd")).successful);
     EXPECT_TRUE(node->has_parameter(name));
     value = node->get_parameter(name);
-    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER);
-    EXPECT_EQ(value.get_value<int64_t>(), 42);
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_STRING);
+    EXPECT_EQ(value.get_value<std::string>(), "asd");
   }
 }
 

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -1531,13 +1531,13 @@ TEST_F(TestNode, describe_parameter_undeclared_parameters_not_allowed) {
     {
       auto result = node->describe_parameter(name1);
       EXPECT_EQ(result.name, name1);
-      EXPECT_EQ(result.type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
+      EXPECT_EQ(result.type, rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER);
       EXPECT_FALSE(result.read_only);
     }
     {
       auto result = node->describe_parameter(name2);
       EXPECT_EQ(result.name, name2);
-      EXPECT_EQ(result.type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
+      EXPECT_EQ(result.type, rcl_interfaces::msg::ParameterType::PARAMETER_STRING);
       EXPECT_TRUE(result.read_only);
     }
   }
@@ -1571,13 +1571,13 @@ TEST_F(TestNode, describe_parameter_undeclared_parameters_allowed) {
     {
       auto result = node->describe_parameter(name1);
       EXPECT_EQ(result.name, name1);
-      EXPECT_EQ(result.type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
+      EXPECT_EQ(result.type, rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER);
       EXPECT_FALSE(result.read_only);
     }
     {
       auto result = node->describe_parameter(name2);
       EXPECT_EQ(result.name, name2);
-      EXPECT_EQ(result.type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
+      EXPECT_EQ(result.type, rcl_interfaces::msg::ParameterType::PARAMETER_STRING);
       EXPECT_TRUE(result.read_only);
     }
   }
@@ -1614,11 +1614,11 @@ TEST_F(TestNode, describe_parameters_undeclared_parameters_not_allowed) {
     EXPECT_EQ(results.size(), 2u);
 
     EXPECT_EQ(results[0].name, name1);
-    EXPECT_EQ(results[0].type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
+    EXPECT_EQ(results[0].type, rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER);
     EXPECT_FALSE(results[0].read_only);
 
     EXPECT_EQ(results[1].name, name2);
-    EXPECT_EQ(results[1].type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
+    EXPECT_EQ(results[1].type, rcl_interfaces::msg::ParameterType::PARAMETER_STRING);
     EXPECT_TRUE(results[1].read_only);
   }
   {
@@ -1659,15 +1659,15 @@ TEST_F(TestNode, describe_parameters_undeclared_parameters_not_allowed) {
     EXPECT_EQ(results.size(), 3u);
 
     EXPECT_EQ(results[0].name, name2);
-    EXPECT_EQ(results[0].type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
+    EXPECT_EQ(results[0].type, rcl_interfaces::msg::ParameterType::PARAMETER_STRING);
     EXPECT_TRUE(results[0].read_only);
 
     EXPECT_EQ(results[1].name, name1);
-    EXPECT_EQ(results[1].type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
+    EXPECT_EQ(results[1].type, rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER);
     EXPECT_FALSE(results[1].read_only);
 
     EXPECT_EQ(results[2].name, name2);
-    EXPECT_EQ(results[2].type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
+    EXPECT_EQ(results[2].type, rcl_interfaces::msg::ParameterType::PARAMETER_STRING);
     EXPECT_TRUE(results[2].read_only);
   }
 }
@@ -1692,11 +1692,11 @@ TEST_F(TestNode, describe_parameters_undeclared_parameters_allowed) {
     EXPECT_EQ(results.size(), 2u);
 
     EXPECT_EQ(results[0].name, name1);
-    EXPECT_EQ(results[0].type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
+    EXPECT_EQ(results[0].type, rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER);
     EXPECT_FALSE(results[0].read_only);
 
     EXPECT_EQ(results[1].name, name2);
-    EXPECT_EQ(results[1].type, rcl_interfaces::msg::ParameterType::PARAMETER_NOT_SET);
+    EXPECT_EQ(results[1].type, rcl_interfaces::msg::ParameterType::PARAMETER_STRING);
     EXPECT_TRUE(results[1].read_only);
   }
   {

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -722,6 +722,32 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     EXPECT_EQ(node->get_parameter(name).get_value<int64_t>(), 18);
   }
   {
+    // setting a parameter with integer range descriptor, step=0
+    auto name = "parameter"_unq;
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.integer_range.resize(1);
+    auto & integer_range = descriptor.integer_range.at(0);
+    integer_range.from_value = 10;
+    integer_range.to_value = 18;
+    integer_range.step = 0;
+    node->declare_parameter(name, 10, descriptor);
+    EXPECT_TRUE(node->has_parameter(name));
+    auto value = node->get_parameter(name);
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER);
+    EXPECT_EQ(value.get_value<int64_t>(), 10);
+
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, 11)).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<int64_t>(), 11);
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, 15)).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<int64_t>(), 15);
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, 18)).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<int64_t>(), 18);
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, 9)).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<int64_t>(), 18);
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, 19)).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<int64_t>(), 18);
+  }
+  {
     // setting a parameter with integer range descriptor and wrong default value will throw
     auto name = "parameter"_unq;
     rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -758,6 +784,32 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, 12.0)).successful);
     EXPECT_EQ(node->get_parameter(name).get_value<double>(), 11.0);
     EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, 9.4)).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<double>(), 11.0);
+  }
+  {
+    // setting a parameter with floating point range descriptor, step=0
+    auto name = "parameter"_unq;
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.floating_point_range.resize(1);
+    auto & floating_point_range = descriptor.floating_point_range.at(0);
+    floating_point_range.from_value = 10.0;
+    floating_point_range.to_value = 11.0;
+    floating_point_range.step = 0.0;
+    node->declare_parameter(name, 10.0, descriptor);
+    EXPECT_TRUE(node->has_parameter(name));
+    auto value = node->get_parameter(name);
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_DOUBLE);
+    EXPECT_EQ(value.get_value<double>(), 10.0);
+
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, 10.0001)).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<double>(), 10.0001);
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, 10.5479051)).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<double>(), 10.5479051);
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, 11.0)).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<double>(), 11.0);
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, 11.001)).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<double>(), 11.0);
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, 9.999)).successful);
     EXPECT_EQ(node->get_parameter(name).get_value<double>(), 11.0);
   }
   {


### PR DESCRIPTION
Closes #728.

As discussed in #728, I'm not applying type enforcement. Commits https://github.com/ros2/rclcpp/commit/4661bf3cc69e1f2125178c1f1072d120269ad260 and https://github.com/ros2/rclcpp/commit/479940c17acdce29d563d5d684b862078e727800 are reverting type enforcement (I started implementing it).

I have to add more test cases, but it would be good to get an early review.