### PR TITLE
Clear sub contexts when starting another init-shutdown cycle

### DIFF
--- a/rclcpp/src/rclcpp/context.cpp
+++ b/rclcpp/src/rclcpp/context.cpp
@@ -288,6 +288,7 @@ Context::clean_up()
 {
   shutdown_reason_ = "";
   rcl_context_.reset();
+  sub_contexts_.clear();
 }
 
 std::vector<Context::SharedPtr>


### PR DESCRIPTION
Fixes ros2/build_cop#254.

See ros2/build_cop#254 (comment).

This PR fixes ros2/build_cop#254 independently of https://github.com/ros2/rclcpp/pull/946, though both aren't exclusive.