### PR TITLE
Allow registering multiple on_parameters_set_callback

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -942,11 +942,12 @@ public:
    * returned unique pointer is valid.
    * The returned unique pointer can be promoted to a shared version.
    *
-   * Releasing the returned unique pointer unregisters the callback.
+   * Resetting or letting the smart pointer go out of scope unregisters the callback.
    * `remove_on_set_parameters_callback` can also be used.
    *
-   * All the registered callbacks are called when a parameter is set.
-   * The order of the callbacks is not important.
+   * The registered callbacks are called when a parameter is set.
+   * When a callback returns a not successful result, the remaining callbacks aren't called.
+   * The order of the callback execution could be different from the registration order.
    *
    * \param callback The callback to register.
    * \returns A unique pointer. The callback is valid as long as the unique pointer is alive.
@@ -972,10 +973,8 @@ public:
    *
    * Calling `remove_on_set_parameters_callback` more than once with the same handler,
    * or calling it after the shared pointer has been released is an error.
-   * Releasing the smart pointer after calling `remove_on_set_parameters_callback` is not a problem.
-   *
-   * All the registered callbacks are called when a parameter is set.
-   * The order of the callbacks is not important.
+   * Resetting or letting the smart pointer go out of scope after calling
+   * `remove_on_set_parameters_callback` is not a problem.
    *
    * \param handler The callback handler to remove.
    * \throws std::runtime_error if the handler was not created with `add_on_set_parameters_callback`,

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -939,40 +939,40 @@ public:
    * rclcpp::exceptions::ParameterModifiedInCallbackException will be thrown.
    *
    * The callback functions must remain valid as long as the
-   * returned unique pointer is valid.
-   * The returned unique pointer can be promoted to a shared version.
+   * returned smart pointer is valid.
+   * The returned smart pointer can be promoted to a shared version.
    *
    * Resetting or letting the smart pointer go out of scope unregisters the callback.
    * `remove_on_set_parameters_callback` can also be used.
    *
    * The registered callbacks are called when a parameter is set.
    * When a callback returns a not successful result, the remaining callbacks aren't called.
-   * The order of the callback execution could be different from the registration order.
+   * The order of the callback is the reverse from the registration order.
    *
    * \param callback The callback to register.
-   * \returns A unique pointer. The callback is valid as long as the unique pointer is alive.
+   * \returns A shared pointer. The callback is valid as long as the smart pointer is alive.
    * \throws std::bad_alloc if the allocation of the OnSetParametersCallbackHandle fails.
    */
   RCLCPP_PUBLIC
-  OnSetParametersCallbackHandle::UniquePtr
+  OnSetParametersCallbackHandle::SharedPtr
   add_on_set_parameters_callback(OnParametersSetCallbackType callback);
 
   /// Remove a callback registered with `add_on_set_parameters_callback`.
   /**
-   * Releases a handler, returned by `add_on_set_parameters_callback`.
+   * Delete a handler returned by `add_on_set_parameters_callback`.
    *
    * e.g.:
    *
    *    `remove_on_set_parameters_callback(scoped_callback.get())`
    *
-   * As an alternative, the unique pointer can be released:
+   * As an alternative, the smart pointer can be reset:
    *
    *    `scoped_callback.reset()`
    *
    * Supposing that `scoped_callback` was the only owner.
    *
    * Calling `remove_on_set_parameters_callback` more than once with the same handler,
-   * or calling it after the shared pointer has been released is an error.
+   * or calling it after the shared pointer has been reset is an error.
    * Resetting or letting the smart pointer go out of scope after calling
    * `remove_on_set_parameters_callback` is not a problem.
    *

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -981,6 +981,7 @@ public:
    * \throws std::runtime_error if the handler was not created with `add_on_set_parameters_callback`,
    *   or if it has been removed before.
    */
+  RCLCPP_PUBLIC
   void
   remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * const handler);
 

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -889,10 +889,12 @@ public:
   rcl_interfaces::msg::ListParametersResult
   list_parameters(const std::vector<std::string> & prefixes, uint64_t depth) const;
 
+  using OnSetParametersCallbackHandle =
+    rclcpp::node_interfaces::OnSetParametersCallbackHandle;
   using OnParametersSetCallbackType =
     rclcpp::node_interfaces::NodeParametersInterface::OnParametersSetCallbackType;
 
