### PR TITLE
Fix unknown macro errors reported by cppcheck 1.90

### DIFF
--- a/rclcpp_action/CMakeLists.txt
+++ b/rclcpp_action/CMakeLists.txt
@@ -65,6 +65,8 @@ ament_export_dependencies(rosidl_generator_c)
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
+  # Give cppcheck hints about macro definitions coming from outside this package
+  set(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS ${rclcpp_INCLUDE_DIRS})
   ament_lint_auto_find_test_dependencies()
 
   ament_add_gtest(test_client test/test_client.cpp TIMEOUT 120)

--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -45,6 +45,8 @@ install(TARGETS
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  # Give cppcheck hints about macro definitions coming from outside this package
+  set(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS ${rclcpp_INCLUDE_DIRS})
   ament_lint_auto_find_test_dependencies()
 
   ament_add_gtest(test_lifecycle_node test/test_lifecycle_node.cpp)


### PR DESCRIPTION
It was complaining about an unknown macro RCLCPP_SMART_PTR_DEFINITIONS.
Passing rclcpp include directories to cppcheck resolves the errors
reported in rclcpp_action and rclcpp_lifecycle.