### PR TITLE
Use absolute topic name for parameter events

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -69,7 +69,7 @@ NodeParameters::NodeParameters(
   if (start_parameter_event_publisher) {
     events_publisher_ = rclcpp::create_publisher<MessageT, AllocatorT, PublisherT>(
       node_topics,
-      "parameter_events",
+      "/parameter_events",
       parameter_event_qos,
       publisher_options);
   }


### PR DESCRIPTION
Currently, we're creating one parameter events topic in each namespace, which IMO doesn't have much sense.

I think that having only one topic for this would be better.
Previous discussion here: https://github.com/ros2/rclcpp/pull/829#issuecomment-557660967.

Same about [rosout](https://github.com/ros2/rcl/blob/fbe299af7f96d2d530d55e633ab82a4514d045db/rcl/src/rcl/logging_rosout.c#L36).

@ros2/team @hidmic I would like to hear your opinion (I think we have talked once offline about this ...).