### PR TITLE
remove mock msgs from rclcpp

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -143,6 +143,8 @@ if(BUILD_TESTING)
 
   find_package(rmw_implementation_cmake REQUIRED)
 
+  find_package(test_msgs REQUIRED)
+
   include(cmake/rclcpp_add_build_failure_test.cmake)
 
   ament_add_gtest(test_client test/test_client.cpp)
@@ -356,7 +358,6 @@ if(BUILD_TESTING)
     )
     target_link_libraries(test_subscription_publisher_count_api ${PROJECT_NAME})
   endif()
-  find_package(test_msgs REQUIRED)
   ament_add_gtest(test_subscription_traits test/test_subscription_traits.cpp)
   if(TARGET test_subscription_traits)
     ament_target_dependencies(test_subscription_traits
@@ -372,38 +373,17 @@ if(BUILD_TESTING)
     target_link_libraries(test_find_weak_nodes ${PROJECT_NAME})
   endif()
 
-  get_default_rmw_implementation(default_rmw)
-  find_package(${default_rmw} REQUIRED)
-  get_rmw_typesupport(typesupport_impls_cpp "${default_rmw}" LANGUAGE "cpp")
-  get_rmw_typesupport(typesupport_impls_c "${default_rmw}" LANGUAGE "c")
-  set(mock_msg_files
-    "test/mock_msgs/srv/Mock.srv")
-  rosidl_generate_interfaces(mock_msgs
-    ${mock_msg_files}
-    LIBRARY_NAME "rclcpp"
-    SKIP_INSTALL)
-
   set(append_library_dirs "${CMAKE_CURRENT_BINARY_DIR}")
   if(WIN32)
     set(append_library_dirs "${append_library_dirs}/$<CONFIG>")
   endif()
 
-  ament_add_gtest(test_externally_defined_services test/test_externally_defined_services.cpp
-    APPEND_LIBRARY_DIRS "${append_library_dirs}")
-  if(TARGET test_externally_defined_services)
-    ament_target_dependencies(test_externally_defined_services
-      "rcl"
-    )
-    target_link_libraries(test_externally_defined_services ${PROJECT_NAME})
-    foreach(typesupport_impl_cpp ${typesupport_impls_cpp})
-      rosidl_target_interfaces(test_externally_defined_services
-        mock_msgs ${typesupport_impl_cpp})
-    endforeach()
-    foreach(typesupport_impl_c ${typesupport_impls_c})
-      rosidl_target_interfaces(test_externally_defined_services
-        mock_msgs ${typesupport_impl_c})
-    endforeach()
-  endif()
+  ament_add_gtest(test_externally_defined_services test/test_externally_defined_services.cpp)
+  ament_target_dependencies(test_externally_defined_services
+    "rcl"
+    "test_msgs"
+  )
+  target_link_libraries(test_externally_defined_services ${PROJECT_NAME})
 
   ament_add_gtest(test_duration test/test_duration.cpp
     APPEND_LIBRARY_DIRS "${append_library_dirs}")

--- a/rclcpp/test/mock_msgs/srv/Mock.srv
+++ b/rclcpp/test/mock_msgs/srv/Mock.srv
@@ -1,3 +1,0 @@
-bool request
----
-bool response

--- a/rclcpp/test/test_externally_defined_services.cpp
+++ b/rclcpp/test/test_externally_defined_services.cpp
@@ -24,8 +24,8 @@
 
 #include "rcl/service.h"
 
-#include "rclcpp/srv/mock.hpp"
-#include "rclcpp/srv/mock.h"
+#include "test_msgs/srv/empty.hpp"
+#include "test_msgs/srv/empty.h"
 
 class TestExternallyDefinedServices : public ::testing::Test
 {
@@ -38,16 +38,15 @@ protected:
 
 void
 callback(
-  const std::shared_ptr<rclcpp::srv::Mock::Request>/*req*/,
-  std::shared_ptr<rclcpp::srv::Mock::Response>/*resp*/)
+  const std::shared_ptr<test_msgs::srv::Empty::Request>/*req*/,
+  std::shared_ptr<test_msgs::srv::Empty::Response>/*resp*/)
 {}
 
 TEST_F(TestExternallyDefinedServices, default_behavior) {
   auto node_handle = rclcpp::Node::make_shared("base_node");
 
   try {
-    auto srv = node_handle->create_service<rclcpp::srv::Mock>("test",
-        callback);
+    auto srv = node_handle->create_service<test_msgs::srv::Empty>("test", callback);
   } catch (const std::exception &) {
     FAIL();
     return;
@@ -55,19 +54,18 @@ TEST_F(TestExternallyDefinedServices, default_behavior) {
   SUCCEED();
 }
 
-
 TEST_F(TestExternallyDefinedServices, extern_defined_uninitialized) {
   auto node_handle = rclcpp::Node::make_shared("base_node");
 
   // mock for externally defined service
   rcl_service_t service_handle = rcl_get_zero_initialized_service();
 
-  rclcpp::AnyServiceCallback<rclcpp::srv::Mock> cb;
+  rclcpp::AnyServiceCallback<test_msgs::srv::Empty> cb;
 
   // don't initialize the service
   // expect fail
   try {
-    rclcpp::Service<rclcpp::srv::Mock>(
+    rclcpp::Service<test_msgs::srv::Empty>(
       node_handle->get_node_base_interface()->get_shared_rcl_node_handle(),
       &service_handle, cb);
   } catch (const std::runtime_error &) {
@@ -85,7 +83,7 @@ TEST_F(TestExternallyDefinedServices, extern_defined_initialized) {
   rcl_service_t service_handle = rcl_get_zero_initialized_service();
   rcl_service_options_t service_options = rcl_service_get_default_options();
   const rosidl_service_type_support_t * ts =
-    rosidl_typesupport_cpp::get_service_type_support_handle<rclcpp::srv::Mock>();
+    rosidl_typesupport_cpp::get_service_type_support_handle<test_msgs::srv::Empty>();
   rcl_ret_t ret = rcl_service_init(
     &service_handle,
     node_handle->get_node_base_interface()->get_rcl_node_handle(),
@@ -95,10 +93,10 @@ TEST_F(TestExternallyDefinedServices, extern_defined_initialized) {
     return;
   }
 
-  rclcpp::AnyServiceCallback<rclcpp::srv::Mock> cb;
+  rclcpp::AnyServiceCallback<test_msgs::srv::Empty> cb;
 
   try {
-    rclcpp::Service<rclcpp::srv::Mock>(
+    rclcpp::Service<test_msgs::srv::Empty>(
       node_handle->get_node_base_interface()->get_shared_rcl_node_handle(),
       &service_handle, cb);
   } catch (const std::runtime_error &) {
@@ -125,7 +123,7 @@ TEST_F(TestExternallyDefinedServices, extern_defined_destructor) {
   rcl_service_t service_handle = rcl_get_zero_initialized_service();
   rcl_service_options_t service_options = rcl_service_get_default_options();
   const rosidl_service_type_support_t * ts =
-    rosidl_typesupport_cpp::get_service_type_support_handle<rclcpp::srv::Mock>();
+    rosidl_typesupport_cpp::get_service_type_support_handle<test_msgs::srv::Empty>();
   rcl_ret_t ret = rcl_service_init(
     &service_handle,
     node_handle->get_node_base_interface()->get_rcl_node_handle(),
@@ -134,11 +132,11 @@ TEST_F(TestExternallyDefinedServices, extern_defined_destructor) {
     FAIL();
     return;
   }
-  rclcpp::AnyServiceCallback<rclcpp::srv::Mock> cb;
+  rclcpp::AnyServiceCallback<test_msgs::srv::Empty> cb;
 
   {
     // Call constructor
-    rclcpp::Service<rclcpp::srv::Mock> srv_cpp(
+    rclcpp::Service<test_msgs::srv::Empty> srv_cpp(
       node_handle->get_node_base_interface()->get_shared_rcl_node_handle(),
       &service_handle, cb);
     // Call destructor


### PR DESCRIPTION
Given that the `test_msgs` are part of the dependency tree for `rclcpp`, there is no need to create separate `mock_msgs` any longer. 

CI (build up to rclcpp, test only rclcpp):
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7687)](http://ci.ros2.org/job/ci_linux/7687/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3790)](http://ci.ros2.org/job/ci_linux-aarch64/3790/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6291)](http://ci.ros2.org/job/ci_osx/6291/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7535)](http://ci.ros2.org/job/ci_windows/7535/)

Signed-off-by: Karsten Knese <karsten@openrobotics.org>