### PR TITLE
[rclcpp_action] Bump test_client timeout.

### DIFF
--- a/rclcpp_action/CMakeLists.txt
+++ b/rclcpp_action/CMakeLists.txt
@@ -68,7 +68,7 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  ament_add_gtest(test_client test/test_client.cpp)
+  ament_add_gtest(test_client test/test_client.cpp TIMEOUT 120)
   if(TARGET test_client)
     ament_target_dependencies(test_client
       "test_msgs"


### PR DESCRIPTION
Precisely what the title says. Should solve flakes seen in nightlies, e.g. http://build.ros2.org/view/Eci/job/Eci__nightly-connext_ubuntu_bionic_amd64/lastCompletedBuild/testReport/