### PR TITLE
Fix asserts on shared_ptr::use_count; expects long, got uint32

### DIFF
--- a/rclcpp/test/test_intra_process_buffer.cpp
+++ b/rclcpp/test/test_intra_process_buffer.cpp
@@ -73,7 +73,7 @@ TEST(TestIntraProcessBuffer, shared_buffer_add) {
 
   intra_process_buffer.add_shared(original_shared_msg);
 
-  EXPECT_EQ(2, original_shared_msg.use_count());
+  EXPECT_EQ(2L, original_shared_msg.use_count());
 
   SharedMessageT popped_shared_msg;
   popped_shared_msg = intra_process_buffer.consume_shared();
@@ -92,7 +92,7 @@ TEST(TestIntraProcessBuffer, shared_buffer_add) {
   popped_shared_msg = intra_process_buffer.consume_shared();
   popped_message_pointer = reinterpret_cast<std::uintptr_t>(popped_shared_msg.get());
 
-  EXPECT_EQ(1, popped_shared_msg.use_count());
+  EXPECT_EQ(1L, popped_shared_msg.use_count());
   EXPECT_EQ(original_value, *popped_shared_msg);
   EXPECT_EQ(original_message_pointer, popped_message_pointer);
 }
@@ -168,7 +168,7 @@ TEST(TestIntraProcessBuffer, shared_buffer_consume) {
 
   intra_process_buffer.add_shared(original_shared_msg);
 
-  EXPECT_EQ(2, original_shared_msg.use_count());
+  EXPECT_EQ(2L, original_shared_msg.use_count());
 
   SharedMessageT popped_shared_msg;
   popped_shared_msg = intra_process_buffer.consume_shared();
@@ -187,7 +187,7 @@ TEST(TestIntraProcessBuffer, shared_buffer_consume) {
   popped_unique_msg = intra_process_buffer.consume_unique();
   popped_message_pointer = reinterpret_cast<std::uintptr_t>(popped_unique_msg.get());
 
-  EXPECT_EQ(1, original_shared_msg.use_count());
+  EXPECT_EQ(1L, original_shared_msg.use_count());
   EXPECT_EQ(*original_shared_msg, *popped_unique_msg);
   EXPECT_NE(original_message_pointer, popped_message_pointer);
 }

--- a/rclcpp/test/test_intra_process_buffer.cpp
+++ b/rclcpp/test/test_intra_process_buffer.cpp
@@ -121,7 +121,7 @@ TEST(TestIntraProcessBuffer, unique_buffer_add) {
 
   intra_process_buffer.add_shared(original_shared_msg);
 
-  EXPECT_EQ(1, original_shared_msg.use_count());
+  EXPECT_EQ(1L, original_shared_msg.use_count());
 
   UniqueMessageT popped_unique_msg;
   popped_unique_msg = intra_process_buffer.consume_unique();

--- a/rclcpp/test/test_intra_process_buffer.cpp
+++ b/rclcpp/test/test_intra_process_buffer.cpp
@@ -73,7 +73,7 @@ TEST(TestIntraProcessBuffer, shared_buffer_add) {
 
   intra_process_buffer.add_shared(original_shared_msg);
 
-  EXPECT_EQ(2u, original_shared_msg.use_count());
+  EXPECT_EQ(2, original_shared_msg.use_count());
 
   SharedMessageT popped_shared_msg;
   popped_shared_msg = intra_process_buffer.consume_shared();
@@ -92,7 +92,7 @@ TEST(TestIntraProcessBuffer, shared_buffer_add) {
   popped_shared_msg = intra_process_buffer.consume_shared();
   popped_message_pointer = reinterpret_cast<std::uintptr_t>(popped_shared_msg.get());
 
-  EXPECT_EQ(1u, popped_shared_msg.use_count());
+  EXPECT_EQ(1, popped_shared_msg.use_count());
   EXPECT_EQ(original_value, *popped_shared_msg);
   EXPECT_EQ(original_message_pointer, popped_message_pointer);
 }
@@ -121,7 +121,7 @@ TEST(TestIntraProcessBuffer, unique_buffer_add) {
 
   intra_process_buffer.add_shared(original_shared_msg);
 
-  EXPECT_EQ(1u, original_shared_msg.use_count());
+  EXPECT_EQ(1, original_shared_msg.use_count());
 
   UniqueMessageT popped_unique_msg;
   popped_unique_msg = intra_process_buffer.consume_unique();
@@ -168,7 +168,7 @@ TEST(TestIntraProcessBuffer, shared_buffer_consume) {
 
   intra_process_buffer.add_shared(original_shared_msg);
 
-  EXPECT_EQ(2u, original_shared_msg.use_count());
+  EXPECT_EQ(2, original_shared_msg.use_count());
 
   SharedMessageT popped_shared_msg;
   popped_shared_msg = intra_process_buffer.consume_shared();
@@ -187,7 +187,7 @@ TEST(TestIntraProcessBuffer, shared_buffer_consume) {
   popped_unique_msg = intra_process_buffer.consume_unique();
   popped_message_pointer = reinterpret_cast<std::uintptr_t>(popped_unique_msg.get());
 
-  EXPECT_EQ(1u, original_shared_msg.use_count());
+  EXPECT_EQ(1, original_shared_msg.use_count());
   EXPECT_EQ(*original_shared_msg, *popped_unique_msg);
   EXPECT_NE(original_message_pointer, popped_message_pointer);
 }


### PR DESCRIPTION
[ARMHF build is triggering a warning](https://ci.ros2.org/view/nightly/job/nightly_linux-armhf_debug/302/consoleFull) "comparison between signed and unsigned integer expressions"


```
00:38:40.142 In file included from /home/jenkins-agent/workspace/nightly_linux-armhf_debug/ws/src/ros2/rclcpp/rclcpp/test/test_intra_process_buffer.cpp:19:0:
00:38:40.142 /home/jenkins-agent/workspace/nightly_linux-armhf_debug/ws/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperEQ(const char*, const char*, const T1&, const T2&) [with T1 = unsigned int; T2 = long int]’:
00:38:40.142 /home/jenkins-agent/workspace/nightly_linux-armhf_debug/ws/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:1495:23:   required from ‘static testing::AssertionResult testing::internal::EqHelper<lhs_is_null_literal>::Compare(const char*, const char*, const T1&, const T2&) [with T1 = unsigned int; T2 = long int; bool lhs_is_null_literal = false]’
00:38:40.142 /home/jenkins-agent/workspace/nightly_linux-armhf_debug/ws/src/ros2/rclcpp/rclcpp/test/test_intra_process_buffer.cpp:76:3:   required from here
00:38:40.142 /home/jenkins-agent/workspace/nightly_linux-armhf_debug/ws/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:1467:11: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
00:38:40.142    if (lhs == rhs) {
```

This is possibly caused by [shared_ptr::use_count returning a long](https://en.cppreference.com/w/cpp/memory/shared_ptr/use_count).

### Changes
* asserts in `test_intra_process_buffer.cpp` now compare against signed int literals.

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>