### PR TITLE
Remove timeout on tests

### DIFF
--- a/rclcpp_components/test/test_component_manager_api.cpp
+++ b/rclcpp_components/test/test_component_manager_api.cpp
@@ -56,7 +56,7 @@ TEST_F(TestComponentManager, load_components)
     request->plugin_name = "test_rclcpp_components::TestComponentFoo";
 
     auto result = client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+    auto ret = exec->spin_until_future_complete(result);  // Wait for the result.
     EXPECT_EQ(ret, rclcpp::executor::FutureReturnCode::SUCCESS);
     EXPECT_EQ(result.get()->success, true);
     EXPECT_EQ(result.get()->error_message, "");
@@ -70,7 +70,7 @@ TEST_F(TestComponentManager, load_components)
     request->plugin_name = "test_rclcpp_components::TestComponentBar";
 
     auto result = client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+    auto ret = exec->spin_until_future_complete(result);  // Wait for the result.
     EXPECT_EQ(ret, rclcpp::executor::FutureReturnCode::SUCCESS);
     EXPECT_EQ(result.get()->success, true);
     EXPECT_EQ(result.get()->error_message, "");
@@ -86,7 +86,7 @@ TEST_F(TestComponentManager, load_components)
     request->node_name = "test_component_baz";
 
     auto result = client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+    auto ret = exec->spin_until_future_complete(result);  // Wait for the result.
     EXPECT_EQ(ret, rclcpp::executor::FutureReturnCode::SUCCESS);
     EXPECT_EQ(result.get()->success, true);
     EXPECT_EQ(result.get()->error_message, "");
@@ -103,7 +103,7 @@ TEST_F(TestComponentManager, load_components)
     request->node_name = "test_component_bing";
 
     auto result = client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+    auto ret = exec->spin_until_future_complete(result);  // Wait for the result.
     EXPECT_EQ(ret, rclcpp::executor::FutureReturnCode::SUCCESS);
     EXPECT_EQ(result.get()->success, true);
     EXPECT_EQ(result.get()->error_message, "");
@@ -146,7 +146,7 @@ TEST_F(TestComponentManager, load_invalid_components)
     request->plugin_name = "test_rclcpp_components::TestComponent";
 
     auto result = client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+    auto ret = exec->spin_until_future_complete(result);  // Wait for the result.
     EXPECT_EQ(ret, rclcpp::executor::FutureReturnCode::SUCCESS);
     EXPECT_EQ(result.get()->success, false);
     EXPECT_EQ(result.get()->error_message, "Failed to find class with the requested plugin name.");
@@ -161,7 +161,7 @@ TEST_F(TestComponentManager, load_invalid_components)
     request->plugin_name = "test_rclcpp_components::TestComponentFoo";
 
     auto result = client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+    auto ret = exec->spin_until_future_complete(result);  // Wait for the result.
     EXPECT_EQ(ret, rclcpp::executor::FutureReturnCode::SUCCESS);
     EXPECT_EQ(result.get()->success, false);
     EXPECT_EQ(result.get()->error_message, "Could not find requested resource in ament index");
@@ -194,7 +194,7 @@ TEST_F(TestComponentManager, list_components)
       request->plugin_name = "test_rclcpp_components::TestComponentFoo";
 
       auto result = client->async_send_request(request);
-      auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+      auto ret = exec->spin_until_future_complete(result);  // Wait for the result.
       EXPECT_EQ(ret, rclcpp::executor::FutureReturnCode::SUCCESS);
       EXPECT_EQ(result.get()->success, true);
       EXPECT_EQ(result.get()->error_message, "");
@@ -214,7 +214,7 @@ TEST_F(TestComponentManager, list_components)
     {
       auto request = std::make_shared<composition_interfaces::srv::ListNodes::Request>();
       auto result = client->async_send_request(request);
-      auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+      auto ret = exec->spin_until_future_complete(result);  // Wait for the result.
       EXPECT_EQ(ret, rclcpp::executor::FutureReturnCode::SUCCESS);
       auto node_names = result.get()->full_node_names;
       auto unique_ids = result.get()->unique_ids;
@@ -250,7 +250,7 @@ TEST_F(TestComponentManager, unload_component)
       request->plugin_name = "test_rclcpp_components::TestComponentFoo";
 
       auto result = client->async_send_request(request);
-      auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+      auto ret = exec->spin_until_future_complete(result);  // Wait for the result.
       EXPECT_EQ(ret, rclcpp::executor::FutureReturnCode::SUCCESS);
       EXPECT_EQ(result.get()->success, true);
       EXPECT_EQ(result.get()->error_message, "");
@@ -278,7 +278,7 @@ TEST_F(TestComponentManager, unload_component)
       request->unique_id = 1;
 
       auto result = client->async_send_request(request);
-      auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+      auto ret = exec->spin_until_future_complete(result);  // Wait for the result.
       EXPECT_EQ(ret, rclcpp::executor::FutureReturnCode::SUCCESS);
       EXPECT_EQ(result.get()->success, true);
       EXPECT_EQ(result.get()->error_message, "");
@@ -289,7 +289,7 @@ TEST_F(TestComponentManager, unload_component)
       request->unique_id = 1;
 
       auto result = client->async_send_request(request);
-      auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+      auto ret = exec->spin_until_future_complete(result);  // Wait for the result.
       EXPECT_EQ(ret, rclcpp::executor::FutureReturnCode::SUCCESS);
       EXPECT_EQ(result.get()->success, false);
       EXPECT_EQ(result.get()->error_message, "No node found with unique_id: 1");


### PR DESCRIPTION
* timeout was not required since the request will fail if the node is not found

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>