### PR TITLE
Delete unnecessary call for get_node_by_group

### DIFF
--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -540,6 +540,7 @@ Executor::get_next_timer(AnyExecutable & any_exec)
         if (timer && timer->is_ready()) {
           any_exec.timer = timer;
           any_exec.callback_group = group;
+          any_exec.node_base = node;
           return;
         }
       }

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -540,7 +540,6 @@ Executor::get_next_timer(AnyExecutable & any_exec)
         if (timer && timer->is_ready()) {
           any_exec.timer = timer;
           any_exec.callback_group = group;
-          node = get_node_by_group(group);
           return;
         }
       }


### PR DESCRIPTION
there is a discussion SingleThreadedExecutor CPU consumption,
https://discourse.ros.org/t/singlethreadedexecutor-creates-a-high-cpu-overhead-in-ros-2/10077/6

i think that this is an unnecessary call for get_node_by_group

this seems to be able to reduce a few percent cpu consumption but not an exactly counter-measure.