### PR TITLE
Fix spin_until_future_complete: check spinning value

### DIFF
--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -342,6 +342,7 @@ protected:
 
   RCLCPP_DISABLE_COPY(Executor)
 
+  RCLCPP_PUBLIC
   void
   spin_once_impl(std::chrono::nanoseconds timeout);
 

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -214,7 +214,7 @@ public:
     std::chrono::nanoseconds timeout_left = timeout_ns;
 
     if (spinning.exchange(true)) {
-      throw std::runtime_error("spin_some() called while already spinning");
+      throw std::runtime_error("spin_until_future_complete() called while already spinning");
     }
     RCLCPP_SCOPE_EXIT(this->spinning.store(false); );
     while (rclcpp::ok(this->context_) && spinning.load()) {

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -219,10 +219,8 @@ public:
     RCLCPP_SCOPE_EXIT(this->spinning.store(false); );
     while (rclcpp::ok(this->context_) && spinning.load()) {
       // Do one item of work.
-      AnyExecutable any_exec;
-      if (get_next_executable(any_exec, timeout_left)) {
-        execute_any_executable(any_exec);
-      }
+      spin_once_impl(timeout_left);
+
       // Check if the future is set, return SUCCESS if it is.
       status = future.wait_for(std::chrono::seconds(0));
       if (status == std::future_status::ready) {
@@ -343,6 +341,9 @@ protected:
   std::shared_ptr<rclcpp::Context> context_;
 
   RCLCPP_DISABLE_COPY(Executor)
+
+  void
+  spin_once_impl(std::chrono::nanoseconds timeout);
 
   std::list<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr> weak_nodes_;
   std::list<const rcl_guard_condition_t *> guard_conditions_;

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -245,16 +245,21 @@ Executor::spin_some(std::chrono::nanoseconds max_duration)
 }
 
 void
+Executor::spin_once_impl(std::chrono::nanoseconds timeout) {
+  AnyExecutable any_exec;
+  if (get_next_executable(any_exec, timeout)) {
+    execute_any_executable(any_exec);
+  }
+}
+
+void
 Executor::spin_once(std::chrono::nanoseconds timeout)
 {
   if (spinning.exchange(true)) {
     throw std::runtime_error("spin_once() called while already spinning");
   }
   RCLCPP_SCOPE_EXIT(this->spinning.store(false); );
-  AnyExecutable any_exec;
-  if (get_next_executable(any_exec, timeout)) {
-    execute_any_executable(any_exec);
-  }
+  spin_once_impl(timeout);
 }
 
 void

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -245,7 +245,8 @@ Executor::spin_some(std::chrono::nanoseconds max_duration)
 }
 
 void
-Executor::spin_once_impl(std::chrono::nanoseconds timeout) {
+Executor::spin_once_impl(std::chrono::nanoseconds timeout)
+{
   AnyExecutable any_exec;
   if (get_next_executable(any_exec, timeout)) {
     execute_any_executable(any_exec);


### PR DESCRIPTION
…h executor is cancaled

Signed-off-by: Donghee Ye <donghee.ye@samsung.com>


rclcpp::executor::spin_until_future_complete is also finished when executor is canceled.

Related to #1022 
