### PR TITLE
expose get_period and set_period from rcl

### DIFF
--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -76,7 +76,7 @@ public:
 
   RCLCPP_PUBLIC
   void
-  set_period(std::chrono::nanoseconds new_period, bool reset=true);
+  set_period(std::chrono::nanoseconds new_period, bool reset = true);
 
   RCLCPP_PUBLIC
   std::chrono::nanoseconds

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -75,6 +75,14 @@ public:
   reset();
 
   RCLCPP_PUBLIC
+  void
+  set_period(std::chrono::nanoseconds new_period, bool reset=true);
+
+  RCLCPP_PUBLIC
+  std::chrono::nanoseconds
+  get_period();
+
+  RCLCPP_PUBLIC
   virtual void
   execute_callback() = 0;
 
@@ -104,6 +112,7 @@ public:
 protected:
   Clock::SharedPtr clock_;
   std::shared_ptr<rcl_timer_t> timer_handle_;
+  int64_t get_period_nanoseconds();
 };
 
 

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -107,11 +107,13 @@ void
 TimerBase::set_period(std::chrono::nanoseconds new_period, bool reset)
 {
   int64_t old_period = get_period_nanoseconds();
-  if (rcl_timer_exchange_period(timer_handle_.get(), new_period.count(), &old_period) != RCL_RET_OK) {
-    throw std::runtime_error(std::string("Couldn't set timer period: ") + rcl_get_error_string().str);
-  }
-  if (reset)
+  if (rcl_timer_exchange_period(timer_handle_.get(), new_period.count(),
+    &old_period) != RCL_RET_OK)
   {
+    throw std::runtime_error(std::string("Couldn't set timer period: ") +
+            rcl_get_error_string().str);
+  }
+  if (reset) {
     this->reset();
   }
 }
@@ -153,7 +155,8 @@ TimerBase::get_period_nanoseconds()
 {
   int64_t period = 0;
   if (rcl_timer_get_period(timer_handle_.get(), &period) != RCL_RET_OK) {
-    throw std::runtime_error(std::string("Couldn't get timer period: ") + rcl_get_error_string().str);
+    throw std::runtime_error(std::string("Couldn't get timer period: ") +
+            rcl_get_error_string().str);
   }
   return period;
 }

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -97,6 +97,25 @@ TimerBase::reset()
   }
 }
 
+std::chrono::nanoseconds
+TimerBase::get_period()
+{
+  return std::chrono::nanoseconds(get_period_nanoseconds());
+}
+
+void
+TimerBase::set_period(std::chrono::nanoseconds new_period, bool reset)
+{
+  int64_t old_period = get_period_nanoseconds();
+  if (rcl_timer_exchange_period(timer_handle_.get(), new_period.count(), &old_period) != RCL_RET_OK) {
+    throw std::runtime_error(std::string("Couldn't set timer period: ") + rcl_get_error_string().str);
+  }
+  if (reset)
+  {
+    this->reset();
+  }
+}
+
 bool
 TimerBase::is_ready()
 {
@@ -127,4 +146,14 @@ std::shared_ptr<const rcl_timer_t>
 TimerBase::get_timer_handle()
 {
   return timer_handle_;
+}
+
+int64_t
+TimerBase::get_period_nanoseconds()
+{
+  int64_t period = 0;
+  if (rcl_timer_get_period(timer_handle_.get(), &period) != RCL_RET_OK) {
+    throw std::runtime_error(std::string("Couldn't get timer period: ") + rcl_get_error_string().str);
+  }
+  return period;
 }

--- a/rclcpp/test/test_timer.cpp
+++ b/rclcpp/test/test_timer.cpp
@@ -160,11 +160,10 @@ TEST_F(TestTimer, test_get_and_set_period)
 
   // Slack is needed to have the tests kind of deterministic since the timer runs
   EXPECT_EQ(timer->get_period(), 100ms);
-  timer->set_period(600s, false); // Set to 10 Minutes --> gives slack for the next check
+  timer->set_period(600s, false);  // Set to 10 Minutes --> gives slack for the next check
   EXPECT_EQ(timer->get_period(), 600s);
   EXPECT_LE(timer->time_until_trigger(), 100ms);
-  timer->set_period(6000s, true); // set to 100 Minutes --> gives slack for next check
+  timer->set_period(6000s, true);  // set to 100 Minutes --> gives slack for next check
   EXPECT_EQ(timer->get_period(), 6000s);
   EXPECT_GT(timer->time_until_trigger(), 5000s);
-
 }

--- a/rclcpp/test/test_timer.cpp
+++ b/rclcpp/test/test_timer.cpp
@@ -151,3 +151,20 @@ TEST_F(TestTimer, test_run_cancel_timer)
   EXPECT_TRUE(has_timer_run.load());
   EXPECT_TRUE(timer->is_canceled());
 }
+
+/// Run and check state, cancel the timer
+TEST_F(TestTimer, test_get_and_set_period)
+{
+  // expect clean state, don't run otherwise
+  test_initial_conditions(timer, has_timer_run);
+
+  // Slack is needed to have the tests kind of deterministic since the timer runs
+  EXPECT_EQ(timer->get_period(), 100ms);
+  timer->set_period(600s, false); // Set to 10 Minutes --> gives slack for the next check
+  EXPECT_EQ(timer->get_period(), 600s);
+  EXPECT_LE(timer->time_until_trigger(), 100ms);
+  timer->set_period(6000s, true); // set to 100 Minutes --> gives slack for next check
+  EXPECT_EQ(timer->get_period(), 6000s);
+  EXPECT_GT(timer->time_until_trigger(), 5000s);
+
+}


### PR DESCRIPTION
Expose the `std::chrono::nanoseconds get_period()` and `set_period(std::chrono::nanoseconds)` functions of the rcl timers to rclcpp.

reset behaves similar to the reset parameter of ros::Timer::setPeriod