### PR TITLE
Assigning make_shared result to variables in test

### DIFF
--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -48,20 +48,23 @@ protected:
  */
 TEST_F(TestNode, construction_and_destruction) {
   {
-    std::make_shared<rclcpp::Node>("my_node", "/ns");
+    auto node = std::make_shared<rclcpp::Node>("my_node", "/ns");
+    (void)node;
   }
 
   {
     ASSERT_THROW(
     {
-      std::make_shared<rclcpp::Node>("invalid_node?", "/ns");
+      auto node = std::make_shared<rclcpp::Node>("invalid_node?", "/ns");
+      (void)node;
     }, rclcpp::exceptions::InvalidNodeNameError);
   }
 
   {
     ASSERT_THROW(
     {
-      std::make_shared<rclcpp::Node>("my_node", "/invalid_ns?");
+      auto node = std::make_shared<rclcpp::Node>("my_node", "/invalid_ns?");
+      (void)node;
     }, rclcpp::exceptions::InvalidNamespaceError);
   }
 }

--- a/rclcpp/test/test_parameter_client.cpp
+++ b/rclcpp/test/test_parameter_client.cpp
@@ -70,7 +70,7 @@ TEST_F(TestParameterClient, async_construction_and_destruction) {
     ASSERT_THROW(
     {
       auto asynchronous_client =
-      std::make_shared<rclcpp::AsyncParametersClient>(node, "invalid_remote_node?");
+        std::make_shared<rclcpp::AsyncParametersClient>(node, "invalid_remote_node?");
       (void)asynchronous_client;
     }, rclcpp::exceptions::InvalidServiceNameError);
   }
@@ -106,7 +106,7 @@ TEST_F(TestParameterClient, sync_construction_and_destruction) {
     ASSERT_THROW(
     {
       auto synchronous_client =
-      std::make_shared<rclcpp::SyncParametersClient>(node, "invalid_remote_node?");
+        std::make_shared<rclcpp::SyncParametersClient>(node, "invalid_remote_node?");
       (void)synchronous_client;
     }, rclcpp::exceptions::InvalidServiceNameError);
   }

--- a/rclcpp/test/test_parameter_client.cpp
+++ b/rclcpp/test/test_parameter_client.cpp
@@ -69,7 +69,9 @@ TEST_F(TestParameterClient, async_construction_and_destruction) {
   {
     ASSERT_THROW(
     {
+      auto asynchronous_client =
       std::make_shared<rclcpp::AsyncParametersClient>(node, "invalid_remote_node?");
+      (void)asynchronous_client;
     }, rclcpp::exceptions::InvalidServiceNameError);
   }
 }
@@ -103,7 +105,9 @@ TEST_F(TestParameterClient, sync_construction_and_destruction) {
   {
     ASSERT_THROW(
     {
+      auto synchronous_client =
       std::make_shared<rclcpp::SyncParametersClient>(node, "invalid_remote_node?");
+      (void)synchronous_client;
     }, rclcpp::exceptions::InvalidServiceNameError);
   }
 }


### PR DESCRIPTION
This PR addresses issue #961, where std::make_shared was marked as `[[nodiscard]]` in the latest MS VC buildtools. This PR only affects test files, which caused the warnings.

Example on most up-to-date buildtools (Windows) without this PR
[![Windows without PR](https://citest.ros2.org/buildStatus/icon?job=ci_windows&build=100)](https://citest.ros2.org/job/ci_windows/100/)
With this PR
[![Build Status](https://citest.ros2.org/buildStatus/icon?job=ci_windows&build=103)](https://citest.ros2.org/job/ci_windows/103/)

Tests on current ci.ros2.org
Mac
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7374)](https://ci.ros2.org/job/ci_osx/7374/)
Linux
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9004)](https://ci.ros2.org/job/ci_linux/9004/)
Windows
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8939)](https://ci.ros2.org/job/ci_windows/8939/)