### PR TITLE
Ensure logging is initialized just once

### DIFF
--- a/rclcpp/include/rclcpp/context.hpp
+++ b/rclcpp/include/rclcpp/context.hpp
@@ -338,6 +338,9 @@ private:
   rclcpp::InitOptions init_options_;
   std::string shutdown_reason_;
 
+  // Keep shared ownership of global logging configure mutex.
+  std::shared_ptr<std::mutex> logging_configure_mutex_;
+
   std::unordered_map<std::type_index, std::shared_ptr<void>> sub_contexts_;
   // This mutex is recursive so that the constructor of a sub context may
   // attempt to acquire another sub context.

--- a/rclcpp/include/rclcpp/init_options.hpp
+++ b/rclcpp/include/rclcpp/init_options.hpp
@@ -42,7 +42,7 @@ public:
   RCLCPP_PUBLIC
   InitOptions(const InitOptions & other);
 
-  /// Return `true` if logging should be initialized.
+  /// Return `true` if logging should be initialized when `rclcpp::Context::init` is called.
   RCLCPP_PUBLIC
   bool
   auto_initialize_logging() const;
@@ -72,7 +72,7 @@ protected:
 
 private:
   std::unique_ptr<rcl_init_options_t> init_options_;
-  bool initialize_logging_ = true;
+  bool initialize_logging_{true};
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/init_options.hpp
+++ b/rclcpp/include/rclcpp/init_options.hpp
@@ -42,6 +42,16 @@ public:
   RCLCPP_PUBLIC
   InitOptions(const InitOptions & other);
 
+  /// Return `true` if logging should be initialized.
+  RCLCPP_PUBLIC
+  bool
+  initialize_logging() const;
+
+  /// Set flag indicating if logging should be initialized or not.
+  RCLCPP_PUBLIC
+  InitOptions &
+  initialize_logging(bool initialize_logging);
+
   /// Assignment operator.
   RCLCPP_PUBLIC
   InitOptions &
@@ -62,6 +72,7 @@ protected:
 
 private:
   std::unique_ptr<rcl_init_options_t> init_options_;
+  bool initialize_logging_ = true;
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/init_options.hpp
+++ b/rclcpp/include/rclcpp/init_options.hpp
@@ -45,12 +45,12 @@ public:
   /// Return `true` if logging should be initialized.
   RCLCPP_PUBLIC
   bool
-  initialize_logging() const;
+  auto_initialize_logging() const;
 
   /// Set flag indicating if logging should be initialized or not.
   RCLCPP_PUBLIC
   InitOptions &
-  initialize_logging(bool initialize_logging);
+  auto_initialize_logging(bool initialize_logging);
 
   /// Assignment operator.
   RCLCPP_PUBLIC

--- a/rclcpp/src/rclcpp/context.cpp
+++ b/rclcpp/src/rclcpp/context.cpp
@@ -115,7 +115,7 @@ Context::init(
     rclcpp::exceptions::throw_from_rcl_error(ret, "failed to initialize rcl");
   }
 
-  if (init_options.initialize_logging()) {
+  if (init_options.auto_initialize_logging()) {
     logging_configure_mutex_ = get_global_logging_configure_mutex();
     if (!logging_configure_mutex_) {
       throw std::runtime_error("global logging configure mutex is 'nullptr'");

--- a/rclcpp/src/rclcpp/init_options.cpp
+++ b/rclcpp/src/rclcpp/init_options.cpp
@@ -47,13 +47,13 @@ InitOptions::InitOptions(const InitOptions & other)
 }
 
 bool
-InitOptions::initialize_logging() const
+InitOptions::auto_initialize_logging() const
 {
   return initialize_logging_;
 }
 
 InitOptions &
-InitOptions::initialize_logging(bool initialize_logging)
+InitOptions::auto_initialize_logging(bool initialize_logging)
 {
   initialize_logging_ = initialize_logging;
   return *this;

--- a/rclcpp/src/rclcpp/init_options.cpp
+++ b/rclcpp/src/rclcpp/init_options.cpp
@@ -46,6 +46,19 @@ InitOptions::InitOptions(const InitOptions & other)
   shutdown_on_sigint = other.shutdown_on_sigint;
 }
 
+bool
+InitOptions::initialize_logging() const
+{
+  return initialize_logging_;
+}
+
+InitOptions &
+InitOptions::initialize_logging(bool initialize_logging)
+{
+  initialize_logging_ = initialize_logging;
+  return *this;
+}
+
 InitOptions &
 InitOptions::operator=(const InitOptions & other)
 {


### PR DESCRIPTION
Alternative to ros2/rcl#560, based on https://github.com/ros2/rcl/pull/560#discussion_r373282259.

I didn't find a solution that:
- Doesn't break ABI.
- Doesn't have problems if somebody creates a global context in another library (both order of inizialization and order of destruction).

I chose to break ABI, and avoid the second problem (though that unfortunatelly will block this from being backported as-is).
I'm avoiding to finish the logger when all context were shut down, and I'm calling `rcl_logging_fini` when all the contexts were finished (not shutdown).

P.S.: The current `g_contexts_mutex` might cause both initialization/destruction order problems if somebody creates a global context in another library, but that's subject of another PR.

Connects to ros2/rcl#579