### PR TITLE
check valid timer handler 1st to reduce the time window for scan.

### DIFF
--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -335,10 +335,6 @@ protected:
   get_group_by_timer(rclcpp::TimerBase::SharedPtr timer);
 
   RCLCPP_PUBLIC
-  void
-  get_next_timer(AnyExecutable & any_exec);
-
-  RCLCPP_PUBLIC
   bool
   get_next_ready_executable(AnyExecutable & any_executable);
 

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -80,6 +80,11 @@ public:
     const WeakNodeList & weak_nodes) = 0;
 
   virtual void
+  get_next_timer(
+    rclcpp::executor::AnyExecutable & any_exec,
+    const WeakNodeList & weak_nodes) = 0;
+
+  virtual void
   get_next_waitable(
     rclcpp::executor::AnyExecutable & any_exec,
     const WeakNodeList & weak_nodes) = 0;
@@ -102,6 +107,11 @@ public:
     std::shared_ptr<const rcl_client_t> client_handle,
     const WeakNodeList & weak_nodes);
 
+  static rclcpp::TimerBase::SharedPtr
+  get_timer_by_handle(
+    std::shared_ptr<const rcl_timer_t> timer_handle,
+    const WeakNodeList & weak_nodes);
+
   static rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
   get_node_by_group(
     rclcpp::callback_group::CallbackGroup::SharedPtr group,
@@ -120,6 +130,11 @@ public:
   static rclcpp::callback_group::CallbackGroup::SharedPtr
   get_group_by_client(
     rclcpp::ClientBase::SharedPtr client,
+    const WeakNodeList & weak_nodes);
+
+  static rclcpp::callback_group::CallbackGroup::SharedPtr
+  get_group_by_timer(
+    rclcpp::TimerBase::SharedPtr timer,
     const WeakNodeList & weak_nodes);
 
   static rclcpp::callback_group::CallbackGroup::SharedPtr


### PR DESCRIPTION
related to the following discussion for SingleThreadedExecutor CPU consumption,
https://discourse.ros.org/t/singlethreadedexecutor-creates-a-high-cpu-overhead-in-ros-2/10077/6

timer_handler_ should be checked if it is valid or not at the 1st entry. this is done for other objects such as subscriptions etc...but not for timer.

confirmed the following optimization result with typical case using ros2_performance nopub.

[Before]
```
root@2e44b65b8217:~/docker_colcon_ws# top | grep nopub
 7301 root      20   0 3220996  79812  17116 S  18.3  0.5   0:07.10 nopub                                               
 7301 root      20   0 3220996  79812  17116 R  17.3  0.5   0:07.62 nopub                                               
 7301 root      20   0 3220996  79812  17116 S  17.3  0.5   0:08.14 nopub                                               
 7301 root      20   0 3220996  79812  17116 S  18.7  0.5   0:08.70 nopub                                               
 7301 root      20   0 3220996  79812  17116 S  19.0  0.5   0:09.27 nopub                                               
 7301 root      20   0 3220996  79812  17116 R  17.6  0.5   0:09.80 nopub                                               
 7301 root      20   0 3220996  79812  17116 R  15.7  0.5   0:10.27 nopub                                               
 7301 root      20   0 3220996  79812  17116 S  16.9  0.5   0:10.78 nopub                                               
 7301 root      20   0 3220996  79812  17116 S  15.0  0.5   0:11.23 nopub                                               
 7301 root      20   0 3220996  79812  17116 S  16.7  0.5   0:11.73 nopub        
```

[After]
```
root@2e44b65b8217:~/docker_colcon_ws# top | grep nopub
11847 root      20   0 3221000  80312  17272 S  13.3  0.5   0:00.57 nopub                                               
11847 root      20   0 3221000  80312  17272 S  12.0  0.5   0:00.93 nopub                                               
11847 root      20   0 3221000  80312  17272 S  12.3  0.5   0:01.30 nopub                                               
11847 root      20   0 3221000  80312  17272 S  12.3  0.5   0:01.67 nopub                                               
11847 root      20   0 3221000  80312  17272 S  11.3  0.5   0:02.01 nopub                                               
11847 root      20   0 3221000  80312  17272 S  11.3  0.5   0:02.35 nopub                                               
11847 root      20   0 3221000  80312  17272 S  11.7  0.5   0:02.70 nopub                                               
11847 root      20   0 3221000  80312  17272 R  10.6  0.5   0:03.02 nopub                                               
11847 root      20   0 3221000  80312  17272 S  12.0  0.5   0:03.38 nopub                                               
11847 root      20   0 3221000  80312  17272 S  11.0  0.5   0:03.71 nopub                                               
```

