### PR TITLE
add mechanism to pass rmw impl specific payloads during pub/sub creation

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -32,6 +32,9 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/clock.cpp
   src/rclcpp/context.cpp
   src/rclcpp/contexts/default_context.cpp
+  src/rclcpp/detail/rmw_implementation_specific_payload.cpp
+  src/rclcpp/detail/rmw_implementation_specific_publisher_payload.cpp
+  src/rclcpp/detail/rmw_implementation_specific_subscription_payload.cpp
   src/rclcpp/duration.cpp
   src/rclcpp/event.cpp
   src/rclcpp/exceptions.cpp

--- a/rclcpp/include/rclcpp/detail/rmw_implementation_specific_payload.hpp
+++ b/rclcpp/include/rclcpp/detail/rmw_implementation_specific_payload.hpp
@@ -1,0 +1,50 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__DETAIL__RMW_IMPLEMENTATION_SPECIFIC_PAYLOAD_HPP_
+#define RCLCPP__DETAIL__RMW_IMPLEMENTATION_SPECIFIC_PAYLOAD_HPP_
+
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+namespace detail
+{
+
+/// Mechanism for passing rmw implementation specific settings through the ROS interfaces.
+struct RCLCPP_PUBLIC RMWImplementationSpecificPayload
+{
+  virtual
+  ~RMWImplementationSpecificPayload() = default;
+
+  /// Return false if this class has not been customized, otherwise true.
+  /**
+   * It does this based on the value of the rmw implementation identifier that
+   * this class reports, and so it is important for a specialization of this
+   * class to override the get_rmw_implementation_identifier() method to return
+   * something other than nullptr.
+   */
+  bool
+  has_been_customized() const;
+
+  /// Derrived classes should override this and return the identifier of its rmw implementation.
+  virtual
+  const char *
+  get_implementation_identifier() const;
+};
+
+}  // namespace detail
+}  // namespace rclcpp
+
+#endif  // RCLCPP__DETAIL__RMW_IMPLEMENTATION_SPECIFIC_PAYLOAD_HPP_

--- a/rclcpp/include/rclcpp/detail/rmw_implementation_specific_payload.hpp
+++ b/rclcpp/include/rclcpp/detail/rmw_implementation_specific_payload.hpp
@@ -23,8 +23,9 @@ namespace detail
 {
 
 /// Mechanism for passing rmw implementation specific settings through the ROS interfaces.
-struct RCLCPP_PUBLIC RMWImplementationSpecificPayload
+class RCLCPP_PUBLIC RMWImplementationSpecificPayload
 {
+public:
   virtual
   ~RMWImplementationSpecificPayload() = default;
 

--- a/rclcpp/include/rclcpp/detail/rmw_implementation_specific_publisher_payload.hpp
+++ b/rclcpp/include/rclcpp/detail/rmw_implementation_specific_publisher_payload.hpp
@@ -1,0 +1,48 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__DETAIL__RMW_IMPLEMENTATION_SPECIFIC_PUBLISHER_PAYLOAD_HPP_
+#define RCLCPP__DETAIL__RMW_IMPLEMENTATION_SPECIFIC_PUBLISHER_PAYLOAD_HPP_
+
+#include "rcl/publisher.h"
+
+#include "rclcpp/detail/rmw_implementation_specific_payload.hpp"
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+namespace detail
+{
+
+struct RCLCPP_PUBLIC RMWImplementationSpecificPublisherPayload
+  : public RMWImplementationSpecificPayload
+{
+  ~RMWImplementationSpecificPublisherPayload() override = default;
+
+  /// Opportunity for a derived class to inject information into the rcl options.
+  /**
+   * This is called after the rcl_publisher_options_t has been prepared by
+   * rclcpp, but before rcl_publisher_init() is called.
+   *
+   * By default the options are unmodified.
+   */
+  virtual
+  void
+  modify_rcl_publisher_options(rcl_publisher_options_t & rcl_publisher_options) const;
+};
+
+}  // namespace detail
+}  // namespace rclcpp
+
+#endif  // RCLCPP__DETAIL__RMW_IMPLEMENTATION_SPECIFIC_PUBLISHER_PAYLOAD_HPP_

--- a/rclcpp/include/rclcpp/detail/rmw_implementation_specific_publisher_payload.hpp
+++ b/rclcpp/include/rclcpp/detail/rmw_implementation_specific_publisher_payload.hpp
@@ -25,9 +25,10 @@ namespace rclcpp
 namespace detail
 {
 
-struct RCLCPP_PUBLIC RMWImplementationSpecificPublisherPayload
+class RCLCPP_PUBLIC RMWImplementationSpecificPublisherPayload
   : public RMWImplementationSpecificPayload
 {
+public:
   ~RMWImplementationSpecificPublisherPayload() override = default;
 
   /// Opportunity for a derived class to inject information into the rcl options.

--- a/rclcpp/include/rclcpp/detail/rmw_implementation_specific_publisher_payload.hpp
+++ b/rclcpp/include/rclcpp/detail/rmw_implementation_specific_publisher_payload.hpp
@@ -36,11 +36,14 @@ public:
    * This is called after the rcl_publisher_options_t has been prepared by
    * rclcpp, but before rcl_publisher_init() is called.
    *
+   * The passed option is the rmw_publisher_options field of the
+   * rcl_publisher_options_t that will be passed to rcl_publisher_init().
+   *
    * By default the options are unmodified.
    */
   virtual
   void
-  modify_rcl_publisher_options(rcl_publisher_options_t & rcl_publisher_options) const;
+  modify_rmw_publisher_options(rmw_publisher_options_t & rmw_publisher_options) const;
 };
 
 }  // namespace detail

--- a/rclcpp/include/rclcpp/detail/rmw_implementation_specific_subscription_payload.hpp
+++ b/rclcpp/include/rclcpp/detail/rmw_implementation_specific_subscription_payload.hpp
@@ -37,11 +37,14 @@ public:
    * This is called after the rcl_subscription_options_t has been prepared by
    * rclcpp, but before rcl_subscription_init() is called.
    *
+   * The passed option is the rmw_subscription_options field of the
+   * rcl_subscription_options_t that will be passed to rcl_subscription_init().
+   *
    * By default the options are unmodified.
    */
   virtual
   void
-  modify_rcl_subscription_options(rcl_subscription_options_t & rcl_subscription_options) const;
+  modify_rmw_subscription_options(rmw_subscription_options_t & rmw_subscription_options) const;
 };
 
 }  // namespace detail

