### PR TITLE
Change order of deprecated and visibility attributes

### DIFF
--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -153,8 +153,8 @@ ok(rclcpp::Context::SharedPtr context = nullptr);
  * \param[in] context Check for initialization of this Context.
  * \return true if the context is initialized, and false otherwise
  */
-RCLCPP_PUBLIC
 [[deprecated("use the function ok() instead, which has the same usage.")]]
+RCLCPP_PUBLIC
 bool
 is_initialized(rclcpp::Context::SharedPtr context = nullptr);
 


### PR DESCRIPTION
~~Clang won't compile if the c++14 deprecated attribute is used next to visibility attributes.~~
Changing the order resolves a compilation issue with Clang.

Addressing https://github.com/ros2/rclcpp/pull/967#issuecomment-577393163