### PR TITLE
Increasing test coverage of rclcpp_components

### DIFF
--- a/rclcpp_components/CMakeLists.txt
+++ b/rclcpp_components/CMakeLists.txt
@@ -79,7 +79,7 @@ if(BUILD_TESTING)
   set(components "${components}test_rclcpp_components::TestComponentNoNode;$<TARGET_FILE:test_component>\n")
   set(components "${components}test_rclcpp_components::TestComponentThrows;$<TARGET_FILE:test_component>\n")
 
-  # Used to catch invalid resource entry
+  # A properly formed resource only has one ';', this is used to catch an invalid resource entry
   set(invalid_components "test_rclcpp_components::TestComponentFoo;;$<TARGET_FILE:test_component>\n")
 
   file(GENERATE

--- a/rclcpp_components/CMakeLists.txt
+++ b/rclcpp_components/CMakeLists.txt
@@ -77,11 +77,20 @@ if(BUILD_TESTING)
   set(components "${components}test_rclcpp_components::TestComponentFoo;$<TARGET_FILE:test_component>\n")
   set(components "${components}test_rclcpp_components::TestComponentBar;$<TARGET_FILE:test_component>\n")
   set(components "${components}test_rclcpp_components::TestComponentNoNode;$<TARGET_FILE:test_component>\n")
+  set(components "${components}test_rclcpp_components::TestComponentThrows;$<TARGET_FILE:test_component>\n")
+
+  # Used to catch invalid resource entry
+  set(invalid_components "test_rclcpp_components::TestComponentFoo;;$<TARGET_FILE:test_component>\n")
 
   file(GENERATE
     OUTPUT
     "${CMAKE_CURRENT_BINARY_DIR}/test_ament_index/$<CONFIG>/share/ament_index/resource_index/rclcpp_components/${PROJECT_NAME}"
     CONTENT "${components}")
+
+  file(GENERATE
+    OUTPUT
+    "${CMAKE_CURRENT_BINARY_DIR}/test_ament_index/$<CONFIG>/share/ament_index/resource_index/rclcpp_components/invalid_${PROJECT_NAME}"
+    CONTENT "${invalid_components}")
 
   set(append_library_dirs "${CMAKE_CURRENT_BINARY_DIR}")
   if(WIN32)

--- a/rclcpp_components/CMakeLists.txt
+++ b/rclcpp_components/CMakeLists.txt
@@ -77,7 +77,6 @@ if(BUILD_TESTING)
   set(components "${components}test_rclcpp_components::TestComponentFoo;$<TARGET_FILE:test_component>\n")
   set(components "${components}test_rclcpp_components::TestComponentBar;$<TARGET_FILE:test_component>\n")
   set(components "${components}test_rclcpp_components::TestComponentNoNode;$<TARGET_FILE:test_component>\n")
-  set(components "${components}test_rclcpp_components::TestComponentThrows;$<TARGET_FILE:test_component>\n")
 
   # A properly formed resource only has one ';', this is used to catch an invalid resource entry
   set(invalid_components "test_rclcpp_components::TestComponentFoo;;$<TARGET_FILE:test_component>\n")

--- a/rclcpp_components/test/components/test_component.cpp
+++ b/rclcpp_components/test/components/test_component.cpp
@@ -55,6 +55,16 @@ private:
   rclcpp::Node node_;
 };
 
+/// Example that throws in constructor
+class TestComponentThrows : public rclcpp::Node
+{
+public:
+  explicit TestComponentThrows(rclcpp::NodeOptions options)
+  : rclcpp::Node("test_component_throws", options)
+  {
+    throw std::invalid_argument("Exception in constructor");
+  }
+};
 
 }  // namespace test_rclcpp_components
 
@@ -66,3 +76,4 @@ private:
 RCLCPP_COMPONENTS_REGISTER_NODE(test_rclcpp_components::TestComponentFoo)
 RCLCPP_COMPONENTS_REGISTER_NODE(test_rclcpp_components::TestComponentBar)
 RCLCPP_COMPONENTS_REGISTER_NODE(test_rclcpp_components::TestComponentNoNode)
