### PR TITLE
documentation and reference fix 

### DIFF
--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -212,7 +212,7 @@ on_shutdown(std::function<void()> callback, rclcpp::Context::SharedPtr context =
 RCLCPP_PUBLIC
 bool
 sleep_for(
-  const std::chrono::nanoseconds & nanoseconds,
+  const std::chrono::nanoseconds nanoseconds,
   rclcpp::Context::SharedPtr context = nullptr);
 
 /// Safely check if addition will overflow.

--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -164,7 +164,7 @@ on_shutdown(std::function<void()> callback, Context::SharedPtr context)
 }
 
 bool
-sleep_for(const std::chrono::nanoseconds & nanoseconds, Context::SharedPtr context)
+sleep_for(const std::chrono::nanoseconds nanoseconds, Context::SharedPtr context)
 {
   using contexts::default_context::get_global_default_context;
   if (nullptr == context) {

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -103,7 +103,6 @@ public:
   /// Create a new lifecycle node with the specified name.
   /**
    * \param[in] node_name Name of the node.
-   * \param[in] namespace_ Namespace of the node.
    * \param[in] options Additional options to control creation of the node.
    */
   RCLCPP_LIFECYCLE_PUBLIC


### PR DESCRIPTION
3 small fixes, they are unrelated to each other, but I didn't want to create separate PRs for such small changes, please let me know if it's fine;
Improvements are (as in commits):
- Removing reference from nanoseconds parameter in sleep_for function
- Removing unnecessary parameter in function description in `lifecycle_node.hpp`