### PR TITLE
More and safer node interfaces' getters

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/get_node_base_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/get_node_base_interface.hpp
@@ -84,6 +84,9 @@ template<
 rclcpp::node_interfaces::NodeBaseInterface *
 get_node_base_interface_from_pointer(NodeType node_pointer)
 {
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
   return node_pointer->get_node_base_interface().get();
 }
 
@@ -98,6 +101,9 @@ template<
 rclcpp::node_interfaces::NodeBaseInterface *
 get_node_base_interface_from_pointer(NodeType node_pointer)
 {
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
   return node_pointer->get_node_base_interface();
 }
 

--- a/rclcpp/include/rclcpp/node_interfaces/get_node_base_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/get_node_base_interface.hpp
@@ -121,6 +121,37 @@ get_node_base_interface_from_pointer(NodeType node_shared_pointer)
   return get_node_base_interface_from_pointer(node_shared_pointer->get());
 }
 
+// If NodeType has a method called get_node_base_interface() which returns a shared pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_base_interface<
+    typename std::remove_pointer<NodeType>::type,
+    std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>
+  >::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>
+get_shared_node_base_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_base_interface();
+}
+
+// Forward shared_ptr's to const node pointer signatures.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_same<
+    NodeType,
+    typename std::shared_ptr<typename std::remove_pointer<NodeType>::type::element_type> *
+  >::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>
+get_shared_node_base_interface_from_pointer(NodeType node_shared_pointer)
+{
+  return get_shared_node_base_interface_from_pointer(node_shared_pointer->get());
+}
+
 }  // namespace detail
 
 /// Get the NodeBaseInterface as a pointer from a pointer to a "Node like" object.
@@ -131,7 +162,7 @@ template<
 rclcpp::node_interfaces::NodeBaseInterface *
 get_node_base_interface(NodeType node_pointer)
 {
-  // Forward pointers to detail implmentation directly.
+  // Forward pointers to detail implementation directly.
   return detail::get_node_base_interface_from_pointer(node_pointer);
 }
 
@@ -145,8 +176,34 @@ template<
 rclcpp::node_interfaces::NodeBaseInterface *
 get_node_base_interface(NodeType && node_reference)
 {
-  // Forward references to detail implmentation as a pointer.
+  // Forward references to detail implementation as a pointer.
   return detail::get_node_base_interface_from_pointer(&node_reference);
+}
+
+/// Get the NodeBaseInterface as an std::shared_ptr from a pointer to a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>
+get_shared_node_base_interface(NodeType node_pointer)
+{
+  // Forward pointers to detail implementation directly.
+  return detail::get_shared_node_base_interface_from_pointer(node_pointer);
+}
+
+/// Get the NodeBaseInterface as an std::shared_ptr from a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<
+    !std::is_pointer<typename std::remove_reference<NodeType>::type>::value, int
+  >::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>
+get_shared_node_base_interface(NodeType && node_reference)
+{
+  // Forward references to detail implementation as a pointer.
+  return detail::get_shared_node_base_interface_from_pointer(&node_reference);
 }
 
 }  // namespace node_interfaces

--- a/rclcpp/include/rclcpp/node_interfaces/get_node_clock_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/get_node_clock_interface.hpp
@@ -1,0 +1,212 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__NODE_INTERFACES__GET_NODE_CLOCK_INTERFACE_HPP_
+#define RCLCPP__NODE_INTERFACES__GET_NODE_CLOCK_INTERFACE_HPP_
+
+#include <memory>
+#include <utility>
+#include <type_traits>
+
+#include "rclcpp/node_interfaces/node_clock_interface.hpp"
+
+/// This header provides the get_node_clock_interface() template function.
+/**
+ * This function is useful for getting the NodeClockInterface pointer from
+ * various kinds of Node-like classes.
+ *
+ * It's able to get the NodeClockInterface pointer so long as the class
+ * has a method called ``get_node_clock_interface()`` which returns
+ * either a pointer (const or not) to a NodeClockInterface or a
+ * std::shared_ptr to a NodeClockInterface.
+ */
+
+namespace rclcpp
+{
+namespace node_interfaces
+{
+
+namespace detail
+{
+
+// This is a meta-programming checker for if a given Node-like object has a
+// getter called get_node_clock_interface() which returns various types,
+// e.g. const pointer or a shared pointer.
+template<typename NodeType, typename ReturnType>
+struct has_get_node_clock_interface
+{
+private:
+  template<typename T>
+  static constexpr
+  auto
+  check(T *)->typename std::is_same<
+    decltype(std::declval<T>().get_node_clock_interface()),
+    ReturnType
+  >::type;
+
+  template<typename>
+  static constexpr
+  std::false_type
+  check(...);
+
+public:
+  using type = decltype(check<NodeType>(nullptr));
+  static constexpr bool value = type::value;
+};
+
+// If NodeType is a pointer to NodeClockInterface already (just normal function overload).
+inline
+rclcpp::node_interfaces::NodeClockInterface *
+get_node_clock_interface_from_pointer(rclcpp::node_interfaces::NodeClockInterface * pointer)
+{
+  return pointer;
+}
+
+// If NodeType has a method called get_node_clock_interface() which returns a shared pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_clock_interface<
+    typename std::remove_pointer<NodeType>::type,
+    std::shared_ptr<rclcpp::node_interfaces::NodeClockInterface>
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeClockInterface *
+get_node_clock_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_clock_interface().get();
+}
+
+// If NodeType has a method called get_node_clock_interface() which returns a pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_clock_interface<
+    typename std::remove_pointer<NodeType>::type,
+    rclcpp::node_interfaces::NodeClockInterface *
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeClockInterface *
+get_node_clock_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_clock_interface();
+}
+
+// Forward shared_ptr's to const node pointer signatures.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_same<
+    NodeType,
+    typename std::shared_ptr<typename std::remove_pointer<NodeType>::type::element_type> *
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeClockInterface *
+get_node_clock_interface_from_pointer(NodeType node_shared_pointer)
+{
+  return get_node_clock_interface_from_pointer(node_shared_pointer->get());
+}
+
+// If NodeType has a method called get_node_clock_interface() which returns a shared pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_clock_interface<
+    typename std::remove_pointer<NodeType>::type,
+    std::shared_ptr<rclcpp::node_interfaces::NodeClockInterface>
+  >::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeClockInterface>
+get_shared_node_clock_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_clock_interface();
+}
+
+// Forward shared_ptr's to const node pointer signatures.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_same<
+    NodeType,
+    typename std::shared_ptr<typename std::remove_pointer<NodeType>::type::element_type> *
+  >::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeClockInterface>
+get_shared_node_clock_interface_from_pointer(NodeType node_shared_pointer)
+{
+  return get_shared_node_clock_interface_from_pointer(node_shared_pointer->get());
+}
+
+}  // namespace detail
+
+/// Get the NodeClockInterface as a pointer from a pointer to a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeClockInterface *
+get_node_clock_interface(NodeType node_pointer)
+{
+  // Forward pointers to detail implementation directly.
+  return detail::get_node_clock_interface_from_pointer(node_pointer);
+}
+
+/// Get the NodeClockInterface as a pointer from a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<
+    !std::is_pointer<typename std::remove_reference<NodeType>::type>::value, int
+  >::type = 0
+>
+rclcpp::node_interfaces::NodeClockInterface *
+get_node_clock_interface(NodeType && node_reference)
+{
+  // Forward references to detail implementation as a pointer.
+  return detail::get_node_clock_interface_from_pointer(&node_reference);
+}
+
+/// Get the NodeClockInterface as an std::shared_ptr from a pointer to a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeClockInterface>
+get_shared_node_clock_interface(NodeType node_pointer)
+{
+  // Forward pointers to detail implementation directly.
+  return detail::get_shared_node_clock_interface_from_pointer(node_pointer);
+}
+
+/// Get the NodeClockInterface as an std::shared_ptr from a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<
+    !std::is_pointer<typename std::remove_reference<NodeType>::type>::value, int
+  >::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeClockInterface>
+get_shared_node_clock_interface(NodeType && node_reference)
+{
+  // Forward references to detail implementation as a pointer.
+  return detail::get_shared_node_clock_interface_from_pointer(&node_reference);
+}
+
+}  // namespace node_interfaces
+}  // namespace rclcpp
+
+#endif  // RCLCPP__NODE_INTERFACES__GET_NODE_CLOCK_INTERFACE_HPP_

