### PR TITLE
Dnae adas/serialized intra process communication

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -208,6 +208,18 @@ if(BUILD_TESTING)
       "rosidl_typesupport_cpp"
     )
   endif()
+  ament_add_gtest(test_intra_process_communication test/test_intra_process_communication.cpp)
+  if(TARGET test_intra_process_communication)
+    ament_target_dependencies(test_intra_process_communication
+      "rcl"
+      "rcl_interfaces"
+      "rmw"
+      "rosidl_generator_cpp"
+      "rosidl_typesupport_cpp"
+      "test_msgs"
+    )
+  endif()
+  target_link_libraries(test_intra_process_communication ${PROJECT_NAME})
   ament_add_gtest(test_node test/test_node.cpp)
   if(TARGET test_node)
     ament_target_dependencies(test_node

--- a/rclcpp/include/rclcpp/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager.hpp
@@ -308,7 +308,6 @@ public:
   {
     using ElemAllocTraits = allocator::AllocRebind<MessageT, Alloc>;
     using ElemAlloc = typename ElemAllocTraits::allocator_type;
-    using MessageAllocTraits = allocator::AllocRebind<MessageT, Alloc>;
 
     MessageT * deserialize(const rmw_serialized_message_t * serialized_msg)
     {
@@ -321,7 +320,7 @@ public:
       }
 
       ElemAlloc allocator;
-      auto ptr = MessageAllocTraits::allocate(allocator, 1);
+      auto ptr = ElemAllocTraits::allocate(allocator, 1);
 
       auto msg_ts =
         rosidl_typesupport_cpp::get_message_type_support_handle<MessageT>();

--- a/rclcpp/include/rclcpp/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager.hpp
@@ -314,9 +314,9 @@ public:
       if (!serialized_msg ||
         serialized_msg->buffer_capacity == 0 ||
         serialized_msg->buffer_length == 0 ||
-        serialized_msg->buffer == nullptr)
+        !serialized_msg->buffer)
       {
-        throw std::runtime_error("failed to deserialize nullptr serialized message");
+        throw std::runtime_error("Failed to deserialize nullptr serialized message.");
       }
 
       ElemAlloc allocator;
@@ -325,9 +325,9 @@ public:
       const auto msg_ts =
         rosidl_typesupport_cpp::get_message_type_support_handle<MessageT>();
 
-      auto ret = rmw_deserialize(serialized_msg, msg_ts, ptr);
+      const auto ret = rmw_deserialize(serialized_msg, msg_ts, ptr);
       if (ret != RMW_RET_OK) {
-        throw std::runtime_error("failed to deserialize serialized message");
+        throw std::runtime_error("Failed to deserialize serialized message.");
       }
 
       return ptr;
@@ -345,7 +345,7 @@ public:
         serialized_msg->buffer_length == 0 ||
         serialized_msg->buffer == nullptr)
       {
-        throw std::runtime_error("failed to deserialize nullptr serialized message b");
+        throw std::runtime_error("Failed to deserialize nullptr serialized message.");
       }
 
       return new rmw_serialized_message_t(*serialized_msg);
@@ -353,7 +353,8 @@ public:
   };
 
   /// Serialize a message if needed. In this case just point to the content (same type).
-  template<typename MessageTIn, typename MessageTOutPtr, typename MessageTOut>
+  template<typename MessageTIn, typename MessageTOutPtr,
+    typename MessageTOut = typename MessageTOutPtr::element_type>
   struct Serializer
   {
     void serialize(
@@ -401,7 +402,7 @@ public:
         type_support,
         &serialized_message);
       if (error != RCL_RET_OK) {
-        throw std::runtime_error("Failed to serialize");
+        throw std::runtime_error("Failed to serialize.");
       }
 
       return serialized_message;
@@ -409,7 +410,8 @@ public:
   };
 
   /// Not serializing a message if same type.
