### PR TITLE
Fix get_node_interfaces functions taking a pointer

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/get_node_base_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/get_node_base_interface.hpp
@@ -123,16 +123,18 @@ template<
   typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
 >
 rclcpp::node_interfaces::NodeBaseInterface *
-get_node_base_interface(NodeType && node_pointer)
+get_node_base_interface(NodeType node_pointer)
 {
   // Forward pointers to detail implmentation directly.
-  return detail::get_node_base_interface_from_pointer(std::forward<NodeType>(node_pointer));
+  return detail::get_node_base_interface_from_pointer(node_pointer);
 }
 
 /// Get the NodeBaseInterface as a pointer from a "Node like" object.
 template<
   typename NodeType,
-  typename std::enable_if<!std::is_pointer<NodeType>::value, int>::type = 0
+  typename std::enable_if<
+    !std::is_pointer<typename std::remove_reference<NodeType>::type>::value, int
+  >::type = 0
 >
 rclcpp::node_interfaces::NodeBaseInterface *
 get_node_base_interface(NodeType && node_reference)

--- a/rclcpp/include/rclcpp/node_interfaces/get_node_timers_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/get_node_timers_interface.hpp
@@ -123,16 +123,18 @@ template<
   typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
 >
 rclcpp::node_interfaces::NodeTimersInterface *
-get_node_timers_interface(NodeType && node_pointer)
+get_node_timers_interface(NodeType node_pointer)
 {
   // Forward pointers to detail implmentation directly.
-  return detail::get_node_timers_interface_from_pointer(std::forward<NodeType>(node_pointer));
+  return detail::get_node_timers_interface_from_pointer(node_pointer);
 }
 
 /// Get the NodeTimersInterface as a pointer from a "Node like" object.
 template<
   typename NodeType,
-  typename std::enable_if<!std::is_pointer<NodeType>::value, int>::type = 0
+  typename std::enable_if<
+    !std::is_pointer<typename std::remove_reference<NodeType>::type>::value, int
+  >::type = 0
 >
 rclcpp::node_interfaces::NodeTimersInterface *
 get_node_timers_interface(NodeType && node_reference)

--- a/rclcpp/include/rclcpp/node_interfaces/get_node_topics_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/get_node_topics_interface.hpp
@@ -123,16 +123,18 @@ template<
   typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
 >
 rclcpp::node_interfaces::NodeTopicsInterface *
-get_node_topics_interface(NodeType && node_pointer)
+get_node_topics_interface(NodeType node_pointer)
 {
   // Forward pointers to detail implmentation directly.
-  return detail::get_node_topics_interface_from_pointer(std::forward<NodeType>(node_pointer));
+  return detail::get_node_topics_interface_from_pointer(node_pointer);
 }
 
 /// Get the NodeTopicsInterface as a pointer from a "Node like" object.
 template<
   typename NodeType,
-  typename std::enable_if<!std::is_pointer<NodeType>::value, int>::type = 0
+  typename std::enable_if<
+    !std::is_pointer<typename std::remove_reference<NodeType>::type>::value, int
+  >::type = 0
 >
 rclcpp::node_interfaces::NodeTopicsInterface *
 get_node_topics_interface(NodeType && node_reference)

--- a/rclcpp/test/node_interfaces/test_get_node_interfaces.cpp
+++ b/rclcpp/test/node_interfaces/test_get_node_interfaces.cpp
@@ -85,6 +85,26 @@ TEST_F(TestGetNodeInterfaces, node_reference) {
     >::value, "expected rclcpp::node_interfaces::NodeTopicsInterface *");
 }
 
+TEST_F(TestGetNodeInterfaces, rclcpp_node_pointer) {
+  rclcpp::Node * node_pointer = this->node.get();
+  auto result = rclcpp::node_interfaces::get_node_topics_interface(node_pointer);
+  static_assert(
+    std::is_same<
+      rclcpp::node_interfaces::NodeTopicsInterface *,
+      decltype(result)
+    >::value, "expected rclcpp::node_interfaces::NodeTopicsInterface *");
+}
+
+TEST_F(TestGetNodeInterfaces, node_pointer) {
+  NodeWrapper * wrapped_node_pointer = this->wrapped_node.get();
+  auto result = rclcpp::node_interfaces::get_node_topics_interface(wrapped_node_pointer);
+  static_assert(
+    std::is_same<
+      rclcpp::node_interfaces::NodeTopicsInterface *,
+      decltype(result)
+    >::value, "expected rclcpp::node_interfaces::NodeTopicsInterface *");
+}
+
 TEST_F(TestGetNodeInterfaces, interface_shared_pointer) {
   std::shared_ptr<rclcpp::node_interfaces::NodeTopicsInterface> interface_shared_ptr =
     this->node->get_node_topics_interface();


### PR DESCRIPTION
Replaces https://github.com/ros2/rclcpp/pull/809