### PR TITLE
Let integer values be assigned to double parameters

### DIFF
--- a/rclcpp/include/rclcpp/parameter_value.hpp
+++ b/rclcpp/include/rclcpp/parameter_value.hpp
@@ -144,7 +144,7 @@ public:
 
   template<ParameterType type>
   constexpr
-  typename std::enable_if<type == ParameterType::PARAMETER_BOOL, const bool &>::type
+  typename std::enable_if<type == ParameterType::PARAMETER_BOOL, bool>::type
   get() const
   {
     if (value_.type != rcl_interfaces::msg::ParameterType::PARAMETER_BOOL) {
@@ -155,7 +155,7 @@ public:
 
   template<ParameterType type>
   constexpr
-  typename std::enable_if<type == ParameterType::PARAMETER_INTEGER, const int64_t &>::type
+  typename std::enable_if<type == ParameterType::PARAMETER_INTEGER, int64_t>::type
   get() const
   {
     if (value_.type != rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER) {
@@ -166,7 +166,7 @@ public:
 
   template<ParameterType type>
   constexpr
-  typename std::enable_if<type == ParameterType::PARAMETER_DOUBLE, const double &>::type
+  typename std::enable_if<type == ParameterType::PARAMETER_DOUBLE, double>::type
   get() const
   {
     if (value_.type != rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE) {
@@ -250,7 +250,7 @@ public:
 
   template<typename type>
   constexpr
-  typename std::enable_if<std::is_same<type, bool>::value, const bool &>::type
+  typename std::enable_if<std::is_same<type, bool>::value, bool>::type
   get() const
   {
     return get<ParameterType::PARAMETER_BOOL>();
@@ -259,7 +259,7 @@ public:
   template<typename type>
   constexpr
   typename std::enable_if<
-    std::is_integral<type>::value && !std::is_same<type, bool>::value, const int64_t &>::type
+    std::is_integral<type>::value && !std::is_same<type, bool>::value, int64_t>::type
   get() const
   {
     return get<ParameterType::PARAMETER_INTEGER>();
@@ -267,7 +267,7 @@ public:
 
   template<typename type>
   constexpr
-  typename std::enable_if<std::is_floating_point<type>::value, const double &>::type
+  typename std::enable_if<std::is_floating_point<type>::value, double>::type
   get() const
   {
     return get<ParameterType::PARAMETER_DOUBLE>();

--- a/rclcpp/include/rclcpp/parameter_value.hpp
+++ b/rclcpp/include/rclcpp/parameter_value.hpp
@@ -169,10 +169,7 @@ public:
   typename std::enable_if<type == ParameterType::PARAMETER_DOUBLE, const double &>::type
   get() const
   {
-    // Allow integers to be cast to doubles
-    if (value_.type != rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE &&
-      value_.type != rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER)
-    {
+    if (value_.type != rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE) {
       throw ParameterTypeException(ParameterType::PARAMETER_DOUBLE, get_type());
     }
     return value_.double_value;
@@ -231,10 +228,7 @@ public:
     type == ParameterType::PARAMETER_DOUBLE_ARRAY, const std::vector<double> &>::type
   get() const
   {
-    // Allow integer arrays to be cast to double arrays
-    if (value_.type != rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE_ARRAY &&
-      value_.type != rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER_ARRAY)
-    {
+    if (value_.type != rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE_ARRAY) {
       throw ParameterTypeException(ParameterType::PARAMETER_DOUBLE_ARRAY, get_type());
     }
     return value_.double_array_value;

--- a/rclcpp/include/rclcpp/parameter_value.hpp
+++ b/rclcpp/include/rclcpp/parameter_value.hpp
@@ -169,10 +169,14 @@ public:
   typename std::enable_if<type == ParameterType::PARAMETER_DOUBLE, double>::type
   get() const
   {
-    if (value_.type != rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE) {
-      throw ParameterTypeException(ParameterType::PARAMETER_DOUBLE, get_type());
+    // Allow integer values to be cast to double
+    if (value_.type == rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER) {
+      return static_cast<double>(value_.integer_value);
     }
-    return value_.double_value;
+    if (value_.type == rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE) {
+      return value_.double_value;
+    }
+    throw ParameterTypeException(ParameterType::PARAMETER_DOUBLE, get_type());
   }
 
   template<ParameterType type>

--- a/rclcpp/include/rclcpp/parameter_value.hpp
+++ b/rclcpp/include/rclcpp/parameter_value.hpp
@@ -169,7 +169,10 @@ public:
   typename std::enable_if<type == ParameterType::PARAMETER_DOUBLE, const double &>::type
   get() const
   {
-    if (value_.type != rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE) {
+    // Allow integers to be cast to doubles
+    if (value_.type != rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE &&
+      value_.type != rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER)
+    {
       throw ParameterTypeException(ParameterType::PARAMETER_DOUBLE, get_type());
     }
     return value_.double_value;
@@ -228,7 +231,10 @@ public:
     type == ParameterType::PARAMETER_DOUBLE_ARRAY, const std::vector<double> &>::type
   get() const
   {
-    if (value_.type != rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE_ARRAY) {
+    // Allow integer arrays to be cast to double arrays
+    if (value_.type != rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE_ARRAY &&
+      value_.type != rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER_ARRAY)
+    {
       throw ParameterTypeException(ParameterType::PARAMETER_DOUBLE_ARRAY, get_type());
     }
     return value_.double_array_value;

--- a/rclcpp/src/rclcpp/parameter_value.cpp
+++ b/rclcpp/src/rclcpp/parameter_value.cpp
@@ -143,12 +143,16 @@ ParameterValue::ParameterValue(const bool bool_value)
 ParameterValue::ParameterValue(const int int_value)
 {
   value_.integer_value = int_value;
+  // Allow integers to be cast to doubles
+  value_.double_value = static_cast<double>(int_value);
   value_.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
 }
 
 ParameterValue::ParameterValue(const int64_t int_value)
 {
   value_.integer_value = int_value;
+  // Allow integers to be cast to doubles
+  value_.double_value = static_cast<double>(int_value);
   value_.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
 }
 
@@ -189,12 +193,16 @@ ParameterValue::ParameterValue(const std::vector<bool> & bool_array_value)
 ParameterValue::ParameterValue(const std::vector<int> & int_array_value)
 {
   value_.integer_array_value.assign(int_array_value.cbegin(), int_array_value.cend());
+  // Allow integer arrays to be cast to double arrays
+  value_.double_array_value.assign(int_array_value.cbegin(), int_array_value.cend());
   value_.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER_ARRAY;
 }
 
 ParameterValue::ParameterValue(const std::vector<int64_t> & int_array_value)
 {
   value_.integer_array_value = int_array_value;
+  // Allow integer arrays to be cast to double arrays
+  value_.double_array_value.assign(int_array_value.cbegin(), int_array_value.cend());
   value_.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER_ARRAY;
 }
 

--- a/rclcpp/src/rclcpp/parameter_value.cpp
+++ b/rclcpp/src/rclcpp/parameter_value.cpp
@@ -143,16 +143,12 @@ ParameterValue::ParameterValue(const bool bool_value)
 ParameterValue::ParameterValue(const int int_value)
 {
   value_.integer_value = int_value;
-  // Allow integers to be cast to doubles
-  value_.double_value = static_cast<double>(int_value);
   value_.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
 }
 
 ParameterValue::ParameterValue(const int64_t int_value)
 {
   value_.integer_value = int_value;
-  // Allow integers to be cast to doubles
-  value_.double_value = static_cast<double>(int_value);
   value_.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
 }
 
@@ -193,16 +189,12 @@ ParameterValue::ParameterValue(const std::vector<bool> & bool_array_value)
 ParameterValue::ParameterValue(const std::vector<int> & int_array_value)
 {
   value_.integer_array_value.assign(int_array_value.cbegin(), int_array_value.cend());
-  // Allow integer arrays to be cast to double arrays
-  value_.double_array_value.assign(int_array_value.cbegin(), int_array_value.cend());
   value_.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER_ARRAY;
 }
 
 ParameterValue::ParameterValue(const std::vector<int64_t> & int_array_value)
 {
   value_.integer_array_value = int_array_value;
-  // Allow integer arrays to be cast to double arrays
-  value_.double_array_value.assign(int_array_value.cbegin(), int_array_value.cend());
   value_.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER_ARRAY;
 }
 

--- a/rclcpp/test/test_parameter.cpp
+++ b/rclcpp/test/test_parameter.cpp
@@ -118,6 +118,7 @@ TEST(TestParameter, bool_variant) {
 
 TEST(TestParameter, integer_variant) {
   const int TEST_VALUE {42};
+  const double TEST_VALUE_DOUBLE {static_cast<double>(TEST_VALUE)};
 
   // Direct instantiation
   rclcpp::Parameter integer_variant("integer_param", TEST_VALUE);
@@ -133,8 +134,10 @@ TEST(TestParameter, integer_variant) {
     integer_variant.get_value_message().type);
   EXPECT_EQ(TEST_VALUE, integer_variant.as_int());
 
+  // Implicit conversion to double
+  EXPECT_EQ(TEST_VALUE_DOUBLE, integer_variant.as_double());
+
   EXPECT_THROW(integer_variant.as_bool(), rclcpp::ParameterTypeException);
-  EXPECT_THROW(integer_variant.as_double(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_variant.as_string(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_variant.as_byte_array(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_variant.as_bool_array(), rclcpp::ParameterTypeException);
@@ -166,6 +169,7 @@ TEST(TestParameter, integer_variant) {
 
 TEST(TestParameter, long_integer_variant) {
   const int64_t TEST_VALUE {std::numeric_limits<int64_t>::max()};
+  const double TEST_VALUE_DOUBLE {static_cast<double>(TEST_VALUE)};
 
   // Direct instantiation
   rclcpp::Parameter long_variant("long_integer_param", TEST_VALUE);
@@ -181,8 +185,10 @@ TEST(TestParameter, long_integer_variant) {
     long_variant.get_value_message().type);
   EXPECT_EQ(TEST_VALUE, long_variant.as_int());
 
+  // Implicit conversion to double
+  EXPECT_EQ(TEST_VALUE_DOUBLE, long_variant.as_double());
+
   EXPECT_THROW(long_variant.as_bool(), rclcpp::ParameterTypeException);
-  EXPECT_THROW(long_variant.as_double(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_variant.as_string(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_variant.as_byte_array(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_variant.as_bool_array(), rclcpp::ParameterTypeException);
@@ -453,6 +459,7 @@ TEST(TestParameter, bool_array_variant) {
 TEST(TestParameter, integer_array_variant) {
   const std::vector<int> TEST_VALUE
   {42, -99, std::numeric_limits<int>::max(), std::numeric_limits<int>::lowest(), 0};
+  const std::vector<double> TEST_VALUE_DOUBLE(TEST_VALUE.cbegin(), TEST_VALUE.cend());
 
   // Direct instantiation
   rclcpp::Parameter integer_array_variant("integer_array_param", TEST_VALUE);
@@ -483,13 +490,15 @@ TEST(TestParameter, integer_array_variant) {
   EXPECT_EQ(TEST_VALUE.end(), mismatches.first);
   EXPECT_EQ(param_value.end(), mismatches.second);
 
+  // Implicit conversion to double array
+  EXPECT_EQ(TEST_VALUE_DOUBLE, integer_array_variant.as_double_array());
+
   EXPECT_THROW(integer_array_variant.as_bool(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_array_variant.as_int(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_array_variant.as_double(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_array_variant.as_string(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_array_variant.as_byte_array(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_array_variant.as_bool_array(), rclcpp::ParameterTypeException);
-  EXPECT_THROW(integer_array_variant.as_double_array(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_array_variant.as_string_array(), rclcpp::ParameterTypeException);
 
   EXPECT_EQ(
@@ -532,6 +541,7 @@ TEST(TestParameter, integer_array_variant) {
 TEST(TestParameter, long_integer_array_variant) {
   const std::vector<int64_t> TEST_VALUE
   {42, -99, std::numeric_limits<int64_t>::max(), std::numeric_limits<int64_t>::lowest(), 0};
+  const std::vector<double> TEST_VALUE_DOUBLE(TEST_VALUE.cbegin(), TEST_VALUE.cend());
 
   rclcpp::Parameter long_array_variant("long_integer_array_param", TEST_VALUE);
   EXPECT_EQ("long_integer_array_param", long_array_variant.get_name());
@@ -548,13 +558,15 @@ TEST(TestParameter, long_integer_array_variant) {
   EXPECT_EQ(TEST_VALUE, long_array_variant.get_value_message().integer_array_value);
   EXPECT_EQ(TEST_VALUE, long_array_variant.as_integer_array());
 
+  // Implicit conversion to double array
+  EXPECT_EQ(TEST_VALUE_DOUBLE, long_array_variant.as_double_array());
+
   EXPECT_THROW(long_array_variant.as_bool(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_array_variant.as_int(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_array_variant.as_double(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_array_variant.as_string(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_array_variant.as_byte_array(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_array_variant.as_bool_array(), rclcpp::ParameterTypeException);
-  EXPECT_THROW(long_array_variant.as_double_array(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_array_variant.as_string_array(), rclcpp::ParameterTypeException);
 
   EXPECT_EQ(

--- a/rclcpp/test/test_parameter.cpp
+++ b/rclcpp/test/test_parameter.cpp
@@ -118,6 +118,7 @@ TEST(TestParameter, bool_variant) {
 
 TEST(TestParameter, integer_variant) {
   const int TEST_VALUE {42};
+  const double TEST_VALUE_DOUBLE {static_cast<double>(TEST_VALUE)};
 
   // Direct instantiation
   rclcpp::Parameter integer_variant("integer_param", TEST_VALUE);
@@ -133,8 +134,10 @@ TEST(TestParameter, integer_variant) {
     integer_variant.get_value_message().type);
   EXPECT_EQ(TEST_VALUE, integer_variant.as_int());
 
+  // Implicit conversion to double
+  EXPECT_EQ(TEST_VALUE_DOUBLE, integer_variant.as_double());
+
   EXPECT_THROW(integer_variant.as_bool(), rclcpp::ParameterTypeException);
-  EXPECT_THROW(integer_variant.as_double(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_variant.as_string(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_variant.as_byte_array(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_variant.as_bool_array(), rclcpp::ParameterTypeException);
@@ -166,6 +169,7 @@ TEST(TestParameter, integer_variant) {
 
 TEST(TestParameter, long_integer_variant) {
   const int64_t TEST_VALUE {std::numeric_limits<int64_t>::max()};
+  const double TEST_VALUE_DOUBLE {static_cast<double>(TEST_VALUE)};
 
   // Direct instantiation
   rclcpp::Parameter long_variant("long_integer_param", TEST_VALUE);
@@ -181,8 +185,10 @@ TEST(TestParameter, long_integer_variant) {
     long_variant.get_value_message().type);
   EXPECT_EQ(TEST_VALUE, long_variant.as_int());
 
+  // Implicit conversion to double
+  EXPECT_EQ(TEST_VALUE_DOUBLE, long_variant.as_double());
+
   EXPECT_THROW(long_variant.as_bool(), rclcpp::ParameterTypeException);
-  EXPECT_THROW(long_variant.as_double(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_variant.as_string(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_variant.as_byte_array(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_variant.as_bool_array(), rclcpp::ParameterTypeException);

--- a/rclcpp/test/test_parameter.cpp
+++ b/rclcpp/test/test_parameter.cpp
@@ -118,7 +118,6 @@ TEST(TestParameter, bool_variant) {
 
 TEST(TestParameter, integer_variant) {
   const int TEST_VALUE {42};
-  const double TEST_VALUE_DOUBLE {static_cast<double>(TEST_VALUE)};
 
   // Direct instantiation
   rclcpp::Parameter integer_variant("integer_param", TEST_VALUE);
@@ -134,10 +133,8 @@ TEST(TestParameter, integer_variant) {
     integer_variant.get_value_message().type);
   EXPECT_EQ(TEST_VALUE, integer_variant.as_int());
 
-  // Implicit conversion to double
-  EXPECT_EQ(TEST_VALUE_DOUBLE, integer_variant.as_double());
-
   EXPECT_THROW(integer_variant.as_bool(), rclcpp::ParameterTypeException);
+  EXPECT_THROW(integer_variant.as_double(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_variant.as_string(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_variant.as_byte_array(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_variant.as_bool_array(), rclcpp::ParameterTypeException);
@@ -169,7 +166,6 @@ TEST(TestParameter, integer_variant) {
 
 TEST(TestParameter, long_integer_variant) {
   const int64_t TEST_VALUE {std::numeric_limits<int64_t>::max()};
-  const double TEST_VALUE_DOUBLE {static_cast<double>(TEST_VALUE)};
 
   // Direct instantiation
   rclcpp::Parameter long_variant("long_integer_param", TEST_VALUE);
@@ -185,10 +181,8 @@ TEST(TestParameter, long_integer_variant) {
     long_variant.get_value_message().type);
   EXPECT_EQ(TEST_VALUE, long_variant.as_int());
 
-  // Implicit conversion to double
-  EXPECT_EQ(TEST_VALUE_DOUBLE, long_variant.as_double());
-
   EXPECT_THROW(long_variant.as_bool(), rclcpp::ParameterTypeException);
+  EXPECT_THROW(long_variant.as_double(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_variant.as_string(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_variant.as_byte_array(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_variant.as_bool_array(), rclcpp::ParameterTypeException);
@@ -459,7 +453,6 @@ TEST(TestParameter, bool_array_variant) {
 TEST(TestParameter, integer_array_variant) {
   const std::vector<int> TEST_VALUE
   {42, -99, std::numeric_limits<int>::max(), std::numeric_limits<int>::lowest(), 0};
-  const std::vector<double> TEST_VALUE_DOUBLE(TEST_VALUE.cbegin(), TEST_VALUE.cend());
 
   // Direct instantiation
   rclcpp::Parameter integer_array_variant("integer_array_param", TEST_VALUE);
@@ -490,15 +483,13 @@ TEST(TestParameter, integer_array_variant) {
   EXPECT_EQ(TEST_VALUE.end(), mismatches.first);
   EXPECT_EQ(param_value.end(), mismatches.second);
 
-  // Implicit conversion to double array
-  EXPECT_EQ(TEST_VALUE_DOUBLE, integer_array_variant.as_double_array());
-
   EXPECT_THROW(integer_array_variant.as_bool(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_array_variant.as_int(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_array_variant.as_double(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_array_variant.as_string(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_array_variant.as_byte_array(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_array_variant.as_bool_array(), rclcpp::ParameterTypeException);
+  EXPECT_THROW(integer_array_variant.as_double_array(), rclcpp::ParameterTypeException);
   EXPECT_THROW(integer_array_variant.as_string_array(), rclcpp::ParameterTypeException);
 
   EXPECT_EQ(
@@ -541,7 +532,6 @@ TEST(TestParameter, integer_array_variant) {
 TEST(TestParameter, long_integer_array_variant) {
   const std::vector<int64_t> TEST_VALUE
   {42, -99, std::numeric_limits<int64_t>::max(), std::numeric_limits<int64_t>::lowest(), 0};
-  const std::vector<double> TEST_VALUE_DOUBLE(TEST_VALUE.cbegin(), TEST_VALUE.cend());
 
   rclcpp::Parameter long_array_variant("long_integer_array_param", TEST_VALUE);
   EXPECT_EQ("long_integer_array_param", long_array_variant.get_name());
@@ -558,15 +548,13 @@ TEST(TestParameter, long_integer_array_variant) {
   EXPECT_EQ(TEST_VALUE, long_array_variant.get_value_message().integer_array_value);
   EXPECT_EQ(TEST_VALUE, long_array_variant.as_integer_array());
 
-  // Implicit conversion to double array
-  EXPECT_EQ(TEST_VALUE_DOUBLE, long_array_variant.as_double_array());
-
   EXPECT_THROW(long_array_variant.as_bool(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_array_variant.as_int(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_array_variant.as_double(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_array_variant.as_string(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_array_variant.as_byte_array(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_array_variant.as_bool_array(), rclcpp::ParameterTypeException);
+  EXPECT_THROW(long_array_variant.as_double_array(), rclcpp::ParameterTypeException);
   EXPECT_THROW(long_array_variant.as_string_array(), rclcpp::ParameterTypeException);
 
   EXPECT_EQ(


### PR DESCRIPTION
Fixes #979.

When constructing integer ParameterValue objects, also set the double member.
When requesting a double value for ParameterValue objects of type integer, do not throw an exception.