### PR TITLE
check valid timer handler 1st to reduce the time window for scan.

### DIFF
--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -334,10 +334,6 @@ protected:
   get_group_by_timer(rclcpp::TimerBase::SharedPtr timer);
 
   RCLCPP_PUBLIC
-  void
-  get_next_timer(AnyExecutable & any_exec);
-
-  RCLCPP_PUBLIC
   bool
   get_next_ready_executable(AnyExecutable & any_executable);
 

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -80,6 +80,11 @@ public:
     const WeakNodeList & weak_nodes) = 0;
 
   virtual void
+  get_next_timer(
+    rclcpp::executor::AnyExecutable & any_exec,
+    const WeakNodeList & weak_nodes) = 0;
+
+  virtual void
   get_next_waitable(
     rclcpp::executor::AnyExecutable & any_exec,
     const WeakNodeList & weak_nodes) = 0;
@@ -102,6 +107,11 @@ public:
     std::shared_ptr<const rcl_client_t> client_handle,
     const WeakNodeList & weak_nodes);
 
+  static rclcpp::TimerBase::SharedPtr
+  get_timer_by_handle(
+    std::shared_ptr<const rcl_timer_t> timer_handle,
+    const WeakNodeList & weak_nodes);
+
   static rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
   get_node_by_group(
     rclcpp::callback_group::CallbackGroup::SharedPtr group,
@@ -120,6 +130,11 @@ public:
   static rclcpp::callback_group::CallbackGroup::SharedPtr
   get_group_by_client(
     rclcpp::ClientBase::SharedPtr client,
+    const WeakNodeList & weak_nodes);
+
+  static rclcpp::callback_group::CallbackGroup::SharedPtr
+  get_group_by_timer(
+    rclcpp::TimerBase::SharedPtr timer,
     const WeakNodeList & weak_nodes);
 
   static rclcpp::callback_group::CallbackGroup::SharedPtr

--- a/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
@@ -375,6 +375,41 @@ public:
   }
 
   virtual void
+  get_next_timer(
+    executor::AnyExecutable & any_exec,
+    const WeakNodeList & weak_nodes)
+  {
+    auto it = timer_handles_.begin();
+    while (it != timer_handles_.end()) {
+      auto timer = get_timer_by_handle(*it, weak_nodes);
+      if (timer) {
+        // Find the group for this handle and see if it can be serviced
+        auto group = get_group_by_timer(timer, weak_nodes);
+        if (!group) {
+          // Group was not found, meaning the timer is not valid...
+          // Remove it from the ready list and continue looking
+          it = timer_handles_.erase(it);
+          continue;
+        }
+        if (!group->can_be_taken_from().load()) {
+          // Group is mutually exclusive and is being used, so skip it for now
+          // Leave it to be checked next time, but continue searching
+          ++it;
+          continue;
+        }
+        // Otherwise it is safe to set and return the any_exec
+        any_exec.timer = timer;
+        any_exec.callback_group = group;
+        any_exec.node_base = get_node_by_group(group, weak_nodes);
+        timer_handles_.erase(it);
+        return;
+      }
+      // Else, the service is no longer valid, remove it and continue
+      it = timer_handles_.erase(it);
+    }
+  }
+
+  virtual void
   get_next_waitable(executor::AnyExecutable & any_exec, const WeakNodeList & weak_nodes)
   {
     auto it = waitable_handles_.begin();

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -522,37 +522,11 @@ Executor::get_group_by_timer(rclcpp::TimerBase::SharedPtr timer)
   return rclcpp::callback_group::CallbackGroup::SharedPtr();
 }
 
-void
-Executor::get_next_timer(AnyExecutable & any_exec)
-{
-  for (auto & weak_node : weak_nodes_) {
-    auto node = weak_node.lock();
-    if (!node) {
-      continue;
-    }
-    for (auto & weak_group : node->get_callback_groups()) {
-      auto group = weak_group.lock();
-      if (!group || !group->can_be_taken_from().load()) {
-        continue;
-      }
-      for (auto & timer_ref : group->get_timer_ptrs()) {
-        auto timer = timer_ref.lock();
-        if (timer && timer->is_ready()) {
-          any_exec.timer = timer;
-          any_exec.callback_group = group;
-          node = get_node_by_group(group);
-          return;
-        }
-      }
-    }
-  }
-}
-
 bool
 Executor::get_next_ready_executable(AnyExecutable & any_executable)
 {
-  // Check the timers to see if there are any that are ready, if so return
-  get_next_timer(any_executable);
+  // Check the timers to see if there are any that are ready
+  memory_strategy_->get_next_timer(any_executable, weak_nodes_);
   if (any_executable.timer) {
     return true;
   }


### PR DESCRIPTION
related to the following discussion for SingleThreadedExecutor CPU consumption,
https://discourse.ros.org/t/singlethreadedexecutor-creates-a-high-cpu-overhead-in-ros-2/10077/6

timer_handler_ should be checked if it is valid or not at the 1st entry. this is done for other objects such as subscriptions etc...but not for timer.

confirmed the following optimization result with typical case using [ros2_performance](https://github.com/nobleo/ros2_performance) nopub.

[Before]
```
root@2e44b65b8217:~/docker_colcon_ws# top | grep nopub
 7301 root      20   0 3220996  79812  17116 S  18.3  0.5   0:07.10 nopub                                               
 7301 root      20   0 3220996  79812  17116 R  17.3  0.5   0:07.62 nopub                                               
 7301 root      20   0 3220996  79812  17116 S  17.3  0.5   0:08.14 nopub                                               
 7301 root      20   0 3220996  79812  17116 S  18.7  0.5   0:08.70 nopub                                               
 7301 root      20   0 3220996  79812  17116 S  19.0  0.5   0:09.27 nopub                                               
 7301 root      20   0 3220996  79812  17116 R  17.6  0.5   0:09.80 nopub                                               
 7301 root      20   0 3220996  79812  17116 R  15.7  0.5   0:10.27 nopub                                               
 7301 root      20   0 3220996  79812  17116 S  16.9  0.5   0:10.78 nopub                                               
 7301 root      20   0 3220996  79812  17116 S  15.0  0.5   0:11.23 nopub                                               
 7301 root      20   0 3220996  79812  17116 S  16.7  0.5   0:11.73 nopub                 
```

[After]
```
root@2e44b65b8217:~/docker_colcon_ws# top | grep nopub
11847 root      20   0 3221000  80312  17272 S  13.3  0.5   0:00.57 nopub                                               
11847 root      20   0 3221000  80312  17272 S  12.0  0.5   0:00.93 nopub                                               
11847 root      20   0 3221000  80312  17272 S  12.3  0.5   0:01.30 nopub                                               
11847 root      20   0 3221000  80312  17272 S  12.3  0.5   0:01.67 nopub                                               
11847 root      20   0 3221000  80312  17272 S  11.3  0.5   0:02.01 nopub                                               
11847 root      20   0 3221000  80312  17272 S  11.3  0.5   0:02.35 nopub                                               
11847 root      20   0 3221000  80312  17272 S  11.7  0.5   0:02.70 nopub                                               
11847 root      20   0 3221000  80312  17272 R  10.6  0.5   0:03.02 nopub                                               
11847 root      20   0 3221000  80312  17272 S  12.0  0.5   0:03.38 nopub                                               
11847 root      20   0 3221000  80312  17272 S  11.0  0.5   0:03.71 nopub                                               
```
