### PR TITLE
Extend timeout of test_node test for opensplice

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -238,7 +238,7 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_loaned_message ${PROJECT_NAME})
 
-  ament_add_gtest(test_node test/test_node.cpp)
+  ament_add_gtest(test_node test/test_node.cpp TIMEOUT 120)
   if(TARGET test_node)
     ament_target_dependencies(test_node
       "rcl_interfaces"


### PR DESCRIPTION
As the title says, this just extends the timeout for the test_node that it was failing for opensplice.