### PR TITLE
Bug fix on shutdown_on_sigint (not set on InitOptions constructors) to implement a custom interrupt signal handler

### DIFF
--- a/rclcpp/src/rclcpp/init_options.cpp
+++ b/rclcpp/src/rclcpp/init_options.cpp
@@ -42,7 +42,9 @@ InitOptions::InitOptions(const rcl_init_options_t & init_options)
 
 InitOptions::InitOptions(const InitOptions & other)
 : InitOptions(*other.get_rcl_init_options())
-{}
+{
+  shutdown_on_sigint = other.shutdown_on_sigint;
+}
 
 InitOptions &
 InitOptions::operator=(const InitOptions & other)
@@ -53,6 +55,7 @@ InitOptions::operator=(const InitOptions & other)
     if (RCL_RET_OK != ret) {
       rclcpp::exceptions::throw_from_rcl_error(ret, "failed to copy rcl init options");
     }
+    this->shutdown_on_sigint = other.shutdown_on_sigint;
   }
   return *this;
 }


### PR DESCRIPTION
The `shutdown_on_sigint` is used select the behavior of the interrupt signal, if the node should be shutdown or not. It's set as true as default on the `InitOptions` class. The code below should supress the shutdown behavior.
```
InitOptions init_options;
init_options.shutdown_on_sigint = false;
rclcpp::init(arc, arv, node_options);
```
Some change on the InitOptions file should have ignored this variable. This commit corrects the copy constructors and the function to pass the object as a reference.

With this, a custom signal handler could be implemented like in ROS 1 ([roscpp/Overview/Initialization and Shutdown](http://wiki.ros.org/roscpp/Overview/Initialization%20and%20Shutdown)).

```
void mySigintHandler(int sig)
{
    // Implement custom signal interrupt behavior

    rclcpp::contexts::default_context::get_global_default_context()->shutdown(
        "custom signal handler"
    );
}

int main(int argc, char** argv)
{
    signal(SIGINT, mySigintHandler);
    rclcpp::InitOptions init_options;
    init_options.shutdown_on_sigint = false;
    rclcpp::init(argc, argv, init_options);

    // Implement rest of the code
    rclcpp::shutdown();
}
```

