### PR TITLE
[timer] Fix malfunction when reset cancelled timer

### DIFF
--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -104,6 +104,7 @@ public:
 protected:
   Clock::SharedPtr clock_;
   std::shared_ptr<rcl_timer_t> timer_handle_;
+  rclcpp::Context::SharedPtr context_;
 };
 
 

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -72,6 +72,7 @@ TimerBase::TimerBase(
       rcl_reset_error();
     }
   }
+  context_ = context;
 }
 
 TimerBase::~TimerBase()
@@ -102,6 +103,7 @@ TimerBase::reset()
   if (rcl_timer_reset(timer_handle_.get()) != RCL_RET_OK) {
     throw std::runtime_error(std::string("Couldn't reset timer: ") + rcl_get_error_string().str);
   }
+  context_->interrupt_all_wait_sets();
 }
 
 bool


### PR DESCRIPTION
Signed-off-by: Donghee Ye <donghee.ye@samsung.com>

Related to https://github.com/ros2/rclcpp/issues/1012

To reset wait_set after reset a cancelled timer, there is needed node handle or context handle. When constructing a timer, there are context handle parameter. To trigger guard condition to reset wait_set, save context handle in constructor and trigger when reset timer.