+RCLCPP_COMPONENTS_REGISTER_NODE(test_rclcpp_components::TestComponentThrows)

--- a/rclcpp_components/test/components/test_component.cpp
+++ b/rclcpp_components/test/components/test_component.cpp
@@ -55,17 +55,6 @@ private:
   rclcpp::Node node_;
 };
 
-/// Example that throws in constructor
-class TestComponentThrows : public rclcpp::Node
-{
-public:
-  explicit TestComponentThrows(rclcpp::NodeOptions options)
-  : rclcpp::Node("test_component_throws", options)
-  {
-    throw std::invalid_argument("Exception in constructor");
-  }
-};
-
 }  // namespace test_rclcpp_components
 
 #include "rclcpp_components/register_node_macro.hpp"
@@ -76,4 +65,3 @@ public:
 RCLCPP_COMPONENTS_REGISTER_NODE(test_rclcpp_components::TestComponentFoo)
 RCLCPP_COMPONENTS_REGISTER_NODE(test_rclcpp_components::TestComponentBar)
 RCLCPP_COMPONENTS_REGISTER_NODE(test_rclcpp_components::TestComponentNoNode)
-RCLCPP_COMPONENTS_REGISTER_NODE(test_rclcpp_components::TestComponentThrows)

--- a/rclcpp_components/test/test_component_manager.cpp
+++ b/rclcpp_components/test/test_component_manager.cpp
@@ -45,17 +45,15 @@ TEST_F(TestComponentManager, get_component_resources_valid)
   auto manager = std::make_shared<rclcpp_components::ComponentManager>(exec);
 
   auto resources = manager->get_component_resources("rclcpp_components");
-  EXPECT_EQ(4u, resources.size());
+  EXPECT_EQ(3u, resources.size());
 
   EXPECT_EQ("test_rclcpp_components::TestComponentFoo", resources[0].first);
   EXPECT_EQ("test_rclcpp_components::TestComponentBar", resources[1].first);
   EXPECT_EQ("test_rclcpp_components::TestComponentNoNode", resources[2].first);
-  EXPECT_EQ("test_rclcpp_components::TestComponentThrows", resources[3].first);
 
   EXPECT_TRUE(rcpputils::fs::path(resources[0].second).exists());
   EXPECT_TRUE(rcpputils::fs::path(resources[1].second).exists());
   EXPECT_TRUE(rcpputils::fs::path(resources[2].second).exists());
-  EXPECT_TRUE(rcpputils::fs::path(resources[3].second).exists());
 }
 
 TEST_F(TestComponentManager, create_component_factory_valid)
@@ -64,7 +62,7 @@ TEST_F(TestComponentManager, create_component_factory_valid)
   auto manager = std::make_shared<rclcpp_components::ComponentManager>(exec);
 
   auto resources = manager->get_component_resources("rclcpp_components");
-  EXPECT_EQ(4u, resources.size());
+  EXPECT_EQ(3u, resources.size());
 
   // Repeated loading should reuse existing class loader and not throw.
   EXPECT_NO_THROW(auto factory = manager->create_component_factory(resources[0]););

--- a/rclcpp_components/test/test_component_manager.cpp
+++ b/rclcpp_components/test/test_component_manager.cpp
@@ -45,15 +45,17 @@ TEST_F(TestComponentManager, get_component_resources_valid)
   auto manager = std::make_shared<rclcpp_components::ComponentManager>(exec);
 
   auto resources = manager->get_component_resources("rclcpp_components");
-  EXPECT_EQ(3u, resources.size());
+  EXPECT_EQ(4u, resources.size());
 
   EXPECT_EQ("test_rclcpp_components::TestComponentFoo", resources[0].first);
   EXPECT_EQ("test_rclcpp_components::TestComponentBar", resources[1].first);
   EXPECT_EQ("test_rclcpp_components::TestComponentNoNode", resources[2].first);
