### PR TITLE
Fixed error messages not printing to terminal

### DIFF
--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -429,7 +429,7 @@ public:
         // TODO(karsten1987): Windows CI doesn't let me print the msg here
         // the todo is to forward the exception to the on_error callback
         RCUTILS_LOG_ERROR("Caught exception in callback for transition %d\n", it->first);
-        // RCUTILS_LOG_ERROR("Original error msg: %s\n", e.what());
+        RCUTILS_LOG_ERROR("Original error msg: %s\n", e.what());
         // maybe directly go for error handling here
         // and pass exception along with it
         cb_success = node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -428,8 +428,8 @@ public:
       } catch (const std::exception & e) {
         // TODO(karsten1987): Windows CI doesn't let me print the msg here
         // the todo is to forward the exception to the on_error callback
-        RCUTILS_LOG_ERROR("Caught exception in callback for transition %d\n", it->first);
-        RCUTILS_LOG_ERROR("Original error msg: %s\n", e.what());
+        RCUTILS_LOG_ERROR("Caught exception in callback for transition %d", it->first);
+        RCUTILS_LOG_ERROR("Original error msg: %s", e.what());
         // maybe directly go for error handling here
         // and pass exception along with it
         cb_success = node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -425,7 +425,7 @@ public:
       auto callback = it->second;
       try {
         cb_success = callback(State(previous_state));
-      } catch (const std::exception &) {
+      } catch (const std::exception & e) {
         // TODO(karsten1987): Windows CI doesn't let me print the msg here
         // the todo is to forward the exception to the on_error callback
         RCUTILS_LOG_ERROR("Caught exception in callback for transition %d\n", it->first);

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -426,12 +426,8 @@ public:
       try {
         cb_success = callback(State(previous_state));
       } catch (const std::exception & e) {
-        // TODO(karsten1987): Windows CI doesn't let me print the msg here
-        // the todo is to forward the exception to the on_error callback
         RCUTILS_LOG_ERROR("Caught exception in callback for transition %d", it->first);
-        RCUTILS_LOG_ERROR("Original error msg: %s", e.what());
-        // maybe directly go for error handling here
-        // and pass exception along with it
+        RCUTILS_LOG_ERROR("Original error: %s", e.what());
         cb_success = node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
       }
     }

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -428,8 +428,7 @@ public:
       } catch (const std::exception &) {
         // TODO(karsten1987): Windows CI doesn't let me print the msg here
         // the todo is to forward the exception to the on_error callback
-        // RCUTILS_LOG_ERROR("Caught exception in callback for transition %d\n",
-        //  it->first);
+        RCUTILS_LOG_ERROR("Caught exception in callback for transition %d\n", it->first);
         // RCUTILS_LOG_ERROR("Original error msg: %s\n", e.what());
         // maybe directly go for error handling here
         // and pass exception along with it


### PR DESCRIPTION
Currently, some ROS2 node exception handling error messages are not being printed to the terminal because the print command was commented out. I have removed the comments and it is working in my system (Ubuntu 18.04, with ROS2).
This will help the debugging process since now, the error messages will be visible.