### PR TITLE
 add support for STREAM logging macros

### DIFF
--- a/rclcpp/test/test_logging.cpp
+++ b/rclcpp/test/test_logging.cpp
@@ -113,6 +113,20 @@ TEST_F(TestLoggingMacros, test_logging_string) {
   EXPECT_EQ("message seven", g_last_log_event.message);
 }
 
+TEST_F(TestLoggingMacros, test_logging_stream) {
+  for (std::string i : {"one", "two", "three"}) {
+    RCLCPP_DEBUG_STREAM(g_logger, "message " << i);
+  }
+  EXPECT_EQ(3u, g_log_calls);
+  EXPECT_EQ("message three", g_last_log_event.message);
+
+  RCLCPP_DEBUG_STREAM(g_logger, 4 << "th message");
+  EXPECT_EQ("4th message", g_last_log_event.message);
+
+  RCLCPP_DEBUG_STREAM(g_logger, "message " << 5);
+  EXPECT_EQ("message 5", g_last_log_event.message);
+}
+
 TEST_F(TestLoggingMacros, test_logging_once) {
   for (int i : {1, 2, 3}) {
     RCLCPP_INFO_ONCE(g_logger, "message %d", i);


### PR DESCRIPTION
Fixes #915. Requires ros2/rcutils#192.

The changes to the `logging.hpp.em` template only result in additional lines and don't change/remove any existing lines.

Since the `STREAM` macros only differ in the vargs / stream_arg handling the new test only covers one of the feature combinations.

The first commit is a pure refactoring without changing the expanded template. The second commit adds `stream` to the feature combinations.

The following details show the added lines for the `DEBUG` log level:

<details>
<summary>New empty STREAM macros for all existing feature combinations in case logging has been disabled.</summary>

> /// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
> #define RCLCPP_DEBUG_STREAM(...)
> /// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
> #define RCLCPP_DEBUG_STREAM_ONCE(...)
> /// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
> #define RCLCPP_DEBUG_STREAM_EXPRESSION(...)
> /// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
> #define RCLCPP_DEBUG_STREAM_FUNCTION(...)
> /// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
> #define RCLCPP_DEBUG_STREAM_SKIPFIRST(...)
> /// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
> #define RCLCPP_DEBUG_STREAM_THROTTLE(...)
> /// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
> #define RCLCPP_DEBUG_STREAM_SKIPFIRST_THROTTLE(...)

</details>

<details>
<summary>New STREAM macros for all existing feature combinations.</summary>

> // The RCLCPP_DEBUG_STREAM macro is surrounded by do { .. } while (0)
> // to implement the standard C macro idiom to make the macro safe in all
> // contexts; see http://c-faq.com/cpp/multistmt.html for more information.
> /**
>  * \def RCLCPP_DEBUG_STREAM
>  * Log a message with severity DEBUG.
>  * \param logger The `rclcpp::Logger` to use
>  * \param stream_arg The argument << into a stringstream
>  */
> #define RCLCPP_DEBUG_STREAM(logger, stream_arg) \
>   do { \
>     static_assert( \
>       ::std::is_same<typename std::remove_cv<typename std::remove_reference<decltype(logger)>::type>::type, \
>       typename ::rclcpp::Logger>::value, \
>       "First argument to logging macros must be an rclcpp::Logger"); \
>  \
>     std::stringstream ss; \
>     ss << stream_arg; \
>     RCUTILS_LOG_DEBUG_NAMED( \
>       logger.get_name(), \
>       "%s", rclcpp::get_c_string(ss.str())); \
>   } while (0)
> 
> // The RCLCPP_DEBUG_STREAM_ONCE macro is surrounded by do { .. } while (0)
> // to implement the standard C macro idiom to make the macro safe in all
> // contexts; see http://c-faq.com/cpp/multistmt.html for more information.
> /**
>  * \def RCLCPP_DEBUG_STREAM_ONCE
>  * Log a message with severity DEBUG with the following conditions:
>  * All subsequent log calls except the first one are being ignored.
>  * \param logger The `rclcpp::Logger` to use
>  * \param stream_arg The argument << into a stringstream
>  */
> #define RCLCPP_DEBUG_STREAM_ONCE(logger, stream_arg) \
>   do { \
>     static_assert( \
>       ::std::is_same<typename std::remove_cv<typename std::remove_reference<decltype(logger)>::type>::type, \
>       typename ::rclcpp::Logger>::value, \
>       "First argument to logging macros must be an rclcpp::Logger"); \
>  \
>     std::stringstream ss; \
>     ss << stream_arg; \
>     RCUTILS_LOG_DEBUG_ONCE_NAMED( \
>       logger.get_name(), \
>       "%s", rclcpp::get_c_string(ss.str())); \
>   } while (0)
> 
> // The RCLCPP_DEBUG_STREAM_EXPRESSION macro is surrounded by do { .. } while (0)
> // to implement the standard C macro idiom to make the macro safe in all
> // contexts; see http://c-faq.com/cpp/multistmt.html for more information.
> /**
>  * \def RCLCPP_DEBUG_STREAM_EXPRESSION
>  * Log a message with severity DEBUG with the following conditions:
>  * Log calls are being ignored when the expression evaluates to false.
>  * \param logger The `rclcpp::Logger` to use
>  * \param expression The expression determining if the message should be logged
>  * \param stream_arg The argument << into a stringstream
>  */
> #define RCLCPP_DEBUG_STREAM_EXPRESSION(logger, expression, stream_arg) \
>   do { \
>     static_assert( \
>       ::std::is_same<typename std::remove_cv<typename std::remove_reference<decltype(logger)>::type>::type, \
>       typename ::rclcpp::Logger>::value, \
>       "First argument to logging macros must be an rclcpp::Logger"); \
>  \
>     std::stringstream ss; \
>     ss << stream_arg; \
>     RCUTILS_LOG_DEBUG_EXPRESSION_NAMED( \
>       expression, \
>       logger.get_name(), \
>       "%s", rclcpp::get_c_string(ss.str())); \
>   } while (0)
> 
> // The RCLCPP_DEBUG_STREAM_FUNCTION macro is surrounded by do { .. } while (0)
> // to implement the standard C macro idiom to make the macro safe in all
> // contexts; see http://c-faq.com/cpp/multistmt.html for more information.
> /**
>  * \def RCLCPP_DEBUG_STREAM_FUNCTION
>  * Log a message with severity DEBUG with the following conditions:
>  * Log calls are being ignored when the function returns false.
>  * \param logger The `rclcpp::Logger` to use
>  * \param function The functions return value determines if the message should be logged
>  * \param stream_arg The argument << into a stringstream
>  */
> #define RCLCPP_DEBUG_STREAM_FUNCTION(logger, function, stream_arg) \
>   do { \
>     static_assert( \
>       ::std::is_same<typename std::remove_cv<typename std::remove_reference<decltype(logger)>::type>::type, \
>       typename ::rclcpp::Logger>::value, \
>       "First argument to logging macros must be an rclcpp::Logger"); \
>  \
>     std::stringstream ss; \
>     ss << stream_arg; \
>     RCUTILS_LOG_DEBUG_FUNCTION_NAMED( \
>       function, \
>       logger.get_name(), \
>       "%s", rclcpp::get_c_string(ss.str())); \
>   } while (0)
> 
> // The RCLCPP_DEBUG_STREAM_SKIPFIRST macro is surrounded by do { .. } while (0)
> // to implement the standard C macro idiom to make the macro safe in all
> // contexts; see http://c-faq.com/cpp/multistmt.html for more information.
> /**
>  * \def RCLCPP_DEBUG_STREAM_SKIPFIRST
>  * Log a message with severity DEBUG with the following conditions:
>  * The first log call is being ignored but all subsequent calls are being processed.
>  * \param logger The `rclcpp::Logger` to use
>  * \param stream_arg The argument << into a stringstream
>  */
> #define RCLCPP_DEBUG_STREAM_SKIPFIRST(logger, stream_arg) \
>   do { \
>     static_assert( \
>       ::std::is_same<typename std::remove_cv<typename std::remove_reference<decltype(logger)>::type>::type, \
>       typename ::rclcpp::Logger>::value, \
>       "First argument to logging macros must be an rclcpp::Logger"); \
>  \
>     std::stringstream ss; \
>     ss << stream_arg; \
>     RCUTILS_LOG_DEBUG_SKIPFIRST_NAMED( \
>       logger.get_name(), \
>       "%s", rclcpp::get_c_string(ss.str())); \
>   } while (0)
> 
> // The RCLCPP_DEBUG_STREAM_THROTTLE macro is surrounded by do { .. } while (0)
> // to implement the standard C macro idiom to make the macro safe in all
> // contexts; see http://c-faq.com/cpp/multistmt.html for more information.
> /**
>  * \def RCLCPP_DEBUG_STREAM_THROTTLE
>  * Log a message with severity DEBUG with the following conditions:
>  * Log calls are being ignored if the last logged message is not longer ago than the specified duration.
>  * \param logger The `rclcpp::Logger` to use
>  * \param clock rclcpp::Clock that will be used to get the time point.
>  * \param duration The duration of the throttle interval
>  * \param stream_arg The argument << into a stringstream
>  */
> #define RCLCPP_DEBUG_STREAM_THROTTLE(logger, clock, duration, stream_arg) \
>   do { \
>     static_assert( \
>       ::std::is_same<typename std::remove_cv<typename std::remove_reference<decltype(logger)>::type>::type, \
>       typename ::rclcpp::Logger>::value, \
>       "First argument to logging macros must be an rclcpp::Logger"); \
> \
>     auto get_time_point = [&clock](rcutils_time_point_value_t * time_point) -> rcutils_ret_t { \
>       try { \
>         *time_point = clock.now().nanoseconds(); \
>       } catch (...) { \
>         RCUTILS_SAFE_FWRITE_TO_STDERR( \
>         "[rclcpp|logging.hpp] RCLCPP_DEBUG_STREAM_THROTTLE could not get current time stamp\n"); \
>         return RCUTILS_RET_ERROR; \
>       } \
>         return RCUTILS_RET_OK; \
>     }; \
>  \
>     std::stringstream ss; \
>     ss << stream_arg; \
>     RCUTILS_LOG_DEBUG_THROTTLE_NAMED( \
>       get_time_point, \
>       duration, \
>       logger.get_name(), \
>       "%s", rclcpp::get_c_string(ss.str())); \
>   } while (0)
> 
> // The RCLCPP_DEBUG_STREAM_SKIPFIRST_THROTTLE macro is surrounded by do { .. } while (0)
> // to implement the standard C macro idiom to make the macro safe in all
> // contexts; see http://c-faq.com/cpp/multistmt.html for more information.
> /**
>  * \def RCLCPP_DEBUG_STREAM_SKIPFIRST_THROTTLE
>  * Log a message with severity DEBUG with the following conditions:
>  * The first log call is being ignored but all subsequent calls are being processed.
>  * Log calls are being ignored if the last logged message is not longer ago than the specified duration.
>  * \param logger The `rclcpp::Logger` to use
>  * \param clock rclcpp::Clock that will be used to get the time point.
>  * \param duration The duration of the throttle interval
>  * \param stream_arg The argument << into a stringstream
>  */
> #define RCLCPP_DEBUG_STREAM_SKIPFIRST_THROTTLE(logger, clock, duration, stream_arg) \
>   do { \
>     static_assert( \
>       ::std::is_same<typename std::remove_cv<typename std::remove_reference<decltype(logger)>::type>::type, \
>       typename ::rclcpp::Logger>::value, \
>       "First argument to logging macros must be an rclcpp::Logger"); \
> \
>     auto get_time_point = [&clock](rcutils_time_point_value_t * time_point) -> rcutils_ret_t { \
>       try { \
>         *time_point = clock.now().nanoseconds(); \
>       } catch (...) { \
>         RCUTILS_SAFE_FWRITE_TO_STDERR( \
>         "[rclcpp|logging.hpp] RCLCPP_DEBUG_STREAM_SKIPFIRST_THROTTLE could not get current time stamp\n"); \
>         return RCUTILS_RET_ERROR; \
>       } \
>         return RCUTILS_RET_OK; \
>     }; \
>  \
>     std::stringstream ss; \
>     ss << stream_arg; \
>     RCUTILS_LOG_DEBUG_SKIPFIRST_THROTTLE_NAMED( \
>       get_time_point, \
>       duration, \
>       logger.get_name(), \
>       "%s", rclcpp::get_c_string(ss.str())); \
>   } while (0)

</details>

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8648)](http://ci.ros2.org/job/ci_linux/8648/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4491)](http://ci.ros2.org/job/ci_linux-aarch64/4491/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7055)](http://ci.ros2.org/job/ci_osx/7055/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8567)](http://ci.ros2.org/job/ci_windows/8567/)
  * unrelated linter failures