+  EXPECT_EQ("test_rclcpp_components::TestComponentThrows", resources[3].first);
 
   EXPECT_TRUE(rcpputils::fs::path(resources[0].second).exists());
   EXPECT_TRUE(rcpputils::fs::path(resources[1].second).exists());
   EXPECT_TRUE(rcpputils::fs::path(resources[2].second).exists());
+  EXPECT_TRUE(rcpputils::fs::path(resources[3].second).exists());
 }
 
 TEST_F(TestComponentManager, create_component_factory_valid)
@@ -62,7 +64,7 @@ TEST_F(TestComponentManager, create_component_factory_valid)
   auto manager = std::make_shared<rclcpp_components::ComponentManager>(exec);
 
   auto resources = manager->get_component_resources("rclcpp_components");
-  EXPECT_EQ(3u, resources.size());
+  EXPECT_EQ(4u, resources.size());
 
   // Repeated loading should reuse existing class loader and not throw.
   EXPECT_NO_THROW(auto factory = manager->create_component_factory(resources[0]););
@@ -88,4 +90,9 @@ TEST_F(TestComponentManager, create_component_factory_invalid)
   auto resources = manager->get_component_resources("rclcpp_components");
   auto factory = manager->create_component_factory({"foo_class", resources[0].second});
   EXPECT_EQ(nullptr, factory);
+
+  // Test improperly formed resources file
+  EXPECT_THROW(
+    auto resources = manager->get_component_resources("invalid_rclcpp_components"),
+    rclcpp_components::ComponentManagerException);
 }

--- a/rclcpp_components/test/test_component_manager_api.cpp
+++ b/rclcpp_components/test/test_component_manager_api.cpp
@@ -202,24 +202,6 @@ TEST_F(TestComponentManager, components_api)
     EXPECT_EQ(result.get()->unique_id, 0u);
   }
 
