### PR TITLE
Add callback handler for use_sim_time parameter #802

### DIFF
--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -135,7 +135,7 @@ private:
   // A vector to store references to associated clocks.
   std::vector<rclcpp::Clock::SharedPtr> associated_clocks_;
   // A handler for the use_sim_time parameter callback.
-  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr sim_time_cb_handler = nullptr;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr sim_time_cb_handler_ = nullptr;
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -25,6 +25,7 @@
 #include "rcl_interfaces/msg/parameter_event.hpp"
 
 #include "rclcpp/node.hpp"
+#include "rclcpp/node_interfaces/node_parameters_interface.hpp"
 
 
 namespace rclcpp
@@ -133,6 +134,8 @@ private:
   std::mutex clock_list_lock_;
   // A vector to store references to associated clocks.
   std::vector<rclcpp::Clock::SharedPtr> associated_clocks_;
+  // A handler for the use_sim_time parameter callback.
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr sim_time_cb_handler = nullptr;
 };
 
 }  // namespace rclcpp

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -102,7 +102,7 @@ void TimeSource::attachNode(
       logger_, "Invalid type '%s' for parameter 'use_sim_time', should be 'bool'",
       rclcpp::to_string(use_sim_time_param.get_type()).c_str());
   }
-  sim_time_cb_handler = node_parameters_->add_on_set_parameters_callback(
+  sim_time_cb_handler_ = node_parameters_->add_on_set_parameters_callback(
     [use_sim_time_name](const std::vector<rclcpp::Parameter> & parameters) {
       rcl_interfaces::msg::SetParametersResult result;
       result.successful = true;
@@ -113,6 +113,7 @@ void TimeSource::attachNode(
         {
           result.successful = false;
           result.reason = "'" + use_sim_time_name + "' must be a bool";
+          break;
         }
       }
       return result;
@@ -135,10 +136,10 @@ void TimeSource::detachNode()
   node_services_.reset();
   node_logging_.reset();
   node_clock_.reset();
-  if (sim_time_cb_handler && node_parameters_) {
-    node_parameters_->remove_on_set_parameters_callback(sim_time_cb_handler.get());
+  if (sim_time_cb_handler_ && node_parameters_) {
+    node_parameters_->remove_on_set_parameters_callback(sim_time_cb_handler_.get());
   }
-  sim_time_cb_handler.reset();
+  sim_time_cb_handler_.reset();
   node_parameters_.reset();
   disable_ros_time();
 }

--- a/rclcpp/test/test_time_source.cpp
+++ b/rclcpp/test/test_time_source.cpp
@@ -242,6 +242,12 @@ TEST_F(TestTimeSource, ROS_time_valid_sim_time) {
   EXPECT_TRUE(ros_clock2->ros_time_is_active());
 }
 
+TEST_F(TestTimeSource, ROS_invalid_sim_time) {
+  rclcpp::TimeSource ts;
+  ts.attachNode(node);
+  EXPECT_FALSE(node->set_parameter(rclcpp::Parameter("use_sim_time", "not boolean")).successful);
+}
+
 TEST_F(TestTimeSource, clock) {
   rclcpp::TimeSource ts(node);
   auto ros_clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);


### PR DESCRIPTION
Fixes #802. As the title says, it adds a parameter callback to the node's parameter when a node is attached to a TimeSource.

- Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8248)](https://ci.ros2.org/job/ci_linux/8248/)
- Arch [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4189)](https://ci.ros2.org/job/ci_linux-aarch64/4189/)
- Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8101)](https://ci.ros2.org/job/ci_windows/8101/)
- OSX [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6699)](https://ci.ros2.org/job/ci_osx/6699/)