### PR TITLE
Create node clock calls const

### DIFF
--- a/rclcpp_action/CMakeLists.txt
+++ b/rclcpp_action/CMakeLists.txt
@@ -68,7 +68,7 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  ament_add_gtest(test_client test/test_client.cpp)
+  ament_add_gtest(test_client test/test_client.cpp TIMEOUT 120)
   if(TARGET test_client)
     ament_target_dependencies(test_client
       "test_msgs"


### PR DESCRIPTION
Per this issue: https://github.com/ros-planning/navigation2/issues/844

In navigation-land we'd like to make more const methods and this is the link stopping us. 