### PR TITLE
Avoid copying AnySubscriptionCallback objects for intraprocess comms

### DIFF
--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
@@ -58,7 +58,7 @@ public:
     >::UniquePtr;
 
   SubscriptionIntraProcess(
-    AnySubscriptionCallback<CallbackMessageT, Alloc> callback,
+    AnySubscriptionCallback<CallbackMessageT, Alloc> & callback,
     std::shared_ptr<Alloc> allocator,
     rclcpp::Context::SharedPtr context,
     const std::string & topic_name,
@@ -153,7 +153,7 @@ private:
     }
   }
 
-  AnySubscriptionCallback<CallbackMessageT, Alloc> any_callback_;
+  AnySubscriptionCallback<CallbackMessageT, Alloc> & any_callback_;
   BufferUniquePtr buffer_;
 };
 

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -145,12 +145,12 @@ public:
           AllocatorT,
           typename MessageUniquePtr::deleter_type
         >>(
-        callback,
+        any_callback_,
         options.get_allocator(),
         context,
         this->get_topic_name(),    // important to get like this, as it has the fully-qualified name
         qos.get_rmw_qos_profile(),
-        resolve_intra_process_buffer_type(options.intra_process_buffer_type, callback)
+        resolve_intra_process_buffer_type(options.intra_process_buffer_type, any_callback_)
         );
 
       // Add it to the intra process manager.


### PR DESCRIPTION
Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>

`ros2_tracing` and the analysis tools use pointers in order to link a subscription to its `AnySubscriptionCallback` object(s) and callback instances. See the [`Subscription` constructor](https://github.com/ros2/rclcpp/blob/2ed445647400bacbff6420cfb8ccc7bee86ee469/rclcpp/include/rclcpp/subscription.hpp#L163-L170).

The new intraprocess comms (https://github.com/ros2/rclcpp/pull/778) changed this by having the `AnySubscriptionCallback` object actually used by `SubscriptionIntraProcess`. However, the problem is that it creates a copy for itself, and thus we can't link the callback back to the original subscription. I wrote a longer explanation [over on the `ros2_tracing` repo](https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing/issues/55#note_243141152).

This makes it clear that the `AnySubscriptionCallback` object belongs to the `Subscription` and not `SubscriptionIntraProcess`, even if it used by the latter. However, this could of course be changed. Let me know if that would be preferable.

I'm hoping this can get in in time for eloquent!