### PR TITLE
Add new type of exception to create_publisher/subscription()

### DIFF
--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -93,7 +93,11 @@ public:
     event_handle_ = rcl_get_zero_initialized_event();
     rcl_ret_t ret = init_func(&event_handle_, parent_handle, event_type);
     if (ret != RCL_RET_OK) {
-      rclcpp::exceptions::throw_from_rcl_error(ret, "could not create event");
+      if (ret == RCL_RET_UNSUPPORTED) {
+        rclcpp::exceptions::throw_from_rcl_error(ret, "event type is not supported");
+      } else {
+        rclcpp::exceptions::throw_from_rcl_error(ret, "could not create event");
+      }
     }
   }
 


### PR DESCRIPTION
Related to https://github.com/ros2/ros2/issues/822

The underlying `rcl_publisher_event_init()` and `rcl_subscription_event_init()` functions can now return the `RCL_RET_UNSUPPORTED` error code to indicate that the `event_type` that was passed in is unsupported by the underlying middleware. `rclcpp`'s `create_publisher()` and `create_subscription()` should notify the user of the error more precisely in this case.