--- a/rclcpp/include/rclcpp/node_interfaces/get_node_graph_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/get_node_graph_interface.hpp
@@ -1,0 +1,212 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__NODE_INTERFACES__GET_NODE_GRAPH_INTERFACE_HPP_
+#define RCLCPP__NODE_INTERFACES__GET_NODE_GRAPH_INTERFACE_HPP_
+
+#include <memory>
+#include <utility>
+#include <type_traits>
+
+#include "rclcpp/node_interfaces/node_graph_interface.hpp"
+
+/// This header provides the get_node_graph_interface() template function.
+/**
+ * This function is useful for getting the NodeGraphInterface pointer from
+ * various kinds of Node-like classes.
+ *
+ * It's able to get the NodeGraphInterface pointer so long as the class
+ * has a method called ``get_node_graph_interface()`` which returns
+ * either a pointer (const or not) to a NodeGraphInterface or a
+ * std::shared_ptr to a NodeGraphInterface.
+ */
+
+namespace rclcpp
+{
+namespace node_interfaces
+{
+
+namespace detail
+{
+
+// This is a meta-programming checker for if a given Node-like object has a
+// getter called get_node_graph_interface() which returns various types,
+// e.g. const pointer or a shared pointer.
+template<typename NodeType, typename ReturnType>
+struct has_get_node_graph_interface
+{
+private:
+  template<typename T>
+  static constexpr
+  auto
+  check(T *)->typename std::is_same<
+    decltype(std::declval<T>().get_node_graph_interface()),
+    ReturnType
+  >::type;
+
+  template<typename>
+  static constexpr
+  std::false_type
+  check(...);
+
+public:
+  using type = decltype(check<NodeType>(nullptr));
+  static constexpr bool value = type::value;
+};
+
+// If NodeType is a pointer to NodeGraphInterface already (just normal function overload).
+inline
+rclcpp::node_interfaces::NodeGraphInterface *
+get_node_graph_interface_from_pointer(rclcpp::node_interfaces::NodeGraphInterface * pointer)
+{
+  return pointer;
+}
+
+// If NodeType has a method called get_node_graph_interface() which returns a shared pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_graph_interface<
+    typename std::remove_pointer<NodeType>::type,
+    std::shared_ptr<rclcpp::node_interfaces::NodeGraphInterface>
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeGraphInterface *
+get_node_graph_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_graph_interface().get();
+}
+
+// If NodeType has a method called get_node_graph_interface() which returns a pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_graph_interface<
+    typename std::remove_pointer<NodeType>::type,
+    rclcpp::node_interfaces::NodeGraphInterface *
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeGraphInterface *
+get_node_graph_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_graph_interface();
+}
+
+// Forward shared_ptr's to const node pointer signatures.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_same<
+    NodeType,
+    typename std::shared_ptr<typename std::remove_pointer<NodeType>::type::element_type> *
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeGraphInterface *
+get_node_graph_interface_from_pointer(NodeType node_shared_pointer)
+{
+  return get_node_graph_interface_from_pointer(node_shared_pointer->get());
+}
+
+// If NodeType has a method called get_node_graph_interface() which returns a shared pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_graph_interface<
+    typename std::remove_pointer<NodeType>::type,
+    std::shared_ptr<rclcpp::node_interfaces::NodeGraphInterface>
+  >::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeGraphInterface>
+get_shared_node_graph_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_graph_interface();
+}
+
+// Forward shared_ptr's to const node pointer signatures.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_same<
+    NodeType,
+    typename std::shared_ptr<typename std::remove_pointer<NodeType>::type::element_type> *
+  >::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeGraphInterface>
+get_shared_node_graph_interface_from_pointer(NodeType node_shared_pointer)
+{
+  return get_shared_node_graph_interface_from_pointer(node_shared_pointer->get());
+}
+
+}  // namespace detail
+
+/// Get the NodeGraphInterface as a pointer from a pointer to a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeGraphInterface *
+get_node_graph_interface(NodeType node_pointer)
+{
+  // Forward pointers to detail implementation directly.
+  return detail::get_node_graph_interface_from_pointer(node_pointer);
+}
+
+/// Get the NodeGraphInterface as a pointer from a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<
+    !std::is_pointer<typename std::remove_reference<NodeType>::type>::value, int
+  >::type = 0
+>
+rclcpp::node_interfaces::NodeGraphInterface *
+get_node_graph_interface(NodeType && node_reference)
+{
+  // Forward references to detail implementation as a pointer.
+  return detail::get_node_graph_interface_from_pointer(&node_reference);
+}
+
+/// Get the NodeGraphInterface as an std::shared_ptr from a pointer to a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeGraphInterface>
+get_shared_node_graph_interface(NodeType node_pointer)
+{
+  // Forward pointers to detail implementation directly.
+  return detail::get_shared_node_graph_interface_from_pointer(node_pointer);
+}
+
+/// Get the NodeGraphInterface as an std::shared_ptr from a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<
+    !std::is_pointer<typename std::remove_reference<NodeType>::type>::value, int
+  >::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeGraphInterface>
+get_shared_node_graph_interface(NodeType && node_reference)
+{
+  // Forward references to detail implementation as a pointer.
+  return detail::get_shared_node_graph_interface_from_pointer(&node_reference);
+}
+
+}  // namespace node_interfaces
+}  // namespace rclcpp
+
+#endif  // RCLCPP__NODE_INTERFACES__GET_NODE_GRAPH_INTERFACE_HPP_

