### PR TITLE
Create node clock calls const (try 2)

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -892,11 +892,11 @@ public:
 
   RCLCPP_PUBLIC
   rclcpp::Clock::SharedPtr
-  get_clock();
+  get_clock() const;
 
   RCLCPP_PUBLIC
   Time
-  now();
+  now() const;
 
   /// Return the Node's internal NodeBaseInterface implementation.
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -892,6 +892,10 @@ public:
 
   RCLCPP_PUBLIC
   rclcpp::Clock::SharedPtr
+  get_clock();
+
+  RCLCPP_PUBLIC
+  rclcpp::Clock::ConstSharedPtr
   get_clock() const;
 
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/node_interfaces/node_clock.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_clock.hpp
@@ -52,6 +52,12 @@ public:
   RCLCPP_PUBLIC
   virtual
   rclcpp::Clock::SharedPtr
+  get_clock();
+
+  /// Get a clock which will be kept up to date by the node.
+  RCLCPP_PUBLIC
+  virtual
+  rclcpp::Clock::ConstSharedPtr
   get_clock() const;
 
 private:

--- a/rclcpp/include/rclcpp/node_interfaces/node_clock.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_clock.hpp
@@ -52,7 +52,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   rclcpp::Clock::SharedPtr
-  get_clock();
+  get_clock() const;
 
 private:
   RCLCPP_DISABLE_COPY(NodeClock)

--- a/rclcpp/include/rclcpp/node_interfaces/node_clock_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_clock_interface.hpp
@@ -39,7 +39,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   rclcpp::Clock::SharedPtr
-  get_clock() = 0;
+  get_clock() const = 0;
 };
 
 }  // namespace node_interfaces

--- a/rclcpp/include/rclcpp/node_interfaces/node_clock_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_clock_interface.hpp
@@ -39,6 +39,12 @@ public:
   RCLCPP_PUBLIC
   virtual
   rclcpp::Clock::SharedPtr
+  get_clock() = 0;
+
+  /// Get a const ROS clock which will be kept up to date by the node.
+  RCLCPP_PUBLIC
+  virtual
+  rclcpp::Clock::ConstSharedPtr
   get_clock() const = 0;
 };
 

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -385,13 +385,13 @@ Node::wait_for_graph_change(
 }
 
 rclcpp::Clock::SharedPtr
-Node::get_clock()
+Node::get_clock() const
 {
   return node_clock_->get_clock();
 }
 
 rclcpp::Time
-Node::now()
+Node::now() const
 {
   return node_clock_->get_clock()->now();
 }

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -385,6 +385,12 @@ Node::wait_for_graph_change(
 }
 
 rclcpp::Clock::SharedPtr
+Node::get_clock()
+{
+  return node_clock_->get_clock();
+}
+
+rclcpp::Clock::ConstSharedPtr
 Node::get_clock() const
 {
   return node_clock_->get_clock();

--- a/rclcpp/src/rclcpp/node_interfaces/node_clock.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_clock.cpp
@@ -37,7 +37,7 @@ NodeClock::~NodeClock()
 {}
 
 std::shared_ptr<rclcpp::Clock>
-NodeClock::get_clock()
+NodeClock::get_clock() const
 {
   return ros_clock_;
 }

--- a/rclcpp/src/rclcpp/node_interfaces/node_clock.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_clock.cpp
@@ -36,7 +36,13 @@ NodeClock::NodeClock(
 NodeClock::~NodeClock()
 {}
 
-std::shared_ptr<rclcpp::Clock>
+rclcpp::Clock::SharedPtr
+NodeClock::get_clock()
+{
+  return ros_clock_;
+}
+
+rclcpp::Clock::ConstSharedPtr
 NodeClock::get_clock() const
 {
   return ros_clock_;

--- a/rclcpp_action/CMakeLists.txt
+++ b/rclcpp_action/CMakeLists.txt
@@ -68,7 +68,7 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  ament_add_gtest(test_client test/test_client.cpp)
+  ament_add_gtest(test_client test/test_client.cpp TIMEOUT 120)
   if(TARGET test_client)
     ament_target_dependencies(test_client
       "test_msgs"

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -465,7 +465,7 @@ public:
   rclcpp::Clock::SharedPtr
   get_clock();
 
-  RCLCPP_PUBLIC
+  RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::Clock::ConstSharedPtr
   get_clock() const;
 

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -463,6 +463,10 @@ public:
 
   RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::Clock::SharedPtr
+  get_clock();
+
+  RCLCPP_PUBLIC
+  rclcpp::Clock::ConstSharedPtr
   get_clock() const;
 
   RCLCPP_LIFECYCLE_PUBLIC

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -463,11 +463,11 @@ public:
 
   RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::Clock::SharedPtr
-  get_clock();
+  get_clock() const;
 
   RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::Time
-  now();
+  now() const;
 
   /// Return the Node's internal NodeBaseInterface implementation.
   RCLCPP_LIFECYCLE_PUBLIC

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -311,13 +311,13 @@ LifecycleNode::wait_for_graph_change(
 }
 
 rclcpp::Clock::SharedPtr
-LifecycleNode::get_clock()
+LifecycleNode::get_clock() const
 {
   return node_clock_->get_clock();
 }
 
 rclcpp::Time
-LifecycleNode::now()
+LifecycleNode::now() const
 {
   return node_clock_->get_clock()->now();
 }

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -311,6 +311,12 @@ LifecycleNode::wait_for_graph_change(
 }
 
 rclcpp::Clock::SharedPtr
+LifecycleNode::get_clock()
+{
+  return node_clock_->get_clock();
+}
+
+rclcpp::Clock::ConstSharedPtr
 LifecycleNode::get_clock() const
 {
   return node_clock_->get_clock();


### PR DESCRIPTION
Per this issue: ros-planning/navigation2#844

In navigation-land we'd like to make more const methods and this is the link stopping us.

Sorry about that, something in my branching got messed up briefly 