### PR TITLE
fix unused parameter warning

### DIFF
--- a/rclcpp/src/rclcpp/detail/utilities.cpp
+++ b/rclcpp/src/rclcpp/detail/utilities.cpp
@@ -35,6 +35,7 @@ get_unparsed_ros_arguments(
   rcl_arguments_t * arguments,
   rcl_allocator_t allocator)
 {
+  (void)argc;
   std::vector<std::string> unparsed_ros_arguments;
   int unparsed_ros_args_count = rcl_arguments_get_count_unparsed_ros(arguments);
   if (unparsed_ros_args_count > 0) {


### PR DESCRIPTION
Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>

```
--- stderr: rclcpp
/opt/ros2_ws/src/ros2/rclcpp/rclcpp/src/rclcpp/detail/utilities.cpp: In function ‘std::vector<std::__cxx11::basic_string<char> > rclcpp::detail::get_unparsed_ros_arguments(int, const char* const*, rcl_arguments_t*, rcl_allocator_t)’:
/opt/ros2_ws/src/ros2/rclcpp/rclcpp/src/rclcpp/detail/utilities.cpp:34:7: warning: unused parameter ‘argc’ [-Wunused-parameter]
   int argc, char const * const argv[],
       ^~~~
---

```