### PR TITLE
Put subscription callback tracepoints in intraprocess subscription too

### DIFF
--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
@@ -64,8 +64,7 @@ public:
     rclcpp::Context::SharedPtr context,
     const std::string & topic_name,
     rmw_qos_profile_t qos_profile,
-    rclcpp::IntraProcessBufferType buffer_type,
-    rcl_subscription_t * subscription_handle)
+    rclcpp::IntraProcessBufferType buffer_type)
   : SubscriptionIntraProcessBase(topic_name, qos_profile),
     any_callback_(callback)
   {
@@ -93,7 +92,7 @@ public:
 
     TRACEPOINT(
       rclcpp_subscription_callback_added,
-      (const void *)subscription_handle,
+      (const void *)this,
       (const void *)&any_callback_);
     // The callback object gets copied, so if registration is done too early/before this point
     // (e.g. in `AnySubscriptionCallback::set()`), its address won't match any address used later

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
@@ -30,6 +30,7 @@
 #include "rclcpp/experimental/subscription_intra_process_base.hpp"
 #include "rclcpp/type_support_decl.hpp"
 #include "rclcpp/waitable.hpp"
+#include "tracetools/tracetools.h"
 
 namespace rclcpp
 {

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -150,9 +150,12 @@ public:
         context,
         this->get_topic_name(),    // important to get like this, as it has the fully-qualified name
         qos.get_rmw_qos_profile(),
-        resolve_intra_process_buffer_type(options.intra_process_buffer_type, callback),
-        get_subscription_handle().get()
+        resolve_intra_process_buffer_type(options.intra_process_buffer_type, callback)
         );
+      TRACEPOINT(
+        rclcpp_subscription_init,
+        (const void *)get_subscription_handle().get(),
+        (const void *)subscription_intra_process.get());
 
       // Add it to the intra process manager.
       using rclcpp::experimental::IntraProcessManager;
@@ -162,8 +165,12 @@ public:
     }
 
     TRACEPOINT(
-      rclcpp_subscription_callback_added,
+      rclcpp_subscription_init,
       (const void *)get_subscription_handle().get(),
+      (const void *)this);
+    TRACEPOINT(
+      rclcpp_subscription_callback_added,
+      (const void *)this,
       (const void *)&any_callback_);
     // The callback object gets copied, so if registration is done too early/before this point
     // (e.g. in `AnySubscriptionCallback::set()`), its address won't match any address used later

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -159,16 +159,16 @@ public:
       auto ipm = context->get_sub_context<IntraProcessManager>();
       uint64_t intra_process_subscription_id = ipm->add_subscription(subscription_intra_process);
       this->setup_intra_process(intra_process_subscription_id, ipm);
-    } else {
-      TRACEPOINT(
-        rclcpp_subscription_callback_added,
-        (const void *)get_subscription_handle().get(),
-        (const void *)&any_callback_);
-      // The callback object gets copied, so if registration is done too early/before this point
-      // (e.g. in `AnySubscriptionCallback::set()`), its address won't match any address used later
-      // in subsequent tracepoints.
-      any_callback_.register_callback_for_tracing();
     }
+
+    TRACEPOINT(
+      rclcpp_subscription_callback_added,
+      (const void *)get_subscription_handle().get(),
+      (const void *)&any_callback_);
+    // The callback object gets copied, so if registration is done too early/before this point
+    // (e.g. in `AnySubscriptionCallback::set()`), its address won't match any address used later
+    // in subsequent tracepoints.
+    any_callback_.register_callback_for_tracing();
   }
 
   /// Called after construction to continue setup that requires shared_from_this().

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -150,7 +150,8 @@ public:
         context,
         this->get_topic_name(),    // important to get like this, as it has the fully-qualified name
         qos.get_rmw_qos_profile(),
-        resolve_intra_process_buffer_type(options.intra_process_buffer_type, callback)
+        resolve_intra_process_buffer_type(options.intra_process_buffer_type, callback),
+        get_subscription_handle().get()
         );
 
       // Add it to the intra process manager.
@@ -158,16 +159,16 @@ public:
       auto ipm = context->get_sub_context<IntraProcessManager>();
       uint64_t intra_process_subscription_id = ipm->add_subscription(subscription_intra_process);
       this->setup_intra_process(intra_process_subscription_id, ipm);
+    } else {
+      TRACEPOINT(
+        rclcpp_subscription_callback_added,
+        (const void *)get_subscription_handle().get(),
+        (const void *)&any_callback_);
+      // The callback object gets copied, so if registration is done too early/before this point
+      // (e.g. in `AnySubscriptionCallback::set()`), its address won't match any address used later
+      // in subsequent tracepoints.
+      any_callback_.register_callback_for_tracing();
     }
-
-    TRACEPOINT(
-      rclcpp_subscription_callback_added,
-      (const void *)get_subscription_handle().get(),
-      (const void *)&any_callback_);
-    // The callback object gets copied, so if registration is done too early/before this point
-    // (e.g. in `AnySubscriptionCallback::set()`), its address won't match any address used later
-    // in subsequent tracepoints.
-    any_callback_.register_callback_for_tracing();
   }
 
   /// Called after construction to continue setup that requires shared_from_this().


### PR DESCRIPTION
Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>

Alternative to #916, following discussion at https://github.com/ros2/rclcpp/pull/916#discussion_r345920151

In order to get a valid `AnySubscriptionCallback` address for tracing, we can have `SubscriptionIntraProcess` call the tracepoints/perform the registration instead (if it is enabled).

The only downside is that I have to pass the subscription handle through to `SubscriptionIntraProcess`. I think this is the simplest fix, but we can always revisit later (as intra-process subscription is considered experimental anyway).