### PR TITLE
De-flake tests for rmw_connext

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -238,7 +238,7 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_loaned_message ${PROJECT_NAME})
 
-  ament_add_gtest(test_node test/test_node.cpp)
+  ament_add_gtest(test_node test/test_node.cpp TIMEOUT 240)
   if(TARGET test_node)
     ament_target_dependencies(test_node
       "rcl_interfaces"

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -147,22 +147,6 @@ TEST_F(TestNode, subnode_get_name_and_namespace) {
     EXPECT_STREQ("/ns", subnode->get_namespace());
     EXPECT_STREQ("sub_ns", subnode->get_sub_namespace().c_str());
     EXPECT_STREQ("/ns/sub_ns", subnode->get_effective_namespace().c_str());
-  }
-  {
-    auto node = std::make_shared<rclcpp::Node>("my_node");
-    auto subnode = node->create_sub_node("sub_ns");
-    EXPECT_STREQ("my_node", subnode->get_name());
-    EXPECT_STREQ("/", subnode->get_namespace());
-    EXPECT_STREQ("sub_ns", subnode->get_sub_namespace().c_str());
-    EXPECT_STREQ("/sub_ns", subnode->get_effective_namespace().c_str());
-  }
-  {
-    auto node = std::make_shared<rclcpp::Node>("my_node", "/ns");
-    auto subnode = node->create_sub_node("sub_ns");
-    EXPECT_STREQ("my_node", subnode->get_name());
-    EXPECT_STREQ("/ns", subnode->get_namespace());
-    EXPECT_STREQ("sub_ns", subnode->get_sub_namespace().c_str());
-    EXPECT_STREQ("/ns/sub_ns", subnode->get_effective_namespace().c_str());
     auto subnode2 = subnode->create_sub_node("sub_ns2");
     EXPECT_STREQ("my_node", subnode2->get_name());
     EXPECT_STREQ("/ns", subnode2->get_namespace());


### PR DESCRIPTION
The `test_node` tests take a bit longer to execute on Connext, so this

- Removes some duplicated test logic
- Increases the timeout for the test (it took approx 200 seconds to execute locally)

