### PR TITLE
Remove absolute path from installed CMake code

### DIFF
--- a/rclcpp_components/rclcpp_components-extras.cmake.in
+++ b/rclcpp_components/rclcpp_components-extras.cmake.in
@@ -25,7 +25,8 @@ macro(_rclcpp_components_register_package_hook)
   endif()
 endmacro()
 
-set(@PROJECT_NAME@_NODE_TEMPLATE "@CMAKE_INSTALL_PREFIX@/@node_main_template_install_dir@/node_main.cpp.in")
+get_filename_component(@PROJECT_NAME@_SHARE_DIR "${@PROJECT_NAME@_DIR}" DIRECTORY)
+set(@PROJECT_NAME@_NODE_TEMPLATE "${@PROJECT_NAME@_SHARE_DIR}/node_main.cpp.in")
 
 include("${rclcpp_components_DIR}/rclcpp_components_register_nodes.cmake")
 include("${rclcpp_components_DIR}/rclcpp_components_register_node.cmake")


### PR DESCRIPTION
Otherwise, rclcpp_components_register_node() fails if used from a fat archive.

Related to https://github.com/ros2/ros2/issues/606.

This fix is similar to that done in https://github.com/ros2/test_interface_files/pull/9.