### PR TITLE
Fix get_parameter_tyeps of AsyncPrameterClient results are always empty

### DIFF
--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -191,7 +191,7 @@ AsyncParametersClient::get_parameter_types(
       std::vector<rclcpp::ParameterType> types;
       auto & pts = cb_f.get()->types;
       for (auto & pt : pts) {
-        pts.push_back(static_cast<rclcpp::ParameterType>(pt));
+        types.push_back(static_cast<rclcpp::ParameterType>(pt));
       }
       promise_result->set_value(types);
       if (callback != nullptr) {


### PR DESCRIPTION
FIx to push results to wrong variable.

Related issue #1018 