### PR TITLE
Take parameter overrides provided through the CLI.

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -144,11 +144,14 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
+  find_package(rcpputils REQUIRED)
   find_package(rmw_implementation_cmake REQUIRED)
 
   find_package(test_msgs REQUIRED)
 
   include(cmake/rclcpp_add_build_failure_test.cmake)
+
+  add_definitions(-DTEST_RESOURCES_DIRECTORY="${CMAKE_CURRENT_BINARY_DIR}/test/resources")
 
   ament_add_gtest(test_client test/test_client.cpp)
   if(TARGET test_client)
@@ -215,6 +218,7 @@ if(BUILD_TESTING)
   if(TARGET test_node)
     ament_target_dependencies(test_node
       "rcl_interfaces"
+      "rcpputils"
       "rmw"
       "rosidl_generator_cpp"
       "rosidl_typesupport_cpp"
@@ -462,6 +466,11 @@ if(BUILD_TESTING)
       "rcl")
     target_link_libraries(test_multi_threaded_executor ${PROJECT_NAME})
   endif()
+
+  # Install test resources
+  install(
+    DIRECTORY test/resources
+    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/test)
 endif()
 
 ament_package()

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -144,7 +144,6 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  find_package(rcpputils REQUIRED)
   find_package(rmw_implementation_cmake REQUIRED)
 
   find_package(test_msgs REQUIRED)

--- a/rclcpp/test/resources/test_node/test_parameters.yaml
+++ b/rclcpp/test/resources/test_node/test_parameters.yaml
@@ -1,0 +1,4 @@
+/**:
+  ros__parameters:
+    parameter_int: 21
+    parameter_string_array: [baz, baz, baz]

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -25,6 +25,9 @@
 #include "rclcpp/scope_exit.hpp"
 #include "rclcpp/rclcpp.hpp"
 
+#include "rcpputils/filesystem_helper.hpp"
+
+
 class TestNode : public ::testing::Test
 {
 protected:
@@ -32,6 +35,13 @@ protected:
   {
     rclcpp::init(0, nullptr);
   }
+
+  void SetUp() override
+  {
+    test_resources_path /= "test_node";
+  }
+
+  rcpputils::fs::path test_resources_path{TEST_RESOURCES_DIRECTORY};
 };
 
 /*
@@ -469,6 +479,7 @@ TEST_F(TestNode, declare_parameter_with_overrides) {
     {"parameter_rejected", 42},
     {"parameter_type_mismatch", "not an int"},
   });
+
   auto node = std::make_shared<rclcpp::Node>("test_declare_parameter_node"_unq, no);
   {
     // no default, with override
@@ -684,6 +695,73 @@ TEST_F(TestNode, declare_parameters_with_no_initial_values) {
       rclcpp::exceptions::InvalidParameterValueException);
   }
 }
+
+TEST_F(TestNode, declare_parameter_with_cli_overrides) {
+  const std::string parameters_filepath = (
+    test_resources_path / "test_parameters.yaml").string();
+  // test cases with overrides
+  rclcpp::NodeOptions no;
+  no.arguments({
+    "--ros-args",
+    "-p", "parameter_bool:=true",
+    "-p", "parameter_int:=42",
+    "-p", "parameter_double:=0.42",
+    "-p", "parameter_string:=foo",
+    "--params-file", parameters_filepath.c_str(),
+    "-p", "parameter_bool_array:=[false, true]",
+    "-p", "parameter_int_array:=[-21, 42]",
+    "-p", "parameter_double_array:=[-1.0, .42]",
+    "-p", "parameter_string_array:=[foo, bar]"
+  });
+
+  auto node = std::make_shared<rclcpp::Node>("test_declare_parameter_node"_unq, no);
+  {
+    rclcpp::ParameterValue value = node->declare_parameter("parameter_bool");
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_BOOL);
+    EXPECT_EQ(value.get<bool>(), true);
+  }
+  {
+    rclcpp::ParameterValue value = node->declare_parameter("parameter_int");
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER);
+    EXPECT_EQ(value.get<int64_t>(), 21);  // set to 42 in CLI, overriden by file
+  }
+  {
+    rclcpp::ParameterValue value = node->declare_parameter("parameter_double");
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_DOUBLE);
+    EXPECT_EQ(value.get<double>(), 0.42);
+  }
+  {
+    rclcpp::ParameterValue value = node->declare_parameter("parameter_string");
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_STRING);
+    EXPECT_EQ(value.get<std::string>(), "foo");
+  }
+  {
+    rclcpp::ParameterValue value = node->declare_parameter("parameter_bool_array");
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_BOOL_ARRAY);
+    std::vector<bool> expected_value{false, true};
+    EXPECT_EQ(value.get<std::vector<bool>>(), expected_value);
+  }
+  {
+    rclcpp::ParameterValue value = node->declare_parameter("parameter_int_array");
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER_ARRAY);
+    std::vector<int64_t> expected_value{-21, 42};
+    EXPECT_EQ(value.get<std::vector<int64_t>>(), expected_value);
+  }
+  {
+    rclcpp::ParameterValue value = node->declare_parameter("parameter_double_array");
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_DOUBLE_ARRAY);
+    std::vector<double> expected_value{-1.0, 0.42};
+    EXPECT_EQ(value.get<std::vector<double>>(), expected_value);
+  }
+  {
+    rclcpp::ParameterValue value = node->declare_parameter("parameter_string_array");
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_STRING_ARRAY);
+    std::vector<std::string> expected_value{"foo", "bar"};
+    // set to [baz, baz, baz] in file, overriden by CLI
+    EXPECT_EQ(value.get<std::vector<std::string>>(), expected_value);
+  }
+}
+
 
 TEST_F(TestNode, undeclare_parameter) {
   auto node = std::make_shared<rclcpp::Node>("test_undeclare_parameter_node"_unq);

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -27,7 +27,6 @@
 
 #include "rcpputils/filesystem_helper.hpp"
 
-
 class TestNode : public ::testing::Test
 {
 protected:
@@ -761,7 +760,6 @@ TEST_F(TestNode, declare_parameter_with_cli_overrides) {
     EXPECT_EQ(value.get<std::vector<std::string>>(), expected_value);
   }
 }
-
 
 TEST_F(TestNode, undeclare_parameter) {
   auto node = std::make_shared<rclcpp::Node>("test_undeclare_parameter_node"_unq);


### PR DESCRIPTION
This pull request delegates all parameter parsing to `rcl`, as introduced in https://github.com/ros2/rcl/pull/508.