-  template<typename MessageTIn, typename MessageTOutPtr, typename MessageTOut>
+  template<typename MessageTIn, typename MessageTOutPtr,
+    typename MessageTOut = typename MessageTOutPtr::element_type>
   struct TypedSerializer
   {
     void serialize(
@@ -497,7 +499,7 @@ public:
       target_subs_size
     );
 
-    if (buffer == nullptr) {
+    if (!buffer) {
       return;
     }
 
@@ -544,8 +546,7 @@ public:
 
       TypedSerializer<
         mapped_ring_buffer::MappedRingBufferBase::ConstVoidSharedPtr,
-        std::unique_ptr<MessageT, Deleter>,
-        MessageT> serializer;
+        std::unique_ptr<MessageT, Deleter>> serializer;
       serializer.serialize(stored_msg, message, buffer->get_type_support());
     } else {
       using MRBMessageAlloc =
@@ -570,7 +571,7 @@ public:
         return;
       }
 
-      Serializer<typename TypedMRB::ElemUniquePtr, std::unique_ptr<MessageT, Deleter>, MessageT>
+      Serializer<typename TypedMRB::ElemUniquePtr, std::unique_ptr<MessageT, Deleter>>
       serializer;
       serializer.serialize(stored_msg, message, typed_buffer->get_type_support());
     }
@@ -597,7 +598,7 @@ public:
       target_subs_size
       );
 
-    if (buffer == nullptr) {
+    if (!buffer) {
       return;
     }
 

--- a/rclcpp/include/rclcpp/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/intra_process_manager.hpp
@@ -322,7 +322,7 @@ public:
       ElemAlloc allocator;
       auto ptr = ElemAllocTraits::allocate(allocator, 1);
 
-      auto msg_ts =
+      const auto msg_ts =
         rosidl_typesupport_cpp::get_message_type_support_handle<MessageT>();
 
       auto ret = rmw_deserialize(serialized_msg, msg_ts, ptr);
@@ -382,10 +382,10 @@ public:
       const MessageTIn & msg,
       const rosidl_message_type_support_t * type_support)
     {
-      rcutils_allocator_t rcutils_allocator_ = rcutils_get_default_allocator();
+      auto rcutils_allocator_ = rcutils_get_default_allocator();
 
       auto serialized_message = rmw_get_zero_initialized_serialized_message();
-      auto ret = rmw_serialized_message_init(&serialized_message, 0, &rcutils_allocator_);
+      const auto ret = rmw_serialized_message_init(&serialized_message, 0, &rcutils_allocator_);
       if (ret != RCUTILS_RET_OK) {
         throw std::runtime_error(
                 "Error allocating resources for serialized message: " +

--- a/rclcpp/include/rclcpp/mapped_ring_buffer.hpp
+++ b/rclcpp/include/rclcpp/mapped_ring_buffer.hpp
@@ -355,7 +355,7 @@ public:
    */
   void pop(uint64_t key, ConstVoidSharedPtr & value) override
   {
-    pop(key, (ConstElemSharedPtr &)value);
+    pop(key, reinterpret_cast<ConstElemSharedPtr &>(value));
   }
 
 
@@ -372,7 +372,7 @@ public:
    */
   void get(uint64_t key, ConstVoidSharedPtr & value) override
   {
-    get(key, (ConstElemSharedPtr &)value);
+    get(key, reinterpret_cast<ConstElemSharedPtr &>(value));
   }
 
 

--- a/rclcpp/include/rclcpp/mapped_ring_buffer.hpp
+++ b/rclcpp/include/rclcpp/mapped_ring_buffer.hpp
@@ -130,6 +130,7 @@ public:
    * The constructor will allocate memory while reserving space.
    *
    * \param size size of the ring buffer; must be positive and non-zero.
+   * \param type_support message type of content; for serialized messages nullptr
    * \param allocator optional custom allocator
    */
   explicit MappedRingBuffer(

--- a/rclcpp/include/rclcpp/publisher_base.hpp
+++ b/rclcpp/include/rclcpp/publisher_base.hpp
@@ -195,7 +195,24 @@ public:
     IntraProcessManagerSharedPtr ipm,
     const rcl_publisher_options_t & intra_process_options);
 
+  void
+  publish(const rcl_serialized_message_t & serialized_msg);
+
+// Skip deprecated attribute in windows, as it raise a warning in template specialization.
+#if !defined(_WIN32)
+  [[deprecated(
+    "Use publish(*serialized_msg). Check against nullptr before calling if necessary.")]]
+#endif
+  void
+  publish(const rcl_serialized_message_t * serialized_msg);
+
 protected:
+  void
+  do_serialized_publish(const rcl_serialized_message_t * serialized_msg);
+
+  void
+  do_intra_process_publish(uint64_t message_seq);
+
   template<typename EventCallbackT>
   void
   add_event_handler(

--- a/rclcpp/src/rclcpp/publisher_base.cpp
+++ b/rclcpp/src/rclcpp/publisher_base.cpp
@@ -183,7 +183,7 @@ PublisherBase::get_subscription_count() const
     }
   }
   if (RCL_RET_OK != status) {
-    rclcpp::exceptions::throw_from_rcl_error(status, "failed to get get subscription count");
+    rclcpp::exceptions::throw_from_rcl_error(status, "Failed to get get subscription count.");
   }
   return inter_process_subscription_count;
 }
@@ -199,8 +199,8 @@ PublisherBase::get_intra_process_subscription_count() const
     // TODO(ivanpauno): should this just return silently? Or maybe return with a warning?
     //                  Same as wjwwood comment in publisher_factory create_shared_publish_callback.
     throw std::runtime_error(
-            "intra process subscriber count called after "
-            "destruction of intra process manager");
+            "Intra process subscriber count called after "
+            "destruction of intra process manager.");
   }
   return ipm->get_subscription_count(intra_process_publisher_id_);
 }
