### PR TITLE
Mark get_clock() as override to fix clang warnings.

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/node_clock.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_clock.hpp
@@ -56,9 +56,8 @@ public:
 
   /// Get a clock which will be kept up to date by the node.
   RCLCPP_PUBLIC
-  virtual
   rclcpp::Clock::ConstSharedPtr
-  get_clock() const;
+  get_clock() const override;
 
 private:
   RCLCPP_DISABLE_COPY(NodeClock)


### PR DESCRIPTION
I'll be grateful for review here as I am just doing what messieurs Compiler and Cppcheck tell me to do.

In https://github.com/ros2/rclcpp/pull/897 when removing `virtual` a blank line was left in. I'm not sure if there's a reason for that and if I should follow that convention here or not.