### PR TITLE
add more context to exception message

### DIFF
--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <limits>
+#include <string>
 #include <utility>
 
 #include "rclcpp/clock.hpp"
@@ -194,7 +195,10 @@ Duration
 Time::operator-(const rclcpp::Time & rhs) const
 {
   if (rcl_time_.clock_type != rhs.rcl_time_.clock_type) {
-    throw std::runtime_error(std::string("can't subtract times with different time sources [") + std::to_string(rcl_time_.clock_type) + " != " + std::to_string(rhs.rcl_time_.clock_type) + "]");
+    throw std::runtime_error(
+            std::string("can't subtract times with different time sources [") +
+            std::to_string(rcl_time_.clock_type) + " != " +
+            std::to_string(rhs.rcl_time_.clock_type) + "]");
   }
 
   if (rclcpp::sub_will_overflow(rcl_time_.nanoseconds, rhs.rcl_time_.nanoseconds)) {

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -194,7 +194,7 @@ Duration
 Time::operator-(const rclcpp::Time & rhs) const
 {
   if (rcl_time_.clock_type != rhs.rcl_time_.clock_type) {
-    throw std::runtime_error("can't subtract times with different time sources");
+    throw std::runtime_error(std::string("can't subtract times with different time sources [") + std::to_string(rcl_time_.clock_type) + " != " + std::to_string(rhs.rcl_time_.clock_type) + "]");
   }
 
   if (rclcpp::sub_will_overflow(rcl_time_.nanoseconds, rhs.rcl_time_.nanoseconds)) {


### PR DESCRIPTION
Helpful when the exception happens to know what the two clock types actually are.