### PR TITLE
Add rclcpp::create_timer()

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -165,6 +165,7 @@ if(BUILD_TESTING)
       "rosidl_typesupport_cpp"
     )
     target_link_libraries(test_create_timer ${PROJECT_NAME})
+    target_include_directories(test_create_timer PRIVATE test/)
   endif()
   ament_add_gtest(test_expand_topic_or_service_name test/test_expand_topic_or_service_name.cpp)
   if(TARGET test_expand_topic_or_service_name)

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -155,6 +155,17 @@ if(BUILD_TESTING)
     )
     target_link_libraries(test_client ${PROJECT_NAME})
   endif()
+  ament_add_gtest(test_create_timer test/test_create_timer.cpp)
+  if(TARGET test_create_timer)
+    ament_target_dependencies(test_create_timer
+      "rcl_interfaces"
+      "rmw"
+      "rcl"
+      "rosidl_generator_cpp"
+      "rosidl_typesupport_cpp"
+    )
+    target_link_libraries(test_create_timer ${PROJECT_NAME})
+  endif()
   ament_add_gtest(test_expand_topic_or_service_name test/test_expand_topic_or_service_name.cpp)
   if(TARGET test_expand_topic_or_service_name)
     ament_target_dependencies(test_expand_topic_or_service_name

--- a/rclcpp/include/rclcpp/create_timer.hpp
+++ b/rclcpp/include/rclcpp/create_timer.hpp
@@ -19,19 +19,21 @@
 #include <string>
 #include <utility>
 
+#include "rclcpp/duration.hpp"
+# include "rclcpp/node_interfaces/get_node_base_interface.hpp"
+# include "rclcpp/node_interfaces/get_node_timers_interface.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/node_interfaces/node_timers_interface.hpp"
-#include "rclcpp/duration.hpp"
-
 
 namespace rclcpp
 {
-/// Create a timer with a given type.
+/// Create a timer with a given clock
+/// \internal
 template<typename CallbackT>
 typename rclcpp::TimerBase::SharedPtr
 create_timer(
-  std::shared_ptr<node_interfaces::NodeBaseInterface> node_base,
-  std::shared_ptr<node_interfaces::NodeTimersInterface> node_timers,
+  node_interfaces::NodeBaseInterface * node_base,
+  node_interfaces::NodeTimersInterface * node_timers,
   rclcpp::Clock::SharedPtr clock,
   rclcpp::Duration period,
   CallbackT && callback,
@@ -45,6 +47,27 @@ create_timer(
 
   node_timers->add_timer(timer, group);
   return timer;
+}
+
+/// Create a timer with a given clock
+template<typename NodeT, typename CallbackT>
+typename rclcpp::TimerBase::SharedPtr
+create_timer(
+  NodeT node,
+  rclcpp::Clock::SharedPtr clock,
+  rclcpp::Duration period,
+  CallbackT && callback,
+  rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr)
+{
+  return create_timer(
+    rclcpp::node_interfaces::get_node_base_interface(node),
+    rclcpp::node_interfaces::get_node_timers_interface(node),
+    clock,
+    period,
+    // *INDENT-OFF*
+    std::forward<CallbackT &&>(callback),
+    // *INDENT-ON*
+    group);
 }
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/create_timer.hpp
+++ b/rclcpp/include/rclcpp/create_timer.hpp
@@ -42,7 +42,7 @@ create_timer(
   auto timer = rclcpp::GenericTimer<CallbackT>::make_shared(
     clock,
     period.to_chrono<std::chrono::nanoseconds>(),
-    std::forward<CallbackT &&>(callback),
+    std::forward<CallbackT>(callback),
     node_base->get_context());
 
   node_timers->add_timer(timer, group);
@@ -64,9 +64,7 @@ create_timer(
     rclcpp::node_interfaces::get_node_timers_interface(node),
     clock,
     period,
-    // *INDENT-OFF*
-    std::forward<CallbackT &&>(callback),
-    // *INDENT-ON*
+    std::forward<CallbackT>(callback),
     group);
 }
 

--- a/rclcpp/include/rclcpp/create_timer.hpp
+++ b/rclcpp/include/rclcpp/create_timer.hpp
@@ -1,0 +1,52 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__CREATE_TIMER_HPP_
+#define RCLCPP__CREATE_TIMER_HPP_
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "rclcpp/node_interfaces/node_base_interface.hpp"
+#include "rclcpp/node_interfaces/node_timers_interface.hpp"
+#include "rclcpp/duration.hpp"
+
+
+namespace rclcpp
+{
+/// Create a timer with a given type.
+template<typename CallbackT>
+typename rclcpp::TimerBase::SharedPtr
+create_timer(
+  std::shared_ptr<node_interfaces::NodeBaseInterface> node_base,
+  std::shared_ptr<node_interfaces::NodeTimersInterface> node_timers,
+  rclcpp::Clock::SharedPtr clock,
+  rclcpp::Duration period,
+  CallbackT && callback,
+  rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr)
+{
+  auto timer = rclcpp::GenericTimer<CallbackT>::make_shared(
+    clock,
+    period.to_chrono<std::chrono::nanoseconds>(),
+    std::forward<CallbackT &&>(callback),
+    node_base->get_context());
+
+  node_timers->add_timer(timer, group);
+  return timer;
+}
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__CREATE_TIMER_HPP_

--- a/rclcpp/include/rclcpp/node_interfaces/get_node_base_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/get_node_base_interface.hpp
@@ -1,0 +1,147 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__NODE_INTERFACES__GET_NODE_BASE_INTERFACE_HPP_
+#define RCLCPP__NODE_INTERFACES__GET_NODE_BASE_INTERFACE_HPP_
+
+#include <memory>
+#include <utility>
+#include <type_traits>
+
+#include "rclcpp/node_interfaces/node_base_interface.hpp"
+
+/// This header provides the get_node_base_interface() template function.
+/**
+ * This function is useful for getting the NodeBaseInterface pointer from
+ * various kinds of Node-like classes.
+ *
+ * It's able to get the NodeBaseInterface pointer so long as the class
+ * has a method called ``get_node_base_interface()`` which returns
+ * either a pointer (const or not) to a NodeBaseInterface or a
+ * std::shared_ptr to a NodeBaseInterface.
+ */
+
+namespace rclcpp
+{
+namespace node_interfaces
+{
+
+namespace detail
+{
+
+// This is a meta-programming checker for if a given Node-like object has a
+// getter called get_node_base_interface() which returns various types,
+// e.g. const pointer or a shared pointer.
+template<typename NodeType, typename ReturnType>
+struct has_get_node_base_interface
+{
+private:
+  template<typename T>
+  static constexpr
+  auto
+  check(T *)->typename std::is_same<
+    decltype(std::declval<T>().get_node_base_interface()),
+    ReturnType
+  >::type;
+
+  template<typename>
+  static constexpr
+  std::false_type
+  check(...);
+
+public:
+  using type = decltype(check<NodeType>(nullptr));
+  static constexpr bool value = type::value;
+};
+
+// If NodeType is a pointer to NodeBaseInterface already (just normal function overload).
+inline
+rclcpp::node_interfaces::NodeBaseInterface *
+get_node_base_interface_from_pointer(rclcpp::node_interfaces::NodeBaseInterface * pointer)
+{
+  return pointer;
+}
+
+// If NodeType has a method called get_node_base_interface() which returns a shared pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_base_interface<
+    typename std::remove_pointer<NodeType>::type,
+    std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeBaseInterface *
+get_node_base_interface_from_pointer(NodeType node_pointer)
+{
+  return node_pointer->get_node_base_interface().get();
+}
+
+// If NodeType has a method called get_node_base_interface() which returns a pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_base_interface<
+    typename std::remove_pointer<NodeType>::type,
+    rclcpp::node_interfaces::NodeBaseInterface *
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeBaseInterface *
+get_node_base_interface_from_pointer(NodeType node_pointer)
+{
+  return node_pointer->get_node_base_interface();
+}
+
+// Forward shared_ptr's to const node pointer signatures.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_same<
+    NodeType,
+    typename std::shared_ptr<typename std::remove_pointer<NodeType>::type::element_type> *
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeBaseInterface *
+get_node_base_interface_from_pointer(NodeType node_shared_pointer)
+{
+  return get_node_base_interface_from_pointer(node_shared_pointer->get());
+}
+
+}  // namespace detail
+
+/// Get the NodeBaseInterface as a pointer from a pointer to a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeBaseInterface *
+get_node_base_interface(NodeType && node_pointer)
+{
+  // Forward pointers to detail implmentation directly.
+  return detail::get_node_base_interface_from_pointer(std::forward<NodeType>(node_pointer));
+}
+
+/// Get the NodeBaseInterface as a pointer from a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<!std::is_pointer<NodeType>::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeBaseInterface *
+get_node_base_interface(NodeType && node_reference)
+{
+  // Forward references to detail implmentation as a pointer.
+  return detail::get_node_base_interface_from_pointer(&node_reference);
+}
+
+}  // namespace node_interfaces
+}  // namespace rclcpp
+
+#endif  // RCLCPP__NODE_INTERFACES__GET_NODE_BASE_INTERFACE_HPP_

--- a/rclcpp/include/rclcpp/node_interfaces/get_node_timers_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/get_node_timers_interface.hpp
@@ -1,0 +1,147 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__NODE_INTERFACES__GET_NODE_TIMERS_INTERFACE_HPP_
+#define RCLCPP__NODE_INTERFACES__GET_NODE_TIMERS_INTERFACE_HPP_
+
+#include <memory>
+#include <utility>
+#include <type_traits>
+
+#include "rclcpp/node_interfaces/node_timers_interface.hpp"
+
+/// This header provides the get_node_timers_interface() template function.
+/**
+ * This function is useful for getting the NodeTimersInterface pointer from
+ * various kinds of Node-like classes.
+ *
+ * It's able to get the NodeTimersInterface pointer so long as the class
+ * has a method called ``get_node_timers_interface()`` which returns
+ * either a pointer (const or not) to a NodeTimersInterface or a
+ * std::shared_ptr to a NodeTimersInterface.
+ */
+
+namespace rclcpp
+{
+namespace node_interfaces
+{
+
+namespace detail
+{
+
+// This is a meta-programming checker for if a given Node-like object has a
+// getter called get_node_timers_interface() which returns various types,
+// e.g. const pointer or a shared pointer.
+template<typename NodeType, typename ReturnType>
+struct has_get_node_timers_interface
+{
+private:
+  template<typename T>
+  static constexpr
+  auto
+  check(T *)->typename std::is_same<
+    decltype(std::declval<T>().get_node_timers_interface()),
+    ReturnType
+  >::type;
+
+  template<typename>
+  static constexpr
+  std::false_type
+  check(...);
+
+public:
+  using type = decltype(check<NodeType>(nullptr));
+  static constexpr bool value = type::value;
+};
+
+// If NodeType is a pointer to NodeTimersInterface already (just normal function overload).
+inline
+rclcpp::node_interfaces::NodeTimersInterface *
+get_node_timers_interface_from_pointer(rclcpp::node_interfaces::NodeTimersInterface * pointer)
+{
+  return pointer;
+}
+
+// If NodeType has a method called get_node_timers_interface() which returns a shared pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_timers_interface<
+    typename std::remove_pointer<NodeType>::type,
+    std::shared_ptr<rclcpp::node_interfaces::NodeTimersInterface>
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeTimersInterface *
+get_node_timers_interface_from_pointer(NodeType node_pointer)
+{
+  return node_pointer->get_node_timers_interface().get();
+}
+
+// If NodeType has a method called get_node_timers_interface() which returns a pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_timers_interface<
+    typename std::remove_pointer<NodeType>::type,
+    rclcpp::node_interfaces::NodeTimersInterface *
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeTimersInterface *
+get_node_timers_interface_from_pointer(NodeType node_pointer)
+{
+  return node_pointer->get_node_timers_interface();
+}
+
+// Forward shared_ptr's to const node pointer signatures.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_same<
+    NodeType,
+    typename std::shared_ptr<typename std::remove_pointer<NodeType>::type::element_type> *
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeTimersInterface *
+get_node_timers_interface_from_pointer(NodeType node_shared_pointer)
+{
+  return get_node_timers_interface_from_pointer(node_shared_pointer->get());
+}
+
+}  // namespace detail
+
+/// Get the NodeTimersInterface as a pointer from a pointer to a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeTimersInterface *
+get_node_timers_interface(NodeType && node_pointer)
+{
+  // Forward pointers to detail implmentation directly.
+  return detail::get_node_timers_interface_from_pointer(std::forward<NodeType>(node_pointer));
+}
+
+/// Get the NodeTimersInterface as a pointer from a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<!std::is_pointer<NodeType>::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeTimersInterface *
+get_node_timers_interface(NodeType && node_reference)
+{
+  // Forward references to detail implmentation as a pointer.
+  return detail::get_node_timers_interface_from_pointer(&node_reference);
+}
+
+}  // namespace node_interfaces
+}  // namespace rclcpp
+
+#endif  // RCLCPP__NODE_INTERFACES__GET_NODE_TIMERS_INTERFACE_HPP_

--- a/rclcpp/test/test_create_timer.cpp
+++ b/rclcpp/test/test_create_timer.cpp
@@ -21,6 +21,7 @@
 #include "rclcpp/create_timer.hpp"
 #include "rclcpp/executors.hpp"
 #include "rclcpp/node.hpp"
+#include "node_interfaces/node_wrapper.hpp"
 
 using namespace std::chrono_literals;
 
@@ -44,5 +45,19 @@ TEST(TestCreateTimer, timer_executes)
   rclcpp::spin_some(node);
 
   ASSERT_TRUE(got_callback);
+  rclcpp::shutdown();
+}
+
+TEST(TestCreateTimer, call_with_node_wrapper_compiles)
+{
+  rclcpp::init(0, nullptr);
+  NodeWrapper node("test_create_timer_call_with_node_wrapper_compiles");
+
+  rclcpp::TimerBase::SharedPtr timer;
+  timer = rclcpp::create_timer(
+    node,
+    node.get_node_clock_interface()->get_clock(),
+    rclcpp::Duration(0ms),
+    []() {});
   rclcpp::shutdown();
 }

--- a/rclcpp/test/test_create_timer.cpp
+++ b/rclcpp/test/test_create_timer.cpp
@@ -1,0 +1,49 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+
+#include "rclcpp/create_timer.hpp"
+#include "rclcpp/executors.hpp"
+#include "rclcpp/node.hpp"
+
+using namespace std::chrono_literals;
+
+TEST(TestCreateTimer, timer_executes)
+{
+  rclcpp::init(0, nullptr);
+  auto node = std::make_shared<rclcpp::Node>("test_create_timer_node");
+
+  std::atomic<bool> got_callback{false};
+
+  rclcpp::TimerBase::SharedPtr timer;
+  timer = rclcpp::create_timer(
+    node->get_node_base_interface(),
+    node->get_node_timers_interface(),
+    node->get_clock(),
+    rclcpp::Duration(0ms),
+    [&got_callback, &timer]() {
+      got_callback = true;
+      timer->cancel();
+    });
+
+  rclcpp::spin_some(node);
+
+  ASSERT_TRUE(got_callback);
+  rclcpp::shutdown();
+}

--- a/rclcpp/test/test_create_timer.cpp
+++ b/rclcpp/test/test_create_timer.cpp
@@ -33,8 +33,7 @@ TEST(TestCreateTimer, timer_executes)
 
   rclcpp::TimerBase::SharedPtr timer;
   timer = rclcpp::create_timer(
-    node->get_node_base_interface(),
-    node->get_node_timers_interface(),
+    node,
     node->get_clock(),
     rclcpp::Duration(0ms),
     [&got_callback, &timer]() {


### PR DESCRIPTION
This is a convenience PR that I'm hoping to get in the first Dashing patch release. It adds `rclcpp::create_timer()` that contains the boilerplate for creating a timer with any clock, [not just wall time](https://github.com/ros2/rclcpp/blob/4532d9cf784a85c899161a9b82e7d65814269f92/rclcpp/include/rclcpp/node.hpp#L335).