--- a/rclcpp/include/rclcpp/detail/rmw_implementation_specific_subscription_payload.hpp
+++ b/rclcpp/include/rclcpp/detail/rmw_implementation_specific_subscription_payload.hpp
@@ -1,0 +1,49 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__DETAIL__RMW_IMPLEMENTATION_SPECIFIC_SUBSCRIPTION_PAYLOAD_HPP_
+#define RCLCPP__DETAIL__RMW_IMPLEMENTATION_SPECIFIC_SUBSCRIPTION_PAYLOAD_HPP_
+
+#include "rcl/subscription.h"
+
+#include "rclcpp/detail/rmw_implementation_specific_payload.hpp"
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+namespace detail
+{
+
+/// Subscription payload that may be rmw implementation specific.
+struct RCLCPP_PUBLIC RMWImplementationSpecificSubscriptionPayload
+  : public RMWImplementationSpecificPayload
+{
+  ~RMWImplementationSpecificSubscriptionPayload() override = default;
+
+  /// Opportunity for a derived class to inject information into the rcl options.
+  /**
+   * This is called after the rcl_subscription_options_t has been prepared by
+   * rclcpp, but before rcl_subscription_init() is called.
+   *
+   * By default the options are unmodified.
+   */
+  virtual
+  void
+  modify_rcl_subscription_options(rcl_subscription_options_t & rcl_subscription_options) const;
+};
+
+}  // namespace detail
+}  // namespace rclcpp
+
+#endif  // RCLCPP__DETAIL__RMW_IMPLEMENTATION_SPECIFIC_SUBSCRIPTION_PAYLOAD_HPP_