-  /// Register a callback to be called anytime a parameter is about to be changed.
+  /// Add a callback for when parameters are being set.
   /**
    * The callback signature is designed to allow handling of any of the above
    * `set_parameter*` or `declare_parameter*` methods, and so it takes a const
@@ -936,9 +938,60 @@ public:
    * of the latter things,
    * rclcpp::exceptions::ParameterModifiedInCallbackException will be thrown.
    *
-   * There may only be one callback set at a time, so the previously set
-   * callback is returned when this method is used, or nullptr will be returned
-   * if no callback was previously set.
+   * The callback functions must remain valid as long as the
+   * returned unique pointer is valid.
+   * The returned unique pointer can be promoted to a shared version.
+   *
+   * Releasing the returned unique pointer unregisters the callback.
+   * `remove_on_set_parameters_callback` can also be used.
+   *
+   * All the registered callbacks are called when a parameter is set.
+   * The order of the callbacks is not important.
+   *
+   * \param callback The callback to register.
+   * \returns A unique pointer. The callback is valid as long as the unique pointer is alive.
+   * \throws std::bad_alloc if the allocation of the OnSetParametersCallbackHandle fails.
+   */
+  RCLCPP_PUBLIC
+  OnSetParametersCallbackHandle::UniquePtr
+  add_on_set_parameters_callback(OnParametersSetCallbackType callback);
+
+  /// Remove a callback registered with `add_on_set_parameters_callback`.
+  /**
+   * Releases a handler, returned by `add_on_set_parameters_callback`.
+   *
+   * e.g.:
+   *
+   *    `remove_on_set_parameters_callback(scoped_callback.get())`
+   *
+   * As an alternative, the unique pointer can be released:
+   *
+   *    `scoped_callback.reset()`
+   *
+   * Supposing that `scoped_callback` was the only owner.
+   *
+   * Calling `remove_on_set_parameters_callback` more than once with the same handler,
+   * or calling it after the shared pointer has been released is an error.
+   * Releasing the smart pointer after calling `remove_on_set_parameters_callback` is not a problem.
+   *
+   * All the registered callbacks are called when a parameter is set.
+   * The order of the callbacks is not important.
+   *
+   * \param handler The callback handler to remove.
+   * \throws std::runtime_error if the handler was not created with `add_on_set_parameters_callback`,
+   *   or if it has been removed before.
+   */
+  void
+  remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * const handler);
+
+  /// Register a callback to be called anytime a parameter is about to be changed.
+  /**
+   * With this method, only one callback can be set at a time. The callback that was previously
+   * set by this method is returned or `nullptr` if no callback was previously set.
+   *
+   * The callbacks added with `add_on_set_parameters_callback` are stored in a different place.
+   * `remove_on_set_parameters_callback` can't be used with the callbacks registered with this
+   * method. For removing it, use `set_on_parameters_set_callback(nullptr)`.
    *
    * \param[in] callback The callback to be called when the value for a
    *   parameter is about to be set.
@@ -946,7 +999,7 @@ public:
    *   otherwise nullptr.
    */
   RCLCPP_PUBLIC
-  rclcpp::Node::OnParametersSetCallbackType
+  OnParametersSetCallbackType
   set_on_parameters_set_callback(rclcpp::Node::OnParametersSetCallbackType callback);
 
   /// Register the callback for parameter changes

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
@@ -193,7 +193,7 @@ private:
   // declare_parameter, etc).  In those cases, this will be set to false.
   bool parameter_modification_enabled_{true};
 
-  OnParametersSetCallbackType on_parameters_set_callback_;
+  OnParametersSetCallbackType on_parameters_set_callback_ = nullptr;
 
   CallbacksContainerType on_parameters_set_callback_set_;
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
@@ -17,6 +17,7 @@
 
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -75,7 +76,9 @@ private:
 };
 
 /// Implementation of the NodeParameters part of the Node API.
-class NodeParameters : public NodeParametersInterface
+class NodeParameters
+  : public NodeParametersInterface,
+  public std::enable_shared_from_this<NodeParameters>
 {
 public:
   RCLCPP_SMART_PTR_ALIASES_ONLY(NodeParameters)
@@ -158,6 +161,14 @@ public:
   list_parameters(const std::vector<std::string> & prefixes, uint64_t depth) const override;
 
   RCLCPP_PUBLIC
+  OnSetParametersCallbackHandle::UniquePtr
+  add_on_set_parameters_callback(OnParametersSetCallbackType callback) override;
+
+  RCLCPP_PUBLIC
+  void
+  remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * const handler) override;
+
+  RCLCPP_PUBLIC
   OnParametersSetCallbackType
   set_on_parameters_set_callback(OnParametersSetCallbackType callback) override;
 
