### PR TITLE
Deprecated is_initialized()

### DIFF
--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -154,6 +154,7 @@ ok(rclcpp::Context::SharedPtr context = nullptr);
  * \return true if the context is initialized, and false otherwise
  */
 RCLCPP_PUBLIC
+[[deprecated("use the function ok() instead, which has the same usage.")]]
 bool
 is_initialized(rclcpp::Context::SharedPtr context = nullptr);
 

--- a/rclcpp/test/test_init.cpp
+++ b/rclcpp/test/test_init.cpp
@@ -17,6 +17,14 @@
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/utilities.hpp"
 
+#if !defined(_WIN32)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else  // !defined(_WIN32)
+# pragma warning(push)
+# pragma warning(disable: 4996)
+#endif
+
 TEST(TestInit, is_initialized) {
   EXPECT_FALSE(rclcpp::is_initialized());
 
@@ -50,3 +58,9 @@ TEST(TestInit, initialize_with_unknown_ros_args) {
 
   EXPECT_FALSE(rclcpp::is_initialized());
 }
+
+#if !defined(_WIN32)
+# pragma GCC diagnostic pop
+#else  // !defined(_WIN32)
+# pragma warning(pop)
+#endif

--- a/rclcpp/test/test_publisher.cpp
+++ b/rclcpp/test/test_publisher.cpp
@@ -28,7 +28,7 @@ class TestPublisher : public ::testing::Test
 public:
   static void SetUpTestCase()
   {
-    if (!rclcpp::is_initialized()) {
+    if (!rclcpp::ok()) {
       rclcpp::init(0, nullptr);
     }
   }


### PR DESCRIPTION
The function was previously documented as being deprecated, but this change adds compiler warnings if it is used.
Ignore compiler warnings where the function is being tested and change to the preferred usage elsewhere.

It doesn't look like where using `is_initialized()` in any other `ros2` packages, but running a build for all of them just in case: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9099)](https://ci.ros2.org/job/ci_linux/9099/) (edit: rebuild with connected PR)