@@ -210,7 +210,7 @@ PublisherBase::get_actual_qos() const
 {
   const rmw_qos_profile_t * qos = rcl_publisher_get_actual_qos(&publisher_handle_);
   if (!qos) {
-    auto msg = std::string("failed to get qos settings: ") + rcl_get_error_string().str;
+    auto msg = std::string("Failed to get qos settings: ") + rcl_get_error_string().str;
     rcl_reset_error();
     throw std::runtime_error(msg);
   }
@@ -235,14 +235,14 @@ PublisherBase::operator==(const rmw_gid_t * gid) const
   bool result = false;
   auto ret = rmw_compare_gids_equal(gid, &this->get_gid(), &result);
   if (ret != RMW_RET_OK) {
-    auto msg = std::string("failed to compare gids: ") + rmw_get_error_string().str;
+    auto msg = std::string("Failed to compare gids: ") + rmw_get_error_string().str;
     rmw_reset_error();
     throw std::runtime_error(msg);
   }
   if (!result) {
     ret = rmw_compare_gids_equal(gid, &this->get_intra_process_gid(), &result);
     if (ret != RMW_RET_OK) {
-      auto msg = std::string("failed to compare gids: ") + rmw_get_error_string().str;
+      auto msg = std::string("Failed to compare gids: ") + rmw_get_error_string().str;
       rmw_reset_error();
       throw std::runtime_error(msg);
     }
@@ -266,7 +266,7 @@ PublisherBase::setup_intra_process(
   // Intraprocess configuration is not allowed with "durability" qos policy non "volatile".
   if (this->get_actual_qos().durability != RMW_QOS_POLICY_DURABILITY_VOLATILE) {
     throw std::invalid_argument(
-            "intraprocess communication is not allowed with durability qos policy non-volatile");
+            "Intraprocess communication is not allowed with durability qos policy non-volatile");
   }
   const char * topic_name = this->get_topic_name();
   if (!topic_name) {
@@ -292,7 +292,7 @@ PublisherBase::setup_intra_process(
         rcl_node_get_namespace(rcl_node_handle));
     }
 
-    rclcpp::exceptions::throw_from_rcl_error(ret, "could not create intra process publisher");
+    rclcpp::exceptions::throw_from_rcl_error(ret, "Could not create intra process publisher");
   }
 
   intra_process_publisher_id_ = intra_process_publisher_id;
@@ -311,7 +311,7 @@ PublisherBase::setup_intra_process(
     publisher_rmw_handle, &intra_process_rmw_gid_);
   if (rmw_ret != RMW_RET_OK) {
     auto msg =
-      std::string("failed to create intra process publisher gid: ") + rmw_get_error_string().str;
+      std::string("Failed to create intra process publisher gid: ") + rmw_get_error_string().str;
     rmw_reset_error();
     throw std::runtime_error(msg);
   }
@@ -338,7 +338,7 @@ void
 PublisherBase::do_serialized_publish(const rcl_serialized_message_t * serialized_msg)
 {
   if (!serialized_msg) {
-    throw std::runtime_error("cannot publisher msg which is a null pointer");
+    throw std::runtime_error("Cannot publisher msg which is a null pointer.");
   }
 
   bool inter_process_publish_needed =
@@ -348,7 +348,7 @@ PublisherBase::do_serialized_publish(const rcl_serialized_message_t * serialized
     auto ipm = weak_ipm_.lock();
     if (!ipm) {
       throw std::runtime_error(
-              "intra process publish called after destruction of intra process manager");
+              "Intra process publish called after destruction of intra process manager.");
     }
     const uint64_t message_seq =
       ipm->template store_intra_process_message<rmw_serialized_message_t>(
@@ -359,7 +359,7 @@ PublisherBase::do_serialized_publish(const rcl_serialized_message_t * serialized
   if (inter_process_publish_needed) {
     auto status = rcl_publish_serialized_message(&publisher_handle_, serialized_msg, nullptr);
     if (RCL_RET_OK != status) {
-      rclcpp::exceptions::throw_from_rcl_error(status, "failed to publish serialized message");
+      rclcpp::exceptions::throw_from_rcl_error(status, "Failed to publish serialized message.");
     }
   }
 }
@@ -382,6 +382,6 @@ PublisherBase::do_intra_process_publish(uint64_t message_seq)
     }
   }
   if (RCL_RET_OK != status) {
-    rclcpp::exceptions::throw_from_rcl_error(status, "failed to publish intra process message");
+    rclcpp::exceptions::throw_from_rcl_error(status, "Failed to publish intra process message.");
   }
 }

