### PR TITLE
[rclcpp_action] Add public cancel goal method to server goal handle

### DIFF
--- a/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
+++ b/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
@@ -60,6 +60,12 @@ public:
   bool
   is_executing() const;
 
+  /// Start canceling the goal.
+  /// \throws rclcpp::exceptions::RCLException if the transition to the canceling state is invalid.
+  RCLCPP_ACTION_PUBLIC
+  void
+  cancel_goal();
+
   RCLCPP_ACTION_PUBLIC
   virtual
   ~ServerGoalHandleBase();

--- a/rclcpp_action/src/server_goal_handle.cpp
+++ b/rclcpp_action/src/server_goal_handle.cpp
@@ -58,6 +58,12 @@ ServerGoalHandleBase::is_executing() const
 }
 
 void
+ServerGoalHandleBase::cancel_goal()
+{
+  _cancel_goal();
+}
+
+void
 ServerGoalHandleBase::_abort()
 {
   std::lock_guard<std::mutex> lock(rcl_handle_mutex_);


### PR DESCRIPTION
This gives the option to cancel an active goal from the action server implementation.
In the context of action servers with a single-goal policy, this let's the server trigger
a cancel event upon receiving a new goal request.

See related discussion in #759 