### PR TITLE
Add missing service callback registration tracepoint

### DIFF
--- a/rclcpp/include/rclcpp/any_service_callback.hpp
+++ b/rclcpp/include/rclcpp/any_service_callback.hpp
@@ -24,6 +24,7 @@
 #include "rclcpp/visibility_control.hpp"
 #include "rmw/types.h"
 #include "tracetools/tracetools.h"
+#include "tracetools/utils.hpp"
 
 namespace rclcpp
 {
@@ -97,6 +98,21 @@ public:
       throw std::runtime_error("unexpected request without any callback set");
     }
     TRACEPOINT(callback_end, (const void *)this);
+  }
+
+  void register_callback_for_tracing()
+  {
+    if (shared_ptr_callback_) {
+      TRACEPOINT(
+        rclcpp_callback_register,
+        (const void *)this,
+        get_symbol(shared_ptr_callback_));
+    } else if (shared_ptr_with_request_header_callback_) {
+      TRACEPOINT(
+        rclcpp_callback_register,
+        (const void *)this,
+        get_symbol(shared_ptr_with_request_header_callback_));
+    }
   }
 };
 

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -159,6 +159,7 @@ public:
       rclcpp_service_callback_added,
       (const void *)get_service_handle().get(),
       (const void *)&any_callback_);
+    any_callback_.register_callback_for_tracing();
   }
 
   Service(
@@ -181,6 +182,7 @@ public:
       rclcpp_service_callback_added,
       (const void *)get_service_handle().get(),
       (const void *)&any_callback_);
+    any_callback_.register_callback_for_tracing();
   }
 
   Service(
@@ -205,6 +207,7 @@ public:
       rclcpp_service_callback_added,
       (const void *)get_service_handle().get(),
       (const void *)&any_callback_);
+    any_callback_.register_callback_for_tracing();
   }
 
   Service() = delete;


### PR DESCRIPTION
This was an oversight on my part when writing the instrumentation. See https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis/issues/25#note_284822856.

I've updated the `ros2_tracing` tests to cover this: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing/-/merge_requests/138

I'd like for this to be considered for a backport to eloquent (https://github.com/ros2/ros2/issues/859)!