### PR TITLE
Include missing rcl headers in use.

### DIFF
--- a/rclcpp/test/test_parameter_map.cpp
+++ b/rclcpp/test/test_parameter_map.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <rcl/allocator.h>
 #include <rcl_yaml_param_parser/parser.h>
 #include <rcutils/strdup.h>
 


### PR DESCRIPTION
This pull requests pulls in missing `rcl` headers and stops relying on transitive dependencies. 

Connected to https://github.com/ros2/rcl/pull/470.