### PR TITLE
Allow passing logger by const ref

### DIFF
--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -95,7 +95,7 @@ def is_supported_feature_combination(feature_combination):
 #define RCLCPP_@(severity)@(suffix)(logger, @(''.join([p + ', ' for p in get_macro_parameters(feature_combination).keys()]))...) \
   do { \
     static_assert( \
-      ::std::is_same<typename std::remove_reference<typename std::remove_cv<decltype(logger)>::type>::type, \
+      ::std::is_same<typename std::remove_cv<typename std::remove_reference<decltype(logger)>::type>::type, \
       typename ::rclcpp::Logger>::value, \
       "First argument to logging macros must be an rclcpp::Logger"); \
     RCUTILS_LOG_@(severity)@(suffix)_NAMED( \

--- a/rclcpp/test/test_logging.cpp
+++ b/rclcpp/test/test_logging.cpp
@@ -162,3 +162,28 @@ TEST_F(TestLoggingMacros, test_logging_skipfirst) {
     EXPECT_EQ(i - 1, g_log_calls);
   }
 }
+
+bool log_function(rclcpp::Logger logger)
+{
+  RCLCPP_INFO(logger, "successful log");
+  return true;
+}
+
+bool log_function_const(const rclcpp::Logger logger)
+{
+  RCLCPP_INFO(logger, "successful log");
+  return true;
+}
+
+bool log_function_const_ref(const rclcpp::Logger & logger)
+{
+  RCLCPP_INFO(logger, "successful log");
+  return true;
+}
+
+TEST_F(TestLoggingMacros, test_log_from_node) {
+  auto logger = rclcpp::get_logger("test_logging_logger");
+  EXPECT_TRUE(log_function(logger));
+  EXPECT_TRUE(log_function_const(logger));
+  EXPECT_TRUE(log_function_const_ref(logger));
+}


### PR DESCRIPTION
type trait order matters

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7841)](http://ci.ros2.org/job/ci_linux/7841/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3909)](http://ci.ros2.org/job/ci_linux-aarch64/3909/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6398)](http://ci.ros2.org/job/ci_osx/6398/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7679)](http://ci.ros2.org/job/ci_windows/7679/)

Signed-off-by: Karsten Knese <karsten@openrobotics.org>