### PR TITLE
[Backport] Make TimeSource ignore use_sim_time events coming from other nodes (#799)

### DIFF
--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -220,13 +220,17 @@ void TimeSource::destroy_clock_sub()
 
 void TimeSource::on_parameter_event(const rcl_interfaces::msg::ParameterEvent::SharedPtr event)
 {
+  // Filter out events on 'use_sim_time' parameter instances in other nodes.
+  if (event->node != node_base_->get_fully_qualified_name()) {
+    return;
+  }
   // Filter for only 'use_sim_time' being added or changed.
   rclcpp::ParameterEventsFilter filter(event, {"use_sim_time"},
     {rclcpp::ParameterEventsFilter::EventType::NEW,
       rclcpp::ParameterEventsFilter::EventType::CHANGED});
   for (auto & it : filter.get_events()) {
     if (it.second->value.type != ParameterType::PARAMETER_BOOL) {
-      RCLCPP_ERROR(logger_, "use_sim_time parameter set to something besides a bool");
+      RCLCPP_ERROR(logger_, "use_sim_time parameter cannot be set to anything but a bool");
       continue;
     }
     if (it.second->value.bool_value) {


### PR DESCRIPTION
Signed-off-by: Michel Hidalgo <michel@ekumenlabs.com>