--- a/rclcpp/include/rclcpp/node_interfaces/get_node_logging_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/get_node_logging_interface.hpp
@@ -1,0 +1,212 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__NODE_INTERFACES__GET_NODE_LOGGING_INTERFACE_HPP_
+#define RCLCPP__NODE_INTERFACES__GET_NODE_LOGGING_INTERFACE_HPP_
+
+#include <memory>
+#include <utility>
+#include <type_traits>
+
+#include "rclcpp/node_interfaces/node_logging_interface.hpp"
+
+/// This header provides the get_node_logging_interface() template function.
+/**
+ * This function is useful for getting the NodeLoggingInterface pointer from
+ * various kinds of Node-like classes.
+ *
+ * It's able to get the NodeLoggingInterface pointer so long as the class
+ * has a method called ``get_node_logging_interface()`` which returns
+ * either a pointer (const or not) to a NodeLoggingInterface or a
+ * std::shared_ptr to a NodeLoggingInterface.
+ */
+
+namespace rclcpp
+{
+namespace node_interfaces
+{
+
+namespace detail
+{
+
+// This is a meta-programming checker for if a given Node-like object has a
+// getter called get_node_logging_interface() which returns various types,
+// e.g. const pointer or a shared pointer.
+template<typename NodeType, typename ReturnType>
+struct has_get_node_logging_interface
+{
+private:
+  template<typename T>
+  static constexpr
+  auto
+  check(T *)->typename std::is_same<
+    decltype(std::declval<T>().get_node_logging_interface()),
+    ReturnType
+  >::type;
+
+  template<typename>
+  static constexpr
+  std::false_type
+  check(...);
+
+public:
+  using type = decltype(check<NodeType>(nullptr));
+  static constexpr bool value = type::value;
+};
+
+// If NodeType is a pointer to NodeLoggingInterface already (just normal function overload).
+inline
+rclcpp::node_interfaces::NodeLoggingInterface *
+get_node_logging_interface_from_pointer(rclcpp::node_interfaces::NodeLoggingInterface * pointer)
+{
+  return pointer;
+}
+
+// If NodeType has a method called get_node_logging_interface() which returns a shared pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_logging_interface<
+    typename std::remove_pointer<NodeType>::type,
+    std::shared_ptr<rclcpp::node_interfaces::NodeLoggingInterface>
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeLoggingInterface *
+get_node_logging_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_logging_interface().get();
+}
+
+// If NodeType has a method called get_node_logging_interface() which returns a pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_logging_interface<
+    typename std::remove_pointer<NodeType>::type,
+    rclcpp::node_interfaces::NodeLoggingInterface *
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeLoggingInterface *
+get_node_logging_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_logging_interface();
+}
+
+// Forward shared_ptr's to const node pointer signatures.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_same<
+    NodeType,
+    typename std::shared_ptr<typename std::remove_pointer<NodeType>::type::element_type> *
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeLoggingInterface *
+get_node_logging_interface_from_pointer(NodeType node_shared_pointer)
+{
+  return get_node_logging_interface_from_pointer(node_shared_pointer->get());
+}
+
+// If NodeType has a method called get_node_logging_interface() which returns a shared pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_logging_interface<
+    typename std::remove_pointer<NodeType>::type,
+    std::shared_ptr<rclcpp::node_interfaces::NodeLoggingInterface>
+  >::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeLoggingInterface>
+get_shared_node_logging_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_logging_interface();
+}
+
+// Forward shared_ptr's to const node pointer signatures.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_same<
+    NodeType,
+    typename std::shared_ptr<typename std::remove_pointer<NodeType>::type::element_type> *
+  >::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeLoggingInterface>
+get_shared_node_logging_interface_from_pointer(NodeType node_shared_pointer)
+{
+  return get_shared_node_logging_interface_from_pointer(node_shared_pointer->get());
+}
+
+}  // namespace detail
+
+/// Get the NodeLoggingInterface as a pointer from a pointer to a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeLoggingInterface *
+get_node_logging_interface(NodeType node_pointer)
+{
+  // Forward pointers to detail implementation directly.
+  return detail::get_node_logging_interface_from_pointer(node_pointer);
+}
+
+/// Get the NodeLoggingInterface as a pointer from a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<
+    !std::is_pointer<typename std::remove_reference<NodeType>::type>::value, int
+  >::type = 0
+>
+rclcpp::node_interfaces::NodeLoggingInterface *
+get_node_logging_interface(NodeType && node_reference)
+{
+  // Forward references to detail implementation as a pointer.
+  return detail::get_node_logging_interface_from_pointer(&node_reference);
+}
+
+/// Get the NodeLoggingInterface as an std::shared_ptr from a pointer to a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeLoggingInterface>
+get_shared_node_logging_interface(NodeType node_pointer)
+{
+  // Forward pointers to detail implementation directly.
+  return detail::get_shared_node_logging_interface_from_pointer(node_pointer);
+}
+
+/// Get the NodeLoggingInterface as an std::shared_ptr from a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<
+    !std::is_pointer<typename std::remove_reference<NodeType>::type>::value, int
+  >::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeLoggingInterface>
+get_shared_node_logging_interface(NodeType && node_reference)
+{
+  // Forward references to detail implementation as a pointer.
+  return detail::get_shared_node_logging_interface_from_pointer(&node_reference);
+}
+
+}  // namespace node_interfaces
+}  // namespace rclcpp
+
+#endif  // RCLCPP__NODE_INTERFACES__GET_NODE_LOGGING_INTERFACE_HPP_