--- a/rclcpp/include/rclcpp/detail/rmw_implementation_specific_subscription_payload.hpp
+++ b/rclcpp/include/rclcpp/detail/rmw_implementation_specific_subscription_payload.hpp
@@ -26,9 +26,10 @@ namespace detail
 {
 
 /// Subscription payload that may be rmw implementation specific.
-struct RCLCPP_PUBLIC RMWImplementationSpecificSubscriptionPayload
+class RCLCPP_PUBLIC RMWImplementationSpecificSubscriptionPayload
   : public RMWImplementationSpecificPayload
 {
+public:
   ~RMWImplementationSpecificSubscriptionPayload() override = default;
 
   /// Opportunity for a derived class to inject information into the rcl options.

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -288,6 +288,11 @@ protected:
     return message_seq;
   }
 
+  /// Copy of original options passed during construction.
+  /**
+   * It is important to save a copy of this so that the rmw payload which it
+   * may contain is kept alive for the duration of the publisher.
+   */
   const rclcpp::PublisherOptionsWithAllocator<AllocatorT> options_;
 
   std::shared_ptr<MessageAllocator> message_allocator_;

--- a/rclcpp/include/rclcpp/publisher_options.hpp
+++ b/rclcpp/include/rclcpp/publisher_options.hpp
@@ -80,7 +80,7 @@ struct PublisherOptionsWithAllocator : public PublisherOptionsBase
 
     // Apply payload to rcl_publisher_options if necessary.
     if (rmw_implementation_payload && rmw_implementation_payload->has_been_customized()) {
-      rmw_implementation_payload->modify_rcl_publisher_options(result);
+      rmw_implementation_payload->modify_rmw_publisher_options(result.rmw_publisher_options);
     }
 
     return result;

--- a/rclcpp/include/rclcpp/publisher_options.hpp
+++ b/rclcpp/include/rclcpp/publisher_options.hpp
@@ -22,6 +22,7 @@
 #include "rcl/publisher.h"
 
 #include "rclcpp/allocator/allocator_common.hpp"
+#include "rclcpp/detail/rmw_implementation_specific_publisher_payload.hpp"
 #include "rclcpp/intra_process_setting.hpp"
 #include "rclcpp/qos.hpp"
 #include "rclcpp/qos_event.hpp"
@@ -45,6 +46,10 @@ struct PublisherOptionsBase
 
   /// Callback group in which the waitable items from the publisher should be placed.
   std::shared_ptr<rclcpp::callback_group::CallbackGroup> callback_group;
+
+  /// Optional RMW implementation specific payload to be used during creation of the publisher.
+  std::shared_ptr<rclcpp::detail::RMWImplementationSpecificPublisherPayload>
+  rmw_implementation_payload = nullptr;
 };
 
 /// Structure containing optional configuration for Publishers.
@@ -72,8 +77,15 @@ struct PublisherOptionsWithAllocator : public PublisherOptionsBase
     auto message_alloc = std::make_shared<MessageAllocatorT>(*this->get_allocator().get());
     result.allocator = rclcpp::allocator::get_rcl_allocator<MessageT>(*message_alloc);
     result.qos = qos.get_rmw_qos_profile();
+
+    // Apply payload to rcl_publisher_options if necessary.
+    if (rmw_implementation_payload && rmw_implementation_payload->has_been_customized()) {
+      rmw_implementation_payload->modify_rcl_publisher_options(result);
+    }
+
     return result;
   }
+
 
   /// Get the allocator, creating one if needed.
   std::shared_ptr<Allocator>

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -104,6 +104,7 @@ public:
       options.template to_rcl_subscription_options<CallbackMessageT>(qos),
       rclcpp::subscription_traits::is_serialized_subscription_argument<CallbackMessageT>::value),
     any_callback_(callback),
