### PR TITLE
reset error message before setting a new one, embed the original one

### DIFF
--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -377,6 +377,7 @@ public:
       RCUTILS_LOG_ERROR(
         "Unable to start transition %u from current state %s: %s",
         transition_id, state_machine_.current_state->label, rcl_get_error_string().str);
+      rcutils_reset_error();
       return RCL_RET_ERROR;
     }
 
@@ -399,8 +400,9 @@ public:
         &state_machine_, transition_label, publish_update) != RCL_RET_OK)
     {
       RCUTILS_LOG_ERROR(
-        "Failed to finish transition %u. Current state is now: %s",
-        transition_id, state_machine_.current_state->label);
+        "Failed to finish transition %u. Current state is now: %s (%s)",
+        transition_id, state_machine_.current_state->label, rcl_get_error_string().str);
+      rcutils_reset_error();
       return RCL_RET_ERROR;
     }
 
@@ -415,7 +417,8 @@ public:
         rcl_lifecycle_trigger_transition_by_label(
           &state_machine_, error_cb_label, publish_update) != RCL_RET_OK)
       {
-        RCUTILS_LOG_ERROR("Failed to call cleanup on error state");
+        RCUTILS_LOG_ERROR("Failed to call cleanup on error state: %s", rcl_get_error_string().str);
+        rcutils_reset_error();
         return RCL_RET_ERROR;
       }
     }


### PR DESCRIPTION
Related to ros2/rcl#501.

Embed the error string and reset it since the callers don't check (maybe they should in the future?).