### PR TITLE
use default parameter descriptor in parameters interface

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -51,7 +51,7 @@ public:
   const rclcpp::ParameterValue &
   declare_parameter(
     const std::string & name,
-    const rclcpp::ParameterValue & default_value,
+    const rclcpp::ParameterValue & default_value = rclcpp::ParameterValue(),
     const rcl_interfaces::msg::ParameterDescriptor & parameter_descriptor =
     rcl_interfaces::msg::ParameterDescriptor()) = 0;
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -52,7 +52,8 @@ public:
   declare_parameter(
     const std::string & name,
     const rclcpp::ParameterValue & default_value,
-    const rcl_interfaces::msg::ParameterDescriptor & parameter_descriptor) = 0;
+    const rcl_interfaces::msg::ParameterDescriptor & parameter_descriptor =
+    rcl_interfaces::msg::ParameterDescriptor()) = 0;
 
   /// Undeclare a parameter.
   /**


### PR DESCRIPTION
When working only with node interfaces, having a default parameter descriptor is convenient and resembles the API on the node

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7400)](http://ci.ros2.org/job/ci_linux/7400/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3556)](http://ci.ros2.org/job/ci_linux-aarch64/3556/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6073)](http://ci.ros2.org/job/ci_osx/6073/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7228)](http://ci.ros2.org/job/ci_windows/7228/)

Signed-off-by: Karsten Knese <karsten@openrobotics.org>