+    options_(options),
     message_memory_strategy_(message_memory_strategy)
   {
     if (options.event_callbacks.deadline_callback) {
@@ -302,6 +303,12 @@ private:
   RCLCPP_DISABLE_COPY(Subscription)
 
   AnySubscriptionCallback<CallbackMessageT, AllocatorT> any_callback_;
+  /// Copy of original options passed during construction.
+  /**
+   * It is important to save a copy of this so that the rmw payload which it
+   * may contain is kept alive for the duration of the subscription.
+   */
+  const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> options_;
   typename message_memory_strategy::MessageMemoryStrategy<CallbackMessageT, AllocatorT>::SharedPtr
     message_memory_strategy_;
 };

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -79,7 +79,7 @@ struct SubscriptionOptionsWithAllocator : public SubscriptionOptionsBase
 
     // Apply payload to rcl_subscription_options if necessary.
     if (rmw_implementation_payload && rmw_implementation_payload->has_been_customized()) {
-      rmw_implementation_payload->modify_rcl_subscription_options(result);
+      rmw_implementation_payload->modify_rmw_subscription_options(result.rmw_subscription_options);
     }
 
     return result;

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "rclcpp/callback_group.hpp"
+#include "rclcpp/detail/rmw_implementation_specific_subscription_payload.hpp"
 #include "rclcpp/intra_process_setting.hpp"
 #include "rclcpp/qos.hpp"
 #include "rclcpp/qos_event.hpp"
@@ -33,12 +34,19 @@ struct SubscriptionOptionsBase
 {
   /// Callbacks for events related to this subscription.
   SubscriptionEventCallbacks event_callbacks;
+
   /// True to ignore local publications.
   bool ignore_local_publications = false;
+
   /// The callback group for this subscription. NULL to use the default callback group.
   rclcpp::callback_group::CallbackGroup::SharedPtr callback_group = nullptr;
+
   /// Setting to explicitly set intraprocess communications.
   IntraProcessSetting use_intra_process_comm = IntraProcessSetting::NodeDefault;
+
+  /// Optional RMW implementation specific payload to be used during creation of the subscription.
+  std::shared_ptr<rclcpp::detail::RMWImplementationSpecificSubscriptionPayload>
+  rmw_implementation_payload = nullptr;
 };
 
 /// Structure containing optional configuration for Subscriptions.
@@ -61,13 +69,19 @@ struct SubscriptionOptionsWithAllocator : public SubscriptionOptionsBase
   rcl_subscription_options_t
   to_rcl_subscription_options(const rclcpp::QoS & qos) const
   {
-    rcl_subscription_options_t result;
+    rcl_subscription_options_t result = rcl_subscription_get_default_options();
     using AllocatorTraits = std::allocator_traits<Allocator>;
     using MessageAllocatorT = typename AllocatorTraits::template rebind_alloc<MessageT>;
     auto message_alloc = std::make_shared<MessageAllocatorT>(*allocator.get());
     result.allocator = allocator::get_rcl_allocator<MessageT>(*message_alloc);
-    result.ignore_local_publications = this->ignore_local_publications;
     result.qos = qos.get_rmw_qos_profile();
+    result.rmw_subscription_options.ignore_local_publications = this->ignore_local_publications;
+
+    // Apply payload to rcl_subscription_options if necessary.
+    if (rmw_implementation_payload && rmw_implementation_payload->has_been_customized()) {
+      rmw_implementation_payload->modify_rcl_subscription_options(result);
+    }
+
     return result;
   }
 

--- a/rclcpp/src/rclcpp/detail/rmw_implementation_specific_payload.cpp
+++ b/rclcpp/src/rclcpp/detail/rmw_implementation_specific_payload.cpp
@@ -1,0 +1,35 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rclcpp/detail/rmw_implementation_specific_payload.hpp>
+
+namespace rclcpp
+{
+namespace detail
+{
+
+bool
+RMWImplementationSpecificPayload::has_been_customized() const
+{
+  return nullptr != this->get_implementation_identifier();
+}
+
+const char *
+RMWImplementationSpecificPayload::get_implementation_identifier() const
+{
+  return nullptr;
+}
+
+}  // namespace detail
+}  // namespace rclcpp

--- a/rclcpp/src/rclcpp/detail/rmw_implementation_specific_publisher_payload.cpp
+++ b/rclcpp/src/rclcpp/detail/rmw_implementation_specific_publisher_payload.cpp
@@ -1,0 +1,33 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rclcpp/detail/rmw_implementation_specific_publisher_payload.hpp>
+
+#include "rcl/publisher.h"
+
+namespace rclcpp
+{
+namespace detail
+{
+
+void
+RMWImplementationSpecificPublisherPayload::modify_rcl_publisher_options(
+  rcl_publisher_options_t & rcl_publisher_options) const
+{
+  // By default, do not mutate the rcl publisher options.
+  (void)rcl_publisher_options;
+}
+
+}  // namespace detail
+}  // namespace rclcpp

--- a/rclcpp/src/rclcpp/detail/rmw_implementation_specific_publisher_payload.cpp
+++ b/rclcpp/src/rclcpp/detail/rmw_implementation_specific_publisher_payload.cpp
@@ -22,11 +22,11 @@ namespace detail
 {
 
 void
-RMWImplementationSpecificPublisherPayload::modify_rcl_publisher_options(
-  rcl_publisher_options_t & rcl_publisher_options) const
+RMWImplementationSpecificPublisherPayload::modify_rmw_publisher_options(
+  rmw_publisher_options_t & rmw_publisher_options) const
 {
-  // By default, do not mutate the rcl publisher options.
-  (void)rcl_publisher_options;
+  // By default, do not mutate the rmw publisher options.
+  (void)rmw_publisher_options;
 }
 
 }  // namespace detail

--- a/rclcpp/src/rclcpp/detail/rmw_implementation_specific_subscription_payload.cpp
+++ b/rclcpp/src/rclcpp/detail/rmw_implementation_specific_subscription_payload.cpp
@@ -22,11 +22,11 @@ namespace detail
 {
 
 void
-RMWImplementationSpecificSubscriptionPayload::modify_rcl_subscription_options(
-  rcl_subscription_options_t & rcl_subscription_options) const
+RMWImplementationSpecificSubscriptionPayload::modify_rmw_subscription_options(
+  rmw_subscription_options_t & rmw_subscription_options) const
 {
-  // By default, do not mutate the rcl subscription options.
-  (void)rcl_subscription_options;
+  // By default, do not mutate the rmw subscription options.
+  (void)rmw_subscription_options;
 }
 
 }  // namespace detail

--- a/rclcpp/src/rclcpp/detail/rmw_implementation_specific_subscription_payload.cpp
+++ b/rclcpp/src/rclcpp/detail/rmw_implementation_specific_subscription_payload.cpp
@@ -1,0 +1,33 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rclcpp/detail/rmw_implementation_specific_subscription_payload.hpp>
+
+#include "rcl/subscription.h"
+
+namespace rclcpp
+{
+namespace detail
+{
+
+void
+RMWImplementationSpecificSubscriptionPayload::modify_rcl_subscription_options(
+  rcl_subscription_options_t & rcl_subscription_options) const
+{
+  // By default, do not mutate the rcl subscription options.
+  (void)rcl_subscription_options;
+}
+
+}  // namespace detail
+}  // namespace rclcpp


### PR DESCRIPTION
This feature was motivated by a use case that ApexAI has, where they want to pass settings and/or pre-fabricated objects as input to the creation of publishers and subscriptions. It's already possible with the "native" API pattern (demonstrated in the `demo_nodes_cpp_native` package) to influence the rmw implementation in a non-portable way before and after a publisher or subscription is created. However, without this feature it's difficult to use this to affect creation of publishers and subscriptions.

The way it works is that there is a new "payload" field in the Publisher/SubscriptionOptions classes which has the opportunity to inject arbitrary data into the `rcl_{publisher,subscription}_options_t` and/or the newly added `rmw_{publisher,subscription}_options_t` structures which are then passed all the way into the rmw implementation, where the payload can be introspected to extract existing objects or configurations needed during construction.

Example uses cases might be like:

- pass custom QoS settings to the middleware that cannot be set via the ROS QoS
  - for example, special resource limit settings or unexposed DDS QoS settings
- pass a specific DDS Publisher/Subscriber object to be used in the creation of a datawriter/datareader
- pass an existing datareader or datawriter to be used directly
- and so on...

This is an advanced and non-portable feature, and it's up to the user and rmw middleware implementation developers to agree on the structure, its contents, and how it interacts with other ROS entities.

Here's a snippet of a demo which sets custom QoS settings, bypassing the ROS QoS completely, using a customized version of the rclcpp payload class:

```c++
    auto payload = std::make_unique<dds_direct_access::SubscriptionPayload>();
    DDS_DataReaderQos datareader_qos;
    datareader_qos.resource_limits.max_instances = 100;
    datareader_qos.resource_limits.max_samples = 100;
    datareader_qos.resource_limits.max_samples_per_instance = 100;
    datareader_qos.history.kind = DDS_KEEP_LAST_HISTORY_QOS;
    datareader_qos.history.depth = 10;
    payload->set_qos(datareader_qos);
    rclcpp::SubscriptionOptions options;
    options.rmw_implementation_payload = std::move(payload);
    // Use a different topic name to avoid interference with demo_nodes_cpp
    sub_ = create_subscription<std_msgs::msg::String>(
      "chatter_with_custom_qos",
      dds_direct_access::SubscriptionPayload::get_placeholder_qos(),
      [this](std_msgs::msg::String::ConstSharedPtr msg) {
        RCLCPP_INFO(this->get_logger(), "I heard: %s", msg->data.c_str());
      },
      options);
```

----

Connected prs:

- https://github.com/ros2/rcl/pull/513
- https://github.com/ros2/rmw/pull/187
- https://github.com/ros2/rmw_implementation/pull/74
- https://github.com/ros2/rmw_fastrtps/pull/329
- https://github.com/ros2/rmw_connext/pull/368
- https://github.com/ros2/rmw_opensplice/pull/284
- https://github.com/ros2/ros2_documentation/pull/345