### PR TITLE
Change rclcpp::Node::now() a const member function

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -896,7 +896,7 @@ public:
 
   RCLCPP_PUBLIC
   Time
-  now();
+  now() const;
 
   /// Return the Node's internal NodeBaseInterface implementation.
   RCLCPP_PUBLIC

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -391,7 +391,7 @@ Node::get_clock()
 }
 
 rclcpp::Time
-Node::now()
+Node::now() const
 {
   return node_clock_->get_clock()->now();
 }


### PR DESCRIPTION
Adding const qualifier to the `now()` member function, so that it is easier to use.