### PR TITLE
Add rclcpp::spin() version with executor reference

### DIFF
--- a/rclcpp/include/rclcpp/executors.hpp
+++ b/rclcpp/include/rclcpp/executors.hpp
@@ -47,6 +47,23 @@ RCLCPP_PUBLIC
 void
 spin(rclcpp::Node::SharedPtr node_ptr);
 
+/// Pass in an executor and spin the specified node.
+/**
+ * \param[in] node_ptr Shared pointer to the node to spin. 
+ * \param[in] executor The executor which will spin the node. 
+ */
+RCLCPP_PUBLIC
+void
+spin(
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr,
+  rclcpp::executor::Executor & executor);
+
+RCLCPP_PUBLIC
+void
+spin(
+  rclcpp::Node::SharedPtr node_ptr,
+  rclcpp::executor::Executor & executor);
+
 namespace executors
 {
 

--- a/rclcpp/src/rclcpp/executors.cpp
+++ b/rclcpp/src/rclcpp/executors.cpp
@@ -41,3 +41,21 @@ rclcpp::spin(rclcpp::Node::SharedPtr node_ptr)
 {
   rclcpp::spin(node_ptr->get_node_base_interface());
 }
+
+void
+rclcpp::spin(
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr,
+  rclcpp::executor::Executor & executor)
+{
+  executor.add_node(node_ptr);
+  executor.spin();
+  executor.remove_node(node_ptr);
+}
+
+void
+rclcpp::spin(
+  rclcpp::Node::SharedPtr node_ptr,
+  rclcpp::executor::Executor & executor)
+{
+  rclcpp::spin(node_ptr->get_node_base_interface(), executor);
+}


### PR DESCRIPTION
To deal with thread cleanup issues upon destruction in https://github.com/ros2/geometry2/pull/114, for example, we needed to stop spinning the node in the thread before it could be joined. Having realized this change using `spin_some` led to high cpu usage, the pattern in https://github.com/ros-planning/navigation2/pull/866 and https://github.com/ros2/geometry2/pull/119 was proposed. 

To consolidate this pattern in `rclcpp`, this PR adds an interface to enable the user to pass in a reference to an Executor to spin the node. This change would allow for the user to manage the executor in order to do things such as call `executor.cancel()` to end the spin before joining a thread.

Signed-off-by: bpwilcox <bpwilcox@eng.ucsd.edu>