-  {
-    // Node constructor throws exception
-    auto request = std::make_shared<composition_interfaces::srv::LoadNode::Request>();
-    request->package_name = "rclcpp_components";
-    request->plugin_name = "test_rclcpp_components::TestComponentThrows";
-    request->node_name = "test_component_throws";
-
-    auto result = client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
-    EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
-    EXPECT_EQ(result.get()->success, false);
-    EXPECT_EQ(
-      result.get()->error_message,
-      "Component constructor threw an exception");
-    EXPECT_EQ(result.get()->full_node_name, "");
-    EXPECT_EQ(result.get()->unique_id, 0u);
-  }
-
   auto node_names = node->get_node_names();
 
   auto find_in_nodes = [node_names](std::string name) {

--- a/rclcpp_components/test/test_component_manager_api.cpp
+++ b/rclcpp_components/test/test_component_manager_api.cpp
@@ -153,7 +153,7 @@ TEST_F(TestComponentManager, components_api)
 
     auto result = client->async_send_request(request);
     auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
-    EXPECT_EQ(ret, rclcpp::executor::FutureReturnCode::SUCCESS);
+    EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
     EXPECT_EQ(result.get()->success, true);
     EXPECT_EQ(result.get()->error_message, "");
     EXPECT_EQ(result.get()->full_node_name, "/test_component_remap");
@@ -172,7 +172,7 @@ TEST_F(TestComponentManager, components_api)
 
     auto result = client->async_send_request(request);
     auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
-    EXPECT_EQ(ret, rclcpp::executor::FutureReturnCode::SUCCESS);
+    EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
     EXPECT_EQ(result.get()->success, true);
     EXPECT_EQ(result.get()->error_message, "");
     std::cout << result.get()->full_node_name << std::endl;
@@ -193,7 +193,7 @@ TEST_F(TestComponentManager, components_api)
 
     auto result = client->async_send_request(request);
     auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
-    EXPECT_EQ(ret, rclcpp::executor::FutureReturnCode::SUCCESS);
+    EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
     EXPECT_EQ(result.get()->success, false);
     EXPECT_EQ(
       result.get()->error_message,
@@ -211,7 +211,7 @@ TEST_F(TestComponentManager, components_api)
 
     auto result = client->async_send_request(request);
     auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
-    EXPECT_EQ(ret, rclcpp::executor::FutureReturnCode::SUCCESS);
+    EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
     EXPECT_EQ(result.get()->success, false);
     EXPECT_EQ(
       result.get()->error_message,
@@ -219,7 +219,6 @@ TEST_F(TestComponentManager, components_api)
     EXPECT_EQ(result.get()->full_node_name, "");
     EXPECT_EQ(result.get()->unique_id, 0u);
   }
-
 
   auto node_names = node->get_node_names();
 

--- a/rclcpp_components/test/test_component_manager_api.cpp
+++ b/rclcpp_components/test/test_component_manager_api.cpp
@@ -143,6 +143,84 @@ TEST_F(TestComponentManager, components_api)
     EXPECT_EQ(result.get()->unique_id, 0u);
   }
 
+  {
+    // Remap rules
+    auto request = std::make_shared<composition_interfaces::srv::LoadNode::Request>();
+    request->package_name = "rclcpp_components";
+    request->plugin_name = "test_rclcpp_components::TestComponentFoo";
+    request->node_name = "test_component_remap";
+    request->remap_rules.push_back("alice:=bob");
+
+    auto result = client->async_send_request(request);
+    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+    EXPECT_EQ(ret, rclcpp::executor::FutureReturnCode::SUCCESS);
+    EXPECT_EQ(result.get()->success, true);
+    EXPECT_EQ(result.get()->error_message, "");
+    EXPECT_EQ(result.get()->full_node_name, "/test_component_remap");
+    EXPECT_EQ(result.get()->unique_id, 5u);
+  }
+
+  {
+    // use_intra_process_comms
+    auto request = std::make_shared<composition_interfaces::srv::LoadNode::Request>();
+    request->package_name = "rclcpp_components";
+    request->plugin_name = "test_rclcpp_components::TestComponentFoo";
+    request->node_name = "test_component_intra_process";
+    rclcpp::Parameter use_intraprocess_comms("use_intra_process_comms",
+      rclcpp::ParameterValue(true));
+    request->extra_arguments.push_back(use_intraprocess_comms.to_parameter_msg());
+
+    auto result = client->async_send_request(request);
+    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+    EXPECT_EQ(ret, rclcpp::executor::FutureReturnCode::SUCCESS);
+    EXPECT_EQ(result.get()->success, true);
+    EXPECT_EQ(result.get()->error_message, "");
+    std::cout << result.get()->full_node_name << std::endl;
+    EXPECT_EQ(result.get()->full_node_name, "/test_component_intra_process");
+    EXPECT_EQ(result.get()->unique_id, 6u);
+  }
+
+  {
+    // use_intra_process_comms is not a bool type parameter
+    auto request = std::make_shared<composition_interfaces::srv::LoadNode::Request>();
+    request->package_name = "rclcpp_components";
+    request->plugin_name = "test_rclcpp_components::TestComponentFoo";
+    request->node_name = "test_component_intra_process_str";
+
+    rclcpp::Parameter use_intraprocess_comms("use_intra_process_comms",
+      rclcpp::ParameterValue("hello"));
+    request->extra_arguments.push_back(use_intraprocess_comms.to_parameter_msg());
+
+    auto result = client->async_send_request(request);
+    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+    EXPECT_EQ(ret, rclcpp::executor::FutureReturnCode::SUCCESS);
+    EXPECT_EQ(result.get()->success, false);
+    EXPECT_EQ(
+      result.get()->error_message,
+      "Extra component argument 'use_intra_process_comms' must be a boolean");
+    EXPECT_EQ(result.get()->full_node_name, "");
+    EXPECT_EQ(result.get()->unique_id, 0u);
+  }
+
+  {
+    // Node constructor throws exception
+    auto request = std::make_shared<composition_interfaces::srv::LoadNode::Request>();
+    request->package_name = "rclcpp_components";
+    request->plugin_name = "test_rclcpp_components::TestComponentThrows";
+    request->node_name = "test_component_throws";
+
+    auto result = client->async_send_request(request);
+    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+    EXPECT_EQ(ret, rclcpp::executor::FutureReturnCode::SUCCESS);
+    EXPECT_EQ(result.get()->success, false);
+    EXPECT_EQ(
+      result.get()->error_message,
+      "Component constructor threw an exception");
+    EXPECT_EQ(result.get()->full_node_name, "");
+    EXPECT_EQ(result.get()->unique_id, 0u);
+  }
+
+
   auto node_names = node->get_node_names();
 
   auto find_in_nodes = [node_names](std::string name) {
@@ -170,16 +248,20 @@ TEST_F(TestComponentManager, components_api)
       auto node_names = result.get()->full_node_names;
       auto unique_ids = result.get()->unique_ids;
 
-      EXPECT_EQ(node_names.size(), 4u);
+      EXPECT_EQ(node_names.size(), 6u);
       EXPECT_EQ(node_names[0], "/test_component_foo");
       EXPECT_EQ(node_names[1], "/test_component_bar");
       EXPECT_EQ(node_names[2], "/test_component_baz");
       EXPECT_EQ(node_names[3], "/ns/test_component_bing");
-      EXPECT_EQ(unique_ids.size(), 4u);
+      EXPECT_EQ(node_names[4], "/test_component_remap");
+      EXPECT_EQ(node_names[5], "/test_component_intra_process");
+      EXPECT_EQ(unique_ids.size(), 6u);
       EXPECT_EQ(unique_ids[0], 1u);
       EXPECT_EQ(unique_ids[1], 2u);
       EXPECT_EQ(unique_ids[2], 3u);
       EXPECT_EQ(unique_ids[3], 4u);
+      EXPECT_EQ(unique_ids[4], 5u);
+      EXPECT_EQ(unique_ids[5], 6u);
     }
   }
 