--- a/rclcpp/include/rclcpp/node_interfaces/get_node_parameters_interface.cpp
+++ b/rclcpp/include/rclcpp/node_interfaces/get_node_parameters_interface.cpp
@@ -1,0 +1,213 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__NODE_INTERFACES__GET_NODE_PARAMETERS_INTERFACE_HPP_
+#define RCLCPP__NODE_INTERFACES__GET_NODE_PARAMETERS_INTERFACE_HPP_
+
+#include <memory>
+#include <utility>
+#include <type_traits>
+
+#include "rclcpp/node_interfaces/node_parameters_interface.hpp"
+
+/// This header provides the get_node_parameters_interface() template function.
+/**
+ * This function is useful for getting the NodeParametersInterface pointer from
+ * various kinds of Node-like classes.
+ *
+ * It's able to get the NodeParametersInterface pointer so long as the class
+ * has a method called ``get_node_parameters_interface()`` which returns
+ * either a pointer (const or not) to a NodeParametersInterface or a
+ * std::shared_ptr to a NodeParametersInterface.
+ */
+
+namespace rclcpp
+{
+namespace node_interfaces
+{
+
+namespace detail
+{
+
+// This is a meta-programming checker for if a given Node-like object has a
+// getter called get_node_parameters_interface() which returns various types,
+// e.g. const pointer or a shared pointer.
+template<typename NodeType, typename ReturnType>
+struct has_get_node_parameters_interface
+{
+private:
+  template<typename T>
+  static constexpr
+  auto
+  check(T *)->typename std::is_same<
+    decltype(std::declval<T>().get_node_parameters_interface()),
+    ReturnType
+  >::type;
+
+  template<typename>
+  static constexpr
+  std::false_type
+  check(...);
+
+public:
+  using type = decltype(check<NodeType>(nullptr));
+  static constexpr bool value = type::value;
+};
+
+// If NodeType is a pointer to NodeParametersInterface already (just normal function overload).
+inline
+rclcpp::node_interfaces::NodeParametersInterface *
+get_node_parameters_interface_from_pointer(
+  rclcpp::node_interfaces::NodeParametersInterface * pointer)
+{
+  return pointer;
+}
+
+// If NodeType has a method called get_node_parameters_interface() which returns a shared pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_parameters_interface<
+    typename std::remove_pointer<NodeType>::type,
+    std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface>
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeParametersInterface *
+get_node_parameters_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_parameters_interface().get();
+}
+
+// If NodeType has a method called get_node_parameters_interface() which returns a pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_parameters_interface<
+    typename std::remove_pointer<NodeType>::type,
+    rclcpp::node_interfaces::NodeParametersInterface *
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeParametersInterface *
+get_node_parameters_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_parameters_interface();
+}
+
+// Forward shared_ptr's to const node pointer signatures.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_same<
+    NodeType,
+    typename std::shared_ptr<typename std::remove_pointer<NodeType>::type::element_type> *
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeParametersInterface *
+get_node_parameters_interface_from_pointer(NodeType node_shared_pointer)
+{
+  return get_node_parameters_interface_from_pointer(node_shared_pointer->get());
+}
+
+// If NodeType has a method called get_node_parameters_interface() which returns a shared pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_parameters_interface<
+    typename std::remove_pointer<NodeType>::type,
+    std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface>
+  >::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface>
+get_shared_node_parameters_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_parameters_interface();
+}
+
+// Forward shared_ptr's to const node pointer signatures.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_same<
+    NodeType,
+    typename std::shared_ptr<typename std::remove_pointer<NodeType>::type::element_type> *
+  >::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface>
+get_shared_node_parameters_interface_from_pointer(NodeType node_shared_pointer)
+{
+  return get_shared_node_parameters_interface_from_pointer(node_shared_pointer->get());
+}
+
+}  // namespace detail
+
+/// Get the NodeParametersInterface as a pointer from a pointer to a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeParametersInterface *
+get_node_parameters_interface(NodeType node_pointer)
+{
+  // Forward pointers to detail implementation directly.
+  return detail::get_node_parameters_interface_from_pointer(node_pointer);
+}
+
+/// Get the NodeParametersInterface as a pointer from a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<
+    !std::is_pointer<typename std::remove_reference<NodeType>::type>::value, int
+  >::type = 0
+>
+rclcpp::node_interfaces::NodeParametersInterface *
+get_node_parameters_interface(NodeType && node_reference)
+{
+  // Forward references to detail implementation as a pointer.
+  return detail::get_node_parameters_interface_from_pointer(&node_reference);
+}
+
+/// Get the NodeParametersInterface as an std::shared_ptr from a pointer to a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface>
+get_shared_node_parameters_interface(NodeType node_pointer)
+{
+  // Forward pointers to detail implementation directly.
+  return detail::get_shared_node_parameters_interface_from_pointer(node_pointer);
+}
+
+/// Get the NodeParametersInterface as an std::shared_ptr from a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<
+    !std::is_pointer<typename std::remove_reference<NodeType>::type>::value, int
+  >::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface>
+get_shared_node_parameters_interface(NodeType && node_reference)
+{
+  // Forward references to detail implementation as a pointer.
+  return detail::get_shared_node_parameters_interface_from_pointer(&node_reference);
+}
+
+}  // namespace node_interfaces
+}  // namespace rclcpp
+
+#endif  // RCLCPP__NODE_INTERFACES__GET_NODE_PARAMETERS_INTERFACE_HPP_

