### PR TITLE
logging.hpp: Added missing include

### DIFF
--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -17,6 +17,7 @@
 #ifndef RCLCPP__LOGGING_HPP_
 #define RCLCPP__LOGGING_HPP_
 
+#include <sstream>
 #include <type_traits>
 
 #include "rclcpp/logger.hpp"


### PR DESCRIPTION
Including just `logging.hpp` and using the new stream macros (#926) is causing the following error:
```
error: aggregate ‘std::stringstream ss’ has incomplete type and cannot be defined
RCLCPP_INFO_STREAM(logger, "Test");
```
I added the required include line to fix this.