### PR TITLE
Bionic use of strerror_r

### DIFF
--- a/rclcpp/src/rclcpp/signal_handler.cpp
+++ b/rclcpp/src/rclcpp/signal_handler.cpp
@@ -165,13 +165,15 @@ __safe_strerror(int errnum, char * buffer, size_t buffer_length)
 {
 #if defined(_WIN32)
   strerror_s(buffer, buffer_length, errnum);
-#elif (defined(_GNU_SOURCE) && !defined(ANDROID))
+#elif defined(_GNU_SOURCE) && (!defined(ANDROID) || __ANDROID_API__ >= 23)
+  /* GNU-specific */
   char * msg = strerror_r(errnum, buffer, buffer_length);
   if (msg != buffer) {
     strncpy(buffer, msg, buffer_length);
     buffer[buffer_length - 1] = '\0';
   }
 #else
+  /* XSI-compliant */
   int error_status = strerror_r(errnum, buffer, buffer_length);
   if (error_status != 0) {
     throw std::runtime_error("Failed to get error string for errno: " + std::to_string(errnum));


### PR DESCRIPTION
Since API 23 Android Bionic uses the GNU convention for strerror_r.

Following the string.h definition in bionic/libc, line 96
  https://android.googlesource.com/platform/bionic.git/+/refs/heads/master/libc/include/string.h
I suggest to add the API variant to select between the GNU or XSI variant.