### PR TITLE
Made options optional. Updated API documentation.

### DIFF
--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -115,14 +115,13 @@ public:
   /**
    * \param[in] node_name Name of the node.
    * \param[in] namespace_ Namespace of the node.
-   * \param[in] context The context for the node (usually represents the state of a process).
    * \param[in] options Additional options to control creation of the node.
    */
   RCLCPP_LIFECYCLE_PUBLIC
   LifecycleNode(
     const std::string & node_name,
     const std::string & namespace_,
-    const rclcpp::NodeOptions & options);
+    const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
   RCLCPP_LIFECYCLE_PUBLIC
   virtual ~LifecycleNode();


### PR DESCRIPTION
This PR updates the constructor to match that of `Node` (i.e. `options` should be optional). I also removed part of the API documentation that was no longer relevant.