### PR TITLE
[rclcpp] removed ament_cmake from package.xml and CMakeLists.txt

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -136,7 +136,6 @@ install(
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 
-ament_export_dependencies(ament_cmake)
 ament_export_dependencies(rcl)
 ament_export_dependencies(rcpputils)
 ament_export_dependencies(builtin_interfaces)

--- a/rclcpp/package.xml
+++ b/rclcpp/package.xml
@@ -30,8 +30,6 @@
   <depend>rmw_implementation</depend>
   <depend>tracetools</depend>
 
-  <exec_depend>ament_cmake</exec_depend>
-
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
I have been checking the package.xml and CMakeLists.txt. `ament_cmake` is defined as a `<build_type>`. In this package was defined as a `<exec_depend>` which I think it doesn't make any sense. 

should be defined here as a `<buildtool_depend>` or `<buildtool_export_depend>` ? o including one of this tag is redundant?