### PR TITLE
Add ignore override argument to declare parameter

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -369,6 +369,8 @@ public:
    * are ignored, and should be specified using the name argument to this
    * function and the default value's type instead.
    *
+   * If `ignore_override` is `true`, the parameter override will be ignored.
+   *
    * This method, if successful, will result in any callback registered with
    * set_on_parameters_set_callback to be called.
    * If that callback prevents the initial value for the parameter from being
@@ -382,6 +384,8 @@ public:
    *   did not override it.
    * \param[in] parameter_descriptor An optional, custom description for
    *   the parameter.
+   * \param[in] ignore_override When `true`, the parameter override is ignored.
+   *    Default to `false`.
    * \return A const reference to the value of the parameter.
    * \throws rclcpp::exceptions::ParameterAlreadyDeclaredException if parameter
    *   has already been declared.
@@ -444,8 +448,7 @@ public:
    *
    * The map contains default values for parameters.
    * There is another overload which takes the std::pair with the default value
-   * and descriptor, and another which takes an std::tuple with the same two
-   * parameters and a bool indicating if overriding the parameter default is allowed.
+   * and descriptor.
    *
    * If `ignore_overrides` is `true`, all the overrides of the parameters declared
    * by the function call will be ignored.
@@ -457,6 +460,8 @@ public:
    *
    * \param[in] namespace_ The namespace in which to declare the parameters.
    * \param[in] parameters The parameters to set in the given namespace.
+   * \param[in] ignore_overrides When `true`, the parameters overrides are ignored.
+   *    Default to `false`.
    * \throws rclcpp::exceptions::ParameterAlreadyDeclaredException if parameter
    *   has already been declared.
    * \throws rclcpp::exceptions::InvalidParametersException if a parameter

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -396,7 +396,8 @@ public:
     const std::string & name,
     const rclcpp::ParameterValue & default_value = rclcpp::ParameterValue(),
     const rcl_interfaces::msg::ParameterDescriptor & parameter_descriptor =
