### PR TITLE
Add ifdefs to remove tracing-related calls if tracing is disabled

### DIFF
--- a/rclcpp/include/rclcpp/any_service_callback.hpp
+++ b/rclcpp/include/rclcpp/any_service_callback.hpp
@@ -100,6 +100,7 @@ public:
     TRACEPOINT(callback_end, (const void *)this);
   }
 
+#ifndef TRACETOOLS_DISABLED
   void register_callback_for_tracing()
   {
     if (shared_ptr_callback_) {
@@ -114,6 +115,7 @@ public:
         get_symbol(shared_ptr_with_request_header_callback_));
     }
   }
+#endif  // TRACETOOLS_DISABLED
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/any_service_callback.hpp
+++ b/rclcpp/include/rclcpp/any_service_callback.hpp
@@ -100,9 +100,9 @@ public:
     TRACEPOINT(callback_end, (const void *)this);
   }
 
-#ifndef TRACETOOLS_DISABLED
   void register_callback_for_tracing()
   {
+#ifndef TRACETOOLS_DISABLED
     if (shared_ptr_callback_) {
       TRACEPOINT(
         rclcpp_callback_register,
@@ -114,8 +114,8 @@ public:
         (const void *)this,
         get_symbol(shared_ptr_with_request_header_callback_));
     }
-  }
 #endif  // TRACETOOLS_DISABLED
+  }
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -232,6 +232,7 @@ public:
     return const_shared_ptr_callback_ || const_shared_ptr_with_info_callback_;
   }
 
+#ifndef TRACETOOLS_DISABLED
   void register_callback_for_tracing()
   {
     if (shared_ptr_callback_) {
@@ -256,6 +257,7 @@ public:
         get_symbol(unique_ptr_with_info_callback_));
     }
   }
+#endif  // TRACETOOLS_DISABLED
 
 private:
   std::shared_ptr<MessageAlloc> message_allocator_;

--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -232,9 +232,9 @@ public:
     return const_shared_ptr_callback_ || const_shared_ptr_with_info_callback_;
   }
 
-#ifndef TRACETOOLS_DISABLED
   void register_callback_for_tracing()
   {
+#ifndef TRACETOOLS_DISABLED
     if (shared_ptr_callback_) {
       TRACEPOINT(
         rclcpp_callback_register,
@@ -256,8 +256,8 @@ public:
         (const void *)this,
         get_symbol(unique_ptr_with_info_callback_));
     }
-  }
 #endif  // TRACETOOLS_DISABLED
+  }
 
 private:
   std::shared_ptr<MessageAlloc> message_allocator_;

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
@@ -97,7 +97,9 @@ public:
     // The callback object gets copied, so if registration is done too early/before this point
     // (e.g. in `AnySubscriptionCallback::set()`), its address won't match any address used later
     // in subsequent tracepoints.
+#ifndef TRACETOOLS_DISABLED
     any_callback_.register_callback_for_tracing();
+#endif
   }
 
   bool

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -159,7 +159,9 @@ public:
       rclcpp_service_callback_added,
       (const void *)get_service_handle().get(),
       (const void *)&any_callback_);
+#ifndef TRACETOOLS_DISABLED
     any_callback_.register_callback_for_tracing();
+#endif
   }
 
   Service(
@@ -182,7 +184,9 @@ public:
       rclcpp_service_callback_added,
       (const void *)get_service_handle().get(),
       (const void *)&any_callback_);
+#ifndef TRACETOOLS_DISABLED
     any_callback_.register_callback_for_tracing();
+#endif
   }
 
   Service(
@@ -207,7 +211,9 @@ public:
       rclcpp_service_callback_added,
       (const void *)get_service_handle().get(),
       (const void *)&any_callback_);
+#ifndef TRACETOOLS_DISABLED
     any_callback_.register_callback_for_tracing();
+#endif
   }
 
   Service() = delete;

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -176,7 +176,9 @@ public:
     // The callback object gets copied, so if registration is done too early/before this point
     // (e.g. in `AnySubscriptionCallback::set()`), its address won't match any address used later
     // in subsequent tracepoints.
+#ifndef TRACETOOLS_DISABLED
     any_callback_.register_callback_for_tracing();
+#endif
   }
 
   /// Called after construction to continue setup that requires shared_from_this().


### PR DESCRIPTION
While it's not the default value, `TRACETOOLS_DISABLED` can be defined through `ros2_tracing`/`tracetools` to remove all `TRACEPOINT` calls. However, we never applied this logic to some other tracing-related function calls.

~~Based on #986 because it was just simpler this way.~~ Rebased