@@ -230,14 +312,18 @@ TEST_F(TestComponentManager, components_api)
       auto node_names = result.get()->full_node_names;
       auto unique_ids = result.get()->unique_ids;
 
-      EXPECT_EQ(node_names.size(), 3u);
+      EXPECT_EQ(node_names.size(), 5u);
       EXPECT_EQ(node_names[0], "/test_component_bar");
       EXPECT_EQ(node_names[1], "/test_component_baz");
       EXPECT_EQ(node_names[2], "/ns/test_component_bing");
-      EXPECT_EQ(unique_ids.size(), 3u);
+      EXPECT_EQ(node_names[3], "/test_component_remap");
+      EXPECT_EQ(node_names[4], "/test_component_intra_process");
+      EXPECT_EQ(unique_ids.size(), 5u);
       EXPECT_EQ(unique_ids[0], 2u);
       EXPECT_EQ(unique_ids[1], 3u);
       EXPECT_EQ(unique_ids[2], 4u);
+      EXPECT_EQ(unique_ids[3], 5u);
+      EXPECT_EQ(unique_ids[4], 6u);
     }
   }
 }


### PR DESCRIPTION
Similar to #1043, this adds tests to increase the test coverage of rclcpp_components as part of the effort to bring it to QL 1. This additions bring the coverage from 88% to 100% of the `include` files and 95% of the `src` files (96% combined).

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9863)](http://ci.ros2.org/job/ci_linux/9863/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5479)](http://ci.ros2.org/job/ci_linux-aarch64/5479/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8023)](http://ci.ros2.org/job/ci_osx/8023/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9719)](http://ci.ros2.org/job/ci_windows/9719/)
* Coverage [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux_coverage&build=78)](https://ci.ros2.org/job/ci_linux_coverage/78/)

Depends on #1043 
New commit: https://github.com/ros2/rclcpp/commit/85193e60c7b0fcd88f3bcb09d9167d2c424cbb73