### PR TITLE
Fix duration.cpp lint error

### DIFF
--- a/rclcpp/src/rclcpp/duration.cpp
+++ b/rclcpp/src/rclcpp/duration.cpp
@@ -182,8 +182,7 @@ bounds_check_duration_scale(int64_t dns, double scale, uint64_t max)
 {
   auto abs_dns = static_cast<uint64_t>(std::abs(dns));
   auto abs_scale = std::abs(scale);
-  if (abs_scale > 1.0 &&
-    abs_dns >
+  if (abs_scale > 1.0 && abs_dns >
     static_cast<uint64_t>(static_cast<long double>(max) / static_cast<long double>(abs_scale)))
   {
     if ((dns > 0 && scale > 0) || (dns < 0 && scale < 0)) {

--- a/rclcpp/src/rclcpp/duration.cpp
+++ b/rclcpp/src/rclcpp/duration.cpp
@@ -183,7 +183,8 @@ bounds_check_duration_scale(int64_t dns, double scale, uint64_t max)
   auto abs_dns = static_cast<uint64_t>(std::abs(dns));
   auto abs_scale = std::abs(scale);
   if (abs_scale > 1.0 &&
-    abs_dns > static_cast<uint64_t>(static_cast<long double>(max) / static_cast<long double>(abs_scale)))
+    abs_dns >
+    static_cast<uint64_t>(static_cast<long double>(max) / static_cast<long double>(abs_scale)))
   {
     if ((dns > 0 && scale > 0) || (dns < 0 && scale < 0)) {
       throw std::overflow_error("duration scaling leads to int64_t overflow");


### PR DESCRIPTION
Fix linting error found via the [nightly build](https://ci.ros2.org/view/nightly/job/nightly_linux_debug/1388/testReport/junit/rclcpp/uncrustify/src_rclcpp_duration_cpp/) test results.