@@ -170,6 +181,8 @@ public:
   const std::map<std::string, rclcpp::ParameterValue> &
   get_parameter_overrides() const override;
 
+  using CallbacksContainerType = std::set<OnSetParametersCallbackHandle *>;
+
 private:
   RCLCPP_DISABLE_COPY(NodeParameters)
 
@@ -180,7 +193,9 @@ private:
   // declare_parameter, etc).  In those cases, this will be set to false.
   bool parameter_modification_enabled_{true};
 
-  OnParametersSetCallbackType on_parameters_set_callback_ = nullptr;
+  OnParametersSetCallbackType on_parameters_set_callback_;
+
+  CallbacksContainerType on_parameters_set_callback_set_;
 
   std::map<std::string, ParameterInfo> parameters_;
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
@@ -17,7 +17,7 @@
 
 #include <map>
 #include <memory>
-#include <set>
+#include <list>
 #include <string>
 #include <vector>
 
@@ -76,9 +76,7 @@ private:
 };
 
 /// Implementation of the NodeParameters part of the Node API.
-class NodeParameters
-  : public NodeParametersInterface,
-  public std::enable_shared_from_this<NodeParameters>
+class NodeParameters : public NodeParametersInterface
 {
 public:
   RCLCPP_SMART_PTR_ALIASES_ONLY(NodeParameters)
@@ -161,7 +159,7 @@ public:
   list_parameters(const std::vector<std::string> & prefixes, uint64_t depth) const override;
 
   RCLCPP_PUBLIC
-  OnSetParametersCallbackHandle::UniquePtr
+  OnSetParametersCallbackHandle::SharedPtr
   add_on_set_parameters_callback(OnParametersSetCallbackType callback) override;
 
   RCLCPP_PUBLIC
@@ -181,7 +179,7 @@ public:
   const std::map<std::string, rclcpp::ParameterValue> &
   get_parameter_overrides() const override;
 
-  using CallbacksContainerType = std::set<OnSetParametersCallbackHandle *>;
+  using CallbacksContainerType = std::list<OnSetParametersCallbackHandle::WeakPtr>;
 
 private:
   RCLCPP_DISABLE_COPY(NodeParameters)
@@ -195,7 +193,7 @@ private:
 
   OnParametersSetCallbackType on_parameters_set_callback_ = nullptr;
 
-  CallbacksContainerType on_parameters_set_callback_set_;
+  CallbacksContainerType on_parameters_set_callback_container_;
 
   std::map<std::string, ParameterInfo> parameters_;
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -16,6 +16,7 @@
 #define RCLCPP__NODE_INTERFACES__NODE_PARAMETERS_INTERFACE_HPP_
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -31,6 +32,21 @@ namespace rclcpp
 {
 namespace node_interfaces
 {
+
+struct OnSetParametersCallbackHandle
+{
+  using UniquePtr = std::unique_ptr<
+    OnSetParametersCallbackHandle, std::function<void (OnSetParametersCallbackHandle *)>
+  >;
+  using SharedPtr = std::shared_ptr<OnSetParametersCallbackHandle>;
+
+  using OnParametersSetCallbackType =
+    std::function<
+    rcl_interfaces::msg::SetParametersResult(
+      const std::vector<rclcpp::Parameter> &)>;
+
+  OnParametersSetCallbackType callback;
+};
 
 /// Pure virtual interface class for the NodeParameters part of the Node API.
 class NodeParametersInterface
@@ -158,13 +174,28 @@ public:
   rcl_interfaces::msg::ListParametersResult
   list_parameters(const std::vector<std::string> & prefixes, uint64_t depth) const = 0;
 
-  using OnParametersSetCallbackType =
-    std::function<
-    rcl_interfaces::msg::SetParametersResult(const std::vector<rclcpp::Parameter> &)
-    >;
+  using OnParametersSetCallbackType = OnSetParametersCallbackHandle::OnParametersSetCallbackType;
 
   using ParametersCallbackFunction [[deprecated("use OnParametersSetCallbackType instead")]] =
     OnParametersSetCallbackType;
+
+  /// Add a callback for when parameters are being set.
+  /**
+   * \sa rclcpp::Node::add_on_set_parameters_callback
+   */
+  RCLCPP_PUBLIC
+  virtual
+  OnSetParametersCallbackHandle::UniquePtr
+  add_on_set_parameters_callback(OnParametersSetCallbackType callback) = 0;
+
+  /// Remove a callback registered with `add_on_set_parameters_callback`.
+  /**
+   * \sa rclcpp::Node::remove_on_set_parameters_callback
+   */
+  RCLCPP_PUBLIC
+  virtual
+  void
+  remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * const handler) = 0;
 
   /// Register a callback for when parameters are being set, return an existing one.
   /**

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -35,10 +35,7 @@ namespace node_interfaces
 
 struct OnSetParametersCallbackHandle
 {
-  using UniquePtr = std::unique_ptr<
-    OnSetParametersCallbackHandle, std::function<void (OnSetParametersCallbackHandle *)>
-  >;
-  using SharedPtr = std::shared_ptr<OnSetParametersCallbackHandle>;
+  RCLCPP_SMART_PTR_DEFINITIONS(OnSetParametersCallbackHandle)
 
   using OnParametersSetCallbackType =
     std::function<
@@ -185,7 +182,7 @@ public:
    */
   RCLCPP_PUBLIC
   virtual
-  OnSetParametersCallbackHandle::UniquePtr
+  OnSetParametersCallbackHandle::SharedPtr
   add_on_set_parameters_callback(OnParametersSetCallbackType callback) = 0;
 
   /// Remove a callback registered with `add_on_set_parameters_callback`.

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -326,6 +326,18 @@ Node::list_parameters(const std::vector<std::string> & prefixes, uint64_t depth)
   return node_parameters_->list_parameters(prefixes, depth);
 }
 
+rclcpp::Node::OnSetParametersCallbackHandle::UniquePtr
+Node::add_on_set_parameters_callback(OnParametersSetCallbackType callback)
+{
+  return node_parameters_->add_on_set_parameters_callback(callback);
+}
+
+void
+Node::remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * const callback)
+{
+  return node_parameters_->remove_on_set_parameters_callback(callback);
+}
+
 rclcpp::Node::OnParametersSetCallbackType
 Node::set_on_parameters_set_callback(rclcpp::Node::OnParametersSetCallbackType callback)
 {

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -326,7 +326,7 @@ Node::list_parameters(const std::vector<std::string> & prefixes, uint64_t depth)
   return node_parameters_->list_parameters(prefixes, depth);
 }
 