--- a/rclcpp/test/test_intra_process_communication.cpp
+++ b/rclcpp/test/test_intra_process_communication.cpp
@@ -62,10 +62,10 @@ std::shared_ptr<rcutils_uint8_array_t> make_serialized_string_msg(
 
   serialized_data->buffer_length = message_size;
 
-  static auto imageTypeSupport =
+  static auto type =
     rosidl_typesupport_cpp::get_message_type_support_handle
     <rcl_interfaces::msg::IntraProcessMessage>();
-  auto error = rmw_serialize(stringMsg.get(), imageTypeSupport, serialized_data.get());
+  auto error = rmw_serialize(stringMsg.get(), type, serialized_data.get());
   if (error != RMW_RET_OK) {
     RCUTILS_LOG_ERROR_NAMED("m4_test", "Something went wrong preparing the serialized message");
   }

--- a/rclcpp/test/test_intra_process_communication.cpp
+++ b/rclcpp/test/test_intra_process_communication.cpp
@@ -17,9 +17,9 @@
 #include <rcl_interfaces/msg/intra_process_message.hpp>
 
 #include <iostream>
-#include <string>
 #include <memory>
 #include <utility>
+#include <string>
 
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/publisher.hpp"

--- a/rclcpp/test/test_intra_process_communication.cpp
+++ b/rclcpp/test/test_intra_process_communication.cpp
@@ -1,0 +1,269 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <rcl_interfaces/msg/intra_process_message.hpp>
+
+#include <iostream>
+#include <string>
+#include <memory>
+#include <utility>
+
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/publisher.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+
+static int g_counter = 0;
+
+std::shared_ptr<rcutils_uint8_array_t> make_serialized_string_msg(
+  const std::shared_ptr<rcl_interfaces::msg::IntraProcessMessage> & stringMsg)
+{
+  auto m_allocator = rcutils_get_default_allocator();
+  size_t message_size = 80u + static_cast<size_t>(sizeof(rcl_interfaces::msg::IntraProcessMessage));
+
+  auto msg = new rcutils_uint8_array_t;
+  *msg = rcutils_get_zero_initialized_uint8_array();
+  auto ret = rcutils_uint8_array_init(msg, message_size, &m_allocator);
+  if (ret != RCUTILS_RET_OK) {
+    throw std::runtime_error("Error allocating resources " + std::to_string(ret));
+  }
+
+  ++g_counter;
+  auto serialized_data = std::shared_ptr<rcutils_uint8_array_t>(
+    msg,
+    [](rcutils_uint8_array_t * msg) {
+      --g_counter;
+      int error = rcutils_uint8_array_fini(msg);
+      delete msg;
+      if (error != RCUTILS_RET_OK) {
+        RCUTILS_LOG_ERROR_NAMED(
+          "m4_test",
+          "Leaking memory %i",
+          error);
+      }
+    });
+
+  serialized_data->buffer_length = message_size;
+
+  static auto imageTypeSupport =
+    rosidl_typesupport_cpp::get_message_type_support_handle
+    <rcl_interfaces::msg::IntraProcessMessage>();
+  auto error = rmw_serialize(stringMsg.get(), imageTypeSupport, serialized_data.get());
+  if (error != RMW_RET_OK) {
+    RCUTILS_LOG_ERROR_NAMED("m4_test", "Something went wrong preparing the serialized message");
+  }
+
+  return serialized_data;
+}
+
+/**
+ * Parameterized test.
+ * The first param are the NodeOptions used to create the nodes.
+ * The second param are the expect intraprocess count results.
+ */
+struct TestParameters
+{
+  rclcpp::NodeOptions node_options[2];
+  uint64_t intraprocess_count_results[2];
+  std::string description;
+};
+
+std::ostream & operator<<(std::ostream & out, const TestParameters & params)
+{
+  out << params.description;
+  return out;
+}
+
+class TestPublisherSubscriptionSerialized : public ::testing::TestWithParam<TestParameters>
+{
+public:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+protected:
+  void SetUp() {}
+
+  void TearDown() {}
+
+  static std::chrono::milliseconds offset;
+};
+
+std::chrono::milliseconds TestPublisherSubscriptionSerialized::offset = std::chrono::milliseconds(
+  2000);
+std::array<uint32_t, 2> counts;
+
+void OnMessageSerialized(const std::shared_ptr<rmw_serialized_message_t> msg)
+{
+  EXPECT_NE(msg->buffer, nullptr);
+  EXPECT_GT(msg->buffer_capacity, 0u);
+
+  ++counts[0];
+}
+
+void OnMessageSerializedU(std::unique_ptr<rmw_serialized_message_t> msg)
+{
+  EXPECT_NE(msg, nullptr);
+  EXPECT_NE(msg->buffer, nullptr);
+  EXPECT_GT(msg->buffer_capacity, 0u);
+
+  ++counts[0];
+}
+
+void OnMessageConst(std::shared_ptr<const rcl_interfaces::msg::IntraProcessMessage> msg)
+{
+  EXPECT_EQ(msg->message_sequence, 1234u);
+
+  ++counts[1];
+}
+
+void OnMessageU(std::unique_ptr<rcl_interfaces::msg::IntraProcessMessage> msg)
+{
+  EXPECT_EQ(msg->message_sequence, 1234u);
+
+  ++counts[1];
+}
+
+void OnMessage(std::shared_ptr<rcl_interfaces::msg::IntraProcessMessage> msg)
+{
+  EXPECT_EQ(msg->message_sequence, 1234u);
+
+  ++counts[1];
+}
+
+TEST_P(TestPublisherSubscriptionSerialized, publish_serialized)
+{
+  TestParameters parameters = GetParam();
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>(
+    "my_node",
+    "/ns",
+    parameters.node_options[0]);
+  auto publisher = node->create_publisher<rcl_interfaces::msg::IntraProcessMessage>("/topic", 10);
+
+  auto mem_strategy =
+    rclcpp::message_memory_strategy::MessageMemoryStrategy<rcl_interfaces::msg::IntraProcessMessage>
+    ::create_default();
+
+  auto stringMsg = std::make_shared<rcl_interfaces::msg::IntraProcessMessage>();
+  stringMsg->message_sequence = 1234u;
+
+  {
+    auto msg0 = make_serialized_string_msg(stringMsg);
+
+    auto sub = node->create_subscription<rcl_interfaces::msg::IntraProcessMessage>("/topic", 10,
+        &OnMessage);
+    auto sub1 = node->create_subscription<rcl_interfaces::msg::IntraProcessMessage>("/topic", 10,
+        &OnMessageU);
+    auto sub2 = node->create_subscription<rcl_interfaces::msg::IntraProcessMessage>("/topic", 10,
+        &OnMessageConst);
+    auto sub_ser = node->create_subscription<rcl_interfaces::msg::IntraProcessMessage>("/topic", 10,
+        &OnMessageSerialized);
+    auto sub_ser2 = node->create_subscription<rcl_interfaces::msg::IntraProcessMessage>("/topic",
+        10,
+        &OnMessageSerialized);
+    auto sub_ser3 = node->create_subscription<rcl_interfaces::msg::IntraProcessMessage>("/topic",
+        10,
+        &OnMessageSerializedU);
+
+    rclcpp::sleep_for(offset);
+
+    counts.fill(0);
+
+    std::unique_ptr<rcl_interfaces::msg::IntraProcessMessage> stringMsgU(
+      new rcl_interfaces::msg::IntraProcessMessage(
+        *stringMsg));
+    std::unique_ptr<rcutils_uint8_array_t> msg0U(new rcutils_uint8_array_t(*msg0));
+
+    publisher->publish(msg0);
+    publisher->publish(stringMsg);
+    publisher->publish(std::move(msg0U));
+    publisher->publish(std::move(stringMsgU));
+
+    rclcpp::spin_some(node);
+    rclcpp::sleep_for(offset);
+
+    rclcpp::spin_some(node);
+
+    EXPECT_EQ(counts[0], 12u);
+    EXPECT_EQ(counts[1], 12u);
+  }
+
+  EXPECT_EQ(g_counter, 0);
+}
+
+auto get_new_context()
+{
+  auto context = rclcpp::Context::make_shared();
+  context->init(0, nullptr);
+  return context;
+}
+
+TestParameters parameters[] = {
+  /*
+     Testing publisher subscription count api and internal process subscription count.
+     Two subscriptions in the same topic, both using intraprocess comm.
+   */
+  {
+    {
+      rclcpp::NodeOptions().use_intra_process_comms(true),
+      rclcpp::NodeOptions().use_intra_process_comms(true)
+    },
+    {1u, 2u},
+    "two_subscriptions_intraprocess_comm"
+  },
+  /*
+     Testing publisher subscription count api and internal process subscription count.
+     Two subscriptions, one using intra-process comm and the other not using it.
+   */
+  {
+    {
+      rclcpp::NodeOptions().use_intra_process_comms(true),
+      rclcpp::NodeOptions().use_intra_process_comms(false)
+    },
+    {1u, 1u},
+    "two_subscriptions_one_intraprocess_one_not"
+  },
+  /*
+     Testing publisher subscription count api and internal process subscription count.
+     Two contexts, both using intra-process.
+   */
+  {
+    {
+      rclcpp::NodeOptions().use_intra_process_comms(true),
+      rclcpp::NodeOptions().context(get_new_context()).use_intra_process_comms(true)
+    },
+    {1u, 1u},
+    "two_subscriptions_in_two_contexts_with_intraprocess_comm"
+  },
+  /*
+     Testing publisher subscription count api and internal process subscription count.
+     Two contexts, both of them not using intra-process comm.
+   */
+  {
+    {
+      rclcpp::NodeOptions().use_intra_process_comms(false),
+      rclcpp::NodeOptions().context(get_new_context()).use_intra_process_comms(false)
+    },
+    {0u, 0u},
+    "two_subscriptions_in_two_contexts_without_intraprocess_comm"
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(
+  TestWithDifferentNodeOptions, TestPublisherSubscriptionSerialized,
+  ::testing::ValuesIn(parameters),
+  ::testing::PrintToStringParamName());

--- a/rclcpp/test/test_intra_process_communication.cpp
+++ b/rclcpp/test/test_intra_process_communication.cpp
@@ -54,7 +54,7 @@ std::shared_ptr<rcutils_uint8_array_t> make_serialized_string_msg(
       delete msg;
       if (error != RCUTILS_RET_OK) {
         RCUTILS_LOG_ERROR_NAMED(
-          "m4_test",
+          "test_intra_process_communication",
           "Leaking memory %i",
           error);
       }
@@ -67,7 +67,8 @@ std::shared_ptr<rcutils_uint8_array_t> make_serialized_string_msg(
     <rcl_interfaces::msg::IntraProcessMessage>();
   auto error = rmw_serialize(stringMsg.get(), type, serialized_data.get());
   if (error != RMW_RET_OK) {
-    RCUTILS_LOG_ERROR_NAMED("m4_test", "Something went wrong preparing the serialized message");
+    RCUTILS_LOG_ERROR_NAMED("test_intra_process_communication",
+      "Something went wrong preparing the serialized message");
   }
 
   return serialized_data;

--- a/rclcpp/test/test_intra_process_communication.cpp
+++ b/rclcpp/test/test_intra_process_communication.cpp
@@ -192,10 +192,23 @@ TEST_P(TestPublisherSubscriptionSerialized, publish_serialized)
         *stringMsg));
     std::unique_ptr<rcutils_uint8_array_t> msg0U(new rcutils_uint8_array_t(*msg0));
 
-    publisher->publish(msg0);
+    // Now deprecated functions.
+#if !defined(_WIN32)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else  // !defined(_WIN32)
+# pragma warning(push)
+# pragma warning(disable: 4996)
+#endif
+    publisher->publish(*msg0);
     publisher->publish(stringMsg);
-    publisher->publish(std::move(msg0U));
+    publisher->publish(*msg0U);
     publisher->publish(std::move(stringMsgU));
+#if !defined(_WIN32)
+# pragma GCC diagnostic pop
+#else  // !defined(_WIN32)
+# pragma warning(pop)
+#endif
 
     rclcpp::spin_some(node);
     rclcpp::sleep_for(offset);

--- a/rclcpp/test/test_intra_process_communication.cpp
+++ b/rclcpp/test/test_intra_process_communication.cpp
@@ -101,10 +101,6 @@ public:
   }
 
 protected:
-  void SetUp() {}
-
-  void TearDown() {}
-
   static std::chrono::milliseconds offset;
 };
 

--- a/rclcpp/test/test_intra_process_communication.cpp
+++ b/rclcpp/test/test_intra_process_communication.cpp
@@ -18,8 +18,8 @@
 
 #include <iostream>
 #include <memory>
-#include <utility>
 #include <string>
+#include <utility>
 
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/publisher.hpp"

--- a/rclcpp/test/test_intra_process_communication.cpp
+++ b/rclcpp/test/test_intra_process_communication.cpp
@@ -26,7 +26,11 @@
 #include "rclcpp/rclcpp.hpp"
 
 
-static int g_counter = 0;
+int32_t & get_test_allocation_counter()
+{
+  static int32_t counter = 0;
+  return counter;
+}
 
 std::shared_ptr<rcutils_uint8_array_t> make_serialized_string_msg(
   const std::shared_ptr<rcl_interfaces::msg::IntraProcessMessage> & stringMsg)
@@ -41,11 +45,11 @@ std::shared_ptr<rcutils_uint8_array_t> make_serialized_string_msg(
     throw std::runtime_error("Error allocating resources " + std::to_string(ret));
   }
 
-  ++g_counter;
+  ++get_test_allocation_counter();
   auto serialized_data = std::shared_ptr<rcutils_uint8_array_t>(
     msg,
     [](rcutils_uint8_array_t * msg) {
-      --g_counter;
+      --get_test_allocation_counter();
       int error = rcutils_uint8_array_fini(msg);
       delete msg;
       if (error != RCUTILS_RET_OK) {
@@ -202,7 +206,7 @@ TEST_P(TestPublisherSubscriptionSerialized, publish_serialized)
     EXPECT_EQ(counts[1], 12u);
   }
 
-  EXPECT_EQ(g_counter, 0);
+  EXPECT_EQ(get_test_allocation_counter(), 0);
 }
 
 auto get_new_context()

--- a/rclcpp/test/test_intra_process_manager.cpp
+++ b/rclcpp/test/test_intra_process_manager.cpp
@@ -91,7 +91,10 @@ public:
     return mapped_ring_buffer::MappedRingBuffer<
       T,
       typename Publisher<T, Alloc>::MessageAlloc
-    >::make_shared(size, allocator_);
+    >::make_shared(
+      size,
+      rosidl_typesupport_cpp::get_message_type_support_handle<T>(),
+      allocator_);
   }
 
   std::shared_ptr<MessageAlloc> get_allocator()

--- a/rclcpp/test/test_mapped_ring_buffer.cpp
+++ b/rclcpp/test/test_mapped_ring_buffer.cpp
@@ -25,9 +25,10 @@
  */
 TEST(TestMappedRingBuffer, empty) {
   // Cannot create a buffer of size zero.
-  EXPECT_THROW(rclcpp::mapped_ring_buffer::MappedRingBuffer<char> mrb(0), std::invalid_argument);
+  EXPECT_THROW(rclcpp::mapped_ring_buffer::MappedRingBuffer<char>
+    mrb(0, nullptr), std::invalid_argument);
   // Getting or popping an empty buffer should result in a nullptr.
-  rclcpp::mapped_ring_buffer::MappedRingBuffer<char> mrb(1);
+  rclcpp::mapped_ring_buffer::MappedRingBuffer<char> mrb(1, nullptr);
 
   std::unique_ptr<char> unique;
   mrb.get(1, unique);
@@ -49,7 +50,7 @@ TEST(TestMappedRingBuffer, empty) {
    get and pop methods with shared_ptr signature.
  */
 TEST(TestMappedRingBuffer, temporary_l_value_with_shared_get_pop) {
-  rclcpp::mapped_ring_buffer::MappedRingBuffer<char> mrb(2);
+  rclcpp::mapped_ring_buffer::MappedRingBuffer<char> mrb(2, nullptr);
   // Pass in value with temporary object
   mrb.push_and_replace(1, std::shared_ptr<const char>(new char('a')));
 
@@ -69,7 +70,7 @@ TEST(TestMappedRingBuffer, temporary_l_value_with_shared_get_pop) {
    get and pop methods with unique_ptr signature.
  */
 TEST(TestMappedRingBuffer, temporary_l_value_with_unique_get_pop) {
-  rclcpp::mapped_ring_buffer::MappedRingBuffer<char> mrb(2);
+  rclcpp::mapped_ring_buffer::MappedRingBuffer<char> mrb(2, nullptr);
   // Pass in value with temporary object
   mrb.push_and_replace(1, std::shared_ptr<const char>(new char('a')));
 
@@ -89,7 +90,7 @@ TEST(TestMappedRingBuffer, temporary_l_value_with_unique_get_pop) {
    Using shared push_and_replace, get and pop methods.
  */
 TEST(TestMappedRingBuffer, nominal_push_shared_get_pop_shared) {
-  rclcpp::mapped_ring_buffer::MappedRingBuffer<char> mrb(2);
+  rclcpp::mapped_ring_buffer::MappedRingBuffer<char> mrb(2, nullptr);
   std::shared_ptr<const char> expected(new char('a'));
 
   EXPECT_FALSE(mrb.push_and_replace(1, expected));
@@ -145,7 +146,7 @@ TEST(TestMappedRingBuffer, nominal_push_shared_get_pop_shared) {
    Using shared push_and_replace, unique get and pop methods.
  */
 TEST(TestMappedRingBuffer, nominal_push_shared_get_pop_unique) {
-  rclcpp::mapped_ring_buffer::MappedRingBuffer<char> mrb(2);
+  rclcpp::mapped_ring_buffer::MappedRingBuffer<char> mrb(2, nullptr);
   std::shared_ptr<const char> expected(new char('a'));
   const char * expected_orig = expected.get();
 
@@ -207,7 +208,7 @@ TEST(TestMappedRingBuffer, nominal_push_shared_get_pop_unique) {
    Using unique push_and_replace, get and pop methods.
  */
 TEST(TestMappedRingBuffer, nominal_push_unique_get_pop_unique) {
-  rclcpp::mapped_ring_buffer::MappedRingBuffer<char> mrb(2);
+  rclcpp::mapped_ring_buffer::MappedRingBuffer<char> mrb(2, nullptr);
   std::unique_ptr<char> expected(new char('a'));
   const char * expected_orig = expected.get();
 
@@ -258,7 +259,7 @@ TEST(TestMappedRingBuffer, nominal_push_unique_get_pop_unique) {
    Using unique push_and_replace, shared get and pop methods.
  */
 TEST(TestMappedRingBuffer, nominal_push_unique_get_pop_shared) {
-  rclcpp::mapped_ring_buffer::MappedRingBuffer<char> mrb(2);
+  rclcpp::mapped_ring_buffer::MappedRingBuffer<char> mrb(2, nullptr);
   std::unique_ptr<char> expected(new char('a'));
   const char * expected_orig = expected.get();
 
@@ -308,7 +309,7 @@ TEST(TestMappedRingBuffer, nominal_push_unique_get_pop_shared) {
    Tests the affect of reusing keys (non-unique keys) in a mrb.
  */
 TEST(TestMappedRingBuffer, non_unique_keys) {
-  rclcpp::mapped_ring_buffer::MappedRingBuffer<char> mrb(2);
+  rclcpp::mapped_ring_buffer::MappedRingBuffer<char> mrb(2, nullptr);
 
   std::shared_ptr<const char> input(new char('a'));
   mrb.push_and_replace(1, input);


### PR DESCRIPTION
Description:
Extended rclcpp to allow serialized intra process communication. Therefore, we extended mapped ring buffer to allow to handle the message type and the (possible custom) deleter of the serialized data. If the subscription or publisher are not serialized the serialized message is converted on demand.

Possible applications:
 * direct recording of serialized data without serialization (with IPM)
 * non-templated publisher of serialized messages (with IPM)

Features:
* extended mapped_ring_buffer to handle serialized data (including deleter)
* added serialization and deserialization functions in intraprocess manager
* converting data content if needed (if non/serialized subscription vs. publisher)
* moved publish(rcl_serialized_message_t) from Publisher<T> to PublisherBase to make it more generic
* added unit tests: test_intra_process_communication