--- a/rclcpp/include/rclcpp/node_interfaces/get_node_services_interface.cpp
+++ b/rclcpp/include/rclcpp/node_interfaces/get_node_services_interface.cpp
@@ -1,0 +1,212 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__NODE_INTERFACES__GET_NODE_SERVICES_INTERFACE_HPP_
+#define RCLCPP__NODE_INTERFACES__GET_NODE_SERVICES_INTERFACE_HPP_
+
+#include <memory>
+#include <utility>
+#include <type_traits>
+
+#include "rclcpp/node_interfaces/node_services_interface.hpp"
+
+/// This header provides the get_node_services_interface() template function.
+/**
+ * This function is useful for getting the NodeServicesInterface pointer from
+ * various kinds of Node-like classes.
+ *
+ * It's able to get the NodeServicesInterface pointer so long as the class
+ * has a method called ``get_node_services_interface()`` which returns
+ * either a pointer (const or not) to a NodeServicesInterface or a
+ * std::shared_ptr to a NodeServicesInterface.
+ */
+
+namespace rclcpp
+{
+namespace node_interfaces
+{
+
+namespace detail
+{
+
+// This is a meta-programming checker for if a given Node-like object has a
+// getter called get_node_services_interface() which returns various types,
+// e.g. const pointer or a shared pointer.
+template<typename NodeType, typename ReturnType>
+struct has_get_node_services_interface
+{
+private:
+  template<typename T>
+  static constexpr
+  auto
+  check(T *)->typename std::is_same<
+    decltype(std::declval<T>().get_node_services_interface()),
+    ReturnType
+  >::type;
+
+  template<typename>
+  static constexpr
+  std::false_type
+  check(...);
+
+public:
+  using type = decltype(check<NodeType>(nullptr));
+  static constexpr bool value = type::value;
+};
+
+// If NodeType is a pointer to NodeServicesInterface already (just normal function overload).
+inline
+rclcpp::node_interfaces::NodeServicesInterface *
+get_node_services_interface_from_pointer(rclcpp::node_interfaces::NodeServicesInterface * pointer)
+{
+  return pointer;
+}
+
+// If NodeType has a method called get_node_services_interface() which returns a shared pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_services_interface<
+    typename std::remove_pointer<NodeType>::type,
+    std::shared_ptr<rclcpp::node_interfaces::NodeServicesInterface>
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeServicesInterface *
+get_node_services_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_services_interface().get();
+}
+
+// If NodeType has a method called get_node_services_interface() which returns a pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_services_interface<
+    typename std::remove_pointer<NodeType>::type,
+    rclcpp::node_interfaces::NodeServicesInterface *
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeServicesInterface *
+get_node_services_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_services_interface();
+}
+
+// Forward shared_ptr's to const node pointer signatures.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_same<
+    NodeType,
+    typename std::shared_ptr<typename std::remove_pointer<NodeType>::type::element_type> *
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeServicesInterface *
+get_node_services_interface_from_pointer(NodeType node_shared_pointer)
+{
+  return get_node_services_interface_from_pointer(node_shared_pointer->get());
+}
+
+// If NodeType has a method called get_node_services_interface() which returns a shared pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_services_interface<
+    typename std::remove_pointer<NodeType>::type,
+    std::shared_ptr<rclcpp::node_interfaces::NodeServicesInterface>
+  >::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeServicesInterface>
+get_shared_node_services_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_services_interface();
+}
+
+// Forward shared_ptr's to const node pointer signatures.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_same<
+    NodeType,
+    typename std::shared_ptr<typename std::remove_pointer<NodeType>::type::element_type> *
+  >::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeServicesInterface>
+get_shared_node_services_interface_from_pointer(NodeType node_shared_pointer)
+{
+  return get_shared_node_services_interface_from_pointer(node_shared_pointer->get());
+}
+
+}  // namespace detail
+
+/// Get the NodeServicesInterface as a pointer from a pointer to a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeServicesInterface *
+get_node_services_interface(NodeType node_pointer)
+{
+  // Forward pointers to detail implementation directly.
+  return detail::get_node_services_interface_from_pointer(node_pointer);
+}
+
+/// Get the NodeServicesInterface as a pointer from a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<
+    !std::is_pointer<typename std::remove_reference<NodeType>::type>::value, int
+  >::type = 0
+>
+rclcpp::node_interfaces::NodeServicesInterface *
+get_node_services_interface(NodeType && node_reference)
+{
+  // Forward references to detail implementation as a pointer.
+  return detail::get_node_services_interface_from_pointer(&node_reference);
+}
+
+/// Get the NodeServicesInterface as an std::shared_ptr from a pointer to a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeServicesInterface>
+get_shared_node_services_interface(NodeType node_pointer)
+{
+  // Forward pointers to detail implementation directly.
+  return detail::get_shared_node_services_interface_from_pointer(node_pointer);
+}
+
+/// Get the NodeServicesInterface as an std::shared_ptr from a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<
+    !std::is_pointer<typename std::remove_reference<NodeType>::type>::value, int
+  >::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeServicesInterface>
+get_shared_node_services_interface(NodeType && node_reference)
+{
+  // Forward references to detail implementation as a pointer.
+  return detail::get_shared_node_services_interface_from_pointer(&node_reference);
+}
+
+}  // namespace node_interfaces
+}  // namespace rclcpp
+
+#endif  // RCLCPP__NODE_INTERFACES__GET_NODE_SERVICES_INTERFACE_HPP_

