### PR TITLE
Enable throttling logs

### DIFF
--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -123,16 +123,15 @@ public:
     JumpHandler::post_callback_t post_callback,
     const rcl_jump_threshold_t & threshold);
 
+  /// Get current time from the time source specified by Clock::get_clock_type() const noexcept.
   /**
-   * Get current time from the time source specified by Clock::get_clock_type() const noexcept.
-   *
-   * \param now. A pointer to time point value, which will be
+   * \param now A pointer to time point value, which will be
    * set to the current time according to the underlying clock.
    * \return RCUTILS_RET_OK if time was successfully retrieved
    */
   RCLCPP_PUBLIC
   rcutils_ret_t
-  get_now_as_time_point_for_logging(rcutils_time_point_value_t * now);
+  get_now_as_rcutils_time_point(rcutils_time_point_value_t * now);
 
 private:
   // Invoke time jump callback

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -123,18 +123,6 @@ public:
     JumpHandler::post_callback_t post_callback,
     const rcl_jump_threshold_t & threshold);
 
-  /**
-   * Get current time from the time source specified by Clock::get_clock_type() const noexcept.
-   *
-   * \return RCUTILS_RET_OK if time was successfully retrieved
-   * \param now. A time point value pointer that will contain the
-   * current time from the underlying clock
-   * \throws anything rclcpp::exceptions::throw_from_rcl_error can throw.
-   */
-  RCLCPP_PUBLIC
-  rcutils_ret_t
-  get_now_as_timepoint(rcutils_time_point_value_t * now);
-
 private:
   // Invoke time jump callback
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -123,16 +123,6 @@ public:
     JumpHandler::post_callback_t post_callback,
     const rcl_jump_threshold_t & threshold);
 
-  /// Get current time from the time source specified by Clock::get_clock_type() const noexcept.
-  /**
-   * \param now A pointer to time point value, which will be
-   * set to the current time according to the underlying clock.
-   * \return RCUTILS_RET_OK if time was successfully retrieved
-   */
-  RCLCPP_PUBLIC
-  rcutils_ret_t
-  get_now_as_rcutils_time_point(rcutils_time_point_value_t * now);
-
 private:
   // Invoke time jump callback
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -123,6 +123,18 @@ public:
     JumpHandler::post_callback_t post_callback,
     const rcl_jump_threshold_t & threshold);
 
+  /**
+   * Get current time from the time source specified by Clock::get_clock_type() const noexcept.
+   *
+   * \return RCUTILS_RET_OK if time was successfully retrieved
+   * \param now. A time point value pointer that will contain the
+   * current time from the underlying clock
+   * \throws anything rclcpp::exceptions::throw_from_rcl_error can throw.
+   */
+  RCLCPP_PUBLIC
+  rcutils_ret_t
+  get_now_as_timepoint(rcutils_time_point_value_t * now);
+
 private:
   // Invoke time jump callback
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -131,7 +131,7 @@ public:
    */
   RCLCPP_PUBLIC
   rcutils_ret_t
-  get_now_as_ns(rcutils_time_point_value_t * now);
+  get_now_as_timepoint(rcutils_time_point_value_t * now);
 
 private:
   // Invoke time jump callback

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -124,9 +124,11 @@ public:
     const rcl_jump_threshold_t & threshold);
 
   /**
-   * Get current time from the time source specified by clock_type as nanoseconds.
+   * Get current time from the time source specified by Clock::get_clock_type() const noexcept.
    *
    * \return RCUTILS_RET_OK if time was successfully retrieved
+   * \param now. A time point value pointer that will contain the
+   * current time from the underlying clock
    * \throws anything rclcpp::exceptions::throw_from_rcl_error can throw.
    */
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -22,6 +22,8 @@
 #include "rclcpp/visibility_control.hpp"
 
 #include "rcl/time.h"
+#include "rcutils/time.h"
+#include "rcutils/types/rcutils_ret.h"
 
 namespace rclcpp
 {
@@ -120,6 +122,16 @@ public:
     JumpHandler::pre_callback_t pre_callback,
     JumpHandler::post_callback_t post_callback,
     const rcl_jump_threshold_t & threshold);
