### PR TITLE
Fail on invalid and unknown ROS specific arguments

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(builtin_interfaces REQUIRED)
 find_package(rcl REQUIRED)
 find_package(rcl_interfaces REQUIRED)
 find_package(rcl_yaml_param_parser REQUIRED)
+find_package(rcpputils REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rmw_implementation REQUIRED)
 find_package(rosgraph_msgs REQUIRED)
@@ -106,6 +107,7 @@ add_library(${PROJECT_NAME}
 ament_target_dependencies(${PROJECT_NAME}
   "rcl"
   "rcl_yaml_param_parser"
+  "rcpputils"
   "builtin_interfaces"
   "rosgraph_msgs"
   "rosidl_typesupport_cpp"
@@ -129,6 +131,7 @@ ament_export_libraries(${PROJECT_NAME})
 
 ament_export_dependencies(ament_cmake)
 ament_export_dependencies(rcl)
+ament_export_dependencies(rcpputils)
 ament_export_dependencies(builtin_interfaces)
 ament_export_dependencies(rosgraph_msgs)
 ament_export_dependencies(rosidl_typesupport_cpp)

--- a/rclcpp/include/rclcpp/exceptions.hpp
+++ b/rclcpp/include/rclcpp/exceptions.hpp
@@ -17,10 +17,13 @@
 
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include "rcl/error_handling.h"
 #include "rcl/types.h"
 #include "rclcpp/visibility_control.hpp"
+
+#include "rcpputils/join.hpp"
 
 namespace rclcpp
 {
@@ -165,6 +168,31 @@ public:
     const std::string & prefix);
   RCLCPP_PUBLIC
   RCLInvalidArgument(const RCLErrorBase & base_exc, const std::string & prefix);
+};
+
+/// Created when the ret is RCL_RET_INVALID_ROS_ARGS.
+class RCLInvalidROSArgsError : public RCLErrorBase, public std::runtime_error
+{
+public:
+  RCLCPP_PUBLIC
+  RCLInvalidROSArgsError(
+    rcl_ret_t ret, const rcl_error_state_t * error_state, const std::string & prefix);
+  RCLCPP_PUBLIC
+  RCLInvalidROSArgsError(const RCLErrorBase & base_exc, const std::string & prefix);
+};
+
+/// Thrown when unparsed ROS specific arguments are found.
+class UnknownROSArgsError : public std::runtime_error
+{
+public:
+  explicit UnknownROSArgsError(std::vector<std::string> && unknown_ros_args_in)
+  : std::runtime_error(
+      "found unknown ROS arguments: '" + rcpputils::join(unknown_ros_args_in, "', '") + "'"),
+    unknown_ros_args(unknown_ros_args_in)
+  {
+  }
+
+  const std::vector<std::string> unknown_ros_args;
 };
 
 /// Thrown when an invalid rclcpp::Event object or SharedPtr is encountered.

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -15,6 +15,7 @@
 #ifndef RCLCPP__UTILITIES_HPP_
 #define RCLCPP__UTILITIES_HPP_
 
+
 #include <chrono>
 #include <functional>
 #include <limits>
@@ -26,7 +27,6 @@
 #include "rclcpp/visibility_control.hpp"
 
 #ifdef ANDROID
-#include <sstream>
 
 namespace std
 {

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -15,7 +15,6 @@
 #ifndef RCLCPP__UTILITIES_HPP_
 #define RCLCPP__UTILITIES_HPP_
 
-
 #include <chrono>
 #include <functional>
 #include <limits>
@@ -27,7 +26,7 @@
 #include "rclcpp/visibility_control.hpp"
 
 #ifdef ANDROID
-
+#include <sstream>
 namespace std
 {
 template<typename T>

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -27,6 +27,7 @@
 
 #ifdef ANDROID
 #include <sstream>
+
 namespace std
 {
 template<typename T>

--- a/rclcpp/package.xml
+++ b/rclcpp/package.xml
@@ -26,6 +26,7 @@
 
   <depend>rcl</depend>
   <depend>rcl_yaml_param_parser</depend>
+  <depend>rcpputils</depend>
   <depend>rmw_implementation</depend>
 
   <exec_depend>ament_cmake</exec_depend>

--- a/rclcpp/src/rclcpp/exceptions.cpp
+++ b/rclcpp/src/rclcpp/exceptions.cpp
@@ -17,6 +17,7 @@
 #include <cstdio>
 #include <functional>
 #include <string>
+#include <vector>
 
 using namespace std::string_literals;
 
@@ -68,6 +69,8 @@ from_rcl_error(
       return std::make_exception_ptr(RCLBadAlloc(base_exc));
     case RCL_RET_INVALID_ARGUMENT:
       return std::make_exception_ptr(RCLInvalidArgument(base_exc, formatted_prefix));
+    case RCL_RET_INVALID_ROS_ARGS:
+      return std::make_exception_ptr(RCLInvalidROSArgsError(base_exc, formatted_prefix));
     default:
       return std::make_exception_ptr(RCLError(base_exc, formatted_prefix));
   }
@@ -124,6 +127,19 @@ RCLInvalidArgument::RCLInvalidArgument(
   const RCLErrorBase & base_exc,
   const std::string & prefix)
 : RCLErrorBase(base_exc), std::invalid_argument(prefix + base_exc.formatted_message)
+{}
+
+RCLInvalidROSArgsError::RCLInvalidROSArgsError(
+  rcl_ret_t ret,
+  const rcl_error_state_t * error_state,
+  const std::string & prefix)
+: RCLInvalidROSArgsError(RCLErrorBase(ret, error_state), prefix)
+{}
+
+RCLInvalidROSArgsError::RCLInvalidROSArgsError(
+  const RCLErrorBase & base_exc,
+  const std::string & prefix)
+: RCLErrorBase(base_exc), std::runtime_error(prefix + base_exc.formatted_message)
 {}
 
 }  // namespace exceptions

--- a/rclcpp/test/test_node_options.cpp
+++ b/rclcpp/test/test_node_options.cpp
@@ -83,3 +83,18 @@ TEST(TestNodeOptions, ros_args_and_non_ros_args) {
   EXPECT_EQ("non-ros-arg", args[output_indices[1]]);
   allocator.deallocate(output_indices, allocator.state);
 }
+
+TEST(TestNodeOptions, bad_ros_args) {
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  auto options = rclcpp::NodeOptions(allocator)
+    .arguments({"--ros-args", "-r", "foo:="});
+
+  EXPECT_THROW(
+    options.get_rcl_node_options(),
+    rclcpp::exceptions::RCLInvalidROSArgsError);
+
+  options.arguments({"--ros-args", "-r", "foo:=bar", "not-a-ros-arg"});
+  EXPECT_THROW(
+    options.get_rcl_node_options(),
+    rclcpp::exceptions::UnknownROSArgsError);
+}


### PR DESCRIPTION
Precisely what the title says. This pull request makes `rclcpp` throw if either an invalid or an unknown ROS argument is found.