--- a/rclcpp/include/rclcpp/node_interfaces/get_node_time_source_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/get_node_time_source_interface.hpp
@@ -1,0 +1,213 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__NODE_INTERFACES__GET_NODE_TIME_SOURCE_INTERFACE_HPP_
+#define RCLCPP__NODE_INTERFACES__GET_NODE_TIME_SOURCE_INTERFACE_HPP_
+
+#include <memory>
+#include <utility>
+#include <type_traits>
+
+#include "rclcpp/node_interfaces/node_time_source_interface.hpp"
+
+/// This header provides the get_node_time_source_interface() template function.
+/**
+ * This function is useful for getting the NodeTimeSourceInterface pointer from
+ * various kinds of Node-like classes.
+ *
+ * It's able to get the NodeTimeSourceInterface pointer so long as the class
+ * has a method called ``get_node_time_source_interface()`` which returns
+ * either a pointer (const or not) to a NodeTimeSourceInterface or a
+ * std::shared_ptr to a NodeTimeSourceInterface.
+ */
+
+namespace rclcpp
+{
+namespace node_interfaces
+{
+
+namespace detail
+{
+
+// This is a meta-programming checker for if a given Node-like object has a
+// getter called get_node_time_source_interface() which returns various types,
+// e.g. const pointer or a shared pointer.
+template<typename NodeType, typename ReturnType>
+struct has_get_node_time_source_interface
+{
+private:
+  template<typename T>
+  static constexpr
+  auto
+  check(T *)->typename std::is_same<
+    decltype(std::declval<T>().get_node_time_source_interface()),
+    ReturnType
+  >::type;
+
+  template<typename>
+  static constexpr
+  std::false_type
+  check(...);
+
+public:
+  using type = decltype(check<NodeType>(nullptr));
+  static constexpr bool value = type::value;
+};
+
+// If NodeType is a pointer to NodeTimeSourceInterface already (just normal function overload).
+inline
+rclcpp::node_interfaces::NodeTimeSourceInterface *
+get_node_time_source_interface_from_pointer(
+  rclcpp::node_interfaces::NodeTimeSourceInterface * pointer)
+{
+  return pointer;
+}
+
+// If NodeType has a method called get_node_time_source_interface() which returns a shared pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_time_source_interface<
+    typename std::remove_pointer<NodeType>::type,
+    std::shared_ptr<rclcpp::node_interfaces::NodeTimeSourceInterface>
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeTimeSourceInterface *
+get_node_time_source_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_time_source_interface().get();
+}
+
+// If NodeType has a method called get_node_time_source_interface() which returns a pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_time_source_interface<
+    typename std::remove_pointer<NodeType>::type,
+    rclcpp::node_interfaces::NodeTimeSourceInterface *
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeTimeSourceInterface *
+get_node_time_source_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_time_source_interface();
+}
+
+// Forward shared_ptr's to const node pointer signatures.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_same<
+    NodeType,
+    typename std::shared_ptr<typename std::remove_pointer<NodeType>::type::element_type> *
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeTimeSourceInterface *
+get_node_time_source_interface_from_pointer(NodeType node_shared_pointer)
+{
+  return get_node_time_source_interface_from_pointer(node_shared_pointer->get());
+}
+
+// If NodeType has a method called get_node_time_source_interface() which returns a shared pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_time_source_interface<
+    typename std::remove_pointer<NodeType>::type,
+    std::shared_ptr<rclcpp::node_interfaces::NodeTimeSourceInterface>
+  >::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeTimeSourceInterface>
+get_shared_node_time_source_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_time_source_interface();
+}
+
+// Forward shared_ptr's to const node pointer signatures.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_same<
+    NodeType,
+    typename std::shared_ptr<typename std::remove_pointer<NodeType>::type::element_type> *
+  >::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeTimeSourceInterface>
+get_shared_node_time_source_interface_from_pointer(NodeType node_shared_pointer)
+{
+  return get_shared_node_time_source_interface_from_pointer(node_shared_pointer->get());
+}
+
+}  // namespace detail
+
+/// Get the NodeTimeSourceInterface as a pointer from a pointer to a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeTimeSourceInterface *
+get_node_time_source_interface(NodeType node_pointer)
+{
+  // Forward pointers to detail implementation directly.
+  return detail::get_node_time_source_interface_from_pointer(node_pointer);
+}
+
+/// Get the NodeTimeSourceInterface as a pointer from a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<
+    !std::is_pointer<typename std::remove_reference<NodeType>::type>::value, int
+  >::type = 0
+>
+rclcpp::node_interfaces::NodeTimeSourceInterface *
+get_node_time_source_interface(NodeType && node_reference)
+{
+  // Forward references to detail implementation as a pointer.
+  return detail::get_node_time_source_interface_from_pointer(&node_reference);
+}
+
+/// Get the NodeTimeSourceInterface as an std::shared_ptr from a pointer to a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeTimeSourceInterface>
+get_shared_node_time_source_interface(NodeType node_pointer)
+{
+  // Forward pointers to detail implementation directly.
+  return detail::get_shared_node_time_source_interface_from_pointer(node_pointer);
+}
+
+/// Get the NodeTimeSourceInterface as an std::shared_ptr from a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<
+    !std::is_pointer<typename std::remove_reference<NodeType>::type>::value, int
+  >::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeTimeSourceInterface>
+get_shared_node_time_source_interface(NodeType && node_reference)
+{
+  // Forward references to detail implementation as a pointer.
+  return detail::get_shared_node_time_source_interface_from_pointer(&node_reference);
+}
+
+}  // namespace node_interfaces
+}  // namespace rclcpp
+
+#endif  // RCLCPP__NODE_INTERFACES__GET_NODE_TIME_SOURCE_INTERFACE_HPP_

--- a/rclcpp/include/rclcpp/node_interfaces/get_node_timers_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/get_node_timers_interface.hpp
@@ -84,6 +84,9 @@ template<
 rclcpp::node_interfaces::NodeTimersInterface *
 get_node_timers_interface_from_pointer(NodeType node_pointer)
 {
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
   return node_pointer->get_node_timers_interface().get();
 }
 
@@ -98,6 +101,9 @@ template<
 rclcpp::node_interfaces::NodeTimersInterface *
 get_node_timers_interface_from_pointer(NodeType node_pointer)
 {
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
   return node_pointer->get_node_timers_interface();
 }
 

--- a/rclcpp/include/rclcpp/node_interfaces/get_node_topics_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/get_node_topics_interface.hpp
@@ -84,6 +84,9 @@ template<
 rclcpp::node_interfaces::NodeTopicsInterface *
 get_node_topics_interface_from_pointer(NodeType node_pointer)
 {
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
   return node_pointer->get_node_topics_interface().get();
 }
 
@@ -98,6 +101,9 @@ template<
 rclcpp::node_interfaces::NodeTopicsInterface *
 get_node_topics_interface_from_pointer(NodeType node_pointer)
 {
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
   return node_pointer->get_node_topics_interface();
 }
 

--- a/rclcpp/include/rclcpp/node_interfaces/get_node_topics_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/get_node_topics_interface.hpp
@@ -121,6 +121,37 @@ get_node_topics_interface_from_pointer(NodeType node_shared_pointer)
   return get_node_topics_interface_from_pointer(node_shared_pointer->get());
 }
 