+
+  /**
+   * Get current time from the time source specified by clock_type as nanoseconds.
+   *
+   * \return RCUTILS_RET_OK if time was successfully retrieved
+   * \throws anything rclcpp::exceptions::throw_from_rcl_error can throw.
+   */
+  RCLCPP_PUBLIC
+  rcutils_ret_t
+  get_now_as_ns(rcutils_time_point_value_t * now);
 
 private:
   // Invoke time jump callback

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -126,14 +126,13 @@ public:
   /**
    * Get current time from the time source specified by Clock::get_clock_type() const noexcept.
    *
+   * \param now. A pointer to time point value, which will be
+   * set to the current time according to the underlying clock.
    * \return RCUTILS_RET_OK if time was successfully retrieved
-   * \param now. A time point value pointer that will contain the
-   * current time from the underlying clock
-   * \throws anything rclcpp::exceptions::throw_from_rcl_error can throw.
    */
   RCLCPP_PUBLIC
   rcutils_ret_t
-  get_now_as_timepoint(rcutils_time_point_value_t * now);
+  get_now_as_time_point_for_logging(rcutils_time_point_value_t * now);
 
 private:
   // Invoke time jump callback

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -44,66 +44,20 @@
 #define RCLCPP_LOG_MIN_SEVERITY RCLCPP_LOG_MIN_SEVERITY_DEBUG
 #endif
 