-rclcpp::Node::OnSetParametersCallbackHandle::UniquePtr
+rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr
 Node::add_on_set_parameters_callback(OnParametersSetCallbackType callback)
 {
   return node_parameters_->add_on_set_parameters_callback(callback);

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -616,7 +616,8 @@ NodeParameters::set_parameters_atomically(const std::vector<rclcpp::Parameter> &
     parameters_,
     // this will get called once, with all the parameters to be set
     on_parameters_set_callback_set_,
-    // this will get called once, with all the parameters to be set
+    // These callbacks are called once. When a callback returns an unsuccessful result,
+    // the remaining aren't called.
     on_parameters_set_callback_);
 
   // If not successful, then stop here.


### PR DESCRIPTION
(Edit)

Fixes https://github.com/ros2/rclcpp/issues/722.

The API looks like this:

```cpp
  OnSetParametersCallbackHandle::SharedPtr
  add_on_set_parameters_callback(OnParametersSetCallbackType callback);
```
```cpp
  void
  remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * const handler);
```

----
(Original comment)

Based in discussion in https://github.com/ros2/rclcpp/issues/769 (TL;DR see [this comment](https://github.com/ros2/rclcpp/issues/769#issuecomment-505107740)), it would be nice to allow registering multiple callbacks with `set_on_parameters_set_callback`.

My idea was the following:

- Calling `set_on_parameters_set_callback` adds a new callback to a vector. It returns a lambda which emulates the behavior of calling all the previous registered callbacks (before, it was returning the previous callback and overriding it). If no callback was registered before, it returns `nullptr`.
- Calling `set_on_parameters_set_callback` with `nullptr` as argument clear all the registered callbacks.

Maybe it would be better to return the vector of all the callbacks instead of a lambda, but that would add a new signature (probably deprecating the old method).

Maybe, we want to implement this in a different way, or not implement it at all.
This is just a proposal of a possible implementation.