### PR TITLE
Stub functions to get publisher and subcription informations like QoS policies from topic name

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/node_graph.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph.hpp
@@ -86,13 +86,13 @@ public:
   count_subscribers(const std::string & topic_name) const override;
 
   RCLCPP_PUBLIC
-  std::vector<rmw_topic_info_t>
+  std::vector<rmw_topic_endpoint_info_t>
   get_publishers_info_by_topic(
     const std::string & topic_name,
     bool no_demangle = false) const override;
 
   RCLCPP_PUBLIC
-  std::vector<rmw_topic_info_t>
+  std::vector<rmw_topic_endpoint_info_t>
   get_subscriptions_info_by_topic(
     const std::string & topic_name,
     bool no_demangle = false) const override;

--- a/rclcpp/include/rclcpp/node_interfaces/node_graph.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph.hpp
@@ -86,6 +86,18 @@ public:
   count_subscribers(const std::string & topic_name) const override;
 
   RCLCPP_PUBLIC
+  std::vector<rmw_topic_info_t>
+  get_publishers_info_by_topic(
+    const std::string & topic_name,
+    bool no_demangle = false) const override;
+
+  RCLCPP_PUBLIC
+  std::vector<rmw_topic_info_t>
+  get_subscriptions_info_by_topic(
+    const std::string & topic_name,
+    bool no_demangle = false) const override;
+
+  RCLCPP_PUBLIC
 
   const rcl_guard_condition_t *
   get_graph_guard_condition() const override;

--- a/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "rcl/guard_condition.h"
+#include "rmw/topic_info.h"
 
 #include "rclcpp/event.hpp"
 #include "rclcpp/macros.hpp"
@@ -88,6 +89,22 @@ public:
   virtual
   size_t
   count_subscribers(const std::string & topic_name) const = 0;
+
+  /// Return a vector of publisher infos publishing to a given topic.
+  RCLCPP_PUBLIC
+  virtual
+  std::vector<rmw_topic_info_t>
+  get_publishers_info_by_topic(
+    const std::string & topic_name,
+    bool no_demangle = false) const = 0;
+
+  /// Return a vector of subscription infos publishing to a given topic.
+  RCLCPP_PUBLIC
+  virtual
+  std::vector<rmw_topic_info_t>
+  get_subscriptions_info_by_topic(
+    const std::string & topic_name,
+    bool no_demangle = false) const = 0;
 
   /// Return the rcl guard condition which is triggered when the ROS graph changes.
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
@@ -22,7 +22,7 @@
 #include <vector>
 
 #include "rcl/guard_condition.h"
-#include "rmw/topic_info.h"
+#include "rmw/topic_endpoint_info.h"
 
 #include "rclcpp/event.hpp"
 #include "rclcpp/macros.hpp"
@@ -93,7 +93,7 @@ public:
   /// Return a vector of publisher infos publishing to a given topic.
   RCLCPP_PUBLIC
   virtual
-  std::vector<rmw_topic_info_t>
+  std::vector<rmw_topic_endpoint_info_t>
   get_publishers_info_by_topic(
     const std::string & topic_name,
     bool no_demangle = false) const = 0;
@@ -101,7 +101,7 @@ public:
   /// Return a vector of subscription infos publishing to a given topic.
   RCLCPP_PUBLIC
   virtual
-  std::vector<rmw_topic_info_t>
+  std::vector<rmw_topic_endpoint_info_t>
   get_subscriptions_info_by_topic(
     const std::string & topic_name,
     bool no_demangle = false) const = 0;

--- a/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
@@ -266,20 +266,20 @@ NodeGraph::count_subscribers(const std::string & topic_name) const
   return count;
 }
 
-std::vector<rmw_topic_info_t>
+std::vector<rmw_topic_endpoint_info_t>
 NodeGraph::get_publishers_info_by_topic(
   const std::string & /*topic_name*/,
   bool /*no_demangle*/) const
 {
-  return std::vector<rmw_topic_info_t>();
+  return std::vector<rmw_topic_endpoint_info_t>();
 }
 
-std::vector<rmw_topic_info_t>
+std::vector<rmw_topic_endpoint_info_t>
 NodeGraph::get_subscriptions_info_by_topic(
   const std::string & /*topic_name*/,
   bool /*no_demangle*/) const
 {
-  return std::vector<rmw_topic_info_t>();
+  return std::vector<rmw_topic_endpoint_info_t>();
 }
 
 const rcl_guard_condition_t *

--- a/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
@@ -266,6 +266,22 @@ NodeGraph::count_subscribers(const std::string & topic_name) const
   return count;
 }
 
+std::vector<rmw_topic_info_t>
+NodeGraph::get_publishers_info_by_topic(
+  const std::string & /*topic_name*/,
+  bool /*no_demangle*/) const
+{
+  return std::vector<rmw_topic_info_t>();
+}
+
+std::vector<rmw_topic_info_t>
+NodeGraph::get_subscriptions_info_by_topic(
+  const std::string & /*topic_name*/,
+  bool /*no_demangle*/) const
+{
+  return std::vector<rmw_topic_info_t>();
+}
+
 const rcl_guard_condition_t *
 NodeGraph::get_graph_guard_condition() const
 {


### PR DESCRIPTION
For addressing https://github.com/ros2/rclcpp/issues/943#issuecomment-570355568

This is similar to https://github.com/ros2/rclpy/pull/454, but for `rclcpp` and will have no implementation right now.