### PR TITLE
Add start-parameter-event-subcriber option

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/node_time_source.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_time_source.hpp
@@ -46,7 +46,8 @@ public:
     rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services,
     rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
     rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock,
-    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
+    bool start_parameter_event_subscriber
   );
 
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/node_options.hpp
+++ b/rclcpp/include/rclcpp/node_options.hpp
@@ -45,6 +45,7 @@ public:
    *   - use_intra_process_comms = false
    *   - start_parameter_services = true
    *   - start_parameter_event_publisher = true
+   *   - start_parameter_event_subscriber = true
    *   - parameter_event_qos = rclcpp::ParameterEventQoS
    *     - with history setting and depth from rmw_qos_profile_parameter_events
    *   - parameter_event_publisher_options = rclcpp::PublisherOptionsBase
@@ -222,6 +223,19 @@ public:
   NodeOptions &
   start_parameter_event_publisher(bool start_parameter_event_publisher);
 
+  /// Return the start_parameter_event_subscriber flag.
+  RCLCPP_PUBLIC
+  bool
+  start_parameter_event_subscriber() const;
+
+  /// Set the start_parameter_event_subscriber flag, return this for parameter idiom.
+  /**
+   * If true, a subscriber to parameter events is created
+   */
+  RCLCPP_PUBLIC
+  NodeOptions &
+  start_parameter_event_subscriber(bool start_parameter_event_subscriber);
+
   /// Return a reference to the parameter_event_qos QoS.
   RCLCPP_PUBLIC
   const rclcpp::QoS &
@@ -335,6 +349,8 @@ private:
   bool start_parameter_services_ {true};
 
   bool start_parameter_event_publisher_ {true};
+
+  bool start_parameter_event_subscriber_ {true};
 
   rclcpp::QoS parameter_event_qos_ = rclcpp::ParameterEventsQoS(
     rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_parameter_events)

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -52,7 +52,8 @@ public:
     rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_interface,
     rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface,
     rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_interface,
-    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_interface);
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_interface,
+    bool start_parameter_event_subscriber);
 
   RCLCPP_PUBLIC
   void detachNode();

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -137,7 +137,8 @@ Node::Node(
       node_services_,
       node_logging_,
       node_clock_,
-      node_parameters_
+      node_parameters_,
+      options.start_parameter_event_subscriber()
     )),
   node_waitables_(new rclcpp::node_interfaces::NodeWaitables(node_base_.get())),
   node_options_(options),

--- a/rclcpp/src/rclcpp/node_interfaces/node_time_source.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_time_source.cpp
@@ -26,7 +26,8 @@ NodeTimeSource::NodeTimeSource(
   rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services,
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
   rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock,
-  rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters)
+  rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
+  bool start_parameter_event_subscriber)
 : node_base_(node_base),
   node_topics_(node_topics),
   node_graph_(node_graph),
@@ -42,7 +43,8 @@ NodeTimeSource::NodeTimeSource(
     node_services_,
     node_logging_,
     node_clock_,
-    node_parameters_);
+    node_parameters_,
+    start_parameter_event_subscriber);
   time_source_.attachClock(node_clock_->get_clock());
 }
 

--- a/rclcpp/src/rclcpp/node_options.cpp
+++ b/rclcpp/src/rclcpp/node_options.cpp
@@ -239,6 +239,19 @@ NodeOptions::start_parameter_event_publisher(bool start_parameter_event_publishe
   return *this;
 }
 
+bool
+NodeOptions::start_parameter_event_subscriber() const
+{
+  return this->start_parameter_event_subscriber_;
+}
+
+NodeOptions &
+NodeOptions::start_parameter_event_subscriber(bool start_parameter_event_subscriber)
+{
+  this->start_parameter_event_subscriber_ = start_parameter_event_subscriber;
+  return *this;
+}
+
 const rclcpp::QoS &
 NodeOptions::parameter_event_qos() const
 {

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -56,7 +56,8 @@ void TimeSource::attachNode(rclcpp::Node::SharedPtr node)
     node->get_node_services_interface(),
     node->get_node_logging_interface(),
     node->get_node_clock_interface(),
-    node->get_node_parameters_interface());
+    node->get_node_parameters_interface(),
+    node->get_node_options().start_parameter_event_subscriber());
 }
 
 void TimeSource::attachNode(
@@ -66,7 +67,8 @@ void TimeSource::attachNode(
   rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_interface,
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface,
   rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_interface,
-  rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_interface)
+  rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_interface,
+  bool start_parameter_event_subscriber)
 {
   node_base_ = node_base_interface;
   node_topics_ = node_topics_interface;
@@ -120,9 +122,11 @@ void TimeSource::attachNode(
     });
 
   // TODO(tfoote) use parameters interface not subscribe to events via topic ticketed #609
-  parameter_subscription_ = rclcpp::AsyncParametersClient::on_parameter_event(
-    node_topics_,
-    std::bind(&TimeSource::on_parameter_event, this, std::placeholders::_1));
+  if (start_parameter_event_subscriber) {
+    parameter_subscription_ = rclcpp::AsyncParametersClient::on_parameter_event(
+      node_topics_,
+      std::bind(&TimeSource::on_parameter_event, this, std::placeholders::_1));
+  }
 }
 
 void TimeSource::detachNode()


### PR DESCRIPTION
In the efforts of reducing CPU usage for embedded platforms, this PR is created to give the option to start or not the parameter event subscriber.

Benchmarks on RPi1 (single core running at 700Mhz) shows that CPU is reduced about 2% when this parameter event subscriber is not created.

Given that currently we have the option to NOT start the parameter event publisher, makes sense to have also the option to not start the parameter event subscriber.

@alsora @dgoel