-    rcl_interfaces::msg::ParameterDescriptor());
+    rcl_interfaces::msg::ParameterDescriptor(),
+    bool ignore_override = false);
 
   /// Declare and initialize a parameter with a type.
   /**
@@ -425,7 +426,8 @@ public:
     const std::string & name,
     const ParameterT & default_value,
     const rcl_interfaces::msg::ParameterDescriptor & parameter_descriptor =
-    rcl_interfaces::msg::ParameterDescriptor());
+    rcl_interfaces::msg::ParameterDescriptor(),
+    bool ignore_override = false);
 
   /// Declare and initialize several parameters with the same namespace and type.
   /**
@@ -440,11 +442,13 @@ public:
    * expanding "namespace.key".
    * This allows you to declare several parameters at once without a namespace.
    *
-   * The map may either contain default values for parameters, or a std::pair
-   * where the first element is a default value and the second is a
-   * parameter descriptor.
-   * This function only takes the default value, but there is another overload
-   * which takes the std::pair with the default value and descriptor.
+   * The map contains default values for parameters.
+   * There is another overload which takes the std::pair with the default value
+   * and descriptor, and another which takes an std::tuple with the same two
+   * parameters and a bool indicating if overriding the parameter default is allowed.
+   *
+   * If `ignore_overrides` is `true`, all the overrides of the parameters declared
+   * by the function call will be ignored.
    *
    * This method, if successful, will result in any callback registered with
    * set_on_parameters_set_callback to be called, once for each parameter.
@@ -464,7 +468,8 @@ public:
   std::vector<ParameterT>
   declare_parameters(
     const std::string & namespace_,
-    const std::map<std::string, ParameterT> & parameters);
+    const std::map<std::string, ParameterT> & parameters,
+    bool ignore_overrides = false);
 
   /// Declare and initialize several parameters with the same namespace and type.
   /**
@@ -480,7 +485,8 @@ public:
     const std::map<
       std::string,
       std::pair<ParameterT, rcl_interfaces::msg::ParameterDescriptor>
-    > & parameters);
+    > & parameters,
+    bool ignore_overrides = false);
 
   /// Undeclare a previously declared parameter.
   /**

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
@@ -80,7 +80,8 @@ public:
   declare_parameter(
     const std::string & name,
     const rclcpp::ParameterValue & default_value,
-    const rcl_interfaces::msg::ParameterDescriptor & parameter_descriptor) override;
+    const rcl_interfaces::msg::ParameterDescriptor & parameter_descriptor,
+    bool ignore_override) override;
 
   RCLCPP_PUBLIC
   void

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -53,7 +53,8 @@ public:
     const std::string & name,
     const rclcpp::ParameterValue & default_value = rclcpp::ParameterValue(),
     const rcl_interfaces::msg::ParameterDescriptor & parameter_descriptor =
-    rcl_interfaces::msg::ParameterDescriptor()) = 0;
+    rcl_interfaces::msg::ParameterDescriptor(),
+    bool ignore_override = false) = 0;
 
   /// Undeclare a parameter.
   /**

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -236,9 +236,14 @@ const rclcpp::ParameterValue &
 Node::declare_parameter(
   const std::string & name,
   const rclcpp::ParameterValue & default_value,
-  const rcl_interfaces::msg::ParameterDescriptor & parameter_descriptor)
+  const rcl_interfaces::msg::ParameterDescriptor & parameter_descriptor,
+  bool ignore_override)
 {
-  return this->node_parameters_->declare_parameter(name, default_value, parameter_descriptor);
+  return this->node_parameters_->declare_parameter(
+    name,
+    default_value,
+    parameter_descriptor,
+    ignore_override);
 }
 
 void

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -419,7 +419,7 @@ TEST_F(TestNode, declare_parameter_with_overrides) {
       rcl_interfaces::msg::ParameterDescriptor(),
       true);
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER);
-    EXPECT_EQ(value.get<int>(), 43);  // and not 43 which is the default value
+    EXPECT_EQ(value.get<int>(), 43);  // and not 42, the parameter override is ignored.
   }
   {
     // int default, with initial, custom parameter descriptor

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -362,14 +362,15 @@ TEST_F(TestNode, declare_parameter_with_no_initial_values) {
   }
 }
 
-TEST_F(TestNode, declare_parameter_with_initial_values) {
-  // test cases with initial values
+TEST_F(TestNode, declare_parameter_with_overrides) {
+  // test cases with overrides
   rclcpp::NodeOptions no;
   no.parameter_overrides({
     {"parameter_no_default", 42},
     {"parameter_no_default_set", 42},
     {"parameter_no_default_set_cvref", 42},
     {"parameter_and_default", 42},
+    {"parameter_and_default_ignore_override", 42},
     {"parameter_custom", 42},
     {"parameter_template", 42},
     {"parameter_already_declared", 42},
@@ -378,13 +379,13 @@ TEST_F(TestNode, declare_parameter_with_initial_values) {
   });
   auto node = std::make_shared<rclcpp::Node>("test_declare_parameter_node"_unq, no);
   {
-    // no default, with initial
+    // no default, with override
     rclcpp::ParameterValue value = node->declare_parameter("parameter_no_default");
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER);
     EXPECT_EQ(value.get<int>(), 42);
   }
   {
-    // no default, with initial, and set after
+    // no default, with override, and set after
     rclcpp::ParameterValue value = node->declare_parameter("parameter_no_default_set");
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER);
     EXPECT_EQ(value.get<int>(), 42);
@@ -393,7 +394,7 @@ TEST_F(TestNode, declare_parameter_with_initial_values) {
     EXPECT_EQ(node->get_parameter("parameter_no_default_set").get_value<int>(), 44);
   }
   {
-    // no default, with initial
+    // no default, with override
     const rclcpp::ParameterValue & value =
       node->declare_parameter("parameter_no_default_set_cvref");
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER);
@@ -403,11 +404,22 @@ TEST_F(TestNode, declare_parameter_with_initial_values) {
     EXPECT_EQ(value.get<int>(), 44);
   }
   {
-    // int default, with initial
+    // int default, with override
     rclcpp::ParameterValue default_value(43);
     rclcpp::ParameterValue value = node->declare_parameter("parameter_and_default", default_value);
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER);
     EXPECT_EQ(value.get<int>(), 42);  // and not 43 which is the default value
+  }
+  {
+    // int default, with override and ignoring it
+    rclcpp::ParameterValue default_value(43);
+    rclcpp::ParameterValue value = node->declare_parameter(
+      "parameter_and_default_ignore_override",
+      default_value,
+      rcl_interfaces::msg::ParameterDescriptor(),
+      true);
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER);
+    EXPECT_EQ(value.get<int>(), 43);  // and not 43 which is the default value
   }
   {
     // int default, with initial, custom parameter descriptor


### PR DESCRIPTION
Closes https://github.com/ros2/rclcpp/issues/750.

I also thought about adding:
```cpp
  template<typename ParameterT>
  std::vector<ParameterT>
  declare_parameters(
    const std::string & namespace_,
    const std::map<
      std::string,
      std::tuple<ParameterT, rcl_interfaces::msg::ParameterDescriptor, bool>
    > & parameters);
```

Where the last element of the tuple is a bool indicating if the override of that parameter is ignored or not.

But this:
https://github.com/ros2/rclcpp/blob/f4a979df0bb7162fcde8b6b50fead9a2c020dcf7/rclcpp/test/test_node.cpp#L510-L513
ended up with an ambiguous overload error:
```
call of overloaded ‘declare_parameters(const char [1], <brace-enclosed initializer list>)’ is ambiguous
```

I didn't find a workaround, so I simple deleted that option.