### PR TITLE
[rclcpp_action] removed rosidl_generator_c dependency

### DIFF
--- a/rclcpp_action/CMakeLists.txt
+++ b/rclcpp_action/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(action_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcl_action REQUIRED)
+find_package(rosidl_generator_c REQUIRED)
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
@@ -31,6 +32,7 @@ add_library(${PROJECT_NAME}
 ament_target_dependencies(${PROJECT_NAME}
   "action_msgs"
   "rcl_action"
+  "rosidl_generator_c"
   "rclcpp"
 )
 
@@ -58,6 +60,7 @@ ament_export_dependencies(ament_cmake)
 ament_export_dependencies(action_msgs)
 ament_export_dependencies(rclcpp)
 ament_export_dependencies(rcl_action)
+ament_export_dependencies(rosidl_generator_c)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/rclcpp_action/CMakeLists.txt
+++ b/rclcpp_action/CMakeLists.txt
@@ -6,7 +6,6 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(action_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcl_action REQUIRED)
-find_package(rosidl_generator_cpp REQUIRED)
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
@@ -33,8 +32,7 @@ ament_target_dependencies(${PROJECT_NAME}
   "action_msgs"
   "rcl_action"
   "rclcpp"
-  "rosidl_generator_c"
-  "rosidl_generator_cpp")
+)
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -60,8 +58,6 @@ ament_export_dependencies(ament_cmake)
 ament_export_dependencies(action_msgs)
 ament_export_dependencies(rclcpp)
 ament_export_dependencies(rcl_action)
-ament_export_dependencies(rosidl_generator_c)
-ament_export_dependencies(rosidl_generator_cpp)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/rclcpp_action/CMakeLists.txt
+++ b/rclcpp_action/CMakeLists.txt
@@ -32,8 +32,8 @@ add_library(${PROJECT_NAME}
 ament_target_dependencies(${PROJECT_NAME}
   "action_msgs"
   "rcl_action"
-  "rosidl_generator_c"
   "rclcpp"
+  "rosidl_generator_c"
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,

--- a/rclcpp_action/package.xml
+++ b/rclcpp_action/package.xml
@@ -9,6 +9,10 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <build_export_depend>rosidl_generator_c</build_export_depend>
+
+  <build_depend>rosidl_generator_c</build_depend>
+
   <depend>action_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rcl_action</depend>

--- a/rclcpp_action/package.xml
+++ b/rclcpp_action/package.xml
@@ -9,12 +9,6 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-  <build_export_depend>rosidl_generator_cpp</build_export_depend>
-  <build_export_depend>rosidl_generator_c</build_export_depend>
-
-  <build_depend>rosidl_generator_c</build_depend>
-  <build_depend>rosidl_generator_cpp</build_depend>
-
   <depend>action_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rcl_action</depend>


### PR DESCRIPTION
After discussing yesterday with @wjwwood we think that these dependencies are not needed anymore here.

I compiled from sources master and I executed the action examples and it's working

```
ros2 run examples_rclcpp_minimal_action_server action_server_member_functions
ros2 run  examples_rclcpp_minimal_action_client action_client_not_composable
```