### PR TITLE
Fix UnknownGoalHandle error string.

### DIFF
--- a/rclcpp_action/include/rclcpp_action/exceptions.hpp
+++ b/rclcpp_action/include/rclcpp_action/exceptions.hpp
@@ -25,7 +25,7 @@ class UnknownGoalHandleError : public std::invalid_argument
 {
 public:
   UnknownGoalHandleError()
-  : std::invalid_argument("Goal handle is not know to this client.")
+  : std::invalid_argument("Goal handle is not known to this client.")
   {
   }
 };


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

No CI: this is just adding one letter to a string, and there don't seem to be tests that look for this exact error message.