### PR TITLE
Ignore parameters overrides in set parameter methods when allowing undeclared parameters

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -516,6 +516,7 @@ public:
    * rclcpp::NodeOptions::allow_undeclared_parameters set to true.
    * If undeclared parameters are allowed, then the parameter is implicitly
    * declared with the default parameter meta data before being set.
+   * Parameter overrides are ignored by set_parameter.
    *
    * This method will result in any callback registered with
    * set_on_parameters_set_callback to be called.

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -1066,9 +1066,20 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
 }
 
 TEST_F(TestNode, set_parameter_undeclared_parameters_allowed) {
-  auto node = std::make_shared<rclcpp::Node>(
-    "test_set_parameter_node"_unq,
-    rclcpp::NodeOptions().allow_undeclared_parameters(true));
+  rclcpp::NodeOptions no;
+  no.parameter_overrides({
+    {"parameter_with_override", 30},
+  });
+  no.allow_undeclared_parameters(true);
+  auto node = std::make_shared<rclcpp::Node>("test_set_parameter_node"_unq, no);
+  {
+    // overrides are ignored when not declaring a parameter
+    auto name = "parameter_with_override";
+    EXPECT_FALSE(node->has_parameter(name));
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, 43)).successful);
+    EXPECT_TRUE(node->has_parameter(name));
+    EXPECT_EQ(node->get_parameter(name).get_value<int>(), 43);
+  }
   {
     // normal use (declare first) still works with this true
     auto name = "parameter"_unq;


### PR DESCRIPTION
See https://github.com/ros2/rclcpp/issues/730#issuecomment-496215079 and https://github.com/ros2/rclcpp/issues/730#issuecomment-496676163.
Partially solves https://github.com/ros2/rclcpp/issues/750.