+// If NodeType has a method called get_node_topics_interface() which returns a shared pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_topics_interface<
+    typename std::remove_pointer<NodeType>::type,
+    std::shared_ptr<rclcpp::node_interfaces::NodeTopicsInterface>
+  >::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeTopicsInterface>
+get_shared_node_topics_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_topics_interface();
+}
+
+// Forward shared_ptr's to const node pointer signatures.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_same<
+    NodeType,
+    typename std::shared_ptr<typename std::remove_pointer<NodeType>::type::element_type> *
+  >::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeTopicsInterface>
+get_shared_node_topics_interface_from_pointer(NodeType node_shared_pointer)
+{
+  return get_shared_node_topics_interface_from_pointer(node_shared_pointer->get());
+}
+
 }  // namespace detail
 
 /// Get the NodeTopicsInterface as a pointer from a pointer to a "Node like" object.
@@ -131,7 +162,7 @@ template<
 rclcpp::node_interfaces::NodeTopicsInterface *
 get_node_topics_interface(NodeType node_pointer)
 {
-  // Forward pointers to detail implmentation directly.
+  // Forward pointers to detail implementation directly.
   return detail::get_node_topics_interface_from_pointer(node_pointer);
 }
 
@@ -145,8 +176,34 @@ template<
 rclcpp::node_interfaces::NodeTopicsInterface *
 get_node_topics_interface(NodeType && node_reference)
 {
-  // Forward references to detail implmentation as a pointer.
+  // Forward references to detail implementation as a pointer.
   return detail::get_node_topics_interface_from_pointer(&node_reference);
+}
+
+/// Get the NodeTopicsInterface as an std::shared_ptr from a pointer to a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeTopicsInterface>
+get_shared_node_topics_interface(NodeType node_pointer)
+{
+  // Forward pointers to detail implementation directly.
+  return detail::get_shared_node_topics_interface_from_pointer(node_pointer);
+}
+
+/// Get the NodeTopicsInterface as an std::shared_ptr from a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<
+    !std::is_pointer<typename std::remove_reference<NodeType>::type>::value, int
+  >::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeTopicsInterface>
+get_shared_node_topics_interface(NodeType && node_reference)
+{
+  // Forward references to detail implementation as a pointer.
+  return detail::get_shared_node_topics_interface_from_pointer(&node_reference);
 }
 
 }  // namespace node_interfaces

--- a/rclcpp/include/rclcpp/node_interfaces/get_node_waitables_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/get_node_waitables_interface.hpp
@@ -1,0 +1,212 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__NODE_INTERFACES__GET_NODE_WAITABLES_INTERFACE_HPP_
+#define RCLCPP__NODE_INTERFACES__GET_NODE_WAITABLES_INTERFACE_HPP_
+
+#include <memory>
+#include <utility>
+#include <type_traits>
+
+#include "rclcpp/node_interfaces/node_waitables_interface.hpp"
+
+/// This header provides the get_node_waitables_interface() template function.
+/**
+ * This function is useful for getting the NodeWaitablesInterface pointer from
+ * various kinds of Node-like classes.
+ *
+ * It's able to get the NodeWaitablesInterface pointer so long as the class
+ * has a method called ``get_node_waitables_interface()`` which returns
+ * either a pointer (const or not) to a NodeWaitablesInterface or a
+ * std::shared_ptr to a NodeWaitablesInterface.
+ */
+
+namespace rclcpp
+{
+namespace node_interfaces
+{
+
+namespace detail
+{
+
+// This is a meta-programming checker for if a given Node-like object has a
+// getter called get_node_waitables_interface() which returns various types,
+// e.g. const pointer or a shared pointer.
+template<typename NodeType, typename ReturnType>
+struct has_get_node_waitables_interface
+{
+private:
+  template<typename T>
+  static constexpr
+  auto
+  check(T *)->typename std::is_same<
+    decltype(std::declval<T>().get_node_waitables_interface()),
+    ReturnType
+  >::type;
+
+  template<typename>
+  static constexpr
+  std::false_type
+  check(...);
+
+public:
+  using type = decltype(check<NodeType>(nullptr));
+  static constexpr bool value = type::value;
+};
+
+// If NodeType is a pointer to NodeWaitablesInterface already (just normal function overload).
+inline
+rclcpp::node_interfaces::NodeWaitablesInterface *
+get_node_waitables_interface_from_pointer(rclcpp::node_interfaces::NodeWaitablesInterface * pointer)
+{
+  return pointer;
+}
+
+// If NodeType has a method called get_node_waitables_interface() which returns a shared pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_waitables_interface<
+    typename std::remove_pointer<NodeType>::type,
+    std::shared_ptr<rclcpp::node_interfaces::NodeWaitablesInterface>
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeWaitablesInterface *
+get_node_waitables_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_waitables_interface().get();
+}
+
+// If NodeType has a method called get_node_waitables_interface() which returns a pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_waitables_interface<
+    typename std::remove_pointer<NodeType>::type,
+    rclcpp::node_interfaces::NodeWaitablesInterface *
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeWaitablesInterface *
+get_node_waitables_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_waitables_interface();
+}
+
+// Forward shared_ptr's to const node pointer signatures.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_same<
+    NodeType,
+    typename std::shared_ptr<typename std::remove_pointer<NodeType>::type::element_type> *
+  >::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeWaitablesInterface *
+get_node_waitables_interface_from_pointer(NodeType node_shared_pointer)
+{
+  return get_node_waitables_interface_from_pointer(node_shared_pointer->get());
+}
+
+// If NodeType has a method called get_node_waitables_interface() which returns a shared pointer.
+template<
+  typename NodeType,
+  typename std::enable_if<has_get_node_waitables_interface<
+    typename std::remove_pointer<NodeType>::type,
+    std::shared_ptr<rclcpp::node_interfaces::NodeWaitablesInterface>
+  >::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeWaitablesInterface>
+get_shared_node_waitables_interface_from_pointer(NodeType node_pointer)
+{
+  if (!node_pointer) {
+    throw std::invalid_argument("node pointer cannot be nullptr");
+  }
+  return node_pointer->get_node_waitables_interface();
+}
+
+// Forward shared_ptr's to const node pointer signatures.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_same<
+    NodeType,
+    typename std::shared_ptr<typename std::remove_pointer<NodeType>::type::element_type> *
+  >::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeWaitablesInterface>
+get_shared_node_waitables_interface_from_pointer(NodeType node_shared_pointer)
+{
+  return get_shared_node_waitables_interface_from_pointer(node_shared_pointer->get());
+}
+
+}  // namespace detail
+
+/// Get the NodeWaitablesInterface as a pointer from a pointer to a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
+>
+rclcpp::node_interfaces::NodeWaitablesInterface *
+get_node_waitables_interface(NodeType node_pointer)
+{
+  // Forward pointers to detail implementation directly.
+  return detail::get_node_waitables_interface_from_pointer(node_pointer);
+}
+
+/// Get the NodeWaitablesInterface as a pointer from a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<
+    !std::is_pointer<typename std::remove_reference<NodeType>::type>::value, int
+  >::type = 0
+>
+rclcpp::node_interfaces::NodeWaitablesInterface *
+get_node_waitables_interface(NodeType && node_reference)
+{
+  // Forward references to detail implementation as a pointer.
+  return detail::get_node_waitables_interface_from_pointer(&node_reference);
+}
+
+/// Get the NodeWaitablesInterface as an std::shared_ptr from a pointer to a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<std::is_pointer<NodeType>::value, int>::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeWaitablesInterface>
+get_shared_node_waitables_interface(NodeType node_pointer)
+{
+  // Forward pointers to detail implementation directly.
+  return detail::get_shared_node_waitables_interface_from_pointer(node_pointer);
+}
+
+/// Get the NodeWaitablesInterface as an std::shared_ptr from a "Node like" object.
+template<
+  typename NodeType,
+  typename std::enable_if<
+    !std::is_pointer<typename std::remove_reference<NodeType>::type>::value, int
+  >::type = 0
+>
+std::shared_ptr<rclcpp::node_interfaces::NodeWaitablesInterface>
+get_shared_node_waitables_interface(NodeType && node_reference)
+{
+  // Forward references to detail implementation as a pointer.
+  return detail::get_shared_node_waitables_interface_from_pointer(&node_reference);
+}
+
+}  // namespace node_interfaces
+}  // namespace rclcpp
+
+#endif  // RCLCPP__NODE_INTERFACES__GET_NODE_WAITABLES_INTERFACE_HPP_

