### PR TITLE
Increasing test coverage of rclcpp_action

### DIFF
--- a/rclcpp_action/CMakeLists.txt
+++ b/rclcpp_action/CMakeLists.txt
@@ -103,6 +103,16 @@ if(BUILD_TESTING)
       ${PROJECT_NAME}
     )
   endif()
+
+  ament_add_gtest(test_types test/test_types.cpp)
+  if(TARGET test_types)
+    ament_target_dependencies(test_types
+      "test_msgs"
+    )
+    target_link_libraries(test_types
+      ${PROJECT_NAME}
+    )
+  endif()
 endif()
 
 ament_package()

--- a/rclcpp_action/test/test_client.cpp
+++ b/rclcpp_action/test/test_client.cpp
@@ -273,7 +273,7 @@ TEST_F(TestClient, construction_and_destruction)
 TEST_F(TestClient, construction_and_destruction_callback_group)
 {
   auto group = client_node->create_callback_group(
-    rclcpp::callback_group::CallbackGroupType::MutuallyExclusive);
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   ASSERT_NO_THROW(
     rclcpp_action::create_client<ActionType>(
       client_node->get_node_base_interface(),

--- a/rclcpp_action/test/test_client.cpp
+++ b/rclcpp_action/test/test_client.cpp
@@ -270,6 +270,21 @@ TEST_F(TestClient, construction_and_destruction)
   ASSERT_NO_THROW(rclcpp_action::create_client<ActionType>(client_node, action_name).reset());
 }
 
+TEST_F(TestClient, construction_and_destruction_callback_group)
+{
+  auto group = client_node->create_callback_group(
+    rclcpp::callback_group::CallbackGroupType::MutuallyExclusive);
+  ASSERT_NO_THROW(
+    rclcpp_action::create_client<ActionType>(
+      client_node->get_node_base_interface(),
+      client_node->get_node_graph_interface(),
+      client_node->get_node_logging_interface(),
+      client_node->get_node_waitables_interface(),
+      action_name,
+      group
+    ).reset());
+}
+
 TEST_F(TestClient, async_send_goal_no_callbacks)
 {
   auto action_client = rclcpp_action::create_client<ActionType>(client_node, action_name);

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -103,21 +103,22 @@ TEST_F(TestServer, construction_and_destruction_callback_group)
   const rcl_action_server_options_t & options = rcl_action_server_get_default_options();
 
   using GoalHandle = rclcpp_action::ServerGoalHandle<Fibonacci>;
-  ASSERT_NO_THROW(rclcpp_action::create_server<Fibonacci>(
-    node->get_node_base_interface(),
-    node->get_node_clock_interface(),
-    node->get_node_logging_interface(),
-    node->get_node_waitables_interface(),
-    "fibonacci",
-    [](const GoalUUID &, std::shared_ptr<const Fibonacci::Goal>) {
-      return rclcpp_action::GoalResponse::REJECT;
-    },
-    [](std::shared_ptr<GoalHandle>) {
-      return rclcpp_action::CancelResponse::REJECT;
-    },
-    [](std::shared_ptr<GoalHandle>) {},
-    options,
-    group));
+  ASSERT_NO_THROW(
+    rclcpp_action::create_server<Fibonacci>(
+      node->get_node_base_interface(),
+      node->get_node_clock_interface(),
+      node->get_node_logging_interface(),
+      node->get_node_waitables_interface(),
+      "fibonacci",
+      [](const GoalUUID &, std::shared_ptr<const Fibonacci::Goal>) {
+        return rclcpp_action::GoalResponse::REJECT;
+      },
+      [](std::shared_ptr<GoalHandle>) {
+        return rclcpp_action::CancelResponse::REJECT;
+      },
+      [](std::shared_ptr<GoalHandle>) {},
+      options,
+      group));
 }
 
 TEST_F(TestServer, handle_goal_called)

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -95,6 +95,32 @@ TEST_F(TestServer, construction_and_destruction)
   (void)as;
 }
 
+TEST_F(TestServer, construction_and_destruction_callback_group)
+{
+  auto node = std::make_shared<rclcpp::Node>("construct_node", "/rclcpp_action/construct");
+  auto group = node->create_callback_group(
+    rclcpp::callback_group::CallbackGroupType::MutuallyExclusive);
+  const rcl_action_server_options_t & options = rcl_action_server_get_default_options();
+
+  using GoalHandle = rclcpp_action::ServerGoalHandle<Fibonacci>;
+  auto as = rclcpp_action::create_server<Fibonacci>(
+    node->get_node_base_interface(),
+    node->get_node_clock_interface(),
+    node->get_node_logging_interface(),
+    node->get_node_waitables_interface(),
+    "fibonacci",
+    [](const GoalUUID &, std::shared_ptr<const Fibonacci::Goal>) {
+      return rclcpp_action::GoalResponse::REJECT;
+    },
+    [](std::shared_ptr<GoalHandle>) {
+      return rclcpp_action::CancelResponse::REJECT;
+    },
+    [](std::shared_ptr<GoalHandle>) {},
+    options,
+    group);
+  (void)as;
+}
+
 TEST_F(TestServer, handle_goal_called)
 {
   auto node = std::make_shared<rclcpp::Node>("handle_goal_node", "/rclcpp_action/handle_goal");

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -99,7 +99,7 @@ TEST_F(TestServer, construction_and_destruction_callback_group)
 {
   auto node = std::make_shared<rclcpp::Node>("construct_node", "/rclcpp_action/construct");
   auto group = node->create_callback_group(
-    rclcpp::callback_group::CallbackGroupType::MutuallyExclusive);
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   const rcl_action_server_options_t & options = rcl_action_server_get_default_options();
 
   using GoalHandle = rclcpp_action::ServerGoalHandle<Fibonacci>;

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -103,7 +103,7 @@ TEST_F(TestServer, construction_and_destruction_callback_group)
   const rcl_action_server_options_t & options = rcl_action_server_get_default_options();
 
   using GoalHandle = rclcpp_action::ServerGoalHandle<Fibonacci>;
-  auto as = rclcpp_action::create_server<Fibonacci>(
+  ASSERT_NO_THROW(rclcpp_action::create_server<Fibonacci>(
     node->get_node_base_interface(),
     node->get_node_clock_interface(),
     node->get_node_logging_interface(),
@@ -117,8 +117,7 @@ TEST_F(TestServer, construction_and_destruction_callback_group)
     },
     [](std::shared_ptr<GoalHandle>) {},
     options,
-    group);
-  (void)as;
+    group));
 }
 
 TEST_F(TestServer, handle_goal_called)

--- a/rclcpp_action/test/test_types.cpp
+++ b/rclcpp_action/test/test_types.cpp
@@ -1,0 +1,62 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include "rclcpp_action/types.hpp"
+
+TEST(TestActionTypes, goal_uuid_to_string) {
+  rclcpp_action::GoalUUID goal_id;
+  for (size_t i = 0; i < UUID_SIZE; ++i) {
+    goal_id[i] = i;
+  }
+  EXPECT_STREQ("0123456789abcdef", rclcpp_action::to_string(goal_id).c_str());
+
+  for (size_t i = 0; i < UUID_SIZE; ++i) {
+    goal_id[i] = 16u + i;
+  }
+  EXPECT_STREQ("101112131415161718191a1b1c1d1e1f", rclcpp_action::to_string(goal_id).c_str());
+
+  for (size_t i = 0; i < UUID_SIZE; ++i) {
+    goal_id[i] = std::numeric_limits<uint8_t>::max() - i;
+  }
+  EXPECT_STREQ("fffefdfcfbfaf9f8f7f6f5f4f3f2f1f0", rclcpp_action::to_string(goal_id).c_str());
+}
+
+TEST(TestActionTypes, goal_uuid_to_rcl_action_goal_info) {
+  rclcpp_action::GoalUUID goal_id;
+  for (size_t i = 0; i < UUID_SIZE; ++i) {
+    goal_id[i] = i;
+  }
+  rcl_action_goal_info_t goal_info = rcl_action_get_zero_initialized_goal_info();
+  rclcpp_action::convert(goal_id, &goal_info);
+  for (size_t i = 0; i < UUID_SIZE; ++i) {
+    EXPECT_EQ(goal_info.goal_id.uuid[i], goal_id[i]);
+  }
+}
+
+TEST(TestActionTypes, rcl_action_goal_info_to_goal_uuid) {
+  rcl_action_goal_info_t goal_info = rcl_action_get_zero_initialized_goal_info();
+  for (size_t i = 0; i < UUID_SIZE; ++i) {
+    goal_info.goal_id.uuid[i] = i;
+  }
+
+  rclcpp_action::GoalUUID goal_id;
+  rclcpp_action::convert(goal_id, &goal_info);
+  for (size_t i = 0; i < UUID_SIZE; ++i) {
+    EXPECT_EQ(goal_info.goal_id.uuid[i], goal_id[i]);
+  }
+}

--- a/rclcpp_action/test/test_types.cpp
+++ b/rclcpp_action/test/test_types.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #include <gtest/gtest.h>
 
 #include <limits>
@@ -20,17 +19,17 @@
 
 TEST(TestActionTypes, goal_uuid_to_string) {
   rclcpp_action::GoalUUID goal_id;
-  for (size_t i = 0; i < UUID_SIZE; ++i) {
+  for (uint8_t i = 0; i < UUID_SIZE; ++i) {
     goal_id[i] = i;
   }
   EXPECT_STREQ("0123456789abcdef", rclcpp_action::to_string(goal_id).c_str());
 
-  for (size_t i = 0; i < UUID_SIZE; ++i) {
+  for (uint8_t i = 0; i < UUID_SIZE; ++i) {
     goal_id[i] = 16u + i;
   }
   EXPECT_STREQ("101112131415161718191a1b1c1d1e1f", rclcpp_action::to_string(goal_id).c_str());
 
-  for (size_t i = 0; i < UUID_SIZE; ++i) {
+  for (uint8_t i = 0; i < UUID_SIZE; ++i) {
     goal_id[i] = std::numeric_limits<uint8_t>::max() - i;
   }
   EXPECT_STREQ("fffefdfcfbfaf9f8f7f6f5f4f3f2f1f0", rclcpp_action::to_string(goal_id).c_str());
@@ -38,25 +37,25 @@ TEST(TestActionTypes, goal_uuid_to_string) {
 
 TEST(TestActionTypes, goal_uuid_to_rcl_action_goal_info) {
   rclcpp_action::GoalUUID goal_id;
-  for (size_t i = 0; i < UUID_SIZE; ++i) {
+  for (uint8_t i = 0; i < UUID_SIZE; ++i) {
     goal_id[i] = i;
   }
   rcl_action_goal_info_t goal_info = rcl_action_get_zero_initialized_goal_info();
   rclcpp_action::convert(goal_id, &goal_info);
-  for (size_t i = 0; i < UUID_SIZE; ++i) {
+  for (uint8_t i = 0; i < UUID_SIZE; ++i) {
     EXPECT_EQ(goal_info.goal_id.uuid[i], goal_id[i]);
   }
 }
 
 TEST(TestActionTypes, rcl_action_goal_info_to_goal_uuid) {
   rcl_action_goal_info_t goal_info = rcl_action_get_zero_initialized_goal_info();
-  for (size_t i = 0; i < UUID_SIZE; ++i) {
+  for (uint8_t i = 0; i < UUID_SIZE; ++i) {
     goal_info.goal_id.uuid[i] = i;
   }
 
   rclcpp_action::GoalUUID goal_id;
   rclcpp_action::convert(goal_id, &goal_info);
-  for (size_t i = 0; i < UUID_SIZE; ++i) {
+  for (uint8_t i = 0; i < UUID_SIZE; ++i) {
     EXPECT_EQ(goal_info.goal_id.uuid[i], goal_id[i]);
   }
 }


### PR DESCRIPTION
As part of the effort to bring the rclcpp packages up to Quality Level 1, this introduces many more tests of the rclcpp_action api. This brings the coverage from 76% to 83% of the `src` files and 94% of the `include` files (87% combined). 

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9862)](http://ci.ros2.org/job/ci_linux/9862/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5478)](http://ci.ros2.org/job/ci_linux-aarch64/5478/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8022)](http://ci.ros2.org/job/ci_osx/8022/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9718)](http://ci.ros2.org/job/ci_windows/9718/)
* Coverage [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux_coverage&build=78)](https://ci.ros2.org/job/ci_linux_coverage/78/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>