-/**
- * \def RCLCPP_LOG_CONDITION_THROTTLE_BEFORE
- * A macro initializing and checking the `throttle` condition.
- */
-#define RCLCPP_LOG_CONDITION_THROTTLE_BEFORE(clock, duration) { \
-    static rcl_time_point_value_t __rclcpp_logging_duration = RCUTILS_MS_TO_NS((rcl_time_point_value_t)duration); \
-    static rcl_time_point_value_t __rclcpp_logging_last_logged = 0; \
-    rcl_time_point_value_t __rclcpp_logging_now = clock.now().nanoseconds(); \
-    bool __rclcpp_logging_condition = __rclcpp_logging_now >= __rclcpp_logging_last_logged + __rclcpp_logging_duration; \
-    if (RCUTILS_LIKELY(__rclcpp_logging_condition)) { \
-      __rclcpp_logging_last_logged = __rclcpp_logging_now;
-
 @{
 from collections import OrderedDict
-from rcutils.logging import default_args
 from rcutils.logging import feature_combinations
-from rcutils.logging import Feature
-from rcutils.logging import get_macro_arguments
 from rcutils.logging import get_macro_parameters
 from rcutils.logging import get_suffix_from_features
-from rcutils.logging import name_args
-from rcutils.logging import name_doc_lines
-from rcutils.logging import name_params
 from rcutils.logging import severities
-from rcutils.logging import skipfirst_args
-from rcutils.logging import skipfirst_doc_lines
 from rcutils.logging import throttle_args
-from rcutils.logging import throttle_doc_lines
 from rcutils.logging import throttle_params
 
-default_args['name'] = 'logger.get_name()'
-throttle_args['condition_before'] = 'RCLCPP_LOG_CONDITION_THROTTLE_BEFORE(clock, duration)'
+throttle_args['condition_before'] = 'RCUTILS_LOG_CONDITION_THROTTLE_BEFORE(clock, duration)'
 del throttle_params['get_time_point_value']
 throttle_params['clock'] = 'rclcpp::Clock that will be used to get the time point.'
 throttle_params.move_to_end('clock', last=False)
 
-feature_combinations[('skip_first', 'throttle')] = Feature(
-        params=throttle_params,
-        args={
-            'condition_before': ' '.join([
-                throttle_args['condition_before'],
-                skipfirst_args['condition_before']]),
-            'condition_after': ' '.join([
-                throttle_args['condition_after'], skipfirst_args['condition_after']]),
-        },
-        doc_lines=skipfirst_doc_lines + throttle_doc_lines)
-
-feature_combinations[('skip_first', 'throttle', 'named')] = Feature(
-        params=OrderedDict((*throttle_params.items(), *name_params.items())),
-        args={
-            **{
-                'condition_before': ' '.join([
-                    throttle_args['condition_before'],
-                    skipfirst_args['condition_before']]),
-                'condition_after': ' '.join([
-                    throttle_args['condition_after'],
-                    skipfirst_args['condition_after']]),
-            }, **name_args
-        },
-        doc_lines=skipfirst_doc_lines + throttle_doc_lines + name_doc_lines)
 
 excluded_features = ['named']
 def is_supported_feature_combination(feature_combination):
@@ -147,7 +101,6 @@ def is_supported_feature_combination(feature_combination):
  * It also accepts a single argument of type std::string.
  */
 @{params = get_macro_parameters(feature_combination).keys()}@
-@[ if not 'throttle' in feature_combination]
 #define RCLCPP_@(severity)@(suffix)(logger, @(''.join([p + ', ' for p in params]))...) \
   do { \
     static_assert( \
@@ -155,6 +108,7 @@ def is_supported_feature_combination(feature_combination):
       typename ::rclcpp::Logger>::value, \
       "First argument to logging macros must be an rclcpp::Logger"); \
     RCUTILS_LOG_@(severity)@(suffix)_NAMED( \
+@{params = ['clock.get_now_as_timepoint' if p == 'clock' and 'throttle' in feature_combination else p for p in params]}@
 @[ if params]@
 @(''.join(['      ' + p + ', \\\n' for p in params]))@
 @[ end if]@
@@ -162,20 +116,7 @@ def is_supported_feature_combination(feature_combination):
       rclcpp::get_c_string(RCLCPP_FIRST_ARG(__VA_ARGS__, "")), \
         RCLCPP_ALL_BUT_FIRST_ARGS(__VA_ARGS__,"")); \
   } while (0)
-@[ else]
-#define RCLCPP_@(severity)@(suffix)(logger, @(''.join([p + ', ' for p in params]))...) \
-  do { \
-    static_assert( \
-      ::std::is_same<typename std::remove_cv<typename std::remove_reference<decltype(logger)>::type>::type, \
-      typename ::rclcpp::Logger>::value, \
-      "First argument to logging macros must be an rclcpp::Logger"); \
-    RCUTILS_LOG_COND_NAMED( \
-      RCUTILS_LOG_SEVERITY_@(severity), \
-      @(''.join([str(a) + ', ' for a in get_macro_arguments(feature_combination)])) \
-      rclcpp::get_c_string(RCLCPP_FIRST_ARG(__VA_ARGS__, "")), \
-        RCLCPP_ALL_BUT_FIRST_ARGS(__VA_ARGS__,"")); \
-  } while (0)
-@[ end if]@
+
 @[ end for]@
 #endif
 ///@@}

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -58,7 +58,6 @@ del throttle_params['get_time_point_value']
 throttle_params['clock'] = 'rclcpp::Clock that will be used to get the time point.'
 throttle_params.move_to_end('clock', last=False)
 
-
 excluded_features = ['named']
 def is_supported_feature_combination(feature_combination):
     is_excluded = any([ef in feature_combination for ef in excluded_features])
@@ -108,7 +107,7 @@ def is_supported_feature_combination(feature_combination):
       typename ::rclcpp::Logger>::value, \
       "First argument to logging macros must be an rclcpp::Logger"); \
     RCUTILS_LOG_@(severity)@(suffix)_NAMED( \
-@{params = ['clock.get_now_as_timepoint' if p == 'clock' and 'throttle' in feature_combination else p for p in params]}@
+@{params = ['clock.get_now_as_time_point_for_logging' if p == 'clock' and 'throttle' in feature_combination else p for p in params]}@
 @[ if params]@
 @(''.join(['      ' + p + ', \\\n' for p in params]))@
 @[ end if]@

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -107,7 +107,7 @@ def is_supported_feature_combination(feature_combination):
       typename ::rclcpp::Logger>::value, \
       "First argument to logging macros must be an rclcpp::Logger"); \
     RCUTILS_LOG_@(severity)@(suffix)_NAMED( \
-@{params = ['clock.get_now_as_time_point_for_logging' if p == 'clock' and 'throttle' in feature_combination else p for p in params]}@
+@{params = ['clock.get_now_as_rcutils_time_point' if p == 'clock' and 'throttle' in feature_combination else p for p in params]}@
 @[ if params]@
 @(''.join(['      ' + p + ', \\\n' for p in params]))@
 @[ end if]@

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -109,9 +109,9 @@ def is_supported_feature_combination(feature_combination):
 @[ if 'throttle' in feature_combination]@ \
     auto get_time_point = [&clock](rcutils_time_point_value_t * time_point) -> rcutils_ret_t { \
     try { \
-        *time_point = clock.now().nanoseconds(); \
+      *time_point = clock.now().nanoseconds(); \
     } catch (...) { \
-        return RCUTILS_RET_ERROR; \
+      return RCUTILS_RET_ERROR; \
     } \
       return RCUTILS_RET_OK; \
     }; \

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -50,8 +50,7 @@ from rcutils.logging import get_macro_parameters
 from rcutils.logging import get_suffix_from_features
 from rcutils.logging import severities
 
-# TODO(dhood): Implement the throttle macro using time sources available in rclcpp
-excluded_features = ['named', 'throttle']
+excluded_features = ['named']
 def is_supported_feature_combination(feature_combination):
     is_excluded = any([ef in feature_combination for ef in excluded_features])
     return not is_excluded

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -49,9 +49,10 @@ from collections import OrderedDict
 import rcutils.logging
 
 rcutils.logging.throttle_args['condition_before'] = 'RCUTILS_LOG_CONDITION_THROTTLE_BEFORE(clock, duration)'
-rcutils.logging.throttle_params = OrderedDict([(
-	'clock', 'rclcpp::Clock that will be used to get the time point.') if k == 'get_time_point_value' else (k,v) for k,v in rcutils.logging.throttle_params.items()])
-rcutils.logging.feature_combinations = rcutils.logging.reconstruct_feature_combinations()
+del rcutils.logging.throttle_params['get_time_point_value']
+rcutils.logging.throttle_params['clock'] = 'rclcpp::Clock that will be used to get the time point.'
+rcutils.logging.throttle_params.move_to_end('clock', last=False)
+
 
 excluded_features = ['named']
 def is_supported_feature_combination(feature_combination):

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -86,19 +86,25 @@ def is_supported_feature_combination(feature_combination):
 @[ end for]@
  * \param logger The `rclcpp::Logger` to use
 @[ for param_name, doc_line in feature_combinations[feature_combination].params.items()]@
+@[ if not param_name == 'time_source']@
  * \param @(param_name) @(doc_line)
+@[ else]@
+ * \param clock rclcpp::Clock that will be used to get the time point.
+@[ end if]@
 @[ end for]@
  * \param ... The format string, followed by the variable arguments for the format string.
  * It also accepts a single argument of type std::string.
  */
-#define RCLCPP_@(severity)@(suffix)(logger, @(''.join([p + ', ' for p in get_macro_parameters(feature_combination).keys()]))...) \
+@{params = get_macro_parameters(feature_combination).keys()}@
+@{params = [p if not p == 'time_source' else 'clock' for p in params]}@
+#define RCLCPP_@(severity)@(suffix)(logger, @(''.join([p + ', ' for p in params]))...) \
   do { \
     static_assert( \
       ::std::is_same<typename std::remove_cv<typename std::remove_reference<decltype(logger)>::type>::type, \
       typename ::rclcpp::Logger>::value, \
       "First argument to logging macros must be an rclcpp::Logger"); \
     RCUTILS_LOG_@(severity)@(suffix)_NAMED( \
-@{params = get_macro_parameters(feature_combination).keys()}@
+@{params = [p if not p == 'clock' else 'clock.get_now_as_timepoint' for p in params]}@
 @[ if params]@
 @(''.join(['      ' + p + ', \\\n' for p in params]))@
 @[ end if]@

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -107,10 +107,14 @@ def is_supported_feature_combination(feature_combination):
       typename ::rclcpp::Logger>::value, \
       "First argument to logging macros must be an rclcpp::Logger"); \
 @[ if 'throttle' in feature_combination]@ \
-      std::function<rcutils_ret_t (rcutils_time_point_value_t *)> get_time_point = [&clock](rcutils_time_point_value_t * time_point) -> rcutils_ret_t { \
+    auto get_time_point = [&clock](rcutils_time_point_value_t * time_point) -> rcutils_ret_t { \
+    try { \
         *time_point = clock.now().nanoseconds(); \
-        return RCUTILS_RET_OK; \
-      }; \
+    } catch (...) { \
+        return RCUTILS_RET_ERROR; \
+    } \
+      return RCUTILS_RET_OK; \
+    }; \
 @[ end if] \
     RCUTILS_LOG_@(severity)@(suffix)_NAMED( \
 @{params = ['get_time_point' if p == 'clock' and 'throttle' in feature_combination else p for p in params]}@

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -108,12 +108,13 @@ def is_supported_feature_combination(feature_combination):
       "First argument to logging macros must be an rclcpp::Logger"); \
 @[ if 'throttle' in feature_combination]@ \
     auto get_time_point = [&clock](rcutils_time_point_value_t * time_point) -> rcutils_ret_t { \
-    try { \
-      *time_point = clock.now().nanoseconds(); \
-    } catch (...) { \
-      return RCUTILS_RET_ERROR; \
-    } \
-      return RCUTILS_RET_OK; \
+      try { \
+        *time_point = clock.now().nanoseconds(); \
+      } catch (...) { \
+        RCUTILS_SAFE_FWRITE_TO_STDERR("could not get current time stamp\n"); \
+        return RCUTILS_RET_ERROR; \
+      } \
+        return RCUTILS_RET_OK; \
     }; \
 @[ end if] \
     RCUTILS_LOG_@(severity)@(suffix)_NAMED( \

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -106,8 +106,14 @@ def is_supported_feature_combination(feature_combination):
       ::std::is_same<typename std::remove_cv<typename std::remove_reference<decltype(logger)>::type>::type, \
       typename ::rclcpp::Logger>::value, \
       "First argument to logging macros must be an rclcpp::Logger"); \
+@[ if 'throttle' in feature_combination]@ \
+      std::function<rcutils_ret_t (rcutils_time_point_value_t *)> get_time_point = [&clock](rcutils_time_point_value_t * time_point) -> rcutils_ret_t { \
+        *time_point = clock.now().nanoseconds(); \
+        return RCUTILS_RET_OK; \
+      }; \
+@[ end if] \
     RCUTILS_LOG_@(severity)@(suffix)_NAMED( \
-@{params = ['clock.get_now_as_rcutils_time_point' if p == 'clock' and 'throttle' in feature_combination else p for p in params]}@
+@{params = ['get_time_point' if p == 'clock' and 'throttle' in feature_combination else p for p in params]}@
 @[ if params]@
 @(''.join(['      ' + p + ', \\\n' for p in params]))@
 @[ end if]@

--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -111,7 +111,8 @@ def is_supported_feature_combination(feature_combination):
       try { \
         *time_point = clock.now().nanoseconds(); \
       } catch (...) { \
-        RCUTILS_SAFE_FWRITE_TO_STDERR("could not get current time stamp\n"); \
+        RCUTILS_SAFE_FWRITE_TO_STDERR( \
+        "[rclcpp|logging.hpp] RCLCPP_@(severity)@(suffix) could not get current time stamp\n"); \
         return RCUTILS_RET_ERROR; \
       } \
         return RCUTILS_RET_OK; \

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -141,4 +141,15 @@ Clock::create_jump_callback(
   // *INDENT-ON*
 }
 
+rcutils_ret_t
+Clock::get_now_as_ns(
+  rcutils_time_point_value_t * now)
+{
+  auto ret = rcl_clock_get_now(&rcl_clock_, now);
+  if (ret != RCL_RET_OK) {
+    exceptions::throw_from_rcl_error(ret, "could not get current time stamp");
+  }
+  return RCUTILS_RET_OK;
+}
+
 }  // namespace rclcpp

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -52,7 +52,7 @@ Clock::now()
 {
   Time now(0, 0, rcl_clock_.type);
 
-  auto ret = rcl_clock_get_now(&rcl_clock_, &now.rcl_time_.nanoseconds);
+  auto ret = get_now_as_timepoint(&now.rcl_time_.nanoseconds);
   if (ret != RCL_RET_OK) {
     exceptions::throw_from_rcl_error(ret, "could not get current time stamp");
   }
@@ -139,6 +139,17 @@ Clock::create_jump_callback(
     }
   });
   // *INDENT-ON*
+}
+
+rcutils_ret_t
+Clock::get_now_as_timepoint(
+  rcutils_time_point_value_t * now)
+{
+  auto ret = rcl_clock_get_now(&rcl_clock_, now);
+  if (ret != RCL_RET_OK) {
+    exceptions::throw_from_rcl_error(ret, "could not get current time stamp");
+  }
+  return RCUTILS_RET_OK;
 }
 
 }  // namespace rclcpp

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -52,7 +52,7 @@ Clock::now()
 {
   Time now(0, 0, rcl_clock_.type);
 
-  auto ret = get_now_as_time_point_for_logging(&now.rcl_time_.nanoseconds);
+  auto ret = get_now_as_rcutils_time_point(&now.rcl_time_.nanoseconds);
   if (ret != RCL_RET_OK) {
     exceptions::throw_from_rcl_error(ret, "could not get current time stamp");
   }
@@ -142,7 +142,7 @@ Clock::create_jump_callback(
 }
 
 rcutils_ret_t
-Clock::get_now_as_time_point_for_logging(
+Clock::get_now_as_rcutils_time_point(
   rcutils_time_point_value_t * now)
 {
   return rcl_clock_get_now(&rcl_clock_, now);

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -52,7 +52,7 @@ Clock::now()
 {
   Time now(0, 0, rcl_clock_.type);
 
-  auto ret = rcl_clock_get_now(&rcl_clock_, &now.rcl_time_.nanoseconds);
+  auto ret = get_now_as_timepoint(&now.rcl_time_.nanoseconds);
   if (ret != RCL_RET_OK) {
     exceptions::throw_from_rcl_error(ret, "could not get current time stamp");
   }
@@ -142,7 +142,7 @@ Clock::create_jump_callback(
 }
 
 rcutils_ret_t
-Clock::get_now_as_ns(
+Clock::get_now_as_timepoint(
   rcutils_time_point_value_t * now)
 {
   auto ret = rcl_clock_get_now(&rcl_clock_, now);

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -52,7 +52,7 @@ Clock::now()
 {
   Time now(0, 0, rcl_clock_.type);
 
-  auto ret = get_now_as_timepoint(&now.rcl_time_.nanoseconds);
+  auto ret = rcl_clock_get_now(&rcl_clock_, &now.rcl_time_.nanoseconds);
   if (ret != RCL_RET_OK) {
     exceptions::throw_from_rcl_error(ret, "could not get current time stamp");
   }
@@ -139,17 +139,6 @@ Clock::create_jump_callback(
     }
   });
   // *INDENT-ON*
-}
-
-rcutils_ret_t
-Clock::get_now_as_timepoint(
-  rcutils_time_point_value_t * now)
-{
-  auto ret = rcl_clock_get_now(&rcl_clock_, now);
-  if (ret != RCL_RET_OK) {
-    exceptions::throw_from_rcl_error(ret, "could not get current time stamp");
-  }
-  return RCUTILS_RET_OK;
 }
 
 }  // namespace rclcpp

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -52,7 +52,7 @@ Clock::now()
 {
   Time now(0, 0, rcl_clock_.type);
 
-  auto ret = get_now_as_rcutils_time_point(&now.rcl_time_.nanoseconds);
+  auto ret = rcl_clock_get_now(&rcl_clock_, &now.rcl_time_.nanoseconds);
   if (ret != RCL_RET_OK) {
     exceptions::throw_from_rcl_error(ret, "could not get current time stamp");
   }
@@ -139,13 +139,6 @@ Clock::create_jump_callback(
     }
   });
   // *INDENT-ON*
-}
-
-rcutils_ret_t
-Clock::get_now_as_rcutils_time_point(
-  rcutils_time_point_value_t * now)
-{
-  return rcl_clock_get_now(&rcl_clock_, now);
 }
 
 }  // namespace rclcpp

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -52,7 +52,7 @@ Clock::now()
 {
   Time now(0, 0, rcl_clock_.type);
 
-  auto ret = get_now_as_timepoint(&now.rcl_time_.nanoseconds);
+  auto ret = get_now_as_time_point_for_logging(&now.rcl_time_.nanoseconds);
   if (ret != RCL_RET_OK) {
     exceptions::throw_from_rcl_error(ret, "could not get current time stamp");
   }
@@ -142,14 +142,10 @@ Clock::create_jump_callback(
 }
 
 rcutils_ret_t
-Clock::get_now_as_timepoint(
+Clock::get_now_as_time_point_for_logging(
   rcutils_time_point_value_t * now)
 {
-  auto ret = rcl_clock_get_now(&rcl_clock_, now);
-  if (ret != RCL_RET_OK) {
-    exceptions::throw_from_rcl_error(ret, "could not get current time stamp");
-  }
-  return RCUTILS_RET_OK;
+  return rcl_clock_get_now(&rcl_clock_, now);
 }
 
 }  // namespace rclcpp

--- a/rclcpp/test/test_logging.cpp
+++ b/rclcpp/test/test_logging.cpp
@@ -173,10 +173,10 @@ TEST_F(TestLoggingMacros, test_throttle) {
   EXPECT_EQ(1u, g_log_calls);
   RCLCPP_DEBUG_SKIPFIRST_THROTTLE(g_logger, steady_clock, 1, "Skip first throttling");
   EXPECT_EQ(1u, g_log_calls);
-  for (uint64_t i = 0; i < 3; ++i) {
+  for (uint64_t i = 0; i < 6; ++i) {
     RCLCPP_DEBUG_THROTTLE(g_logger, steady_clock, 10, "Throttling");
     RCLCPP_DEBUG_SKIPFIRST_THROTTLE(g_logger, steady_clock, 40, "Throttling");
-    std::this_thread::sleep_for(10ms);
+    std::this_thread::sleep_for(5ms);
   }
   EXPECT_EQ(4u, g_log_calls);
   rclcpp::Clock ros_clock(RCL_ROS_TIME);

--- a/rclcpp/test/test_logging.cpp
+++ b/rclcpp/test/test_logging.cpp
@@ -175,6 +175,7 @@ TEST_F(TestLoggingMacros, test_throttle) {
   EXPECT_EQ(1u, g_log_calls);
   for (uint64_t i = 0; i < 3; ++i) {
     RCLCPP_DEBUG_THROTTLE(g_logger, steady_clock, 10, "Throttling");
+    RCLCPP_DEBUG_SKIPFIRST_THROTTLE(g_logger, steady_clock, 40, "Throttling");
     std::this_thread::sleep_for(10ms);
   }
   EXPECT_EQ(4u, g_log_calls);

--- a/rclcpp/test/test_logging.cpp
+++ b/rclcpp/test/test_logging.cpp
@@ -166,26 +166,27 @@ TEST_F(TestLoggingMacros, test_logging_skipfirst) {
 
 TEST_F(TestLoggingMacros, test_throttle) {
   using namespace std::chrono_literals;
+  rclcpp::Clock steady_clock(RCL_STEADY_TIME);
   for (uint64_t i = 0; i < 3; ++i) {
-    RCLCPP_DEBUG_THROTTLE(g_logger, rcutils_steady_time_now, 10000, "Throttling");
+    RCLCPP_DEBUG_THROTTLE(g_logger, steady_clock, 10000, "Throttling");
   }
   EXPECT_EQ(1u, g_log_calls);
-  RCLCPP_DEBUG_SKIPFIRST_THROTTLE(g_logger, rcutils_steady_time_now, 1, "Skip first throttling");
+  RCLCPP_DEBUG_SKIPFIRST_THROTTLE(g_logger, steady_clock, 1, "Skip first throttling");
   EXPECT_EQ(1u, g_log_calls);
   for (uint64_t i = 0; i < 3; ++i) {
-    RCLCPP_DEBUG_THROTTLE(g_logger, rcutils_steady_time_now, 10, "Throttling");
+    RCLCPP_DEBUG_THROTTLE(g_logger, steady_clock, 10, "Throttling");
     std::this_thread::sleep_for(10ms);
   }
   EXPECT_EQ(4u, g_log_calls);
   rclcpp::Clock ros_clock(RCL_ROS_TIME);
   ASSERT_EQ(RCL_RET_OK, rcl_enable_ros_time_override(ros_clock.get_clock_handle()));
-  RCLCPP_DEBUG_THROTTLE(g_logger, ros_clock.get_now_as_ns, 10000, "Throttling");
+  RCLCPP_DEBUG_THROTTLE(g_logger, ros_clock, 10000, "Throttling");
   rcl_clock_t * clock = ros_clock.get_clock_handle();
   ASSERT_TRUE(clock);
   EXPECT_EQ(4u, g_log_calls);
   EXPECT_EQ(RCL_RET_OK, rcl_set_ros_time_override(clock, RCUTILS_MS_TO_NS(10)));
   for (uint64_t i = 0; i < 2; ++i) {
-    RCLCPP_DEBUG_THROTTLE(g_logger, ros_clock.get_now_as_ns, 10, "Throttling");
+    RCLCPP_DEBUG_THROTTLE(g_logger, ros_clock, 10, "Throttling");
     if (i == 0) {
       EXPECT_EQ(5u, g_log_calls);
       rcl_time_point_value_t clock_ns = ros_clock.now().nanoseconds() + RCUTILS_MS_TO_NS(10);

--- a/rclcpp/test/test_logging.cpp
+++ b/rclcpp/test/test_logging.cpp
@@ -19,6 +19,7 @@
 #include <thread>
 #include <vector>
 
+#include "rclcpp/clock.hpp"
 #include "rclcpp/logger.hpp"
 #include "rclcpp/logging.hpp"
 #include "rcutils/logging.h"
@@ -85,7 +86,7 @@ TEST_F(TestLoggingMacros, test_logging_named) {
   if (g_last_log_event.location) {
     EXPECT_STREQ("TestBody", g_last_log_event.location->function_name);
     EXPECT_THAT(g_last_log_event.location->file_name, EndsWith("test_logging.cpp"));
-    EXPECT_EQ(81u, g_last_log_event.location->line_number);
+    EXPECT_EQ(82u, g_last_log_event.location->line_number);
   }
   EXPECT_EQ(RCUTILS_LOG_SEVERITY_DEBUG, g_last_log_event.level);
   EXPECT_EQ("name", g_last_log_event.name);
@@ -160,6 +161,38 @@ TEST_F(TestLoggingMacros, test_logging_skipfirst) {
   for (uint32_t i : {1, 2, 3, 4, 5}) {
     RCLCPP_WARN_SKIPFIRST(g_logger, "message %u", i);
     EXPECT_EQ(i - 1, g_log_calls);
+  }
+}
+
+TEST_F(TestLoggingMacros, test_throttle) {
+  using namespace std::chrono_literals;
+  for (uint64_t i = 0; i < 3; ++i) {
+    RCLCPP_DEBUG_THROTTLE(g_logger, rcutils_steady_time_now, 10000, "Throttling");
+  }
+  EXPECT_EQ(1u, g_log_calls);
+  RCLCPP_DEBUG_SKIPFIRST_THROTTLE(g_logger, rcutils_steady_time_now, 1, "Skip first throttling");
+  EXPECT_EQ(1u, g_log_calls);
+  for (uint64_t i = 0; i < 3; ++i) {
+    RCLCPP_DEBUG_THROTTLE(g_logger, rcutils_steady_time_now, 10, "Throttling");
+    std::this_thread::sleep_for(10ms);
+  }
+  EXPECT_EQ(4u, g_log_calls);
+  rclcpp::Clock ros_clock(RCL_ROS_TIME);
+  ASSERT_EQ(RCL_RET_OK, rcl_enable_ros_time_override(ros_clock.get_clock_handle()));
+  RCLCPP_DEBUG_THROTTLE(g_logger, ros_clock.get_now_as_ns, 10000, "Throttling");
+  rcl_clock_t * clock = ros_clock.get_clock_handle();
+  ASSERT_TRUE(clock);
+  EXPECT_EQ(4u, g_log_calls);
+  EXPECT_EQ(RCL_RET_OK, rcl_set_ros_time_override(clock, RCUTILS_MS_TO_NS(10)));
+  for (uint64_t i = 0; i < 2; ++i) {
+    RCLCPP_DEBUG_THROTTLE(g_logger, ros_clock.get_now_as_ns, 10, "Throttling");
+    if (i == 0) {
+      EXPECT_EQ(5u, g_log_calls);
+      rcl_time_point_value_t clock_ns = ros_clock.now().nanoseconds() + RCUTILS_MS_TO_NS(10);
+      EXPECT_EQ(RCL_RET_OK, rcl_set_ros_time_override(clock, clock_ns));
+    } else {
+      EXPECT_EQ(6u, g_log_calls);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #797. As the title says, enables throttling logs.

- Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8497)](https://ci.ros2.org/job/ci_linux/8497/)
- Arch [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4382)](https://ci.ros2.org/job/ci_linux-aarch64/4382/)
- Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8350)](https://ci.ros2.org/job/ci_windows/8350/)
- OSX [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6913)](https://ci.ros2.org/job/ci_osx/6913/)
