### PR TITLE
fix behavior of get_parameter when used with allow_undeclared_parameter

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -649,8 +649,11 @@ public:
    *
    * If undeclared parameters are allowed, see the node option
    * rclcpp::NodeOptions::allow_undeclared_parameters, then this method will
-   * not throw an exception, and instead return a default initialized
-   * rclcpp::Parameter, which has a type of
+   * not throw an exception.
+   * It will instead attempt to get a value from the "initial parameter values",
+   * i.e. from rclcpp::NodeOptions::initial_parameters or a YAML file on the
+   * command line, and if it is not found there either, it will return a
+   * default initialized rclcpp::Parameter, which has a type of
    * rclcpp::ParameterType::PARAMETER_NOT_SET.
    *
    * \param[in] name The name of the parameter to get.
@@ -670,6 +673,16 @@ public:
    *
    * If the parameter was not declared, then the output argument for this
    * method which is called "parameter" will not be assigned a value.
+   *
+   * However, if undeclared parameters are allowed, see the node option
+   * rclcpp::NodeOptions::allow_undeclared_parameters, this function will
+   * instead attempt to get a value from the "initial parameter values",
+   * i.e. from rclcpp::NodeOptions::initial_parameters or a YAML file on the
+   * command line.
+   * If a value is found from there, true will returned.
+   * If not found there, it will not assign the "parameter" arugment and then
+   * return false.
+   *
    * If the parameter was declared, and therefore has a value, then it is
    * assigned into the "parameter" argument of this method.
    *

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -1208,6 +1208,38 @@ TEST_F(TestNode, get_parameter_undeclared_parameters_allowed) {
   }
 }
 
+// test get_parameter with undeclared allowed and initial parameter values
+TEST_F(TestNode, get_parameter_undeclared_parameters_allowed_with_initial_values) {
+  rclcpp::NodeOptions options;
+  options
+  .allow_undeclared_parameters(true)
+  .initial_parameters({
+    {"my_string", "str"},
+    {"my_int", 42},
+    {"my_double", 3.14},
+    {"my_bool", true},
+    {"my_unset", rclcpp::ParameterValue()},
+  });
+  auto node = std::make_shared<rclcpp::Node>(
+    "test_get_parameter_node"_unq,
+    options);
+  {
+    // getting an undeclared parameter, which has an initial parameter value, returns that value
+    for (const auto & initial_param : options.initial_parameters()) {
+      const auto & name = initial_param.get_name();
+
+      EXPECT_FALSE(node->has_parameter(name));
+
+      EXPECT_EQ(node->get_parameter(name).get_type(), initial_param.get_type());
+      {
+        rclcpp::Parameter parameter;
+        EXPECT_TRUE(node->get_parameter(name, parameter));
+        EXPECT_EQ(parameter, initial_param);
+      }
+    }
+  }
+}
+
 // test get_parameter_or with undeclared not allowed
 TEST_F(TestNode, get_parameter_or_undeclared_parameters_not_allowed) {
   auto node = std::make_shared<rclcpp::Node>(


### PR DESCRIPTION
Should fix https://github.com/ros2/rclcpp/issues/730.

I think I missed this case when testing because I tested `declare_parameter` in combination with `allow_undeclared_parameters` AND `rclcpp::NodeOptions::initial_parameters`, but for `get_parameter` I only tested with and without `allow_undeclared_parameters` but not in conjunction with `rclcpp::NodeOptions::initial_parameters`.

@chapulina I don't know how easy it is for you to try this pr out, but hopefully it should make your porting only _require_ switching the `allows_undeclared_parameter` flag to `true`, even if you decide to do more changes and use `declare_parameters`.