### PR TITLE
rename return functions for loaned messages

### DIFF
--- a/rclcpp/include/rclcpp/loaned_message.hpp
+++ b/rclcpp/include/rclcpp/loaned_message.hpp
@@ -137,7 +137,7 @@ public:
     if (pub_.can_loan_messages()) {
       // return allocated memory to the middleware
       auto ret =
-        rcl_return_loaned_message(pub_.get_publisher_handle(), message_);
+        rcl_return_loaned_message_from_publisher(pub_.get_publisher_handle(), message_);
       if (ret != RCL_RET_OK) {
         RCLCPP_ERROR(
           error_logger, "rcl_deallocate_loaned_message failed: %s", rcl_get_error_string().str);

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -129,15 +129,6 @@ public:
   virtual ~Publisher()
   {}
 
-  mapped_ring_buffer::MappedRingBufferBase::SharedPtr
-  make_mapped_ring_buffer(size_t size) const override
-  {
-    return mapped_ring_buffer::MappedRingBuffer<
-      MessageT,
-      typename Publisher<MessageT, AllocatorT>::MessageAllocator
-    >::make_shared(size, this->get_allocator());
-  }
-
   /// Borrow a loaned ROS message from the middleware.
   /**
    * If the middleware is capable of loaning memory for a ROS message instance,

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -138,7 +138,7 @@ public:
     >::make_shared(size, this->get_allocator());
   }
 
-  /// Loan memory for a ROS message from the middleware.
+  /// Borrow a loaned ROS message from the middleware.
   /**
    * If the middleware is capable of loaning memory for a ROS message instance,
    * the loaned message will be directly allocated in the middleware.
@@ -154,7 +154,7 @@ public:
    * \return LoanedMessage containing memory for a ROS message of type MessageT
    */
   rclcpp::LoanedMessage<MessageT, AllocatorT>
-  loan_message()
+  borrow_loaned_message()
   {
     return rclcpp::LoanedMessage<MessageT, AllocatorT>(this, this->get_allocator());
   }

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -134,7 +134,6 @@ public:
   void
   handle_message(std::shared_ptr<void> & message, const rmw_message_info_t & message_info) = 0;
 
-  // TODO(karsten1987): Does it make sense to pass in a weak_ptr?
   RCLCPP_PUBLIC
   virtual
   void

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -344,13 +344,13 @@ Executor::execute_subscription(
         subscription->get_topic_name(), rcl_get_error_string().str);
       rcl_reset_error();
     }
-    ret = rcl_release_loaned_message(
+    ret = rcl_return_loaned_message_from_subscription(
       subscription->get_subscription_handle().get(),
       loaned_msg);
     if (RCL_RET_OK != ret) {
       RCUTILS_LOG_ERROR_NAMED(
         "rclcpp",
-        "release_loaned failed for subscription on topic '%s': %s",
+        "return_loaned_message failed for subscription on topic '%s': %s",
         subscription->get_topic_name(), rcl_get_error_string().str);
     }
     loaned_msg = nullptr;

--- a/rclcpp/test/test_loaned_message.cpp
+++ b/rclcpp/test/test_loaned_message.cpp
@@ -53,7 +53,7 @@ TEST_F(TestLoanedMessage, loan_from_pub) {
   auto node = std::make_shared<rclcpp::Node>("loaned_message_test_node");
   auto pub = node->create_publisher<MessageT>("loaned_message_test_topic", 1);
 
-  auto loaned_msg = pub->loan_message();
+  auto loaned_msg = pub->borrow_loaned_message();
   ASSERT_TRUE(loaned_msg.is_valid());
   loaned_msg.get().float64_value = 42.0f;
   ASSERT_EQ(42.0f, loaned_msg.get().float64_value);
@@ -67,7 +67,7 @@ TEST_F(TestLoanedMessage, release) {
 
   MessageT * msg = nullptr;
   {
-    auto loaned_msg = pub->loan_message();
+    auto loaned_msg = pub->borrow_loaned_message();
     ASSERT_TRUE(loaned_msg.is_valid());
     loaned_msg.get().float64_value = 42.0f;
     ASSERT_EQ(42.0f, loaned_msg.get().float64_value);


### PR DESCRIPTION
connects to https://github.com/ros2/rclcpp/pull/864#discussion_r336714833

This PR also touches up on some doc review comments and renames `rclcpp::Publisher::loan_message()` into `rclcpp::Publisher::borrow_loaned_message()`