--- a/rclcpp_action/include/rclcpp_action/create_client.hpp
+++ b/rclcpp_action/include/rclcpp_action/create_client.hpp
@@ -16,6 +16,14 @@
 #define RCLCPP_ACTION__CREATE_CLIENT_HPP_
 
 #include <rclcpp/node.hpp>
+#include <rclcpp/node_interfaces/get_node_base_interface.hpp>
+#include <rclcpp/node_interfaces/get_node_graph_interface.hpp>
+#include <rclcpp/node_interfaces/get_node_logging_interface.hpp>
+#include <rclcpp/node_interfaces/get_node_waitables_interface.hpp>
+#include <rclcpp/node_interfaces/node_base_interface.hpp>
+#include <rclcpp/node_interfaces/node_graph_interface.hpp>
+#include <rclcpp/node_interfaces/node_logging_interface.hpp>
+#include <rclcpp/node_interfaces/node_waitables_interface.hpp>
 
 #include <memory>
 #include <string>
@@ -100,15 +108,15 @@ create_client(
 template<typename ActionT, typename NodeT>
 typename Client<ActionT>::SharedPtr
 create_client(
-  NodeT node,
+  NodeT & node,
   const std::string & name,
   rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr)
 {
   return create_client<ActionT>(
-    node->get_node_base_interface(),
-    node->get_node_graph_interface(),
-    node->get_node_logging_interface(),
-    node->get_node_waitables_interface(),
+    rclcpp::node_interfaces::get_shared_node_base_interface(node),
+    rclcpp::node_interfaces::get_shared_node_graph_interface(node),
+    rclcpp::node_interfaces::get_shared_node_logging_interface(node),
+    rclcpp::node_interfaces::get_shared_node_waitables_interface(node),
     name,
     group);
 }

--- a/rclcpp_action/include/rclcpp_action/create_server.hpp
+++ b/rclcpp_action/include/rclcpp_action/create_server.hpp
@@ -18,6 +18,10 @@
 #include <rcl_action/action_server.h>
 
 #include <rclcpp/node.hpp>
+#include <rclcpp/node_interfaces/get_node_base_interface.hpp>
+#include <rclcpp/node_interfaces/get_node_clock_interface.hpp>
+#include <rclcpp/node_interfaces/get_node_logging_interface.hpp>
+#include <rclcpp/node_interfaces/get_node_waitables_interface.hpp>
 #include <rclcpp/node_interfaces/node_base_interface.hpp>
 #include <rclcpp/node_interfaces/node_clock_interface.hpp>
 #include <rclcpp/node_interfaces/node_logging_interface.hpp>
@@ -140,10 +144,10 @@ create_server(
   rclcpp::callback_group::CallbackGroup::SharedPtr group = nullptr)
 {
   return create_server<ActionT>(
-    node->get_node_base_interface(),
-    node->get_node_clock_interface(),
-    node->get_node_logging_interface(),
-    node->get_node_waitables_interface(),
+    rclcpp::node_interfaces::get_shared_node_base_interface(node),
+    rclcpp::node_interfaces::get_shared_node_clock_interface(node),
+    rclcpp::node_interfaces::get_shared_node_logging_interface(node),
+    rclcpp::node_interfaces::get_shared_node_waitables_interface(node),
     name,
     handle_goal,
     handle_cancel,

--- a/rclcpp_action/test/test_client.cpp
+++ b/rclcpp_action/test/test_client.cpp
@@ -267,6 +267,16 @@ protected:
 
 TEST_F(TestClient, construction_and_destruction)
 {
+  ASSERT_THROW(
+  {
+    rclcpp::Node * null_node = nullptr;
+    rclcpp_action::create_client<ActionType>(null_node, action_name);}, std::invalid_argument);
+
+  ASSERT_THROW(
+  {
+    rclcpp::Node::SharedPtr null_node;
+    rclcpp_action::create_client<ActionType>(null_node, action_name);}, std::invalid_argument);
+
   ASSERT_NO_THROW(rclcpp_action::create_client<ActionType>(client_node, action_name).reset());
 }
 


### PR DESCRIPTION
This pull requests indirectly addresses https://github.com/ros2/geometry2/issues/244 by adding more and safer node interfaces' getters, and then using them where applicable (e.g. in `rclcpp_action::create_*()`, indirectly solving the aforementioned issue).

I'm opening this as a draft PR for @Karsten1987 to weigh in and for @wjwwood to comment on how this may or may not be in line with the ongoing `rclcpp` API review.