### PR TITLE
[rclcpp] add WaitSet class and modify entities to work without executor

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -86,6 +86,7 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/timer.cpp
   src/rclcpp/type_support.cpp
   src/rclcpp/utilities.cpp
+  src/rclcpp/wait_set_policies/detail/write_preferring_read_write_lock.cpp
   src/rclcpp/waitable.cpp
 )
 

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -531,6 +531,7 @@ if(BUILD_TESTING)
   ament_add_gtest(test_wait_set test/test_wait_set.cpp
     APPEND_LIBRARY_DIRS "${append_library_dirs}")
   if(TARGET test_wait_set)
+    ament_target_dependencies(test_wait_set "test_msgs")
     target_link_libraries(test_wait_set ${PROJECT_NAME})
   endif()
 

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -526,6 +526,12 @@ if(BUILD_TESTING)
     target_link_libraries(test_guard_condition ${PROJECT_NAME})
   endif()
 
+  ament_add_gtest(test_wait_set test/test_wait_set.cpp
+    APPEND_LIBRARY_DIRS "${append_library_dirs}")
+  if(TARGET test_wait_set)
+    target_link_libraries(test_wait_set ${PROJECT_NAME})
+  endif()
+
   # Install test resources
   install(
     DIRECTORY test/resources

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -49,6 +49,7 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/executors/static_executor_entities_collector.cpp
   src/rclcpp/executors/static_single_threaded_executor.cpp
   src/rclcpp/graph_listener.cpp
+  src/rclcpp/guard_condition.cpp
   src/rclcpp/init_options.cpp
   src/rclcpp/intra_process_manager.cpp
   src/rclcpp/logger.cpp
@@ -517,6 +518,12 @@ if(BUILD_TESTING)
     ament_target_dependencies(test_multi_threaded_executor
       "rcl")
     target_link_libraries(test_multi_threaded_executor ${PROJECT_NAME})
+  endif()
+
+  ament_add_gtest(test_guard_condition test/test_guard_condition.cpp
+    APPEND_LIBRARY_DIRS "${append_library_dirs}")
+  if(TARGET test_guard_condition)
+    target_link_libraries(test_guard_condition ${PROJECT_NAME})
   endif()
 
   # Install test resources

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -55,6 +55,7 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/logger.cpp
   src/rclcpp/memory_strategies.cpp
   src/rclcpp/memory_strategy.cpp
+  src/rclcpp/message_info.cpp
   src/rclcpp/node.cpp
   src/rclcpp/node_options.cpp
   src/rclcpp/node_interfaces/node_base.cpp

--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -25,6 +25,7 @@
 
 #include "rclcpp/allocator/allocator_common.hpp"
 #include "rclcpp/function_traits.hpp"
+#include "rclcpp/message_info.hpp"
 #include "rclcpp/visibility_control.hpp"
 #include "tracetools/tracetools.h"
 #include "tracetools/utils.hpp"
@@ -43,13 +44,13 @@ class AnySubscriptionCallback
 
   using SharedPtrCallback = std::function<void (const std::shared_ptr<MessageT>)>;
   using SharedPtrWithInfoCallback =
-    std::function<void (const std::shared_ptr<MessageT>, const rmw_message_info_t &)>;
+    std::function<void (const std::shared_ptr<MessageT>, const rclcpp::MessageInfo &)>;
   using ConstSharedPtrCallback = std::function<void (const std::shared_ptr<const MessageT>)>;
   using ConstSharedPtrWithInfoCallback =
-    std::function<void (const std::shared_ptr<const MessageT>, const rmw_message_info_t &)>;
+    std::function<void (const std::shared_ptr<const MessageT>, const rclcpp::MessageInfo &)>;
   using UniquePtrCallback = std::function<void (MessageUniquePtr)>;
   using UniquePtrWithInfoCallback =
-    std::function<void (MessageUniquePtr, const rmw_message_info_t &)>;
+    std::function<void (MessageUniquePtr, const rclcpp::MessageInfo &)>;
 
   SharedPtrCallback shared_ptr_callback_;
   SharedPtrWithInfoCallback shared_ptr_with_info_callback_;
@@ -155,7 +156,7 @@ public:
   }
 
   void dispatch(
-    std::shared_ptr<MessageT> message, const rmw_message_info_t & message_info)
+    std::shared_ptr<MessageT> message, const rclcpp::MessageInfo & message_info)
   {
     TRACEPOINT(callback_start, (const void *)this, false);
     if (shared_ptr_callback_) {
@@ -181,7 +182,7 @@ public:
   }
 
   void dispatch_intra_process(
-    ConstMessageSharedPtr message, const rmw_message_info_t & message_info)
+    ConstMessageSharedPtr message, const rclcpp::MessageInfo & message_info)
   {
     TRACEPOINT(callback_start, (const void *)this, true);
     if (const_shared_ptr_callback_) {
@@ -204,7 +205,7 @@ public:
   }
 
   void dispatch_intra_process(
-    MessageUniquePtr message, const rmw_message_info_t & message_info)
+    MessageUniquePtr message, const rclcpp::MessageInfo & message_info)
   {
     TRACEPOINT(callback_start, (const void *)this, true);
     if (shared_ptr_callback_) {

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -125,6 +125,7 @@ public:
    *   longer in use by a wait set.
    * \returns the previous state.
    */
+  RCLCPP_PUBLIC
   bool
   exchange_in_use_by_wait_set_state(bool in_use_state);
 

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -15,6 +15,7 @@
 #ifndef RCLCPP__CLIENT_HPP_
 #define RCLCPP__CLIENT_HPP_
 
+#include <atomic>
 #include <future>
 #include <map>
 #include <memory>
@@ -114,6 +115,19 @@ public:
   virtual void handle_response(
     std::shared_ptr<rmw_request_id_t> request_header, std::shared_ptr<void> response) = 0;
 
+  /// Exchange the "in use by wait set" state for this client.
+  /**
+   * This is used to ensure this client is not used by multiple
+   * wait sets at the same time.
+   *
+   * \param[in] in_use_state the new state to exchange into the state, true
+   *   indicates it is now in use by a wait set, and false is that it is no
+   *   longer in use by a wait set.
+   * \returns the previous state.
+   */
+  bool
+  exchange_in_use_by_wait_set_state(bool in_use_state);
+
 protected:
   RCLCPP_DISABLE_COPY(ClientBase)
 
@@ -134,6 +148,8 @@ protected:
   std::shared_ptr<rclcpp::Context> context_;
 
   std::shared_ptr<rcl_client_t> client_handle_;
+
+  std::atomic<bool> in_use_by_wait_set_{false};
 };
 
 template<typename ServiceT>

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -62,6 +62,27 @@ public:
   RCLCPP_PUBLIC
   virtual ~ClientBase();
 
+  /// Take the next response for this client as a type erased pointer.
+  /**
+   * The type erased pointer allows for this method to be used in a type
+   * agnostic way along with ClientBase::create_response(),
+   * ClientBase::create_request_header(), and ClientBase::handle_response().
+   * The typed version of this can be used if the Service type is known,
+   * \sa Client::take_response().
+   *
+   * \param[out] response_out The type erased pointer to a Service Response into
+   *   which the middleware will copy the response being taken.
+   * \param[out] request_header_out The request header to be filled by the
+   *   middleware when taking, and which can be used to associte the response
+   *   to a specific request.
+   * \returns true if the response was taken, otherwise false.
+   * \throws rclcpp::exceptions::RCLError based exceptions if the underlying
+   *   rcl function fail.
+   */
+  RCLCPP_PUBLIC
+  bool
+  take_type_erased_response(void * response_out, rmw_request_id_t & request_header_out);
+
   RCLCPP_PUBLIC
   const char *
   get_service_name() const;
@@ -169,6 +190,25 @@ public:
 
   virtual ~Client()
   {
+  }
+
+  /// Take the next response for this client.
+  /**
+   * \sa ClientBase::take_type_erased_response().
+   *
+   * \param[out] response_out The reference to a Service Response into
+   *   which the middleware will copy the response being taken.
+   * \param[out] request_header_out The request header to be filled by the
+   *   middleware when taking, and which can be used to associte the response
+   *   to a specific request.
+   * \returns true if the response was taken, otherwise false.
+   * \throws rclcpp::exceptions::RCLError based exceptions if the underlying
+   *   rcl function fail.
+   */
+  bool
+  take_response(typename ServiceT::Response & response_out, rmw_request_id_t & request_header_out)
+  {
+    return this->take_type_erased_response(&response_out, request_header_out);
   }
 
   std::shared_ptr<void>

--- a/rclcpp/include/rclcpp/context.hpp
+++ b/rclcpp/include/rclcpp/context.hpp
@@ -159,7 +159,7 @@ public:
    *
    * \param[in] reason the description of why shutdown happened
    * \return true if shutdown was successful, false if context was already shutdown
-   * \throw various exceptions derived from RCLErrorBase, if rcl_shutdown fails
+   * \throw various exceptions derived from rclcpp::exceptions::RCLError, if rcl_shutdown fails
    */
   RCLCPP_PUBLIC
   virtual

--- a/rclcpp/include/rclcpp/guard_condition.hpp
+++ b/rclcpp/include/rclcpp/guard_condition.hpp
@@ -39,13 +39,13 @@ public:
    *   Shared ownership of the context is held with the guard condition until
    *   destruction.
    * \throws std::invalid_argument if the context is nullptr.
-   * \throws rclcpp::exceptions::RCLErrorBase based exceptions when underlying
+   * \throws rclcpp::exceptions::RCLError based exceptions when underlying
    *   rcl functions fail.
    */
   RCLCPP_PUBLIC
   explicit GuardCondition(
     rclcpp::Context::SharedPtr context =
-      rclcpp::contexts::default_context::get_global_default_context());
+    rclcpp::contexts::default_context::get_global_default_context());
 
   RCLCPP_PUBLIC
   virtual
@@ -66,7 +66,7 @@ public:
    * This function is thread-safe, and may be called concurrently with waiting
    * on this guard condition in a wait set.
    *
-   * \throws rclcpp::exceptions::RCLErrorBase based exceptions when underlying
+   * \throws rclcpp::exceptions::RCLError based exceptions when underlying
    *   rcl functions fail.
    */
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/guard_condition.hpp
+++ b/rclcpp/include/rclcpp/guard_condition.hpp
@@ -15,6 +15,8 @@
 #ifndef RCLCPP__GUARD_CONDITION_HPP_
 #define RCLCPP__GUARD_CONDITION_HPP_
 
+#include <atomic>
+
 #include "rcl/guard_condition.h"
 
 #include "rclcpp/context.hpp"
@@ -73,9 +75,23 @@ public:
   void
   trigger();
 
+  /// Exchange the "in use by wait set" state for this guard condition.
+  /**
+   * This is used to ensure this guard condition is not used by multiple
+   * wait sets at the same time.
+   *
+   * \param[in] in_use_state the new state to exchange into the state, true
+   *   indicates it is now in use by a wait set, and false is that it is no
+   *   longer in use by a wait set.
+   * \returns the previous state.
+   */
+  bool
+  exchange_in_use_by_wait_set_state(bool in_use_state);
+
 protected:
   rclcpp::Context::SharedPtr context_;
   rcl_guard_condition_t rcl_guard_condition_;
+  std::atomic<bool> in_use_by_wait_set_{false};
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/guard_condition.hpp
+++ b/rclcpp/include/rclcpp/guard_condition.hpp
@@ -59,7 +59,7 @@ public:
   /// Return the underlying rcl guard condition structure.
   RCLCPP_PUBLIC
   const rcl_guard_condition_t &
-  get_rcl_guard_condtion() const;
+  get_rcl_guard_condition() const;
 
   /// Notify the wait set waiting on this condition, if any, that the condition had been met.
   /**

--- a/rclcpp/include/rclcpp/guard_condition.hpp
+++ b/rclcpp/include/rclcpp/guard_condition.hpp
@@ -1,0 +1,83 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__GUARD_CONDITION_HPP_
+#define RCLCPP__GUARD_CONDITION_HPP_
+
+#include "rcl/guard_condition.h"
+
+#include "rclcpp/context.hpp"
+#include "rclcpp/contexts/default_context.hpp"
+#include "rclcpp/macros.hpp"
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+
+/// A condition that can be waited on in a single wait set and asynchronously triggered.
+class GuardCondition
+{
+public:
+  RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(GuardCondition)
+
+  // TODO(wjwwood): support custom allocator, maybe restrict to polymorphic allocator
+  /// Construct the guard condition, optionally specifying which Context to use.
+  /**
+   * \param[in] context Optional custom context to be used.
+   *   Defaults to using the global default context singleton.
+   *   Shared ownership of the context is held with the guard condition until
+   *   destruction.
+   * \throws std::invalid_argument if the context is nullptr.
+   * \throws rclcpp::exceptions::RCLErrorBase based exceptions when underlying
+   *   rcl functions fail.
+   */
+  RCLCPP_PUBLIC
+  explicit GuardCondition(
+    rclcpp::Context::SharedPtr context =
+      rclcpp::contexts::default_context::get_global_default_context());
+
+  RCLCPP_PUBLIC
+  virtual
+  ~GuardCondition();
+
+  /// Return the context used when creating this guard condition.
+  RCLCPP_PUBLIC
+  rclcpp::Context::SharedPtr
+  get_context() const;
+
+  /// Return the underlying rcl guard condition structure.
+  RCLCPP_PUBLIC
+  const rcl_guard_condition_t &
+  get_rcl_guard_condtion() const;
+
+  /// Notify the wait set waiting on this condition, if any, that the condition had been met.
+  /**
+   * This function is thread-safe, and may be called concurrently with waiting
+   * on this guard condition in a wait set.
+   *
+   * \throws rclcpp::exceptions::RCLErrorBase based exceptions when underlying
+   *   rcl functions fail.
+   */
+  RCLCPP_PUBLIC
+  void
+  trigger();
+
+protected:
+  rclcpp::Context::SharedPtr context_;
+  rcl_guard_condition_t rcl_guard_condition_;
+};
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__GUARD_CONDITION_HPP_

--- a/rclcpp/include/rclcpp/guard_condition.hpp
+++ b/rclcpp/include/rclcpp/guard_condition.hpp
@@ -85,6 +85,7 @@ public:
    *   longer in use by a wait set.
    * \returns the previous state.
    */
+  RCLCPP_PUBLIC
   bool
   exchange_in_use_by_wait_set_state(bool in_use_state);
 

--- a/rclcpp/include/rclcpp/message_info.hpp
+++ b/rclcpp/include/rclcpp/message_info.hpp
@@ -1,0 +1,52 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__MESSAGE_INFO_HPP_
+#define RCLCPP__MESSAGE_INFO_HPP_
+
+#include "rmw/types.h"
+
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+
+/// Additional meta data about messages taken from subscriptions.
+class RCLCPP_PUBLIC MessageInfo
+{
+public:
+  /// Default empty constructor.
+  MessageInfo() = default;
+
+  /// Conversion constructor, which is intentionally not marked as explicit.
+  // cppcheck-suppress noExplicitConstructor
+  MessageInfo(const rmw_message_info_t & rmw_message_info);  // NOLINT(runtime/explicit)
+
+  virtual ~MessageInfo();
+
+  /// Return the message info as the underlying rmw message info type.
+  const rmw_message_info_t &
+  get_rmw_message_info() const;
+
+  /// Return the message info as the underlying rmw message info type.
+  rmw_message_info_t &
+  get_rmw_message_info();
+
+private:
+  rmw_message_info_t rmw_message_info_;
+};
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__MESSAGE_INFO_HPP_

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -153,6 +153,7 @@
 #include "rclcpp/time.hpp"
 #include "rclcpp/utilities.hpp"
 #include "rclcpp/visibility_control.hpp"
+#include "rclcpp/wait_set.hpp"
 #include "rclcpp/waitable.hpp"
 
 #endif  // RCLCPP__RCLCPP_HPP_

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -143,6 +143,7 @@
 #include <memory>
 
 #include "rclcpp/executors.hpp"
+#include "rclcpp/guard_condition.hpp"
 #include "rclcpp/logging.hpp"
 #include "rclcpp/node.hpp"
 #include "rclcpp/parameter.hpp"

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -15,6 +15,7 @@
 #ifndef RCLCPP__SERVICE_HPP_
 #define RCLCPP__SERVICE_HPP_
 
+#include <atomic>
 #include <functional>
 #include <iostream>
 #include <memory>
@@ -94,6 +95,19 @@ public:
     std::shared_ptr<rmw_request_id_t> request_header,
     std::shared_ptr<void> request) = 0;
 
+  /// Exchange the "in use by wait set" state for this service.
+  /**
+   * This is used to ensure this service is not used by multiple
+   * wait sets at the same time.
+   *
+   * \param[in] in_use_state the new state to exchange into the state, true
+   *   indicates it is now in use by a wait set, and false is that it is no
+   *   longer in use by a wait set.
+   * \returns the previous state.
+   */
+  bool
+  exchange_in_use_by_wait_set_state(bool in_use_state);
+
 protected:
   RCLCPP_DISABLE_COPY(ServiceBase)
 
@@ -109,6 +123,8 @@ protected:
 
   std::shared_ptr<rcl_service_t> service_handle_;
   bool owns_rcl_handle_ = true;
+
+  std::atomic<bool> in_use_by_wait_set_{false};
 };
 
 template<typename ServiceT>

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -105,6 +105,7 @@ public:
    *   longer in use by a wait set.
    * \returns the previous state.
    */
+  RCLCPP_PUBLIC
   bool
   exchange_in_use_by_wait_set_state(bool in_use_state);
 

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -44,8 +44,7 @@ public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(ServiceBase)
 
   RCLCPP_PUBLIC
-  explicit ServiceBase(
-    std::shared_ptr<rcl_node_t> node_handle);
+  explicit ServiceBase(std::shared_ptr<rcl_node_t> node_handle);
 
   RCLCPP_PUBLIC
   virtual ~ServiceBase();
@@ -62,9 +61,36 @@ public:
   std::shared_ptr<const rcl_service_t>
   get_service_handle() const;
 
-  virtual std::shared_ptr<void> create_request() = 0;
-  virtual std::shared_ptr<rmw_request_id_t> create_request_header() = 0;
-  virtual void handle_request(
+  /// Take the next request from the service as a type erased pointer.
+  /**
+   * This type erased version of \sa Service::take_request() is useful when
+   * using the service in a type agnostic way with methods like
+   * ServiceBase::create_request(), ServiceBase::create_request_header(), and
+   * ServiceBase::handle_request().
+   *
+   * \param[out] request_out The type erased pointer to a service request object
+   *   into which the middleware will copy the taken request.
+   * \param[out] request_id_out The output id for the request which can be used
+   *   to associate response with this request in the future.
+   * \returns true if the request was taken, otherwise false.
+   * \throws rclcpp::exceptions::RCLError based exceptions if the underlying
+   *   rcl calls fail.
+   */
+  RCLCPP_PUBLIC
+  bool
+  take_type_erased_request(void * request_out, rmw_request_id_t & request_id_out);
+
+  virtual
+  std::shared_ptr<void>
+  create_request() = 0;
+
+  virtual
+  std::shared_ptr<rmw_request_id_t>
+  create_request_header() = 0;
+
+  virtual
+  void
+  handle_request(
     std::shared_ptr<rmw_request_id_t> request_header,
     std::shared_ptr<void> request) = 0;
 
@@ -222,36 +248,63 @@ public:
   {
   }
 
-  std::shared_ptr<void> create_request() override
+  /// Take the next request from the service.
+  /**
+   * \sa ServiceBase::take_type_erased_request().
+   *
+   * \param[out] request_out The reference to a service request object
+   *   into which the middleware will copy the taken request.
+   * \param[out] request_id_out The output id for the request which can be used
+   *   to associate response with this request in the future.
+   * \returns true if the request was taken, otherwise false.
+   * \throws rclcpp::exceptions::RCLError based exceptions if the underlying
+   *   rcl calls fail.
+   */
+  bool
+  take_request(typename ServiceT::Request & request_out, rmw_request_id_t & request_id_out)
   {
-    return std::shared_ptr<void>(new typename ServiceT::Request());
+    return this->take_type_erased_request(&request_out, request_id_out);
   }
 
-  std::shared_ptr<rmw_request_id_t> create_request_header() override
+  std::shared_ptr<void>
+  create_request() override
   {
-    // TODO(wjwwood): This should probably use rmw_request_id's allocator.
-    //                (since it is a C type)
-    return std::shared_ptr<rmw_request_id_t>(new rmw_request_id_t);
+    return std::make_shared<typename ServiceT::Request>();
   }
 
-  void handle_request(
+  std::shared_ptr<rmw_request_id_t>
+  create_request_header() override
+  {
+    return std::make_shared<rmw_request_id_t>();
+  }
+
+  void
+  handle_request(
     std::shared_ptr<rmw_request_id_t> request_header,
     std::shared_ptr<void> request) override
   {
     auto typed_request = std::static_pointer_cast<typename ServiceT::Request>(request);
-    auto response = std::shared_ptr<typename ServiceT::Response>(new typename ServiceT::Response);
+    auto response = std::make_shared<typename ServiceT::Response>();
     any_callback_.dispatch(request_header, typed_request, response);
-    send_response(request_header, response);
+    send_response(*request_header, *response);
   }
 
-  void send_response(
+  [[deprecated("use the send_response() which takes references instead of shared pointers")]]
+  void
+  send_response(
     std::shared_ptr<rmw_request_id_t> req_id,
     std::shared_ptr<typename ServiceT::Response> response)
   {
-    rcl_ret_t status = rcl_send_response(get_service_handle().get(), req_id.get(), response.get());
+    send_response(*req_id, *response);
+  }
 
-    if (status != RCL_RET_OK) {
-      rclcpp::exceptions::throw_from_rcl_error(status, "failed to send response");
+  void
+  send_response(rmw_request_id_t & req_id, typename ServiceT::Response & response)
+  {
+    rcl_ret_t ret = rcl_send_response(get_service_handle().get(), &req_id, &response);
+
+    if (ret != RCL_RET_OK) {
+      rclcpp::exceptions::throw_from_rcl_error(ret, "failed to send response");
     }
   }
 

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -186,7 +186,8 @@ public:
   }
 
   /// Called after construction to continue setup that requires shared_from_this().
-  void post_init_setup(
+  void
+  post_init_setup(
     rclcpp::node_interfaces::NodeBaseInterface * node_base,
     const rclcpp::QoS & qos,
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options)
@@ -252,7 +253,8 @@ public:
 
   void
   handle_loaned_message(
-    void * loaned_message, const rclcpp::MessageInfo & message_info) override
+    void * loaned_message,
+    const rclcpp::MessageInfo & message_info) override
   {
     auto typed_message = static_cast<CallbackMessageT *>(loaned_message);
     // message is loaned, so we have to make sure that the deleter does not deallocate the message
@@ -263,18 +265,21 @@ public:
 
   /// Return the borrowed message.
   /** \param message message to be returned */
-  void return_message(std::shared_ptr<void> & message) override
+  void
+  return_message(std::shared_ptr<void> & message) override
   {
     auto typed_message = std::static_pointer_cast<CallbackMessageT>(message);
     message_memory_strategy_->return_message(typed_message);
   }
 
-  void return_serialized_message(std::shared_ptr<rcl_serialized_message_t> & message) override
+  void
+  return_serialized_message(std::shared_ptr<rcl_serialized_message_t> & message) override
   {
     message_memory_strategy_->return_serialized_message(message);
   }
 
-  bool use_take_shared_method() const
+  bool
+  use_take_shared_method() const
   {
     return any_callback_.use_take_shared_method();
   }

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -131,6 +131,7 @@ public:
    * \returns true if data was taken and is valid, otherwise false
    * \throws any rcl errors from rcl_take, \sa rclcpp::exceptions::throw_from_rcl_error()
    */
+  RCLCPP_PUBLIC
   bool
   take_type_erased(void * message_out, rclcpp::MessageInfo & message_info_out);
 
@@ -148,6 +149,7 @@ public:
    * \returns true if data was taken and is valid, otherwise false
    * \throws any rcl errors from rcl_take, \sa rclcpp::exceptions::throw_from_rcl_error()
    */
+  RCLCPP_PUBLIC
   bool
   take_serialized(rcl_serialized_message_t & message_out, rclcpp::MessageInfo & message_info_out);
 

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -146,7 +146,7 @@ public:
    * \throws any rcl errors from rcl_take, \sa rclcpp::exceptions::throw_from_rcl_error()
    */
   bool
-  take_serialized(rmw_serialized_message_t & message_out, rclcpp::MessageInfo & message_info_out);
+  take_serialized(rcl_serialized_message_t & message_out, rclcpp::MessageInfo & message_info_out);
 
   /// Borrow a new message.
   /** \return Shared pointer to the fresh message. */

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -111,6 +111,43 @@ public:
   rclcpp::QoS
   get_actual_qos() const;
 
+  /// Take the next inter-process message from the subscription as a type erased poiner.
+  /**
+   * \sa Subscription::take() for details on how this function works.
+   *
+   * The only difference is that it takes a type erased pointer rather than a
+   * reference to the exact message type.
+   *
+   * This type erased version facilitates using the subscriptions in a type
+   * agnostic way using SubscriptionBase::create_message() and
+   * SubscriptionBase::handle_message().
+   *
+   * \param[out] message_out The type erased message pointer into which take
+   *   will copy the data.
+   * \param[out] message_info_out The message info for the taken message.
+   * \returns true if data was taken and is valid, otherwise false
+   * \throws any rcl errors from rcl_take, \sa rclcpp::exceptions::throw_from_rcl_error()
+   */
+  bool
+  take_type_erased(void * message_out, rclcpp::MessageInfo & message_info_out);
+
+  /// Take the next inter-process message, in its serialized form, from the subscription.
+  /**
+   * For now, if data is taken (written) into the message_out and
+   * message_info_out then true will be returned.
+   * Unlike Subscription::take(), taking data serialized is not possible via
+   * intra-process for the time being, so it will not need to de-duplicate
+   * data in any case.
+   *
+   * \param[out] message_out The serialized message data structure used to
+   *   store the taken message.
+   * \param[out] message_info_out The message info for the taken message.
+   * \returns true if data was taken and is valid, otherwise false
+   * \throws any rcl errors from rcl_take, \sa rclcpp::exceptions::throw_from_rcl_error()
+   */
+  bool
+  take_serialized(rmw_serialized_message_t & message_out, rclcpp::MessageInfo & message_info_out);
+
   /// Borrow a new message.
   /** \return Shared pointer to the fresh message. */
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -27,6 +27,7 @@
 #include "rclcpp/experimental/intra_process_manager.hpp"
 #include "rclcpp/experimental/subscription_intra_process_base.hpp"
 #include "rclcpp/macros.hpp"
+#include "rclcpp/message_info.hpp"
 #include "rclcpp/qos.hpp"
 #include "rclcpp/qos_event.hpp"
 #include "rclcpp/type_support_decl.hpp"
@@ -132,12 +133,12 @@ public:
   RCLCPP_PUBLIC
   virtual
   void
-  handle_message(std::shared_ptr<void> & message, const rmw_message_info_t & message_info) = 0;
+  handle_message(std::shared_ptr<void> & message, const rclcpp::MessageInfo & message_info) = 0;
 
   RCLCPP_PUBLIC
   virtual
   void
-  handle_loaned_message(void * loaned_message, const rmw_message_info_t & message_info) = 0;
+  handle_loaned_message(void * loaned_message, const rclcpp::MessageInfo & message_info) = 0;
 
   /// Return the message borrowed in create_message.
   /** \param[in] message Shared pointer to the returned message. */

--- a/rclcpp/include/rclcpp/subscription_wait_set_mask.hpp
+++ b/rclcpp/include/rclcpp/subscription_wait_set_mask.hpp
@@ -15,11 +15,13 @@
 #ifndef RCLCPP__SUBSCRIPTION_WAIT_SET_MASK_HPP_
 #define RCLCPP__SUBSCRIPTION_WAIT_SET_MASK_HPP_
 
+#include "rclcpp/visibility_control.hpp"
+
 namespace rclcpp
 {
 
 /// Options used to determine what parts of a subscription get added to or removed from a wait set.
-class SubscriptionWaitSetMask
+class RCLCPP_PUBLIC SubscriptionWaitSetMask
 {
 public:
   /// If true, include the actual subscription.

--- a/rclcpp/include/rclcpp/subscription_wait_set_mask.hpp
+++ b/rclcpp/include/rclcpp/subscription_wait_set_mask.hpp
@@ -1,0 +1,35 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__SUBSCRIPTION_WAIT_SET_MASK_HPP_
+#define RCLCPP__SUBSCRIPTION_WAIT_SET_MASK_HPP_
+
+namespace rclcpp
+{
+
+/// Options used to determine what parts of a subscription get added to or removed from a wait set.
+class SubscriptionWaitSetMask
+{
+public:
+  /// If true, include the actual subscription.
+  bool include_subscription = true;
+  /// If true, include any events attached to the subscription.
+  bool include_events = true;
+  /// If true, include the waitable used to handle intra process communication.
+  bool include_intra_process_waitable = true;
+};
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__SUBSCRIPTION_WAIT_SET_MASK_HPP_

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -112,6 +112,7 @@ public:
    *   longer in use by a wait set.
    * \returns the previous state.
    */
+  RCLCPP_PUBLIC
   bool
   exchange_in_use_by_wait_set_state(bool in_use_state);
 

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -64,7 +64,7 @@ public:
   /**
    * \return true if the timer has been cancelled, false otherwise
    * \throws std::runtime_error if the rcl_get_error_state returns 0
-   * \throws RCLErrorBase some child class exception based on ret
+   * \throws rclcpp::exceptions::RCLError some child class exception based on ret
    */
   RCLCPP_PUBLIC
   bool

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -15,6 +15,7 @@
 #ifndef RCLCPP__TIMER_HPP_
 #define RCLCPP__TIMER_HPP_
 
+#include <atomic>
 #include <chrono>
 #include <functional>
 #include <memory>
@@ -101,9 +102,24 @@ public:
   RCLCPP_PUBLIC
   bool is_ready();
 
+  /// Exchange the "in use by wait set" state for this timer.
+  /**
+   * This is used to ensure this timer is not used by multiple
+   * wait sets at the same time.
+   *
+   * \param[in] in_use_state the new state to exchange into the state, true
+   *   indicates it is now in use by a wait set, and false is that it is no
+   *   longer in use by a wait set.
+   * \returns the previous state.
+   */
+  bool
+  exchange_in_use_by_wait_set_state(bool in_use_state);
+
 protected:
   Clock::SharedPtr clock_;
   std::shared_ptr<rcl_timer_t> timer_handle_;
+
+  std::atomic<bool> in_use_by_wait_set_{false};
 };
 
 

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -121,7 +121,7 @@ init_and_remove_ros_arguments(
  * \param[in] argv Argument vector.
  * \returns Members of the argument vector that are not ROS arguments.
  * \throws anything throw_from_rcl_error can throw
- * \throws rclcpp::exceptions::RCLErrorBase if the parsing fails
+ * \throws rclcpp::exceptions::RCLError if the parsing fails
  */
 RCLCPP_PUBLIC
 std::vector<std::string>

--- a/rclcpp/include/rclcpp/wait_result.hpp
+++ b/rclcpp/include/rclcpp/wait_result.hpp
@@ -1,0 +1,155 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__WAIT_RESULT_HPP_
+#define RCLCPP__WAIT_RESULT_HPP_
+
+#include <cassert>
+#include <functional>
+#include <stdexcept>
+
+#include "rcl/wait.h"
+
+#include "rclcpp/macros.hpp"
+#include "rclcpp/wait_result_kind.hpp"
+
+namespace rclcpp
+{
+
+// TODO(wjwwood): the union-like design of this class could be replaced with
+//   std::variant, when we have access to that...
+/// Interface for introspecting a wait set after waiting on it.
+/**
+ * This class:
+ *
+ *   - provides the result of waiting, i.e. ready, timeout, or empty, and
+ *   - holds the ownership of the entities of the wait set, if needed, and
+ *   - provides the necessary information for iterating over the wait set.
+ *
+ * This class is only valid as long as the wait set which created it is valid,
+ * and it must be deleted before the wait set is deleted, as it contains a
+ * back reference to the wait set.
+ *
+ * An instance of this, which is returned from rclcpp::WaitSetTemplate::wait(),
+ * will cause the wait set to keep ownership of the entities because it only
+ * holds a reference to the sequences of them, rather than taking a copy.
+ * Also, in the thread-safe case, an instance of this will cause the wait set,
+ * to block calls which modify the sequences of the entities, e.g. add/remove
+ * guard condition or subscription methods.
+ *
+ * \tparam WaitSetT The wait set type which created this class.
+ */
+template<class WaitSetT>
+class WaitResult final
+{
+public:
+  /// Create WaitResult from a "ready" result.
+  /**
+   * \param[in] wait_set A reference to the wait set, which this class
+   *   will keep for the duration of its lifetime.
+   */
+  static
+  WaitResult
+  from_ready_wait_result_kind(WaitSetT & wait_set)
+  {
+    return WaitResult(WaitResultKind::Ready, wait_set);
+  }
+
+  /// Create WaitResult from a "timeout" result.
+  static
+  WaitResult
+  from_timeout_wait_result_kind()
+  {
+    return WaitResult(WaitResultKind::Timeout);
+  }
+
+  /// Create WaitResult from a "empty" result.
+  static
+  WaitResult
+  from_empty_wait_result_kind()
+  {
+    return WaitResult(WaitResultKind::Empty);
+  }
+
+  /// Return the kind of the WaitResult.
+  WaitResultKind
+  kind() const
+  {
+    return wait_result_kind_;
+  }
+
+  /// Return the rcl wait set.
+  const WaitSetT &
+  get_wait_set() const
+  {
+    if (this->kind() != WaitResultKind::Ready) {
+      throw std::runtime_error("cannot access wait set when the result was not ready");
+    }
+    // This should never happen, defensive (and debug mode) check only.
+    assert(wait_set_pointer_);
+    return *wait_set_pointer_;
+  }
+
+  /// Return the rcl wait set.
+  WaitSetT &
+  get_wait_set()
+  {
+    if (this->kind() != WaitResultKind::Ready) {
+      throw std::runtime_error("cannot access wait set when the result was not ready");
+    }
+    // This should never happen, defensive (and debug mode) check only.
+    assert(wait_set_pointer_);
+    return *wait_set_pointer_;
+  }
+
+  WaitResult(WaitResult && other) noexcept
+  : wait_result_kind_(other.wait_result_kind_),
+    wait_set_pointer_(std::exchange(other.wait_set_pointer_, nullptr))
+  {}
+
+  ~WaitResult()
+  {
+    if (wait_set_pointer_) {
+      wait_set_pointer_->wait_result_release();
+    }
+  }
+
+private:
+  RCLCPP_DISABLE_COPY(WaitResult)
+
+  explicit WaitResult(WaitResultKind wait_result_kind)
+  : wait_result_kind_(wait_result_kind)
+  {
+    // Should be enforced by the static factory methods on this class.
+    assert(WaitResultKind::Ready != wait_result_kind);
+  }
+
+  WaitResult(WaitResultKind wait_result_kind, WaitSetT & wait_set)
+  : wait_result_kind_(wait_result_kind),
+    wait_set_pointer_(&wait_set)
+  {
+    // Should be enforced by the static factory methods on this class.
+    assert(WaitResultKind::Ready == wait_result_kind);
+    // Secure thread-safety (if provided) and shared ownership (if needed).
+    wait_set_pointer_->wait_result_acquire();
+  }
+
+  const WaitResultKind wait_result_kind_;
+
+  WaitSetT * wait_set_pointer_ = nullptr;
+};
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__WAIT_RESULT_HPP_

--- a/rclcpp/include/rclcpp/wait_result_kind.hpp
+++ b/rclcpp/include/rclcpp/wait_result_kind.hpp
@@ -1,0 +1,31 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__WAIT_RESULT_KIND_HPP_
+#define RCLCPP__WAIT_RESULT_KIND_HPP_
+
+namespace rclcpp
+{
+
+/// Represents the various kinds of results from waiting on a wait set.
+enum WaitResultKind
+{
+  Ready,  //<! Kind used when something in the wait set was ready.
+  Timeout,  //<! Kind used when the wait resulted in a timeout.
+  Empty,  //<! Kind used when trying to wait on an empty wait set.
+};
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__WAIT_RESULT_KIND_HPP_

--- a/rclcpp/include/rclcpp/wait_result_kind.hpp
+++ b/rclcpp/include/rclcpp/wait_result_kind.hpp
@@ -15,11 +15,13 @@
 #ifndef RCLCPP__WAIT_RESULT_KIND_HPP_
 #define RCLCPP__WAIT_RESULT_KIND_HPP_
 
+#include "rclcpp/visibility_control.hpp"
+
 namespace rclcpp
 {
 
 /// Represents the various kinds of results from waiting on a wait set.
-enum WaitResultKind
+enum RCLCPP_PUBLIC WaitResultKind
 {
   Ready,  //<! Kind used when something in the wait set was ready.
   Timeout,  //<! Kind used when the wait resulted in a timeout.

--- a/rclcpp/include/rclcpp/wait_set.hpp
+++ b/rclcpp/include/rclcpp/wait_set.hpp
@@ -1,0 +1,108 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__WAIT_SET_HPP_
+#define RCLCPP__WAIT_SET_HPP_
+
+#include <memory>
+
+#include "rcl/wait.h"
+
+#include "rclcpp/guard_condition.hpp"
+#include "rclcpp/macros.hpp"
+#include "rclcpp/visibility_control.hpp"
+#include "rclcpp/wait_set_policies/dynamic_storage.hpp"
+#include "rclcpp/wait_set_policies/sequential_synchronization.hpp"
+#include "rclcpp/wait_set_policies/static_storage.hpp"
+// #include "rclcpp/wait_set_policies/thread_safe_synchronization.hpp"
+#include "rclcpp/wait_set_template.hpp"
+
+namespace rclcpp
+{
+
+/// Most common user configuration of a WaitSet, which is dynamic but not thread-safe.
+/**
+ * This wait set allows you to add and remove items dynamically, and it will
+ * automatically remove items that are let out of scope each time wait() or
+ * prune_destroyed_entities() is called.
+ *
+ * It will not, however, provide thread-safety for adding and removing entities
+ * while waiting.
+ *
+ * \sa rclcpp::WaitSetTemplate for API documentation
+ */
+using WaitSet = rclcpp::WaitSetTemplate<
+  rclcpp::wait_set_policies::DynamicStorage,
+  rclcpp::wait_set_policies::SequentialSynchronization
+>;
+
+/// WaitSet configuration which does not allow changes after construction.
+/**
+ * This wait set requires that you specify all entities at construction, and
+ * prevents you from calling the typical add and remove functions.
+ * It also requires that you specify how many of each item there will be as a
+ * template argument.
+ *
+ * It will share ownership of the entities until destroyed, therefore it will
+ * prevent the destruction of entities so long as the wait set exists, even if
+ * the user lets their copy of the shared pointer to the entity go out of scope.
+ *
+ * Since the wait set cannot be mutated, it does not need to be thread-safe.
+ *
+ * \sa rclcpp::WaitSetTemplate for API documentation
+ */
+template<
+  // std::size_t NumberOfSubscriptions,
+  std::size_t NumberOfGuardCondtions
+  // std::size_t NumberOfTimers,
+  // std::size_t NumberOfClients,
+  // std::size_t NumberOfServices,
+  // std::size_t NumberOfEvents,
+  // std::size_t NumberOfWaitables
+>
+using StaticWaitSet = rclcpp::WaitSetTemplate<
+  rclcpp::wait_set_policies::StaticStorage<
+    // NumberOfSubscriptions,
+    NumberOfGuardCondtions
+    // NumberOfTimers,
+    // NumberOfClients,
+    // NumberOfServices,
+    // NumberOfEvents,
+    // NumberOfWaitables
+  >,
+  rclcpp::wait_set_policies::SequentialSynchronization
+>;
+
+/// Like WaitSet, this configuration is dynamic, but is also thread-safe.
+/**
+ * This wait set allows you to add and remove items dynamically, and it will
+ * automatically remove items that are let out of scope each time wait() or
+ * prune_destroyed_entities() is called.
+ *
+ * It will also ensure that adding and removing items explicitly from the
+ * wait set is done in a thread-safe way, protecting against concurrent add and
+ * deletes, as well as add and deletes during a wait().
+ * This thread-safety comes at some overhead and the use of thread
+ * synchronization primitives.
+ *
+ * \sa rclcpp::WaitSetTemplate for API documentation
+ */
+// using ThreadSafeWaitSet = rclcpp::WaitSetTemplate<
+//   rclcpp::wait_set_policies::DynamicStorage,
+//   rclcpp::wait_set_policies::ThreadSafeSynchronization
+// >;
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__WAIT_SET_HPP_

--- a/rclcpp/include/rclcpp/wait_set.hpp
+++ b/rclcpp/include/rclcpp/wait_set.hpp
@@ -25,7 +25,7 @@
 #include "rclcpp/wait_set_policies/dynamic_storage.hpp"
 #include "rclcpp/wait_set_policies/sequential_synchronization.hpp"
 #include "rclcpp/wait_set_policies/static_storage.hpp"
-// #include "rclcpp/wait_set_policies/thread_safe_synchronization.hpp"
+#include "rclcpp/wait_set_policies/thread_safe_synchronization.hpp"
 #include "rclcpp/wait_set_template.hpp"
 
 namespace rclcpp
@@ -43,8 +43,8 @@ namespace rclcpp
  * \sa rclcpp::WaitSetTemplate for API documentation
  */
 using WaitSet = rclcpp::WaitSetTemplate<
-  rclcpp::wait_set_policies::DynamicStorage,
-  rclcpp::wait_set_policies::SequentialSynchronization
+  rclcpp::wait_set_policies::SequentialSynchronization,
+  rclcpp::wait_set_policies::DynamicStorage
 >;
 
 /// WaitSet configuration which does not allow changes after construction.
@@ -71,6 +71,7 @@ template<
   std::size_t NumberOfWaitables
 >
 using StaticWaitSet = rclcpp::WaitSetTemplate<
+  rclcpp::wait_set_policies::SequentialSynchronization,
   rclcpp::wait_set_policies::StaticStorage<
     NumberOfSubscriptions,
     NumberOfGuardCondtions,
@@ -78,8 +79,7 @@ using StaticWaitSet = rclcpp::WaitSetTemplate<
     NumberOfClients,
     NumberOfServices,
     NumberOfWaitables
-  >,
-  rclcpp::wait_set_policies::SequentialSynchronization
+  >
 >;
 
 /// Like WaitSet, this configuration is dynamic, but is also thread-safe.
@@ -96,10 +96,10 @@ using StaticWaitSet = rclcpp::WaitSetTemplate<
  *
  * \sa rclcpp::WaitSetTemplate for API documentation
  */
-// using ThreadSafeWaitSet = rclcpp::WaitSetTemplate<
-//   rclcpp::wait_set_policies::DynamicStorage,
-//   rclcpp::wait_set_policies::ThreadSafeSynchronization
-// >;
+using ThreadSafeWaitSet = rclcpp::WaitSetTemplate<
+  rclcpp::wait_set_policies::ThreadSafeSynchronization,
+  rclcpp::wait_set_policies::DynamicStorage
+>;
 
 }  // namespace rclcpp
 

--- a/rclcpp/include/rclcpp/wait_set.hpp
+++ b/rclcpp/include/rclcpp/wait_set.hpp
@@ -63,23 +63,21 @@ using WaitSet = rclcpp::WaitSetTemplate<
  * \sa rclcpp::WaitSetTemplate for API documentation
  */
 template<
-  // std::size_t NumberOfSubscriptions,
-  std::size_t NumberOfGuardCondtions
-  // std::size_t NumberOfTimers,
+  std::size_t NumberOfSubscriptions,
+  std::size_t NumberOfGuardCondtions,
+  std::size_t NumberOfTimers,
   // std::size_t NumberOfClients,
   // std::size_t NumberOfServices,
-  // std::size_t NumberOfEvents,
-  // std::size_t NumberOfWaitables
+  std::size_t NumberOfWaitables
 >
 using StaticWaitSet = rclcpp::WaitSetTemplate<
   rclcpp::wait_set_policies::StaticStorage<
-    // NumberOfSubscriptions,
-    NumberOfGuardCondtions
-    // NumberOfTimers,
+    NumberOfSubscriptions,
+    NumberOfGuardCondtions,
+    NumberOfTimers,
     // NumberOfClients,
     // NumberOfServices,
-    // NumberOfEvents,
-    // NumberOfWaitables
+    NumberOfWaitables
   >,
   rclcpp::wait_set_policies::SequentialSynchronization
 >;

--- a/rclcpp/include/rclcpp/wait_set.hpp
+++ b/rclcpp/include/rclcpp/wait_set.hpp
@@ -66,8 +66,8 @@ template<
   std::size_t NumberOfSubscriptions,
   std::size_t NumberOfGuardCondtions,
   std::size_t NumberOfTimers,
-  // std::size_t NumberOfClients,
-  // std::size_t NumberOfServices,
+  std::size_t NumberOfClients,
+  std::size_t NumberOfServices,
   std::size_t NumberOfWaitables
 >
 using StaticWaitSet = rclcpp::WaitSetTemplate<
@@ -75,8 +75,8 @@ using StaticWaitSet = rclcpp::WaitSetTemplate<
     NumberOfSubscriptions,
     NumberOfGuardCondtions,
     NumberOfTimers,
-    // NumberOfClients,
-    // NumberOfServices,
+    NumberOfClients,
+    NumberOfServices,
     NumberOfWaitables
   >,
   rclcpp::wait_set_policies::SequentialSynchronization

--- a/rclcpp/include/rclcpp/wait_set_policies/detail/storage_policy_common.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/detail/storage_policy_common.hpp
@@ -218,8 +218,9 @@ protected:
     }
 
     // Add subscriptions.
-    for (const auto & subscription : subscriptions) {
-      auto subscription_ptr_pair = get_raw_pointer_from_smart_pointer(subscription);
+    for (const auto & subscription_entry : subscriptions) {
+      auto subscription_ptr_pair =
+        get_raw_pointer_from_smart_pointer(subscription_entry.subscription);
       if (nullptr == subscription_ptr_pair.second) {
         // In this case it was probably stored as a weak_ptr, but is now locking to nullptr.
         if (HasStrongOwnership) {

--- a/rclcpp/include/rclcpp/wait_set_policies/detail/storage_policy_common.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/detail/storage_policy_common.hpp
@@ -94,7 +94,11 @@ protected:
     }
 
     // (Re)build the wait set for the first time.
-    this->storage_rebuild_rcl_wait_set_with_sets(subscriptions, guard_conditions, timers, waitables);
+    this->storage_rebuild_rcl_wait_set_with_sets(
+      subscriptions,
+      guard_conditions,
+      timers,
+      waitables);
   }
 
   ~StoragePolicyCommon()

--- a/rclcpp/include/rclcpp/wait_set_policies/detail/storage_policy_common.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/detail/storage_policy_common.hpp
@@ -184,7 +184,7 @@ protected:
       }
       rcl_ret_t ret = rcl_wait_set_add_guard_condition(
         &rcl_wait_set_,
-        &guard_condition_ptr_pair.second->get_rcl_guard_condtion(),
+        &guard_condition_ptr_pair.second->get_rcl_guard_condition(),
         nullptr);
       if (RCL_RET_OK != ret) {
         rclcpp::exceptions::throw_from_rcl_error(ret);

--- a/rclcpp/include/rclcpp/wait_set_policies/detail/storage_policy_common.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/detail/storage_policy_common.hpp
@@ -1,0 +1,224 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__WAIT_SET_POLICIES__DETAIL__STORAGE_POLICY_COMMON_HPP_
+#define RCLCPP__WAIT_SET_POLICIES__DETAIL__STORAGE_POLICY_COMMON_HPP_
+
+#include <array>
+#include <memory>
+
+#include "rcl/wait.h"
+
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/guard_condition.hpp"
+#include "rclcpp/logging.hpp"
+#include "rclcpp/macros.hpp"
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+namespace wait_set_policies
+{
+namespace detail
+{
+
+/// Common structure for storage policies, which provides rcl wait set access.
+template<bool HasStrongOwnership>
+class StoragePolicyCommon
+{
+protected:
+  template<
+    // class SubscriptionsIterable,
+    class GuardConditionsIterable
+    // class ServicesIterable,
+    // class ClientsIterable,
+    // class TimersIterable,
+    // class EventsIterable,
+    // class WaitablesIterable
+  >
+  explicit
+  StoragePolicyCommon(
+    const GuardConditionsIterable & guard_conditions,
+    rclcpp::Context::SharedPtr context
+  )
+  : rcl_wait_set_(rcl_get_zero_initialized_wait_set()), context_(context)
+  {
+    // Check context is not nullptr.
+    if (nullptr == context) {
+      throw std::invalid_argument("context is nullptr");
+    }
+    // Initialize wait set using initial inputs.
+    rcl_ret_t ret = rcl_wait_set_init(
+      &rcl_wait_set_,
+      0,  // subs
+      guard_conditions.size(),
+      0,  // timers
+      0,  // clients
+      0,  // services
+      0,  // events
+      context_->get_rcl_context().get(),
+      // TODO(wjwwood): support custom allocator, maybe restrict to polymorphic allocator
+      rcl_get_default_allocator());
+    if (RCL_RET_OK != ret) {
+      rclcpp::exceptions::throw_from_rcl_error(ret);
+    }
+
+    // (Re)build the wait set for the first time.
+    this->storage_rebuild_rcl_wait_set_with_sets(guard_conditions);
+  }
+
+  ~StoragePolicyCommon()
+  {
+    rcl_ret_t ret = rcl_wait_set_fini(&rcl_wait_set_);
+    if (RCL_RET_OK != ret) {
+      try {
+        rclcpp::exceptions::throw_from_rcl_error(ret);
+      } catch (const std::exception & exception) {
+        RCLCPP_ERROR(
+          rclcpp::get_logger("rclcpp"),
+          "Error in destruction of rcl wait set: %s", exception.what());
+      }
+    }
+  }
+
+  template<class EntityT>
+  std::pair<void *, EntityT *>
+  get_raw_pointer_from_smart_pointer(const std::shared_ptr<EntityT> & shared_pointer)
+  {
+    return {nullptr, shared_pointer.get()};
+  }
+
+  template<class EntityT>
+  std::pair<std::shared_ptr<EntityT>, EntityT *>
+  get_raw_pointer_from_smart_pointer(const std::weak_ptr<EntityT> & weak_pointer)
+  {
+    auto shared_pointer = weak_pointer.lock();
+    return {shared_pointer, shared_pointer.get()};
+  }
+
+  /// Rebuild the wait set, preparing it for the next wait call.
+  /**
+   * The wait set is rebuilt by:
+   *
+   *   - resizing the wait set if needed,
+   *   - clearing the wait set if not already done by resizing, and
+   *   - re-adding the entities.
+   */
+  template<
+    // class SubscriptionsIterable,
+    class GuardConditionsIterable
+    // class ServicesIterable,
+    // class ClientsIterable,
+    // class TimersIterable,
+    // class EventsIterable,
+    // class WaitablesIterable
+  >
+  void
+  storage_rebuild_rcl_wait_set_with_sets(
+    const GuardConditionsIterable & guard_conditions
+  )
+  {
+    bool was_resized = false;
+    // Resize the wait set, but only if it needs to be.
+    if (needs_resize_) {
+      // Resizing with rcl_wait_set_resize() is a no-op if nothing has changed,
+      // but tracking the need to resize in this class avoids an unnecessary
+      // library call (rcl is most likely a separate shared library) each wait
+      // loop.
+      // Also, since static storage wait sets will never need resizing, so it
+      // avoids completely redundant calls to this function in that case.
+      rcl_ret_t ret = rcl_wait_set_resize(
+        &rcl_wait_set_,
+        0,  // subscriptions_size
+        guard_conditions.size(),
+        0,  // timers_size
+        0,  // clients_size
+        0,  // services_size
+        0  // events_size
+      );
+      if (RCL_RET_OK != ret) {
+        rclcpp::exceptions::throw_from_rcl_error(ret);
+      }
+      was_resized = true;
+      // Assumption: the calling code ensures this function is not called
+      // concurrently with functions that set this variable to true, either
+      // with documentation (as is the case for the SequentialSychronization
+      // policy), or with synchronization primitives (as is the case with
+      // the ThreadSafeSynchronization policy).
+      needs_resize_ = false;
+    }
+
+    // Now clear the wait set, but only if it was not resized, as resizing also
+    // clears the wait set.
+    if (!was_resized) {
+      rcl_ret_t ret = rcl_wait_set_clear(&rcl_wait_set_);
+      if (RCL_RET_OK != ret) {
+        rclcpp::exceptions::throw_from_rcl_error(ret);
+      }
+    }
+
+    // Add guard conditions.
+    for (const auto & guard_condition : guard_conditions) {
+      auto guard_condition_ptr_pair = get_raw_pointer_from_smart_pointer(guard_condition);
+      if (nullptr == guard_condition_ptr_pair.second) {
+        // In this case it was probably stored as a weak_ptr, but is now locking to nullptr.
+        if (HasStrongOwnership) {
+          // This will not happen in fixed sized storage, as it holds
+          // shared ownership the whole time and is never in need of pruning.
+          throw std::runtime_error("unexpected condition, fixed storage policy needs pruning");
+        }
+        // Flag for pruning.
+        needs_pruning_ = true;
+        continue;
+      }
+      rcl_ret_t ret = rcl_wait_set_add_guard_condition(
+        &rcl_wait_set_,
+        &guard_condition_ptr_pair.second->get_rcl_guard_condtion(),
+        nullptr);
+      if (RCL_RET_OK != ret) {
+        rclcpp::exceptions::throw_from_rcl_error(ret);
+      }
+    }
+  }
+
+  const rcl_wait_set_t &
+  storage_get_rcl_wait_set() const
+  {
+    return rcl_wait_set_;
+  }
+
+  rcl_wait_set_t &
+  storage_get_rcl_wait_set()
+  {
+    return rcl_wait_set_;
+  }
+
+  void
+  storage_flag_for_resize()
+  {
+    needs_resize_ = true;
+  }
+
+  rcl_wait_set_t rcl_wait_set_;
+  rclcpp::Context::SharedPtr context_;
+
+  bool needs_pruning_ = false;
+  bool needs_resize_ = false;
+};
+
+}  // namespace detail
+}  // namespace wait_set_policies
+}  // namespace rclcpp
+
+#endif  // RCLCPP__WAIT_SET_POLICIES__DETAIL__STORAGE_POLICY_COMMON_HPP_

--- a/rclcpp/include/rclcpp/wait_set_policies/detail/synchronization_policy_common.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/detail/synchronization_policy_common.hpp
@@ -1,0 +1,72 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__WAIT_SET_POLICIES__DETAIL__SYNCHRONIZATION_POLICY_COMMON_HPP_
+#define RCLCPP__WAIT_SET_POLICIES__DETAIL__SYNCHRONIZATION_POLICY_COMMON_HPP_
+
+#include <chrono>
+#include <functional>
+
+namespace rclcpp
+{
+namespace wait_set_policies
+{
+namespace detail
+{
+
+/// Common structure for synchronization policies.
+class SynchronizationPolicyCommon
+{
+protected:
+  SynchronizationPolicyCommon() = default;
+  ~SynchronizationPolicyCommon() = default;
+
+  std::function<bool ()>
+  create_loop_predicate(
+    std::chrono::nanoseconds time_to_wait_ns,
+    std::chrono::steady_clock::time_point start)
+  {
+    if (time_to_wait_ns >= std::chrono::nanoseconds(0)) {
+      // If time_to_wait_ns is >= 0 schedule against a deadline.
+      auto deadline = start + time_to_wait_ns;
+      return [deadline]() -> bool { return std::chrono::steady_clock::now() < deadline; };
+    } else {
+      // In the case of time_to_wait_ns < 0, just always return true to loop forever.
+      return []() -> bool { return true; };
+    }
+  }
+
+  std::chrono::nanoseconds
+  calculate_time_left_to_wait(
+    std::chrono::nanoseconds original_time_to_wait_ns,
+    std::chrono::steady_clock::time_point start)
+  {
+    std::chrono::nanoseconds time_left_to_wait;
+    if (original_time_to_wait_ns < std::chrono::nanoseconds(0)) {
+      time_left_to_wait = original_time_to_wait_ns;
+    } else {
+      time_left_to_wait = original_time_to_wait_ns - (std::chrono::steady_clock::now() - start);
+      if (time_left_to_wait < std::chrono::nanoseconds(0)) {
+        time_left_to_wait = std::chrono::nanoseconds(0);
+      }
+    }
+    return time_left_to_wait;
+  }
+};
+
+}  // namespace detail
+}  // namespace wait_set_policies
+}  // namespace rclcpp
+
+#endif  // RCLCPP__WAIT_SET_POLICIES__DETAIL__SYNCHRONIZATION_POLICY_COMMON_HPP_

--- a/rclcpp/include/rclcpp/wait_set_policies/detail/synchronization_policy_common.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/detail/synchronization_policy_common.hpp
@@ -32,7 +32,7 @@ protected:
   SynchronizationPolicyCommon() = default;
   ~SynchronizationPolicyCommon() = default;
 
-  std::function<bool ()>
+  std::function<bool()>
   create_loop_predicate(
     std::chrono::nanoseconds time_to_wait_ns,
     std::chrono::steady_clock::time_point start)
@@ -40,10 +40,10 @@ protected:
     if (time_to_wait_ns >= std::chrono::nanoseconds(0)) {
       // If time_to_wait_ns is >= 0 schedule against a deadline.
       auto deadline = start + time_to_wait_ns;
-      return [deadline]() -> bool { return std::chrono::steady_clock::now() < deadline; };
+      return [deadline]() -> bool {return std::chrono::steady_clock::now() < deadline;};
     } else {
       // In the case of time_to_wait_ns < 0, just always return true to loop forever.
-      return []() -> bool { return true; };
+      return []() -> bool {return true;};
     }
   }
 

--- a/rclcpp/include/rclcpp/wait_set_policies/detail/write_preferring_read_write_lock.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/detail/write_preferring_read_write_lock.hpp
@@ -1,0 +1,243 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__WAIT_SET_POLICIES__DETAIL__WRITE_PREFERRING_READ_WRITE_LOCK_HPP_
+#define RCLCPP__WAIT_SET_POLICIES__DETAIL__WRITE_PREFERRING_READ_WRITE_LOCK_HPP_
+
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+namespace wait_set_policies
+{
+namespace detail
+{
+
+/// Writer-perferring read-write lock.
+/**
+ * This class is based on an implementation of a "write-preferring RW lock" as described in this
+ * wikipedia page:
+ *
+ * https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock#Using_a_condition_variable_and_a_mutex
+ *
+ * Copying here for posterity:
+ *
+ * \verbatim
+ *   For a write-preferring RW lock one can use two integer counters and one boolean flag:
+ *
+ *       num_readers_active: the number of readers that have acquired the lock (integer)
+ *       num_writers_waiting: the number of writers waiting for access (integer)
+ *       writer_active: whether a writer has acquired the lock (boolean).
+ *
+ *   Initially num_readers_active and num_writers_waiting are zero and writer_active is false.
+ *
+ *   The lock and release operations can be implemented as
+ *
+ *   Begin Read
+ *
+ *       Lock g
+ *       While num_writers_waiting > 0 or writer_active:
+ *           wait cond, g[a]
+ *       Increment num_readers_active
+ *       Unlock g.
+ *
+ *   End Read
+ *
+ *       Lock g
+ *       Decrement num_readers_active
+ *       If num_readers_active = 0:
+ *           Notify cond (broadcast)
+ *       Unlock g.
+ *
+ *   Begin Write
+ *
+ *       Lock g
+ *       Increment num_writers_waiting
+ *       While num_readers_active > 0 or writer_active is true:
+ *           wait cond, g
+ *       Decrement num_writers_waiting
+ *       Set writer_active to true
+ *       Unlock g.
+ *
+ *   End Write
+ *
+ *       Lock g
+ *       Set writer_active to false
+ *       Notify cond (broadcast)
+ *       Unlock g.
+ * \endverbatim
+ *
+ * It will prefer any waiting write calls to any waiting read calls, meaning
+ * that excessive write calls can starve read calls.
+ *
+ * This class diverges from that design in two important ways.
+ * First, it is a single reader, single writer version.
+ * Second, it allows for user defined code to be run after a writer enters the
+ * waiting state, and the purpose of this feature is to allow the user to
+ * interrupt any potentially long blocking read activities.
+ *
+ * Together these two features allow new waiting writers to not only ensure
+ * they get the lock before any queued readers, but also that it can safely
+ * interrupt read activities if needed, without allowing new read activities to
+ * start before it gains the lock.
+ *
+ * The first difference prevents the case that a multiple read activities occur
+ * at the same time but the writer can only reliably interrupt one of them.
+ * By preventing multiple read activities concurrently, this case is avoided.
+ * The second difference allows the user to define how to interrupt read
+ * activity that could be blocking the write activities that need to happen
+ * as soon as possible.
+ *
+ * To implement the differences, this class replaces the "num_readers_active"
+ * counter with a "reader_active" boolean.
+ * It also changes the "Begin Read" section from above, like this:
+ *
+ * \verbatim
+ *   Begin Read
+ *
+ *       Lock g
+ *       While num_writers_waiting > 0 or writer_active or reader_active:  // changed
+ *           wait cond, g[a]
+ *       Set reader_active to true  // changed
+ *       Unlock g.
+ * \endverbatim
+ *
+ * And changes the "End Read" section from above, like this:
+ *
+ * \verbatim
+ *   End Read
+ *
+ *       Lock g
+ *       Set reader_active to false  // changed
+ *       Notify cond (broadcast)  // changed, now unconditional
+ *       Unlock g.
+ * \endverbatim
+ *
+ * The "Begin Write" section is also updated as follows:
+ *
+ * \verbatim
+ *   Begin Write
+ *
+ *       Lock g
+ *       Increment num_writers_waiting
+ *       Call user defined enter_waiting function  // new
+ *       While reader_active is true or writer_active is true:  // changed
+ *           wait cond, g
+ *       Decrement num_writers_waiting
+ *       Set writer_active to true
+ *       Unlock g.
+ * \endverbatim
+ *
+ * The implementation uses a single condition variable, single lock, and several
+ * state variables.
+ *
+ * The typical use of this class is as follows:
+ *
+ *     class MyClass
+ *     {
+ *       WritePreferringReadWriteLock wprw_lock_;
+ *     public:
+ *       MyClass() {}
+ *       void do_some_reading()
+ *       {
+ *         using rclcpp::wait_set_policies::detail::WritePreferringReadWriteLock;
+ *         std::lock_guard<WritePreferringReadWriteLock::ReadMutex> lock(wprw_lock_.get_read_mutex());
+ *         // Do reading...
+ *       }
+ *       void do_some_writing()
+ *       {
+ *         using rclcpp::wait_set_policies::detail::WritePreferringReadWriteLock;
+ *         std::lock_guard<WritePreferringReadWriteLock::WriteMutex> lock(wprw_lock_.get_write_mutex());
+ *         // Do writing...
+ *       }
+ *     };
+ */
+class WritePreferringReadWriteLock final
+{
+public:
+  RCLCPP_PUBLIC
+  explicit WritePreferringReadWriteLock(std::function<void ()> enter_waiting_function = nullptr);
+
+  /// Read mutex for the WritePreferringReadWriteLock.
+  /**
+   * Implements the "C++ named requirements: BasicLockable".
+   */
+  class RCLCPP_PUBLIC ReadMutex
+  {
+  public:
+    void
+    lock();
+
+    void
+    unlock();
+
+  protected:
+    explicit ReadMutex(WritePreferringReadWriteLock & parent_lock);
+
+    WritePreferringReadWriteLock & parent_lock_;
+
+    friend WritePreferringReadWriteLock;
+  };
+
+  /// Write mutex for the WritePreferringReadWriteLock.
+  /**
+   * Implements the "C++ named requirements: BasicLockable".
+   */
+  class RCLCPP_PUBLIC WriteMutex
+  {
+  public:
+    void
+    lock();
+
+    void
+    unlock();
+
+  protected:
+    explicit WriteMutex(WritePreferringReadWriteLock & parent_lock);
+
+    WritePreferringReadWriteLock & parent_lock_;
+
+    friend WritePreferringReadWriteLock;
+  };
+
+  /// Return read mutex which can be used with standard constructs like std::lock_guard.
+  RCLCPP_PUBLIC
+  ReadMutex &
+  get_read_mutex();
+
+  /// Return write mutex which can be used with standard constructs like std::lock_guard.
+  RCLCPP_PUBLIC
+  WriteMutex &
+  get_write_mutex();
+
+protected:
+  bool reader_active_ = false;
+  std::size_t number_of_writers_waiting_ = 0;
+  bool writer_active_ = false;
+  std::mutex mutex_;
+  std::condition_variable condition_variable_;
+  ReadMutex read_mutex_;
+  WriteMutex write_mutex_;
+  std::function<void ()> enter_waiting_function_;
+};
+
+}  // namespace detail
+}  // namespace wait_set_policies
+}  // namespace rclcpp
+
+#endif  // RCLCPP__WAIT_SET_POLICIES__DETAIL__WRITE_PREFERRING_READ_WRITE_LOCK_HPP_

--- a/rclcpp/include/rclcpp/wait_set_policies/detail/write_preferring_read_write_lock.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/detail/write_preferring_read_write_lock.hpp
@@ -171,7 +171,7 @@ class WritePreferringReadWriteLock final
 {
 public:
   RCLCPP_PUBLIC
-  explicit WritePreferringReadWriteLock(std::function<void ()> enter_waiting_function = nullptr);
+  explicit WritePreferringReadWriteLock(std::function<void()> enter_waiting_function = nullptr);
 
   /// Read mutex for the WritePreferringReadWriteLock.
   /**
@@ -179,14 +179,14 @@ public:
    */
   class RCLCPP_PUBLIC ReadMutex
   {
-  public:
+public:
     void
     lock();
 
     void
     unlock();
 
-  protected:
+protected:
     explicit ReadMutex(WritePreferringReadWriteLock & parent_lock);
 
     WritePreferringReadWriteLock & parent_lock_;
@@ -200,14 +200,14 @@ public:
    */
   class RCLCPP_PUBLIC WriteMutex
   {
-  public:
+public:
     void
     lock();
 
     void
     unlock();
 
-  protected:
+protected:
     explicit WriteMutex(WritePreferringReadWriteLock & parent_lock);
 
     WritePreferringReadWriteLock & parent_lock_;
@@ -233,7 +233,7 @@ protected:
   std::condition_variable condition_variable_;
   ReadMutex read_mutex_;
   WriteMutex write_mutex_;
-  std::function<void ()> enter_waiting_function_;
+  std::function<void()> enter_waiting_function_;
 };
 
 }  // namespace detail

--- a/rclcpp/include/rclcpp/wait_set_policies/dynamic_storage.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/dynamic_storage.hpp
@@ -16,8 +16,9 @@
 #define RCLCPP__WAIT_SET_POLICIES__DYNAMIC_STORAGE_HPP_
 
 #include <algorithm>
-#include <array>
 #include <memory>
+#include <utility>
+#include <vector>
 
 #include "rclcpp/guard_condition.hpp"
 #include "rclcpp/macros.hpp"
@@ -41,7 +42,9 @@ protected:
 
   class SubscriptionEntry
   {
-  public:
+    // (wjwwood): indent of 'public:' is weird, I know. uncrustify is dumb.
+
+public:
     std::shared_ptr<rclcpp::SubscriptionBase> subscription;
     rclcpp::SubscriptionWaitSetMask mask;
 
@@ -61,7 +64,7 @@ protected:
   };
   class WeakSubscriptionEntry
   {
-  public:
+public:
     std::weak_ptr<rclcpp::SubscriptionBase> subscription;
     rclcpp::SubscriptionWaitSetMask mask;
 
@@ -100,7 +103,7 @@ protected:
 
   class WaitableEntry
   {
-  public:
+public:
     std::shared_ptr<rclcpp::Waitable> waitable;
     std::shared_ptr<void> associated_entity;
 
@@ -121,7 +124,7 @@ protected:
   };
   class WeakWaitableEntry
   {
-  public:
+public:
     std::weak_ptr<rclcpp::Waitable> waitable;
     std::weak_ptr<void> associated_entity;
 
@@ -192,7 +195,7 @@ protected:
     return std::any_of(
       entities.cbegin(),
       entities.cend(),
-      [&entity](const auto & inner) { return &entity == inner.lock().get(); });
+      [&entity](const auto & inner) {return &entity == inner.lock().get();});
   }
 
   template<class EntityT, class SequenceOfEntitiesT>
@@ -203,7 +206,7 @@ protected:
     return std::find_if(
       entities.cbegin(),
       entities.cend(),
-      [&entity](const auto & inner) { return &entity == inner.lock().get(); });
+      [&entity](const auto & inner) {return &entity == inner.lock().get();});
   }
 
   void
@@ -323,26 +326,26 @@ protected:
     }
     // Setup common locking function.
     auto lock_all = [](const auto & weak_ptrs, auto & shared_ptrs) {
-      shared_ptrs.resize(weak_ptrs.size());
-      size_t index = 0;
-      for (const auto & weak_ptr : weak_ptrs) {
-        shared_ptrs[index++] = weak_ptr.lock();
-      }
-    };
+        shared_ptrs.resize(weak_ptrs.size());
+        size_t index = 0;
+        for (const auto & weak_ptr : weak_ptrs) {
+          shared_ptrs[index++] = weak_ptr.lock();
+        }
+      };
     // Lock all the weak pointers and hold them until released.
     lock_all(guard_conditions_, shared_guard_conditions_);
     lock_all(timers_, shared_timers_);
 
     // We need a specialized version of this for waitables.
     auto lock_all_waitables = [](const auto & weak_ptrs, auto & shared_ptrs) {
-      shared_ptrs.resize(weak_ptrs.size());
-      size_t index = 0;
-      for (const auto & weak_ptr : weak_ptrs) {
-        shared_ptrs[index++] = WaitableEntry{
-          weak_ptr.waitable.lock(),
-          weak_ptr.associated_entity.lock()};
-      }
-    };
+        shared_ptrs.resize(weak_ptrs.size());
+        size_t index = 0;
+        for (const auto & weak_ptr : weak_ptrs) {
+          shared_ptrs[index++] = WaitableEntry{
+            weak_ptr.waitable.lock(),
+            weak_ptr.associated_entity.lock()};
+        }
+      };
     lock_all_waitables(waitables_, shared_waitables_);
   }
 
@@ -355,10 +358,10 @@ protected:
     }
     // "Unlock" all shared pointers by resetting them.
     auto reset_all = [](auto & shared_ptrs) {
-      for (auto & shared_ptr : shared_ptrs) {
-        shared_ptr.reset();
-      }
-    };
+        for (auto & shared_ptr : shared_ptrs) {
+          shared_ptr.reset();
+        }
+      };
     reset_all(shared_guard_conditions_);
     reset_all(shared_timers_);
     reset_all(shared_waitables_);

--- a/rclcpp/include/rclcpp/wait_set_policies/dynamic_storage.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/dynamic_storage.hpp
@@ -1,0 +1,161 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__WAIT_SET_POLICIES__DYNAMIC_STORAGE_HPP_
+#define RCLCPP__WAIT_SET_POLICIES__DYNAMIC_STORAGE_HPP_
+
+#include <algorithm>
+#include <array>
+#include <memory>
+
+#include "rclcpp/guard_condition.hpp"
+#include "rclcpp/macros.hpp"
+#include "rclcpp/visibility_control.hpp"
+#include "rclcpp/wait_set_policies/detail/storage_policy_common.hpp"
+
+namespace rclcpp
+{
+namespace wait_set_policies
+{
+
+/// WaitSet policy that provides dynamically sized storage.
+class DynamicStorage : public rclcpp::wait_set_policies::detail::StoragePolicyCommon<false>
+{
+protected:
+  using is_mutable = std::true_type;
+
+  using SequenceOfWeakGuardConditions = std::vector<std::weak_ptr<rclcpp::GuardCondition>>;
+  using GuardConditionsIterable = std::vector<std::shared_ptr<rclcpp::GuardCondition>>;
+
+  explicit
+  DynamicStorage(
+    const GuardConditionsIterable & guard_conditions,
+    rclcpp::Context::SharedPtr context
+  )
+  : StoragePolicyCommon(guard_conditions, context),
+    guard_conditions_(guard_conditions.cbegin(), guard_conditions.cend()),
+    shared_guard_conditions_(guard_conditions_.size())
+  {}
+
+  ~DynamicStorage() = default;
+
+  void
+  storage_rebuild_rcl_wait_set()
+  {
+    this->storage_rebuild_rcl_wait_set_with_sets(
+      guard_conditions_
+    );
+  }
+
+  bool
+  storage_has_guard_condition(const rclcpp::GuardCondition & guard_condition)
+  {
+    return std::any_of(
+      guard_conditions_.cbegin(),
+      guard_conditions_.cend(),
+      [&guard_condition](const auto & gc) { return &guard_condition == gc.lock().get(); });
+  }
+
+  auto
+  storage_find_guard_condition(const rclcpp::GuardCondition & guard_condition)
+  {
+    return std::find_if(
+      guard_conditions_.begin(),
+      guard_conditions_.end(),
+      [&guard_condition](const auto & gc) { return &guard_condition == gc.lock().get(); });
+  }
+
+  void
+  storage_add_guard_condition(std::shared_ptr<rclcpp::GuardCondition> && guard_condition)
+  {
+    if (this->storage_has_guard_condition(*guard_condition)) {
+      throw std::runtime_error("guard_condition already in wait set");
+    }
+    guard_conditions_.push_back(std::move(guard_condition));
+    this->storage_flag_for_resize();
+  }
+
+  void
+  storage_remove_guard_condition(std::shared_ptr<rclcpp::GuardCondition> && guard_condition)
+  {
+    auto it = this->storage_find_guard_condition(*guard_condition);
+    if (guard_conditions_.cend() == it) {
+      throw std::runtime_error("guard_condition not in wait set");
+    }
+    guard_conditions_.erase(it);
+    this->storage_flag_for_resize();
+  }
+
+  // this is noexcept because:
+  //   - std::weak_ptr::expired is noexcept
+  //   - the erase-remove idiom is noexcept, since we're not using the ExecutionPolicy version
+  //   - std::vector::erase is noexcept if the assignment operator of T is also
+  //     - and, the operator= for std::weak_ptr is noexcept
+  void
+  storage_prune_deleted_entities() noexcept
+  {
+    // reusable (templated) lambda for removal predicate
+    auto p =
+      [](const auto & weak_ptr) {
+        // remove entries which have expired
+        return weak_ptr.expired();
+      };
+    // remove guard conditions which have been deleted
+    guard_conditions_.erase(std::remove_if(guard_conditions_.begin(), guard_conditions_.end(), p));
+  }
+
+  void
+  storage_acquire_ownerships()
+  {
+    if (++ownership_reference_counter_ > 1) {
+      // Avoid redundant locking.
+      return;
+    }
+    // Setup common locking function.
+    auto lock_all = [](const auto & weak_ptrs, auto & shared_ptrs) {
+      shared_ptrs.resize(weak_ptrs.size());
+      size_t index = 0;
+      for (const auto & weak_ptr : weak_ptrs) {
+        shared_ptrs[index++] = weak_ptr.lock();
+      }
+    };
+    // Lock all the weak pointers and hold them until released.
+    lock_all(guard_conditions_, shared_guard_conditions_);
+  }
+
+  void
+  storage_release_ownerships()
+  {
+    if (--ownership_reference_counter_ > 0) {
+      // Avoid releasing ownership until reference count is 0.
+      return;
+    }
+    // "Unlock" all shared pointers by resetting them.
+    auto reset_all = [](auto & shared_ptrs) {
+      for (auto & shared_ptr : shared_ptrs) {
+        shared_ptr.reset();
+      }
+    };
+    reset_all(shared_guard_conditions_);
+  }
+
+  size_t ownership_reference_counter_ = 0;
+  SequenceOfWeakGuardConditions guard_conditions_;
+  GuardConditionsIterable shared_guard_conditions_;
+};
+
+}  // namespace wait_set_policies
+}  // namespace rclcpp
+
+#endif  // RCLCPP__WAIT_SET_POLICIES__DYNAMIC_STORAGE_HPP_

--- a/rclcpp/include/rclcpp/wait_set_policies/dynamic_storage.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/dynamic_storage.hpp
@@ -163,10 +163,12 @@ public:
   using SequenceOfWeakWaitables = std::vector<WeakWaitableEntry>;
   using WaitablesIterable = std::vector<WaitableEntry>;
 
+  template<class ArrayOfExtraGuardConditions>
   explicit
   DynamicStorage(
     const SubscriptionsIterable & subscriptions,
     const GuardConditionsIterable & guard_conditions,
+    const ArrayOfExtraGuardConditions & extra_guard_conditions,
     const TimersIterable & timers,
     const ClientsIterable & clients,
     const ServicesIterable & services,
@@ -176,6 +178,7 @@ public:
   : StoragePolicyCommon(
       subscriptions,
       guard_conditions,
+      extra_guard_conditions,
       timers,
       clients,
       services,
@@ -197,12 +200,14 @@ public:
 
   ~DynamicStorage() = default;
 
+  template<class ArrayOfExtraGuardConditions>
   void
-  storage_rebuild_rcl_wait_set()
+  storage_rebuild_rcl_wait_set(const ArrayOfExtraGuardConditions & extra_guard_conditions)
   {
     this->storage_rebuild_rcl_wait_set_with_sets(
       subscriptions_,
       guard_conditions_,
+      extra_guard_conditions,
       timers_,
       clients_,
       services_,

--- a/rclcpp/include/rclcpp/wait_set_policies/sequential_synchronization.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/sequential_synchronization.hpp
@@ -43,8 +43,20 @@ namespace wait_set_policies
 class SequentialSynchronization : public detail::SynchronizationPolicyCommon
 {
 protected:
-  SequentialSynchronization() = default;
+  explicit SequentialSynchronization(rclcpp::Context::SharedPtr) {}
   ~SequentialSynchronization() = default;
+
+  /// Return any "extra" guard conditions needed to implement the synchronization policy.
+  /**
+   * Since this policy provides no thread-safety, it also needs no extra guard
+   * conditions to implement it.
+   */
+  const std::array<std::shared_ptr<rclcpp::GuardCondition>, 0> &
+  get_extra_guard_conditions()
+  {
+    static const std::array<std::shared_ptr<rclcpp::GuardCondition>, 0> empty{};
+    return empty;
+  }
 
   /// Add subscription without thread-safety.
   /**

--- a/rclcpp/include/rclcpp/wait_set_policies/sequential_synchronization.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/sequential_synchronization.hpp
@@ -18,6 +18,7 @@
 #include <chrono>
 #include <functional>
 #include <memory>
+#include <utility>
 
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/guard_condition.hpp"
@@ -52,7 +53,7 @@ protected:
     std::shared_ptr<rclcpp::SubscriptionBase> && subscription,
     const rclcpp::SubscriptionWaitSetMask & mask,
     std::function<
-      void (std::shared_ptr<rclcpp::SubscriptionBase> &&, const rclcpp::SubscriptionWaitSetMask &)
+      void(std::shared_ptr<rclcpp::SubscriptionBase>&&, const rclcpp::SubscriptionWaitSetMask &)
     > add_subscription_function)
   {
     // Explicitly no thread synchronization.
@@ -68,7 +69,7 @@ protected:
     std::shared_ptr<rclcpp::SubscriptionBase> && subscription,
     const rclcpp::SubscriptionWaitSetMask & mask,
     std::function<
-      void (std::shared_ptr<rclcpp::SubscriptionBase> &&, const rclcpp::SubscriptionWaitSetMask &)
+      void(std::shared_ptr<rclcpp::SubscriptionBase>&&, const rclcpp::SubscriptionWaitSetMask &)
     > remove_subscription_function)
   {
     // Explicitly no thread synchronization.
@@ -82,7 +83,7 @@ protected:
   void
   sync_add_guard_condition(
     std::shared_ptr<rclcpp::GuardCondition> && guard_condition,
-    std::function<void (std::shared_ptr<rclcpp::GuardCondition> &&)> add_guard_condition_function)
+    std::function<void(std::shared_ptr<rclcpp::GuardCondition>&&)> add_guard_condition_function)
   {
     // Explicitly no thread synchronization.
     add_guard_condition_function(std::move(guard_condition));
@@ -95,7 +96,7 @@ protected:
   void
   sync_remove_guard_condition(
     std::shared_ptr<rclcpp::GuardCondition> && guard_condition,
-    std::function<void (std::shared_ptr<rclcpp::GuardCondition> &&)> remove_guard_condition_function)
+    std::function<void(std::shared_ptr<rclcpp::GuardCondition>&&)> remove_guard_condition_function)
   {
     // Explicitly no thread synchronization.
     remove_guard_condition_function(std::move(guard_condition));
@@ -108,7 +109,7 @@ protected:
   void
   sync_add_timer(
     std::shared_ptr<rclcpp::TimerBase> && timer,
-    std::function<void (std::shared_ptr<rclcpp::TimerBase> &&)> add_timer_function)
+    std::function<void(std::shared_ptr<rclcpp::TimerBase>&&)> add_timer_function)
   {
     // Explicitly no thread synchronization.
     add_timer_function(std::move(timer));
@@ -121,7 +122,7 @@ protected:
   void
   sync_remove_timer(
     std::shared_ptr<rclcpp::TimerBase> && timer,
-    std::function<void (std::shared_ptr<rclcpp::TimerBase> &&)> remove_timer_function)
+    std::function<void(std::shared_ptr<rclcpp::TimerBase>&&)> remove_timer_function)
   {
     // Explicitly no thread synchronization.
     remove_timer_function(std::move(timer));
@@ -136,7 +137,7 @@ protected:
     std::shared_ptr<rclcpp::Waitable> && waitable,
     std::shared_ptr<void> && associated_entity,
     std::function<
-      void (std::shared_ptr<rclcpp::Waitable> &&, std::shared_ptr<void> &&)
+      void(std::shared_ptr<rclcpp::Waitable>&&, std::shared_ptr<void>&&)
     > add_waitable_function)
   {
     // Explicitly no thread synchronization.
@@ -150,7 +151,7 @@ protected:
   void
   sync_remove_waitable(
     std::shared_ptr<rclcpp::Waitable> && waitable,
-    std::function<void (std::shared_ptr<rclcpp::Waitable> &&)> remove_waitable_function)
+    std::function<void(std::shared_ptr<rclcpp::Waitable>&&)> remove_waitable_function)
   {
     // Explicitly no thread synchronization.
     remove_waitable_function(std::move(waitable));
@@ -161,7 +162,7 @@ protected:
    * Does not throw, but storage function may throw.
    */
   void
-  sync_prune_deleted_entities(std::function<void ()> prune_deleted_entities_function)
+  sync_prune_deleted_entities(std::function<void()> prune_deleted_entities_function)
   {
     // Explicitly no thread synchronization.
     prune_deleted_entities_function();
@@ -172,9 +173,9 @@ protected:
   WaitResultT
   sync_wait(
     std::chrono::nanoseconds time_to_wait_ns,
-    std::function<void ()> rebuild_rcl_wait_set,
+    std::function<void()> rebuild_rcl_wait_set,
     std::function<rcl_wait_set_t & ()> get_rcl_wait_set,
-    std::function<WaitResultT (WaitResultKind wait_result_kind)> create_wait_result)
+    std::function<WaitResultT(WaitResultKind wait_result_kind)> create_wait_result)
   {
     // Assumption: this function assumes that some measure has been taken to
     // ensure none of the entities being waited on by the wait set are allowed
@@ -187,7 +188,7 @@ protected:
 
     // Setup looping predicate.
     auto start = std::chrono::steady_clock::now();
-    std::function<bool ()> should_loop = this->create_loop_predicate(time_to_wait_ns, start);
+    std::function<bool()> should_loop = this->create_loop_predicate(time_to_wait_ns, start);
 
     // Wait until exit condition is met.
     do {

--- a/rclcpp/include/rclcpp/wait_set_policies/sequential_synchronization.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/sequential_synchronization.hpp
@@ -248,7 +248,7 @@ protected:
     do {
       // Rebuild the wait set.
       // This will resize the wait set if needed, due to e.g. adding or removing
-      // entities since the laster wait, but this should never occur in static
+      // entities since the last wait, but this should never occur in static
       // storage wait sets since they cannot be changed after construction.
       // This will also clear the wait set and re-add all the entities, which
       // prepares it to be waited on again.

--- a/rclcpp/include/rclcpp/wait_set_policies/sequential_synchronization.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/sequential_synchronization.hpp
@@ -1,0 +1,159 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__WAIT_SET_POLICIES__SEQUENTIAL_SYNCHRONIZATION_HPP_
+#define RCLCPP__WAIT_SET_POLICIES__SEQUENTIAL_SYNCHRONIZATION_HPP_
+
+#include <chrono>
+#include <functional>
+#include <memory>
+
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/guard_condition.hpp"
+#include "rclcpp/macros.hpp"
+#include "rclcpp/visibility_control.hpp"
+#include "rclcpp/wait_result.hpp"
+#include "rclcpp/wait_result_kind.hpp"
+#include "rclcpp/wait_set_policies/detail/synchronization_policy_common.hpp"
+
+namespace rclcpp
+{
+namespace wait_set_policies
+{
+
+/// WaitSet policy that explicitly provides no thread synchronization.
+class SequentialSynchronization : public detail::SynchronizationPolicyCommon
+{
+protected:
+  SequentialSynchronization() = default;
+  ~SequentialSynchronization() = default;
+
+  /// Add guard condition without thread-safety.
+  /**
+   * Does not throw, but storage function may throw.
+   */
+  void
+  sync_add_guard_condition(
+    std::shared_ptr<rclcpp::GuardCondition> && guard_condition,
+    std::function<void (std::shared_ptr<rclcpp::GuardCondition> &&)> add_guard_condition_function)
+  {
+    // Explicitly no thread synchronization.
+    add_guard_condition_function(std::move(guard_condition));
+  }
+
+  /// Remove guard condition without thread-safety.
+  /**
+   * Does not throw, but storage function may throw.
+   */
+  void
+  sync_remove_guard_condition(
+    std::shared_ptr<rclcpp::GuardCondition> && guard_condition,
+    std::function<void (std::shared_ptr<rclcpp::GuardCondition> &&)> remove_guard_condition_function)
+  {
+    // Explicitly no thread synchronization.
+    remove_guard_condition_function(std::move(guard_condition));
+  }
+
+  /// Prune deleted entities without thread-safety.
+  /**
+   * Does not throw, but storage function may throw.
+   */
+  void
+  sync_prune_deleted_entities(std::function<void ()> prune_deleted_entities_function)
+  {
+    // Explicitly no thread synchronization.
+    prune_deleted_entities_function();
+  }
+
+  /// Implements wait without any thread-safety.
+  template<class WaitResultT>
+  WaitResultT
+  sync_wait(
+    std::chrono::nanoseconds time_to_wait_ns,
+    std::function<void ()> rebuild_rcl_wait_set,
+    std::function<rcl_wait_set_t & ()> get_rcl_wait_set,
+    std::function<WaitResultT (WaitResultKind wait_result_kind)> create_wait_result)
+  {
+    // Assumption: this function assumes that some measure has been taken to
+    // ensure none of the entities being waited on by the wait set are allowed
+    // to go out of scope and therefore be deleted.
+    // In the case of the StaticStorage policy, this is ensured because it
+    // retains shared ownership of all entites for the duration of its own life.
+    // In the case of the DynamicStorage policy, this is ensured by the function
+    // which calls this function, by acquiring shared ownership of the entites
+    // for the duration of this function.
+
+    // Setup looping predicate.
+    auto start = std::chrono::steady_clock::now();
+    std::function<bool ()> should_loop = this->create_loop_predicate(time_to_wait_ns, start);
+
+    // Wait until exit condition is met.
+    do {
+      // Rebuild the wait set.
+      // This will resize the wait set if needed, due to e.g. adding or removing
+      // entities since the laster wait, but this should never occur in static
+      // storage wait sets since they cannot be changed after construction.
+      // This will also clear the wait set and re-add all the entities, which
+      // prepares it to be waited on again.
+      rebuild_rcl_wait_set();
+
+      rcl_wait_set_t & rcl_wait_set = get_rcl_wait_set();
+
+      // Wait unconditionally until timeout condition occurs since we assume
+      // there are no conditions that would require the wait to stop and reset,
+      // like asynchronously adding or removing an entity, i.e. explicitly
+      // providing no thread-safety.
+
+      // Calculate how much time there is left to wait, unless blocking indefinitely.
+      auto time_left_to_wait_ns = this->calculate_time_left_to_wait(time_to_wait_ns, start);
+
+      // Then wait for entities to become ready.
+      rcl_ret_t ret = rcl_wait(&rcl_wait_set, time_left_to_wait_ns.count());
+      if (RCL_RET_OK == ret) {
+        // Something has become ready in the wait set, and since this class
+        // did not add anything to it, it is a user entity that is ready.
+        return create_wait_result(WaitResultKind::Ready);
+      } else if (RCL_RET_TIMEOUT == ret) {
+        // The wait set timed out, exit the loop.
+        break;
+      } else if (RCL_RET_WAIT_SET_EMPTY == ret) {
+        // Wait set was empty, return Empty.
+        return create_wait_result(WaitResultKind::Empty);
+      } else {
+        // Some other error case, throw.
+        rclcpp::exceptions::throw_from_rcl_error(ret);
+      }
+    } while (should_loop());
+
+    // Wait did not result in ready items, return timeout.
+    return create_wait_result(WaitResultKind::Timeout);
+  }
+
+  void
+  sync_wait_result_acquire()
+  {
+    // Explicitly do nothing.
+  }
+
+  void
+  sync_wait_result_release()
+  {
+    // Explicitly do nothing.
+  }
+};
+
+}  // namespace wait_set_policies
+}  // namespace rclcpp
+
+#endif  // RCLCPP__WAIT_SET_POLICIES__SEQUENTIAL_SYNCHRONIZATION_HPP_

--- a/rclcpp/include/rclcpp/wait_set_policies/sequential_synchronization.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/sequential_synchronization.hpp
@@ -22,10 +22,14 @@
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/guard_condition.hpp"
 #include "rclcpp/macros.hpp"
+#include "rclcpp/subscription_base.hpp"
+#include "rclcpp/subscription_wait_set_mask.hpp"
+#include "rclcpp/timer.hpp"
 #include "rclcpp/visibility_control.hpp"
 #include "rclcpp/wait_result.hpp"
 #include "rclcpp/wait_result_kind.hpp"
 #include "rclcpp/wait_set_policies/detail/synchronization_policy_common.hpp"
+#include "rclcpp/waitable.hpp"
 
 namespace rclcpp
 {
@@ -38,6 +42,38 @@ class SequentialSynchronization : public detail::SynchronizationPolicyCommon
 protected:
   SequentialSynchronization() = default;
   ~SequentialSynchronization() = default;
+
+  /// Add subscription without thread-safety.
+  /**
+   * Does not throw, but storage function may throw.
+   */
+  void
+  sync_add_subscription(
+    std::shared_ptr<rclcpp::SubscriptionBase> && subscription,
+    const rclcpp::SubscriptionWaitSetMask & mask,
+    std::function<
+      void (std::shared_ptr<rclcpp::SubscriptionBase> &&, const rclcpp::SubscriptionWaitSetMask &)
+    > add_subscription_function)
+  {
+    // Explicitly no thread synchronization.
+    add_subscription_function(std::move(subscription), mask);
+  }
+
+  /// Remove guard condition without thread-safety.
+  /**
+   * Does not throw, but storage function may throw.
+   */
+  void
+  sync_remove_subscription(
+    std::shared_ptr<rclcpp::SubscriptionBase> && subscription,
+    const rclcpp::SubscriptionWaitSetMask & mask,
+    std::function<
+      void (std::shared_ptr<rclcpp::SubscriptionBase> &&, const rclcpp::SubscriptionWaitSetMask &)
+    > remove_subscription_function)
+  {
+    // Explicitly no thread synchronization.
+    remove_subscription_function(std::move(subscription), mask);
+  }
 
   /// Add guard condition without thread-safety.
   /**
@@ -63,6 +99,61 @@ protected:
   {
     // Explicitly no thread synchronization.
     remove_guard_condition_function(std::move(guard_condition));
+  }
+
+  /// Add timer without thread-safety.
+  /**
+   * Does not throw, but storage function may throw.
+   */
+  void
+  sync_add_timer(
+    std::shared_ptr<rclcpp::TimerBase> && timer,
+    std::function<void (std::shared_ptr<rclcpp::TimerBase> &&)> add_timer_function)
+  {
+    // Explicitly no thread synchronization.
+    add_timer_function(std::move(timer));
+  }
+
+  /// Remove timer without thread-safety.
+  /**
+   * Does not throw, but storage function may throw.
+   */
+  void
+  sync_remove_timer(
+    std::shared_ptr<rclcpp::TimerBase> && timer,
+    std::function<void (std::shared_ptr<rclcpp::TimerBase> &&)> remove_timer_function)
+  {
+    // Explicitly no thread synchronization.
+    remove_timer_function(std::move(timer));
+  }
+
+  /// Add waitable without thread-safety.
+  /**
+   * Does not throw, but storage function may throw.
+   */
+  void
+  sync_add_waitable(
+    std::shared_ptr<rclcpp::Waitable> && waitable,
+    std::shared_ptr<void> && associated_entity,
+    std::function<
+      void (std::shared_ptr<rclcpp::Waitable> &&, std::shared_ptr<void> &&)
+    > add_waitable_function)
+  {
+    // Explicitly no thread synchronization.
+    add_waitable_function(std::move(waitable), std::move(associated_entity));
+  }
+
+  /// Remove waitable without thread-safety.
+  /**
+   * Does not throw, but storage function may throw.
+   */
+  void
+  sync_remove_waitable(
+    std::shared_ptr<rclcpp::Waitable> && waitable,
+    std::function<void (std::shared_ptr<rclcpp::Waitable> &&)> remove_waitable_function)
+  {
+    // Explicitly no thread synchronization.
+    remove_waitable_function(std::move(waitable));
   }
 
   /// Prune deleted entities without thread-safety.

--- a/rclcpp/include/rclcpp/wait_set_policies/sequential_synchronization.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/sequential_synchronization.hpp
@@ -20,9 +20,11 @@
 #include <memory>
 #include <utility>
 
+#include "rclcpp/client.hpp"
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/guard_condition.hpp"
 #include "rclcpp/macros.hpp"
+#include "rclcpp/service.hpp"
 #include "rclcpp/subscription_base.hpp"
 #include "rclcpp/subscription_wait_set_mask.hpp"
 #include "rclcpp/timer.hpp"
@@ -126,6 +128,58 @@ protected:
   {
     // Explicitly no thread synchronization.
     remove_timer_function(std::move(timer));
+  }
+
+  /// Add client without thread-safety.
+  /**
+   * Does not throw, but storage function may throw.
+   */
+  void
+  sync_add_client(
+    std::shared_ptr<rclcpp::ClientBase> && client,
+    std::function<void(std::shared_ptr<rclcpp::ClientBase>&&)> add_client_function)
+  {
+    // Explicitly no thread synchronization.
+    add_client_function(std::move(client));
+  }
+
+  /// Remove client without thread-safety.
+  /**
+   * Does not throw, but storage function may throw.
+   */
+  void
+  sync_remove_client(
+    std::shared_ptr<rclcpp::ClientBase> && client,
+    std::function<void(std::shared_ptr<rclcpp::ClientBase>&&)> remove_client_function)
+  {
+    // Explicitly no thread synchronization.
+    remove_client_function(std::move(client));
+  }
+
+  /// Add service without thread-safety.
+  /**
+   * Does not throw, but storage function may throw.
+   */
+  void
+  sync_add_service(
+    std::shared_ptr<rclcpp::ServiceBase> && service,
+    std::function<void(std::shared_ptr<rclcpp::ServiceBase>&&)> add_service_function)
+  {
+    // Explicitly no thread synchronization.
+    add_service_function(std::move(service));
+  }
+
+  /// Remove service without thread-safety.
+  /**
+   * Does not throw, but storage function may throw.
+   */
+  void
+  sync_remove_service(
+    std::shared_ptr<rclcpp::ServiceBase> && service,
+    std::function<void(std::shared_ptr<rclcpp::ServiceBase>&&)> remove_service_function)
+  {
+    // Explicitly no thread synchronization.
+    remove_service_function(std::move(service));
   }
 
   /// Add waitable without thread-safety.

--- a/rclcpp/include/rclcpp/wait_set_policies/static_storage.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/static_storage.hpp
@@ -1,0 +1,97 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__WAIT_SET_POLICIES__STATIC_STORAGE_HPP_
+#define RCLCPP__WAIT_SET_POLICIES__STATIC_STORAGE_HPP_
+
+#include <array>
+#include <memory>
+
+#include "rclcpp/guard_condition.hpp"
+#include "rclcpp/macros.hpp"
+#include "rclcpp/visibility_control.hpp"
+#include "rclcpp/wait_set_policies/detail/storage_policy_common.hpp"
+
+namespace rclcpp
+{
+namespace wait_set_policies
+{
+
+/// WaitSet policy that explicitly provides fixed sized storage only.
+/**
+ * Note the underlying rcl_wait_set_t is still dynamically allocated, but only
+ * once during construction, and deallocated once during destruction.
+ */
+template<
+  // std::size_t NumberOfSubscriptions,
+  std::size_t NumberOfGuardCondtions
+  // std::size_t NumberOfTimers,
+  // std::size_t NumberOfClients,
+  // std::size_t NumberOfServices,
+  // std::size_t NumberOfEvents,
+  // std::size_t NumberOfWaitables
+>
+class StaticStorage : public rclcpp::wait_set_policies::detail::StoragePolicyCommon<true>
+{
+protected:
+  using is_mutable = std::false_type;
+
+  using ArrayOfGuardConditions = std::array<
+    std::shared_ptr<rclcpp::GuardCondition>,
+    NumberOfGuardCondtions
+  >;
+  using GuardConditionsIterable = ArrayOfGuardConditions;
+
+  explicit
+  StaticStorage(
+    const ArrayOfGuardConditions & guard_conditions,
+    rclcpp::Context::SharedPtr context
+  )
+  : StoragePolicyCommon(guard_conditions, context),
+    guard_conditions_(guard_conditions)
+  {}
+
+  ~StaticStorage() = default;
+
+  void
+  storage_rebuild_rcl_wait_set()
+  {
+    this->storage_rebuild_rcl_wait_set_with_sets(
+      guard_conditions_
+    );
+  }
+
+  // storage_add_guard_condition() explicitly not declared here
+  // storage_remove_guard_condition() explicitly not declared here
+  // storage_prune_deleted_entities() explicitly not declared here
+
+  void
+  storage_acquire_ownerships()
+  {
+    // Explicitly do nothing.
+  }
+
+  void
+  storage_release_ownerships()
+  {
+    // Explicitly do nothing.
+  }
+
+  const ArrayOfGuardConditions guard_conditions_;
+};
+
+}  // namespace wait_set_policies
+}  // namespace rclcpp
+
+#endif  // RCLCPP__WAIT_SET_POLICIES__STATIC_STORAGE_HPP_

--- a/rclcpp/include/rclcpp/wait_set_policies/static_storage.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/static_storage.hpp
@@ -115,10 +115,12 @@ public:
   >;
   using WaitablesIterable = ArrayOfWaitables;
 
+  template<class ArrayOfExtraGuardConditions>
   explicit
   StaticStorage(
     const ArrayOfSubscriptions & subscriptions,
     const ArrayOfGuardConditions & guard_conditions,
+    const ArrayOfExtraGuardConditions & extra_guard_conditions,
     const ArrayOfTimers & timers,
     const ArrayOfClients & clients,
     const ArrayOfServices & services,
@@ -128,6 +130,7 @@ public:
   : StoragePolicyCommon(
       subscriptions,
       guard_conditions,
+      extra_guard_conditions,
       timers,
       clients,
       services,
@@ -143,12 +146,14 @@ public:
 
   ~StaticStorage() = default;
 
+  template<class ArrayOfExtraGuardConditions>
   void
-  storage_rebuild_rcl_wait_set()
+  storage_rebuild_rcl_wait_set(const ArrayOfExtraGuardConditions & extra_guard_conditions)
   {
     this->storage_rebuild_rcl_wait_set_with_sets(
       subscriptions_,
       guard_conditions_,
+      extra_guard_conditions,
       timers_,
       clients_,
       services_,

--- a/rclcpp/include/rclcpp/wait_set_policies/static_storage.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/static_storage.hpp
@@ -18,8 +18,10 @@
 #include <array>
 #include <memory>
 
+#include "rclcpp/client.hpp"
 #include "rclcpp/guard_condition.hpp"
 #include "rclcpp/macros.hpp"
+#include "rclcpp/service.hpp"
 #include "rclcpp/subscription_base.hpp"
 #include "rclcpp/subscription_wait_set_mask.hpp"
 #include "rclcpp/timer.hpp"
@@ -41,8 +43,8 @@ template<
   std::size_t NumberOfSubscriptions,
   std::size_t NumberOfGuardCondtions,
   std::size_t NumberOfTimers,
-  // std::size_t NumberOfClients,
-  // std::size_t NumberOfServices,
+  std::size_t NumberOfClients,
+  std::size_t NumberOfServices,
   std::size_t NumberOfWaitables
 >
 class StaticStorage : public rclcpp::wait_set_policies::detail::StoragePolicyCommon<true>
@@ -82,6 +84,18 @@ public:
   >;
   using TimersIterable = ArrayOfTimers;
 
+  using ArrayOfClients = std::array<
+    std::shared_ptr<rclcpp::ClientBase>,
+    NumberOfClients
+  >;
+  using ClientsIterable = ArrayOfClients;
+
+  using ArrayOfServices = std::array<
+    std::shared_ptr<rclcpp::ServiceBase>,
+    NumberOfServices
+  >;
+  using ServicesIterable = ArrayOfServices;
+
   struct WaitableEntry
   {
     /// Conversion constructor, which is intentionally not marked explicit.
@@ -106,13 +120,24 @@ public:
     const ArrayOfSubscriptions & subscriptions,
     const ArrayOfGuardConditions & guard_conditions,
     const ArrayOfTimers & timers,
+    const ArrayOfClients & clients,
+    const ArrayOfServices & services,
     const ArrayOfWaitables & waitables,
     rclcpp::Context::SharedPtr context
   )
-  : StoragePolicyCommon(subscriptions, guard_conditions, timers, waitables, context),
+  : StoragePolicyCommon(
+      subscriptions,
+      guard_conditions,
+      timers,
+      clients,
+      services,
+      waitables,
+      context),
     subscriptions_(subscriptions),
     guard_conditions_(guard_conditions),
     timers_(timers),
+    clients_(clients),
+    services_(services),
     waitables_(waitables)
   {}
 
@@ -125,6 +150,8 @@ public:
       subscriptions_,
       guard_conditions_,
       timers_,
+      clients_,
+      services_,
       waitables_
     );
   }
@@ -135,6 +162,10 @@ public:
   // storage_remove_guard_condition() explicitly not declared here
   // storage_add_timer() explicitly not declared here
   // storage_remove_timer() explicitly not declared here
+  // storage_add_client() explicitly not declared here
+  // storage_remove_client() explicitly not declared here
+  // storage_add_service() explicitly not declared here
+  // storage_remove_service() explicitly not declared here
   // storage_add_waitable() explicitly not declared here
   // storage_remove_waitable() explicitly not declared here
   // storage_prune_deleted_entities() explicitly not declared here
@@ -154,6 +185,8 @@ public:
   const ArrayOfSubscriptions subscriptions_;
   const ArrayOfGuardConditions guard_conditions_;
   const ArrayOfTimers timers_;
+  const ArrayOfClients clients_;
+  const ArrayOfServices services_;
   const ArrayOfWaitables waitables_;
 };
 

--- a/rclcpp/include/rclcpp/wait_set_policies/static_storage.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/static_storage.hpp
@@ -52,7 +52,7 @@ protected:
 
   class SubscriptionEntry
   {
-  public:
+public:
     std::shared_ptr<rclcpp::SubscriptionBase> subscription;
     rclcpp::SubscriptionWaitSetMask mask;
 

--- a/rclcpp/include/rclcpp/wait_set_policies/thread_safe_synchronization.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/thread_safe_synchronization.hpp
@@ -1,0 +1,379 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__WAIT_SET_POLICIES__THREAD_SAFE_SYNCHRONIZATION_HPP_
+#define RCLCPP__WAIT_SET_POLICIES__THREAD_SAFE_SYNCHRONIZATION_HPP_
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <utility>
+
+#include "rclcpp/client.hpp"
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/guard_condition.hpp"
+#include "rclcpp/macros.hpp"
+#include "rclcpp/service.hpp"
+#include "rclcpp/subscription_base.hpp"
+#include "rclcpp/subscription_wait_set_mask.hpp"
+#include "rclcpp/timer.hpp"
+#include "rclcpp/visibility_control.hpp"
+#include "rclcpp/wait_result.hpp"
+#include "rclcpp/wait_result_kind.hpp"
+#include "rclcpp/wait_set_policies/detail/synchronization_policy_common.hpp"
+#include "rclcpp/wait_set_policies/detail/write_preferring_read_write_lock.hpp"
+#include "rclcpp/waitable.hpp"
+
+namespace rclcpp
+{
+namespace wait_set_policies
+{
+
+/// WaitSet policy that provides thread-safe synchronization for the wait set.
+/**
+ * This class uses a "write-preferring RW lock" so that adding items to, and
+ * removing items from, the wait set will take priority over reading, i.e.
+ * waiting.
+ * This is done since add and remove calls will interrupt the wait set anyways
+ * so it is wasteful to do "fair" locking when there are many add/remove
+ * operations queued up.
+ *
+ * There are some things to consider about the thread-safety provided by this
+ * policy.
+ * There are two categories of activities, reading and writing activities.
+ * The writing activities include all of the add and remove methods, as well as
+ * the prune_deleted_entities() method.
+ * The reading methods include the wait() method and keeping a WaitResult in
+ * scope.
+ * The reading and writing activities will not be run at the same time, and one
+ * will block the other.
+ * Therefore, if you are holding a WaitResult in scope, and try to add or
+ * remove an entity at the same time, they will block each other.
+ * The write activities will try to interrupt the wait() method by triggering
+ * a guard condition, but they have no way of causing the WaitResult to release
+ * its lock.
+ */
+class ThreadSafeSynchronization : public detail::SynchronizationPolicyCommon
+{
+protected:
+  explicit ThreadSafeSynchronization(rclcpp::Context::SharedPtr context)
+  : extra_guard_conditions_{{std::make_shared<rclcpp::GuardCondition>(context)}},
+    wprw_lock_([this]() {this->interrupt_waiting_wait_set();})
+  {}
+  ~ThreadSafeSynchronization() = default;
+
+  /// Return any "extra" guard conditions needed to implement the synchronization policy.
+  /**
+   * This policy has one guard condition which is used to interrupt the wait
+   * set when adding and removing entities.
+   */
+  const std::array<std::shared_ptr<rclcpp::GuardCondition>, 1> &
+  get_extra_guard_conditions()
+  {
+    return extra_guard_conditions_;
+  }
+
+  /// Interrupt any waiting wait set.
+  /**
+   * Used to interrupt the wait set when adding or removing items.
+   */
+  void
+  interrupt_waiting_wait_set()
+  {
+    extra_guard_conditions_[0]->trigger();
+  }
+
+  /// Add subscription.
+  void
+  sync_add_subscription(
+    std::shared_ptr<rclcpp::SubscriptionBase> && subscription,
+    const rclcpp::SubscriptionWaitSetMask & mask,
+    std::function<
+      void(std::shared_ptr<rclcpp::SubscriptionBase>&&, const rclcpp::SubscriptionWaitSetMask &)
+    > add_subscription_function)
+  {
+    using rclcpp::wait_set_policies::detail::WritePreferringReadWriteLock;
+    std::lock_guard<WritePreferringReadWriteLock::WriteMutex> lock(wprw_lock_.get_write_mutex());
+    add_subscription_function(std::move(subscription), mask);
+  }
+
+  /// Remove guard condition.
+  void
+  sync_remove_subscription(
+    std::shared_ptr<rclcpp::SubscriptionBase> && subscription,
+    const rclcpp::SubscriptionWaitSetMask & mask,
+    std::function<
+      void(std::shared_ptr<rclcpp::SubscriptionBase>&&, const rclcpp::SubscriptionWaitSetMask &)
+    > remove_subscription_function)
+  {
+    using rclcpp::wait_set_policies::detail::WritePreferringReadWriteLock;
+    std::lock_guard<WritePreferringReadWriteLock::WriteMutex> lock(wprw_lock_.get_write_mutex());
+    remove_subscription_function(std::move(subscription), mask);
+  }
+
+  /// Add guard condition.
+  void
+  sync_add_guard_condition(
+    std::shared_ptr<rclcpp::GuardCondition> && guard_condition,
+    std::function<void(std::shared_ptr<rclcpp::GuardCondition>&&)> add_guard_condition_function)
+  {
+    using rclcpp::wait_set_policies::detail::WritePreferringReadWriteLock;
+    std::lock_guard<WritePreferringReadWriteLock::WriteMutex> lock(wprw_lock_.get_write_mutex());
+    add_guard_condition_function(std::move(guard_condition));
+  }
+
+  /// Remove guard condition.
+  void
+  sync_remove_guard_condition(
+    std::shared_ptr<rclcpp::GuardCondition> && guard_condition,
+    std::function<void(std::shared_ptr<rclcpp::GuardCondition>&&)> remove_guard_condition_function)
+  {
+    using rclcpp::wait_set_policies::detail::WritePreferringReadWriteLock;
+    std::lock_guard<WritePreferringReadWriteLock::WriteMutex> lock(wprw_lock_.get_write_mutex());
+    remove_guard_condition_function(std::move(guard_condition));
+  }
+
+  /// Add timer.
+  void
+  sync_add_timer(
+    std::shared_ptr<rclcpp::TimerBase> && timer,
+    std::function<void(std::shared_ptr<rclcpp::TimerBase>&&)> add_timer_function)
+  {
+    using rclcpp::wait_set_policies::detail::WritePreferringReadWriteLock;
+    std::lock_guard<WritePreferringReadWriteLock::WriteMutex> lock(wprw_lock_.get_write_mutex());
+    add_timer_function(std::move(timer));
+  }
+
+  /// Remove timer.
+  void
+  sync_remove_timer(
+    std::shared_ptr<rclcpp::TimerBase> && timer,
+    std::function<void(std::shared_ptr<rclcpp::TimerBase>&&)> remove_timer_function)
+  {
+    using rclcpp::wait_set_policies::detail::WritePreferringReadWriteLock;
+    std::lock_guard<WritePreferringReadWriteLock::WriteMutex> lock(wprw_lock_.get_write_mutex());
+    remove_timer_function(std::move(timer));
+  }
+
+  /// Add client.
+  void
+  sync_add_client(
+    std::shared_ptr<rclcpp::ClientBase> && client,
+    std::function<void(std::shared_ptr<rclcpp::ClientBase>&&)> add_client_function)
+  {
+    using rclcpp::wait_set_policies::detail::WritePreferringReadWriteLock;
+    std::lock_guard<WritePreferringReadWriteLock::WriteMutex> lock(wprw_lock_.get_write_mutex());
+    add_client_function(std::move(client));
+  }
+
+  /// Remove client.
+  void
+  sync_remove_client(
+    std::shared_ptr<rclcpp::ClientBase> && client,
+    std::function<void(std::shared_ptr<rclcpp::ClientBase>&&)> remove_client_function)
+  {
+    using rclcpp::wait_set_policies::detail::WritePreferringReadWriteLock;
+    std::lock_guard<WritePreferringReadWriteLock::WriteMutex> lock(wprw_lock_.get_write_mutex());
+    remove_client_function(std::move(client));
+  }
+
+  /// Add service.
+  void
+  sync_add_service(
+    std::shared_ptr<rclcpp::ServiceBase> && service,
+    std::function<void(std::shared_ptr<rclcpp::ServiceBase>&&)> add_service_function)
+  {
+    using rclcpp::wait_set_policies::detail::WritePreferringReadWriteLock;
+    std::lock_guard<WritePreferringReadWriteLock::WriteMutex> lock(wprw_lock_.get_write_mutex());
+    add_service_function(std::move(service));
+  }
+
+  /// Remove service.
+  void
+  sync_remove_service(
+    std::shared_ptr<rclcpp::ServiceBase> && service,
+    std::function<void(std::shared_ptr<rclcpp::ServiceBase>&&)> remove_service_function)
+  {
+    using rclcpp::wait_set_policies::detail::WritePreferringReadWriteLock;
+    std::lock_guard<WritePreferringReadWriteLock::WriteMutex> lock(wprw_lock_.get_write_mutex());
+    remove_service_function(std::move(service));
+  }
+
+  /// Add waitable.
+  void
+  sync_add_waitable(
+    std::shared_ptr<rclcpp::Waitable> && waitable,
+    std::shared_ptr<void> && associated_entity,
+    std::function<
+      void(std::shared_ptr<rclcpp::Waitable>&&, std::shared_ptr<void>&&)
+    > add_waitable_function)
+  {
+    using rclcpp::wait_set_policies::detail::WritePreferringReadWriteLock;
+    std::lock_guard<WritePreferringReadWriteLock::WriteMutex> lock(wprw_lock_.get_write_mutex());
+    add_waitable_function(std::move(waitable), std::move(associated_entity));
+  }
+
+  /// Remove waitable.
+  void
+  sync_remove_waitable(
+    std::shared_ptr<rclcpp::Waitable> && waitable,
+    std::function<void(std::shared_ptr<rclcpp::Waitable>&&)> remove_waitable_function)
+  {
+    using rclcpp::wait_set_policies::detail::WritePreferringReadWriteLock;
+    std::lock_guard<WritePreferringReadWriteLock::WriteMutex> lock(wprw_lock_.get_write_mutex());
+    remove_waitable_function(std::move(waitable));
+  }
+
+  /// Prune deleted entities.
+  void
+  sync_prune_deleted_entities(std::function<void()> prune_deleted_entities_function)
+  {
+    using rclcpp::wait_set_policies::detail::WritePreferringReadWriteLock;
+    std::lock_guard<WritePreferringReadWriteLock::WriteMutex> lock(wprw_lock_.get_write_mutex());
+    prune_deleted_entities_function();
+  }
+
+  /// Implements wait.
+  template<class WaitResultT>
+  WaitResultT
+  sync_wait(
+    std::chrono::nanoseconds time_to_wait_ns,
+    std::function<void()> rebuild_rcl_wait_set,
+    std::function<rcl_wait_set_t & ()> get_rcl_wait_set,
+    std::function<WaitResultT(WaitResultKind wait_result_kind)> create_wait_result)
+  {
+    // Assumption: this function assumes that some measure has been taken to
+    // ensure none of the entities being waited on by the wait set are allowed
+    // to go out of scope and therefore be deleted.
+    // In the case of the StaticStorage policy, this is ensured because it
+    // retains shared ownership of all entites for the duration of its own life.
+    // In the case of the DynamicStorage policy, this is ensured by the function
+    // which calls this function, by acquiring shared ownership of the entites
+    // for the duration of this function.
+
+    // Setup looping predicate.
+    auto start = std::chrono::steady_clock::now();
+    std::function<bool()> should_loop = this->create_loop_predicate(time_to_wait_ns, start);
+
+    // Wait until exit condition is met.
+    do {
+      {
+        // We have to prevent the entity sets from being mutated while building
+        // the rcl wait set.
+        using rclcpp::wait_set_policies::detail::WritePreferringReadWriteLock;
+        std::lock_guard<WritePreferringReadWriteLock::ReadMutex> lock(wprw_lock_.get_read_mutex());
+        // Rebuild the wait set.
+        // This will resize the wait set if needed, due to e.g. adding or removing
+        // entities since the last wait, but this should never occur in static
+        // storage wait sets since they cannot be changed after construction.
+        // This will also clear the wait set and re-add all the entities, which
+        // prepares it to be waited on again.
+        rebuild_rcl_wait_set();
+      }
+
+      rcl_wait_set_t & rcl_wait_set = get_rcl_wait_set();
+
+      // Wait unconditionally until timeout condition occurs since we assume
+      // there are no conditions that would require the wait to stop and reset,
+      // like asynchronously adding or removing an entity, i.e. explicitly
+      // providing no thread-safety.
+
+      // Calculate how much time there is left to wait, unless blocking indefinitely.
+      auto time_left_to_wait_ns = this->calculate_time_left_to_wait(time_to_wait_ns, start);
+
+      // Then wait for entities to become ready.
+
+      // It is ok to wait while not having the lock acquired, because the state
+      // in the rcl wait set will not be updated until this method calls
+      // rebuild_rcl_wait_set().
+      rcl_ret_t ret = rcl_wait(&rcl_wait_set, time_left_to_wait_ns.count());
+      if (RCL_RET_OK == ret) {
+        // Something has become ready in the wait set, first check if it was
+        // the guard condition added by this class and/or a user defined guard condition.
+        const rcl_guard_condition_t * interrupt_guard_condition_ptr =
+          &(extra_guard_conditions_[0]->get_rcl_guard_condition());
+        bool was_interrupted_by_this_class = false;
+        bool any_user_guard_conditions_triggered = false;
+        for (size_t index = 0; index < rcl_wait_set.size_of_guard_conditions; ++index) {
+          const rcl_guard_condition_t * current = rcl_wait_set.guard_conditions[index];
+          if (nullptr != current) {
+            // Something is ready.
+            if (rcl_wait_set.guard_conditions[index] == interrupt_guard_condition_ptr) {
+              // This means that this class triggered a guard condition to interrupt this wait.
+              was_interrupted_by_this_class = true;
+            } else {
+              // This means it was a user guard condition.
+              any_user_guard_conditions_triggered = true;
+            }
+          }
+        }
+
+        if (!was_interrupted_by_this_class || any_user_guard_conditions_triggered) {
+          // In this case we know:
+          //   - something was ready
+          //   - it was either:
+          //     - not interrupted by this class, or
+          //     - maybe it was, but there were also user defined guard conditions.
+          //
+          // We cannot ignore user defined guard conditions, but we can ignore
+          // other kinds of user defined entities, because they will still be
+          // ready next time we wait, whereas guard conditions are cleared.
+          // Therefore we need to create a WaitResult and return it.
+
+          // The WaitResult will call sync_wait_result_acquire() and
+          // sync_wait_result_release() to ensure thread-safety by preventing
+          // the mutation of the entity sets while introspecting after waiting.
+          return create_wait_result(WaitResultKind::Ready);
+        }
+        // If we get here the we interrupted the wait set and there were no user
+        // guard conditions that needed to be handled.
+        // So we will loop and it will re-acquire the lock and rebuild the
+        // rcl wait set.
+      } else if (RCL_RET_TIMEOUT == ret) {
+        // The wait set timed out, exit the loop.
+        break;
+      } else if (RCL_RET_WAIT_SET_EMPTY == ret) {
+        // Wait set was empty, return Empty.
+        return create_wait_result(WaitResultKind::Empty);
+      } else {
+        // Some other error case, throw.
+        rclcpp::exceptions::throw_from_rcl_error(ret);
+      }
+    } while (should_loop());
+
+    // Wait did not result in ready items, return timeout.
+    return create_wait_result(WaitResultKind::Timeout);
+  }
+
+  void
+  sync_wait_result_acquire()
+  {
+    wprw_lock_.get_read_mutex().lock();
+  }
+
+  void
+  sync_wait_result_release()
+  {
+    wprw_lock_.get_read_mutex().unlock();
+  }
+
+protected:
+  std::array<std::shared_ptr<rclcpp::GuardCondition>, 1> extra_guard_conditions_;
+  rclcpp::wait_set_policies::detail::WritePreferringReadWriteLock wprw_lock_;
+};
+
+}  // namespace wait_set_policies
+}  // namespace rclcpp
+
+#endif  // RCLCPP__WAIT_SET_POLICIES__THREAD_SAFE_SYNCHRONIZATION_HPP_

--- a/rclcpp/include/rclcpp/wait_set_template.hpp
+++ b/rclcpp/include/rclcpp/wait_set_template.hpp
@@ -67,7 +67,6 @@ public:
    */
   explicit
   WaitSetTemplate(
-    // TODO(wjwwood): support subscription wait set masks in constructor
     const typename StoragePolicy::SubscriptionsIterable & subscriptions = {},
     const typename StoragePolicy::GuardConditionsIterable & guard_conditions = {},
     const typename StoragePolicy::TimersIterable & timers = {},

--- a/rclcpp/include/rclcpp/wait_set_template.hpp
+++ b/rclcpp/include/rclcpp/wait_set_template.hpp
@@ -95,7 +95,6 @@ public:
    * The state of this structure can be updated at anytime by methods like
    * wait(), add_*(), remove_*(), etc.
    */
-  RCLCPP_PUBLIC
   const rcl_wait_set_t &
   get_rcl_wait_set() const
   {

--- a/rclcpp/include/rclcpp/wait_set_template.hpp
+++ b/rclcpp/include/rclcpp/wait_set_template.hpp
@@ -559,7 +559,7 @@ public:
    * This function can either wait for a period of time, do no waiting
    * (non-blocking), or wait indefinitely, all based on the value of the
    * time_to_wait parameter.
-   * Waiting is always measured against the std::chrono::stead_clock.
+   * Waiting is always measured against the std::chrono::steady_clock.
    * If waiting indefinitely, the Timeout result is not possible.
    * There is no "cancel wait" function on this class, but if you want to wait
    * indefinitely but have a way to asynchronously interrupt this method, then

--- a/rclcpp/include/rclcpp/wait_set_template.hpp
+++ b/rclcpp/include/rclcpp/wait_set_template.hpp
@@ -21,11 +21,13 @@
 
 #include "rcl/wait.h"
 
+#include "rclcpp/client.hpp"
 #include "rclcpp/context.hpp"
 #include "rclcpp/contexts/default_context.hpp"
 #include "rclcpp/guard_condition.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/scope_exit.hpp"
+#include "rclcpp/service.hpp"
 #include "rclcpp/subscription_base.hpp"
 #include "rclcpp/subscription_wait_set_mask.hpp"
 #include "rclcpp/timer.hpp"
@@ -69,6 +71,8 @@ public:
     const typename StoragePolicy::SubscriptionsIterable & subscriptions = {},
     const typename StoragePolicy::GuardConditionsIterable & guard_conditions = {},
     const typename StoragePolicy::TimersIterable & timers = {},
+    const typename StoragePolicy::ClientsIterable & clients = {},
+    const typename StoragePolicy::ServicesIterable & services = {},
     const typename StoragePolicy::WaitablesIterable & waitables = {},
     rclcpp::Context::SharedPtr context =
     rclcpp::contexts::default_context::get_global_default_context())
@@ -76,6 +80,8 @@ public:
       subscriptions,
       guard_conditions,
       timers,
+      clients,
+      services,
       waitables,
       context),
     SynchronizationPolicy()
@@ -338,6 +344,110 @@ public:
         // fixed sized storage policies.
         // It will throw if the timer is not in the wait set.
         this->storage_remove_timer(std::move(inner_timer));
+      });
+  }
+
+  /// Add a client to this wait set.
+  /**
+   * \sa add_guard_condition() for details of how this method works.
+   *
+   * \param[in] client Client to be added.
+   * \throws std::invalid_argument if client is nullptr.
+   * \throws std::runtime_error if client has already been added.
+   * \throws exceptions based on the policies used.
+   */
+  void
+  add_client(std::shared_ptr<rclcpp::ClientBase> client)
+  {
+    if (nullptr == client) {
+      throw std::invalid_argument("client is nullptr");
+    }
+    // this method comes from the SynchronizationPolicy
+    this->sync_add_client(
+      std::move(client),
+      [this](std::shared_ptr<rclcpp::ClientBase> && inner_client) {
+        // This method comes from the StoragePolicy, and it may not exist for
+        // fixed sized storage policies.
+        // It will throw if the client has already been added.
+        this->storage_add_client(std::move(inner_client));
+      });
+  }
+
+  /// Remove a client from this wait set.
+  /**
+   * \sa remove_guard_condition() for details of how this method works.
+   *
+   * \param[in] client Client to be removed.
+   * \throws std::invalid_argument if client is nullptr.
+   * \throws std::runtime_error if client is not part of the wait set.
+   * \throws exceptions based on the policies used.
+   */
+  void
+  remove_client(std::shared_ptr<rclcpp::ClientBase> client)
+  {
+    if (nullptr == client) {
+      throw std::invalid_argument("client is nullptr");
+    }
+    // this method comes from the SynchronizationPolicy
+    this->sync_remove_client(
+      std::move(client),
+      [this](std::shared_ptr<rclcpp::ClientBase> && inner_client) {
+        // This method comes from the StoragePolicy, and it may not exist for
+        // fixed sized storage policies.
+        // It will throw if the client is not in the wait set.
+        this->storage_remove_client(std::move(inner_client));
+      });
+  }
+
+  /// Add a service to this wait set.
+  /**
+   * \sa add_guard_condition() for details of how this method works.
+   *
+   * \param[in] service Service to be added.
+   * \throws std::invalid_argument if service is nullptr.
+   * \throws std::runtime_error if service has already been added.
+   * \throws exceptions based on the policies used.
+   */
+  void
+  add_service(std::shared_ptr<rclcpp::ServiceBase> service)
+  {
+    if (nullptr == service) {
+      throw std::invalid_argument("service is nullptr");
+    }
+    // this method comes from the SynchronizationPolicy
+    this->sync_add_service(
+      std::move(service),
+      [this](std::shared_ptr<rclcpp::ServiceBase> && inner_service) {
+        // This method comes from the StoragePolicy, and it may not exist for
+        // fixed sized storage policies.
+        // It will throw if the service has already been added.
+        this->storage_add_service(std::move(inner_service));
+      });
+  }
+
+  /// Remove a service from this wait set.
+  /**
+   * \sa remove_guard_condition() for details of how this method works.
+   *
+   * \param[in] service Service to be removed.
+   * \throws std::invalid_argument if service is nullptr.
+   * \throws std::runtime_error if service is not part of the wait set.
+   * \throws exceptions based on the policies used.
+   */
+  void
+  remove_service(std::shared_ptr<rclcpp::ServiceBase> service)
+  {
+    if (nullptr == service) {
+      throw std::invalid_argument("service is nullptr");
+    }
+    // this method comes from the SynchronizationPolicy
+    this->sync_remove_service(
+      std::move(service),
+      [this](std::shared_ptr<rclcpp::ServiceBase> && inner_service) {
+        // This method comes from the StoragePolicy, and it may not exist for
+        // fixed sized storage policies.
+        // It will throw if the service is not in the wait set.
+        this->storage_remove_service(std::move(inner_service));
       });
   }
 

--- a/rclcpp/include/rclcpp/wait_set_template.hpp
+++ b/rclcpp/include/rclcpp/wait_set_template.hpp
@@ -46,6 +46,7 @@ class WaitSetTemplate final : private StoragePolicy, private SynchronizationPoli
 public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(WaitSetTemplate)
 
+  using typename StoragePolicy::SubscriptionEntry;
   using typename StoragePolicy::WaitableEntry;
 
   /// Construct a wait set with optional initial waitable entities and optional custom context.

--- a/rclcpp/include/rclcpp/wait_set_template.hpp
+++ b/rclcpp/include/rclcpp/wait_set_template.hpp
@@ -1,0 +1,312 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__WAIT_SET_TEMPLATE_HPP_
+#define RCLCPP__WAIT_SET_TEMPLATE_HPP_
+
+#include <chrono>
+#include <memory>
+
+#include "rcl/wait.h"
+
+#include "rclcpp/context.hpp"
+#include "rclcpp/contexts/default_context.hpp"
+#include "rclcpp/guard_condition.hpp"
+#include "rclcpp/macros.hpp"
+#include "rclcpp/scope_exit.hpp"
+#include "rclcpp/visibility_control.hpp"
+#include "rclcpp/wait_result.hpp"
+
+namespace rclcpp
+{
+
+/// Encapsulates sets of waitable items which can be waited on as a group.
+/**
+ * This class uses the rcl_wait_set_t as storage, but it also helps manage the
+ * ownership of associated rclcpp types.
+ */
+template<class StoragePolicy, class SynchronizationPolicy>
+class WaitSetTemplate final : private StoragePolicy, private SynchronizationPolicy
+{
+public:
+  RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(WaitSetTemplate)
+
+  /// Construct a wait set with optional initial waitable entities and optional custom context.
+  /**
+   * \param[in] guard_conditions Vector of guard conditions to be added.
+   * \param[in] context Custom context to be used, defaults to global default.
+   * \throws std::invalid_argument If context is nullptr.
+   */
+  explicit
+  WaitSetTemplate(
+    const typename StoragePolicy::GuardConditionsIterable & guard_conditions = {},
+    rclcpp::Context::SharedPtr context =
+      rclcpp::contexts::default_context::get_global_default_context())
+  : StoragePolicy(guard_conditions, context), SynchronizationPolicy()
+  {}
+
+  /// Return the internal rcl wait set object.
+  /**
+   * This method provides no thread-safety when accessing this structure.
+   * The state of this structure can be updated at anytime by methods like
+   * wait(), add_*(), remove_*(), etc.
+   */
+  RCLCPP_PUBLIC
+  const rcl_wait_set_t &
+  get_rcl_wait_set() const
+  {
+    // this method comes from the StoragePolicy
+    return this->storage_get_rcl_wait_set();
+  }
+
+  /// Add a guard condition to this wait set.
+  /**
+   * Guard condition is added to the wait set, and shared ownership is held
+   * while waiting.
+   * However, if between calls to wait() the guard condition's reference count
+   * goes to zero, it will be implicitly removed on the next call to wait().
+   *
+   * Except in the case of a fixed sized storage, where changes to the wait set
+   * cannot occur after construction, in which case it holds shared ownership
+   * at all times until the wait set is destroy, but this method also does not
+   * exist on a fixed sized wait set.
+   *
+   * This function may be thread-safe depending on the SynchronizationPolicy
+   * used with this class.
+   * Using the ThreadSafeWaitSetPolicy will ensure that wait() is interrupted
+   * and returns before this function adds the guard condition.
+   * Otherwise, it is not safe to call this function concurrently with wait().
+   *
+   * This function will not be enabled (will not be available) if the
+   * StoragePolicy does not allow editing of the wait set after initialization.
+   *
+   * \param[in] guard_condition Guard condition to be added.
+   * \throws std::invalid_argument if guard_condition is nullptr.
+   * \throws std::runtime_error if guard_condition has already been added.
+   * \throws exceptions based on the policies used.
+   */
+  void
+  add_guard_condition(std::shared_ptr<rclcpp::GuardCondition> guard_condition)
+  {
+    if (nullptr == guard_condition) {
+      throw std::invalid_argument("guard_condition is nullptr");
+    }
+    // this method comes from the SynchronizationPolicy
+    this->sync_add_guard_condition(
+      std::move(guard_condition),
+      [this](std::shared_ptr<rclcpp::GuardCondition> && inner_guard_condition) {
+        // This method comes from the StoragePolicy, and it may not exist for
+        // fixed sized storage policies.
+        // It will throw if the guard condition has already been added.
+        this->storage_add_guard_condition(std::move(inner_guard_condition));
+      });
+  }
+
+  /// Remove a guard condition from this wait set.
+  /**
+   * Guard condition is removed from the wait set, and if needed the shared
+   * ownership is released.
+   *
+   * This function may be thread-safe depending on the SynchronizationPolicy
+   * used with this class.
+   * Using the ThreadSafeWaitSetPolicy will ensure that wait() is interrupted
+   * and returns before this function removes the guard condition.
+   * Otherwise, it is not safe to call this function concurrently with wait().
+   *
+   * This function will not be enabled (will not be available) if the
+   * StoragePolicy does not allow editing of the wait set after initialization.
+   *
+   * \param[in] guard_condition Guard condition to be removed.
+   * \throws std::invalid_argument if guard_condition is nullptr.
+   * \throws std::runtime_error if guard_condition is not part of the wait set.
+   * \throws exceptions based on the policies used.
+   */
+  void
+  remove_guard_condition(std::shared_ptr<rclcpp::GuardCondition> guard_condition)
+  {
+    if (nullptr == guard_condition) {
+      throw std::invalid_argument("guard_condition is nullptr");
+    }
+    // this method comes from the SynchronizationPolicy
+    this->sync_remove_guard_condition(
+      std::move(guard_condition),
+      [this](std::shared_ptr<rclcpp::GuardCondition> && inner_guard_condition) {
+        // This method comes from the StoragePolicy, and it may not exist for
+        // fixed sized storage policies.
+        // It will throw if the guard condition is not in the wait set.
+        this->storage_remove_guard_condition(std::move(inner_guard_condition));
+      });
+  }
+
+  /// Remove any destroyed entities from the wait set.
+  /**
+   * When the storage policy does not maintain shared ownership for the life
+   * of the wait set, e.g. the DynamicStorage policy, it is possible for an
+   * entity to go out of scope and be deleted without this wait set noticing.
+   * Therefore there are weak references in this wait set which need to be
+   * periodically cleared.
+   * This function performs that clean up.
+   *
+   * Since this involves removing entities from the wait set, and is only
+   * needed if the wait set does not keep ownership of the added entities, the
+   * storage policies which are static will not need this function and therefore
+   * do not provide this function.
+   *
+   * \throws exceptions based on the policies used.
+   */
+  void
+  prune_deleted_entities()
+  {
+    // this method comes from the SynchronizationPolicy
+    this->sync_prune_deleted_entities(
+      [this]() {
+        // This method comes from the StoragePolicy, and it may not exist for
+        // fixed sized storage policies.
+        this->storage_prune_deleted_entities();
+      });
+  }
+
+  /// Wait for any of the entities in the wait set to be ready, or a period of time to pass.
+  /**
+   * This function will return when either one of the entities within this wait
+   * set is ready, or a period of time has passed, which ever is first.
+   * The term "ready" means different things for different entities, but
+   * generally it means some condition is met asynchronously for which this
+   * function waits.
+   *
+   * This function can either wait for a period of time, do no waiting
+   * (non-blocking), or wait indefinitely, all based on the value of the
+   * time_to_wait parameter.
+   * Waiting is always measured against the std::chrono::stead_clock.
+   * If waiting indefinitely, the Timeout result is not possible.
+   * There is no "cancel wait" function on this class, but if you want to wait
+   * indefinitely but have a way to asynchronously interrupt this method, then
+   * you can use a dedicated rclcpp::GuardCondition for that purpose.
+   *
+   * This function will modify the internal rcl_wait_set_t, so introspecting
+   * the wait set during a call to wait is never safe.
+   * You should always wait, then introspect, and then, only when done waiting,
+   * introspect again.
+   *
+   * It may be thread-safe to add and remove entities to the wait set
+   * concurrently with this function, depending on the SynchronizationPolicy
+   * that is used.
+   * With the rclcpp::wait_set_policies::ThreadSafeSynchronization policy this
+   * function will stop waiting to allow add or remove of an entity, and then
+   * resume waiting, so long as the timeout has not been reached.
+   *
+   * \param[in] time_to_wait If > 0, time to wait for entities to be ready,
+   *   if == 0, check if anything is ready without blocking, or
+   *   if < 0, wait indefinitely until one of the items is ready.
+   *   Default is -1, so wait indefinitely.
+   * \returns Ready when one of the entities is ready, or
+   * \returns Timeout when the given time to wait is exceeded, not possible
+   *   when time_to_wait is < 0, or
+   * \returns Empty if the wait set is empty, avoiding the possibility of
+   *   waiting indefinitely on an empty wait set.
+   * \throws rclcpp::exceptions::RCLErrorBase on unhandled rcl errors
+   */
+  template<class Rep = int64_t, class Period = std::milli>
+  RCUTILS_WARN_UNUSED
+  WaitResult<WaitSetTemplate>
+  wait(std::chrono::duration<Rep, Period> time_to_wait = std::chrono::duration<Rep, Period>(-1))
+  {
+    auto time_to_wait_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(time_to_wait);
+
+    // ensure the ownership of the entities in the wait set is shared for the duration of wait
+    this->storage_acquire_ownerships();
+    RCLCPP_SCOPE_EXIT({this->storage_release_ownerships();});
+
+    // this method comes from the SynchronizationPolicy
+    return this->template sync_wait<WaitResult<WaitSetTemplate>>(
+      // pass along the time_to_wait duration as nanoseconds
+      time_to_wait_ns,
+      // this method provides the ability to rebuild the wait set, if needed
+      [this]() {
+        // This method comes from the StoragePolicy
+        this->storage_rebuild_rcl_wait_set();
+      },
+      // this method provides access to the rcl wait set
+      [this]() -> rcl_wait_set_t & {
+        // This method comes from the StoragePolicy
+        return this->storage_get_rcl_wait_set();
+      },
+      // this method provides a way to create the WaitResult
+      [this](WaitResultKind wait_result_kind) -> WaitResult<WaitSetTemplate> {
+        // convert the result into a WaitResult
+        switch (wait_result_kind) {
+          case WaitResultKind::Ready:
+            return WaitResult<WaitSetTemplate>::from_ready_wait_result_kind(*this);
+          case WaitResultKind::Timeout:
+            return WaitResult<WaitSetTemplate>::from_timeout_wait_result_kind();
+          case WaitResultKind::Empty:
+            return WaitResult<WaitSetTemplate>::from_empty_wait_result_kind();
+          default:
+            auto msg = "unknown WaitResultKind with value: " + std::to_string(wait_result_kind);
+            throw std::runtime_error(msg);
+        }
+      }
+    );
+  }
+
+private:
+  // Add WaitResult type as a friend so it can call private methods for
+  // acquiring and releasing resources as the WaitResult is initialized and
+  // destructed, respectively.
+  friend WaitResult<WaitSetTemplate>;
+
+  /// Called by the WaitResult's constructor to place a hold on ownership and thread-safety.
+  /**
+   * Should only be called in pairs with wait_result_release().
+   *
+   * \throws std::runtime_error If called twice before wait_result_release().
+   */
+  void
+  wait_result_acquire()
+  {
+    if (wait_result_holding_) {
+      throw std::runtime_error("wait_result_acquire() called while already holding");
+    }
+    wait_result_holding_ = true;
+    // this method comes from the SynchronizationPolicy
+    this->sync_wait_result_acquire();
+    // this method comes from the StoragePolicy
+    this->storage_acquire_ownerships();
+  }
+
+  /// Called by the WaitResult's destructor to release resources.
+  /**
+   * Should only be called if wait_result_acquire() has been called.
+   *
+   * \throws std::runtime_error If called before wait_result_acquire().
+   */
+  void
+  wait_result_release()
+  {
+    if (!wait_result_holding_) {
+      throw std::runtime_error("wait_result_release() called while not holding");
+    }
+    wait_result_holding_ = false;
+    // this method comes from the StoragePolicy
+    this->storage_release_ownerships();
+    // this method comes from the SynchronizationPolicy
+    this->sync_wait_result_release();
+  }
+
+  bool wait_result_holding_ = false;
+};
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__WAIT_SET_TEMPLATE_HPP_

--- a/rclcpp/include/rclcpp/wait_set_template.hpp
+++ b/rclcpp/include/rclcpp/wait_set_template.hpp
@@ -17,6 +17,7 @@
 
 #include <chrono>
 #include <memory>
+#include <utility>
 
 #include "rcl/wait.h"
 
@@ -70,7 +71,7 @@ public:
     const typename StoragePolicy::TimersIterable & timers = {},
     const typename StoragePolicy::WaitablesIterable & waitables = {},
     rclcpp::Context::SharedPtr context =
-      rclcpp::contexts::default_context::get_global_default_context())
+    rclcpp::contexts::default_context::get_global_default_context())
   : StoragePolicy(
       subscriptions,
       guard_conditions,
@@ -475,7 +476,7 @@ public:
    *   when time_to_wait is < 0, or
    * \returns Empty if the wait set is empty, avoiding the possibility of
    *   waiting indefinitely on an empty wait set.
-   * \throws rclcpp::exceptions::RCLErrorBase on unhandled rcl errors
+   * \throws rclcpp::exceptions::RCLError on unhandled rcl errors
    */
   template<class Rep = int64_t, class Period = std::milli>
   RCUTILS_WARN_UNUSED

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -94,7 +94,6 @@ public:
   size_t
   get_number_of_ready_guard_conditions();
 
-  // TODO(jacobperron): smart pointer?
   /// Add the Waitable to a wait set.
   /**
    * \param[in] wait_set A handle to the wait set to add the Waitable to.

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -15,6 +15,8 @@
 #ifndef RCLCPP__WAITABLE_HPP_
 #define RCLCPP__WAITABLE_HPP_
 
+#include <atomic>
+
 #include "rclcpp/macros.hpp"
 #include "rclcpp/visibility_control.hpp"
 
@@ -145,6 +147,22 @@ public:
   virtual
   void
   execute() = 0;
+
+  /// Exchange the "in use by wait set" state for this timer.
+  /**
+   * This is used to ensure this timer is not used by multiple
+   * wait sets at the same time.
+   *
+   * \param[in] in_use_state the new state to exchange into the state, true
+   *   indicates it is now in use by a wait set, and false is that it is no
+   *   longer in use by a wait set.
+   * \returns the previous state.
+   */
+  bool
+  exchange_in_use_by_wait_set_state(bool in_use_state);
+
+private:
+  std::atomic<bool> in_use_by_wait_set_{false};
 };  // class Waitable
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -158,6 +158,7 @@ public:
    *   longer in use by a wait set.
    * \returns the previous state.
    */
+  RCLCPP_PUBLIC
   bool
   exchange_in_use_by_wait_set_state(bool in_use_state);
 

--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -192,3 +192,9 @@ ClientBase::get_rcl_node_handle() const
 {
   return node_handle_.get();
 }
+
+bool
+ClientBase::exchange_in_use_by_wait_set_state(bool in_use_state)
+{
+  return in_use_by_wait_set_.exchange(in_use_state);
+}

--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -70,6 +70,21 @@ ClientBase::~ClientBase()
   client_handle_.reset();
 }
 
+bool
+ClientBase::take_type_erased_response(void * response_out, rmw_request_id_t & request_header_out)
+{
+  rcl_ret_t ret = rcl_take_response(
+    this->get_client_handle().get(),
+    &request_header_out,
+    response_out);
+  if (RCL_RET_CLIENT_TAKE_FAILED == ret) {
+    return false;
+  } else if (RCL_RET_OK != ret) {
+    rclcpp::exceptions::throw_from_rcl_error(ret);
+  }
+  return true;
+}
+
 const char *
 ClientBase::get_service_name() const
 {

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -305,54 +305,56 @@ Executor::execute_any_executable(AnyExecutable & any_exec)
   }
 }
 
+static
+void
+take_and_do_error_handling(
+  const char * action_description,
+  const char * topic_or_service_name,
+  std::function<bool()> take_action,
+  std::function<void()> handle_action)
+{
+  bool taken;
+  try {
+    taken = take_action();
+  } catch (const rclcpp::exceptions::RCLError & rcl_error) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("rclcpp"),
+      "executor %s '%s' unexpectedly failed: %s",
+      action_description,
+      topic_or_service_name,
+      rcl_error.what());
+  }
+  if (taken) {
+    handle_action();
+  } else {
+    // Message or Service was not taken for some reason.
+    // Note that this can be normal, if the underlying middleware needs to
+    // interrupt wait spuriously it is allowed.
+    // So in that case the executor cannot tell the difference in a
+    // spurious wake up and an entity actually having data until trying
+    // to take the data.
+    RCLCPP_DEBUG(
+      rclcpp::get_logger("rclcpp"),
+      "executor %s '%s' failed to take anything",
+      action_description,
+      topic_or_service_name);
+  }
+}
+
 void
 Executor::execute_subscription(rclcpp::SubscriptionBase::SharedPtr subscription)
 {
   rclcpp::MessageInfo message_info;
   message_info.get_rmw_message_info().from_intra_process = false;
 
-  // Reduce code duplication by generalize error handling into lambda.
-  auto take_message_and_do_error_handling =
-    [&subscription](
-    const char * message_adjective,
-    std::function<bool()> take_action,
-    std::function<void()> handle_action)
-    {
-      bool taken;
-      try {
-        taken = take_action();
-      } catch (const rclcpp::exceptions::RCLError & rcl_error) {
-        RCLCPP_ERROR(
-          rclcpp::get_logger("rclcpp"),
-          "executor taking a %smessage from topic '%s' unexpectedly failed: %s",
-          message_adjective,
-          subscription->get_topic_name(),
-          rcl_error.what());
-      }
-      if (taken) {
-        handle_action();
-      } else {
-        // Message was not taken for some reason.
-        // Note that this can be normal, if the underlying middleware needs to
-        // interrupt wait spuriously it is allowed.
-        // So in that case the executor cannot tell the difference in a
-        // spurious wake up and a subscription actually having data until trying
-        // to take the data.
-        RCLCPP_DEBUG(
-          rclcpp::get_logger("rclcpp"),
-          "executor taking a %smessage from topic '%s' failed to take anything",
-          message_adjective,
-          subscription->get_topic_name());
-      }
-    };
-
   if (subscription->is_serialized()) {
     // This is the case where a copy of the serialized message is taken from
     // the middleware via inter-process communication.
     std::shared_ptr<rcl_serialized_message_t> serialized_msg =
       subscription->create_serialized_message();
-    take_message_and_do_error_handling(
-      "serialzed ",
+    take_and_do_error_handling(
+      "taking a serialized message from topic",
+      subscription->get_topic_name(),
       [&]() {return subscription->take_serialized(*serialized_msg.get(), message_info);},
       [&]()
       {
@@ -367,8 +369,9 @@ Executor::execute_subscription(rclcpp::SubscriptionBase::SharedPtr subscription)
     void * loaned_msg = nullptr;
     // TODO(wjwwood): refactor this into methods on subscription when LoanedMessage
     //   is extened to support subscriptions as well.
-    take_message_and_do_error_handling(
-      "loaned ",
+    take_and_do_error_handling(
+      "taking a loaned message from topic",
+      subscription->get_topic_name(),
       [&]()
       {
         rcl_ret_t ret = rcl_take_loaned_message(
@@ -398,8 +401,9 @@ Executor::execute_subscription(rclcpp::SubscriptionBase::SharedPtr subscription)
     // This case is taking a copy of the message data from the middleware via
     // inter-process communication.
     std::shared_ptr<void> message = subscription->create_message();
-    take_message_and_do_error_handling(
-      "",  // no message adjective
+    take_and_do_error_handling(
+      "taking a message from topic",
+      subscription->get_topic_name(),
       [&]() {return subscription->take_type_erased(message.get(), message_info);},
       [&]() {subscription->handle_message(message, message_info);});
     subscription->return_message(message);
@@ -417,19 +421,11 @@ Executor::execute_service(rclcpp::ServiceBase::SharedPtr service)
 {
   auto request_header = service->create_request_header();
   std::shared_ptr<void> request = service->create_request();
-  rcl_ret_t status = rcl_take_request(
-    service->get_service_handle().get(),
-    request_header.get(),
-    request.get());
-  if (status == RCL_RET_OK) {
-    service->handle_request(request_header, request);
-  } else if (status != RCL_RET_SERVICE_TAKE_FAILED) {
-    RCUTILS_LOG_ERROR_NAMED(
-      "rclcpp",
-      "take request failed for server of service '%s': %s",
-      service->get_service_name(), rcl_get_error_string().str);
-    rcl_reset_error();
-  }
+  take_and_do_error_handling(
+    "taking a service server request from service",
+    service->get_service_name(),
+    [&]() {return service->take_type_erased_request(request.get(), *request_header);},
+    [&]() {service->handle_request(request_header, request);});
 }
 
 void
@@ -438,19 +434,11 @@ Executor::execute_client(
 {
   auto request_header = client->create_request_header();
   std::shared_ptr<void> response = client->create_response();
-  rcl_ret_t status = rcl_take_response(
-    client->get_client_handle().get(),
-    request_header.get(),
-    response.get());
-  if (status == RCL_RET_OK) {
-    client->handle_response(request_header, response);
-  } else if (status != RCL_RET_CLIENT_TAKE_FAILED) {
-    RCUTILS_LOG_ERROR_NAMED(
-      "rclcpp",
-      "take response failed for client of service '%s': %s",
-      client->get_service_name(), rcl_get_error_string().str);
-    rcl_reset_error();
-  }
+  take_and_do_error_handling(
+    "taking a service client response from service",
+    client->get_service_name(),
+    [&]() {return client->take_type_erased_response(response.get(), *request_header);},
+    [&]() {client->handle_response(request_header, response);});
 }
 
 void

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -313,7 +313,7 @@ take_and_do_error_handling(
   std::function<bool()> take_action,
   std::function<void()> handle_action)
 {
-  bool taken;
+  bool taken = false;
   try {
     taken = take_action();
   } catch (const rclcpp::exceptions::RCLError & rcl_error) {

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -314,9 +314,9 @@ Executor::execute_subscription(rclcpp::SubscriptionBase::SharedPtr subscription)
   // Reduce code duplication by generalize error handling into lambda.
   auto take_message_and_do_error_handling =
     [&subscription](
-      const char * message_adjective,
-      std::function<bool ()> take_action,
-      std::function<void ()> handle_action)
+    const char * message_adjective,
+    std::function<bool()> take_action,
+    std::function<void()> handle_action)
     {
       bool taken;
       try {
@@ -353,7 +353,7 @@ Executor::execute_subscription(rclcpp::SubscriptionBase::SharedPtr subscription)
       subscription->create_serialized_message();
     take_message_and_do_error_handling(
       "serialzed ",
-      [&]() { return subscription->take_serialized(*serialized_msg.get(), message_info); },
+      [&]() {return subscription->take_serialized(*serialized_msg.get(), message_info);},
       [&]()
       {
         auto void_serialized_msg = std::static_pointer_cast<void>(serialized_msg);
@@ -383,7 +383,7 @@ Executor::execute_subscription(rclcpp::SubscriptionBase::SharedPtr subscription)
         }
         return true;
       },
-      [&]() { subscription->handle_loaned_message(loaned_msg, message_info); });
+      [&]() {subscription->handle_loaned_message(loaned_msg, message_info);});
     rcl_ret_t ret = rcl_return_loaned_message_from_subscription(
       subscription->get_subscription_handle().get(),
       loaned_msg);
@@ -400,8 +400,8 @@ Executor::execute_subscription(rclcpp::SubscriptionBase::SharedPtr subscription)
     std::shared_ptr<void> message = subscription->create_message();
     take_message_and_do_error_handling(
       "",  // no message adjective
-      [&]() { return subscription->take_type_erased(message.get(), message_info); },
-      [&]() { subscription->handle_message(message, message_info); });
+      [&]() {return subscription->take_type_erased(message.get(), message_info);},
+      [&]() {subscription->handle_message(message, message_info);});
     subscription->return_message(message);
   }
 }

--- a/rclcpp/src/rclcpp/guard_condition.cpp
+++ b/rclcpp/src/rclcpp/guard_condition.cpp
@@ -1,0 +1,74 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/guard_condition.hpp"
+
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/logging.hpp"
+
+namespace rclcpp
+{
+
+GuardCondition::GuardCondition(rclcpp::Context::SharedPtr context)
+: context_(context), rcl_guard_condition_{rcl_get_zero_initialized_guard_condition()}
+{
+  if (!context_) {
+    throw std::invalid_argument("context argument unexpectedly nullptr");
+  }
+  rcl_guard_condition_options_t guard_condition_options = rcl_guard_condition_get_default_options();
+  rcl_ret_t ret = rcl_guard_condition_init(
+    &this->rcl_guard_condition_,
+    context_->get_rcl_context().get(),
+    guard_condition_options);
+  if (RCL_RET_OK != ret) {
+    rclcpp::exceptions::throw_from_rcl_error(ret);
+  }
+}
+
+GuardCondition::~GuardCondition()
+{
+  rcl_ret_t ret = rcl_guard_condition_fini(&this->rcl_guard_condition_);
+  if (RCL_RET_OK != ret) {
+    try {
+      rclcpp::exceptions::throw_from_rcl_error(ret);
+    } catch (const std::exception & exception) {
+      RCLCPP_ERROR(
+        rclcpp::get_logger("rclcpp"),
+        "Error in destruction of rcl guard condition: %s", exception.what());
+    }
+  }
+}
+
+rclcpp::Context::SharedPtr
+GuardCondition::get_context() const
+{
+  return context_;
+}
+
+const rcl_guard_condition_t &
+GuardCondition::get_rcl_guard_condtion() const
+{
+  return rcl_guard_condition_;
+}
+
+void
+GuardCondition::trigger()
+{
+  rcl_ret_t ret = rcl_trigger_guard_condition(&rcl_guard_condition_);
+  if (RCL_RET_OK != ret) {
+    rclcpp::exceptions::throw_from_rcl_error(ret);
+  }
+}
+
+}  // namespace rclcpp

--- a/rclcpp/src/rclcpp/guard_condition.cpp
+++ b/rclcpp/src/rclcpp/guard_condition.cpp
@@ -71,4 +71,10 @@ GuardCondition::trigger()
   }
 }
 
+bool
+GuardCondition::exchange_in_use_by_wait_set_state(bool in_use_state)
+{
+  return in_use_by_wait_set_.exchange(in_use_state);
+}
+
 }  // namespace rclcpp

--- a/rclcpp/src/rclcpp/guard_condition.cpp
+++ b/rclcpp/src/rclcpp/guard_condition.cpp
@@ -57,7 +57,7 @@ GuardCondition::get_context() const
 }
 
 const rcl_guard_condition_t &
-GuardCondition::get_rcl_guard_condtion() const
+GuardCondition::get_rcl_guard_condition() const
 {
   return rcl_guard_condition_;
 }

--- a/rclcpp/src/rclcpp/message_info.cpp
+++ b/rclcpp/src/rclcpp/message_info.cpp
@@ -1,0 +1,39 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/message_info.hpp"
+
+namespace rclcpp
+{
+
+MessageInfo::MessageInfo(const rmw_message_info_t & rmw_message_info)
+: rmw_message_info_(rmw_message_info)
+{}
+
+MessageInfo::~MessageInfo()
+{}
+
+const rmw_message_info_t &
+MessageInfo::get_rmw_message_info() const
+{
+  return rmw_message_info_;
+}
+
+rmw_message_info_t &
+MessageInfo::get_rmw_message_info()
+{
+  return rmw_message_info_;
+}
+
+}  // namespace rclcpp

--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -34,6 +34,21 @@ ServiceBase::ServiceBase(std::shared_ptr<rcl_node_t> node_handle)
 ServiceBase::~ServiceBase()
 {}
 
+bool
+ServiceBase::take_type_erased_request(void * request_out, rmw_request_id_t & request_id_out)
+{
+  rcl_ret_t ret = rcl_take_request(
+    this->get_service_handle().get(),
+    &request_id_out,
+    request_out);
+  if (RCL_RET_CLIENT_TAKE_FAILED == ret) {
+    return false;
+  } else if (RCL_RET_OK != ret) {
+    rclcpp::exceptions::throw_from_rcl_error(ret);
+  }
+  return true;
+}
+
 const char *
 ServiceBase::get_service_name()
 {

--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -78,3 +78,9 @@ ServiceBase::get_rcl_node_handle() const
 {
   return node_handle_.get();
 }
+
+bool
+ServiceBase::exchange_in_use_by_wait_set_state(bool in_use_state)
+{
+  return in_use_by_wait_set_.exchange(in_use_state);
+}

--- a/rclcpp/src/rclcpp/subscription_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_base.cpp
@@ -159,7 +159,7 @@ SubscriptionBase::take_type_erased(void * message_out, rclcpp::MessageInfo & mes
 
 bool
 SubscriptionBase::take_serialized(
-  rmw_serialized_message_t & message_out,
+  rcl_serialized_message_t & message_out,
   rclcpp::MessageInfo & message_info_out)
 {
   rcl_ret_t ret = rcl_take_serialized_message(

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -135,3 +135,9 @@ TimerBase::get_timer_handle()
 {
   return timer_handle_;
 }
+
+bool
+TimerBase::exchange_in_use_by_wait_set_state(bool in_use_state)
+{
+  return in_use_by_wait_set_.exchange(in_use_state);
+}

--- a/rclcpp/src/rclcpp/wait_set_policies/detail/write_preferring_read_write_lock.cpp
+++ b/rclcpp/src/rclcpp/wait_set_policies/detail/write_preferring_read_write_lock.cpp
@@ -1,0 +1,100 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/wait_set_policies/detail/write_preferring_read_write_lock.hpp"
+
+namespace rclcpp
+{
+namespace wait_set_policies
+{
+namespace detail
+{
+
+WritePreferringReadWriteLock::WritePreferringReadWriteLock(
+  std::function<void ()> enter_waiting_function)
+: read_mutex_(*this), write_mutex_(*this), enter_waiting_function_(enter_waiting_function)
+{}
+
+WritePreferringReadWriteLock::ReadMutex &
+WritePreferringReadWriteLock::get_read_mutex()
+{
+  return read_mutex_;
+}
+
+WritePreferringReadWriteLock::WriteMutex &
+WritePreferringReadWriteLock::get_write_mutex()
+{
+  return write_mutex_;
+}
+
+WritePreferringReadWriteLock::ReadMutex::ReadMutex(WritePreferringReadWriteLock & parent_lock)
+: parent_lock_(parent_lock)
+{}
+
+void
+WritePreferringReadWriteLock::ReadMutex::lock()
+{
+  std::unique_lock<std::mutex> lock(parent_lock_.mutex_);
+  while (
+    parent_lock_.number_of_writers_waiting_ > 0 ||
+    parent_lock_.writer_active_ ||
+    parent_lock_.reader_active_)
+  {
+    parent_lock_.condition_variable_.wait(lock);
+  }
+  parent_lock_.reader_active_ = true;
+  // implicit unlock of parent_lock_.mutex_
+}
+
+void
+WritePreferringReadWriteLock::ReadMutex::unlock()
+{
+  std::unique_lock<std::mutex> lock(parent_lock_.mutex_);
+  parent_lock_.reader_active_ = false;
+  parent_lock_.condition_variable_.notify_all();
+  // implicit unlock of parent_lock_.mutex_
+}
+
+WritePreferringReadWriteLock::WriteMutex::WriteMutex(WritePreferringReadWriteLock & parent_lock)
+: parent_lock_(parent_lock)
+{}
+
+void
+WritePreferringReadWriteLock::WriteMutex::lock()
+{
+  std::unique_lock<std::mutex> lock(parent_lock_.mutex_);
+  parent_lock_.number_of_writers_waiting_ += 1;
+  if (nullptr != parent_lock_.enter_waiting_function_) {
+    parent_lock_.enter_waiting_function_();
+  }
+  while (parent_lock_.reader_active_ || parent_lock_.writer_active_) {
+    parent_lock_.condition_variable_.wait(lock);
+  }
+  parent_lock_.number_of_writers_waiting_ -= 1;
+  parent_lock_.writer_active_ = true;
+  // implicit unlock of parent_lock_.mutex_
+}
+
+void
+WritePreferringReadWriteLock::WriteMutex::unlock()
+{
+  std::unique_lock<std::mutex> lock(parent_lock_.mutex_);
+  parent_lock_.writer_active_ = false;
+  parent_lock_.condition_variable_.notify_all();
+  // implicit unlock of parent_lock_.mutex_
+}
+
+}  // namespace detail
+}  // namespace wait_set_policies
+}  // namespace rclcpp

--- a/rclcpp/src/rclcpp/wait_set_policies/detail/write_preferring_read_write_lock.cpp
+++ b/rclcpp/src/rclcpp/wait_set_policies/detail/write_preferring_read_write_lock.cpp
@@ -22,7 +22,7 @@ namespace detail
 {
 
 WritePreferringReadWriteLock::WritePreferringReadWriteLock(
-  std::function<void ()> enter_waiting_function)
+  std::function<void()> enter_waiting_function)
 : read_mutex_(*this), write_mutex_(*this), enter_waiting_function_(enter_waiting_function)
 {}
 

--- a/rclcpp/src/rclcpp/waitable.cpp
+++ b/rclcpp/src/rclcpp/waitable.cpp
@@ -51,3 +51,9 @@ Waitable::get_number_of_ready_guard_conditions()
 {
   return 0u;
 }
+
+bool
+Waitable::exchange_in_use_by_wait_set_state(bool in_use_state)
+{
+  return in_use_by_wait_set_.exchange(in_use_state);
+}

--- a/rclcpp/test/test_guard_condition.cpp
+++ b/rclcpp/test/test_guard_condition.cpp
@@ -1,0 +1,87 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+class TestGuardCondition : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+};
+
+/*
+ * Testing normal construction and destruction.
+ */
+TEST_F(TestGuardCondition, construction_and_destruction) {
+  {
+    auto gc = std::make_shared<rclcpp::GuardCondition>();
+    (void)gc;
+  }
+
+  {
+    // invalid context (nullptr)
+    ASSERT_THROW(
+    {
+      auto gc = std::make_shared<rclcpp::GuardCondition>(nullptr);
+      (void)gc;
+    }, std::invalid_argument);
+  }
+
+  {
+    // invalid context (uninitialized)
+    auto context = std::make_shared<rclcpp::Context>();
+    ASSERT_THROW(
+    {
+      auto gc = std::make_shared<rclcpp::GuardCondition>(context);
+      (void)gc;
+    }, rclcpp::exceptions::RCLInvalidArgument);
+  }
+}
+
+/*
+ * Testing context accessor.
+ */
+TEST_F(TestGuardCondition, get_context) {
+  {
+    auto gc = std::make_shared<rclcpp::GuardCondition>();
+    gc->get_context();
+  }
+}
+
+/*
+ * Testing rcl guard condition accessor.
+ */
+TEST_F(TestGuardCondition, get_rcl_guard_condition) {
+  {
+    auto gc = std::make_shared<rclcpp::GuardCondition>();
+    gc->get_rcl_guard_condtion();
+  }
+}
+
+/*
+ * Testing tigger method.
+ */
+TEST_F(TestGuardCondition, trigger) {
+  {
+    auto gc = std::make_shared<rclcpp::GuardCondition>();
+    gc->trigger();
+  }
+}

--- a/rclcpp/test/test_guard_condition.cpp
+++ b/rclcpp/test/test_guard_condition.cpp
@@ -72,7 +72,7 @@ TEST_F(TestGuardCondition, get_context) {
 TEST_F(TestGuardCondition, get_rcl_guard_condition) {
   {
     auto gc = std::make_shared<rclcpp::GuardCondition>();
-    gc->get_rcl_guard_condtion();
+    gc->get_rcl_guard_condition();
   }
 }
 

--- a/rclcpp/test/test_subscription.cpp
+++ b/rclcpp/test/test_subscription.cpp
@@ -262,7 +262,7 @@ TEST_F(TestSubscription, callback_bind) {
 TEST_F(TestSubscription, take) {
   initialize();
   using test_msgs::msg::Empty;
-  auto do_nothing = [](std::shared_ptr<const test_msgs::msg::Empty>){};
+  auto do_nothing = [](std::shared_ptr<const test_msgs::msg::Empty>) {};
   {
     auto sub = node->create_subscription<test_msgs::msg::Empty>("~/test_take", 1, do_nothing);
     test_msgs::msg::Empty msg;

--- a/rclcpp/test/test_subscription.cpp
+++ b/rclcpp/test/test_subscription.cpp
@@ -262,7 +262,7 @@ TEST_F(TestSubscription, callback_bind) {
 TEST_F(TestSubscription, take) {
   initialize();
   using test_msgs::msg::Empty;
-  auto do_nothing = [](std::shared_ptr<const test_msgs::msg::Empty>) { FAIL(); };
+  auto do_nothing = [](std::shared_ptr<const test_msgs::msg::Empty>) {FAIL();};
   {
     auto sub = node->create_subscription<test_msgs::msg::Empty>("~/test_take", 1, do_nothing);
     test_msgs::msg::Empty msg;
@@ -299,7 +299,7 @@ TEST_F(TestSubscription, take) {
 TEST_F(TestSubscription, take_serialized) {
   initialize();
   using test_msgs::msg::Empty;
-  auto do_nothing = [](std::shared_ptr<const rcl_serialized_message_t>) { FAIL(); };
+  auto do_nothing = [](std::shared_ptr<const rcl_serialized_message_t>) {FAIL();};
   {
     auto sub = node->create_subscription<test_msgs::msg::Empty>("~/test_take", 1, do_nothing);
     std::shared_ptr<rcl_serialized_message_t> msg = sub->create_serialized_message();

--- a/rclcpp/test/test_subscription.cpp
+++ b/rclcpp/test/test_subscription.cpp
@@ -14,14 +14,18 @@
 
 #include <gtest/gtest.h>
 
-#include <string>
+#include <chrono>
 #include <memory>
+#include <string>
+#include <thread>
 #include <vector>
 
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include "test_msgs/msg/empty.hpp"
+
+using namespace std::chrono_literals;
 
 class TestSubscription : public ::testing::Test
 {
@@ -235,13 +239,13 @@ TEST_F(TestSubscription, callback_bind) {
   using test_msgs::msg::Empty;
   {
     // Member callback for plain class
-    SubscriptionClass subscriptionObject;
-    subscriptionObject.CreateSubscription();
+    SubscriptionClass subscription_object;
+    subscription_object.CreateSubscription();
   }
   {
     // Member callback for class inheriting from rclcpp::Node
-    SubscriptionClassNodeInheritance subscriptionObject;
-    subscriptionObject.CreateSubscription();
+    SubscriptionClassNodeInheritance subscription_object;
+    subscription_object.CreateSubscription();
   }
   {
     // Member callback for class inheriting from testing::Test
@@ -250,6 +254,43 @@ TEST_F(TestSubscription, callback_bind) {
     auto callback = std::bind(&TestSubscription::OnMessage, this, std::placeholders::_1);
     auto sub = node->create_subscription<Empty>("topic", 1, callback);
   }
+}
+
+/*
+   Testing take.
+ */
+TEST_F(TestSubscription, take) {
+  initialize();
+  using test_msgs::msg::Empty;
+  auto do_nothing = [](std::shared_ptr<const test_msgs::msg::Empty>){};
+  {
+    auto sub = node->create_subscription<test_msgs::msg::Empty>("~/test_take", 1, do_nothing);
+    test_msgs::msg::Empty msg;
+    rmw_message_info_t msg_info;
+    EXPECT_FALSE(sub->take(msg, msg_info));
+  }
+  {
+    rclcpp::SubscriptionOptions so;
+    so.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
+    auto sub = node->create_subscription<test_msgs::msg::Empty>("~/test_take", 1, do_nothing, so);
+    rclcpp::PublisherOptions po;
+    po.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
+    auto pub = node->create_publisher<test_msgs::msg::Empty>("~/test_take", 1, po);
+    {
+      test_msgs::msg::Empty msg;
+      pub->publish(msg);
+    }
+    test_msgs::msg::Empty msg;
+    rmw_message_info_t msg_info;
+    bool message_recieved = false;
+    auto start = std::chrono::steady_clock::now();
+    do {
+      message_recieved = sub->take(msg, msg_info);
+      std::this_thread::sleep_for(100ms);
+    } while (!message_recieved && std::chrono::steady_clock::now() - start < 10s);
+    EXPECT_TRUE(message_recieved);
+  }
+  // TODO(wjwwood): figure out a good way to test the intra-process exclusion behavior.
 }
 
 /*

--- a/rclcpp/test/test_subscription.cpp
+++ b/rclcpp/test/test_subscription.cpp
@@ -262,7 +262,7 @@ TEST_F(TestSubscription, callback_bind) {
 TEST_F(TestSubscription, take) {
   initialize();
   using test_msgs::msg::Empty;
-  auto do_nothing = [](std::shared_ptr<const test_msgs::msg::Empty>) {};
+  auto do_nothing = [](std::shared_ptr<const test_msgs::msg::Empty>) { FAIL(); };
   {
     auto sub = node->create_subscription<test_msgs::msg::Empty>("~/test_take", 1, do_nothing);
     test_msgs::msg::Empty msg;
@@ -291,6 +291,42 @@ TEST_F(TestSubscription, take) {
     EXPECT_TRUE(message_recieved);
   }
   // TODO(wjwwood): figure out a good way to test the intra-process exclusion behavior.
+}
+
+/*
+   Testing take_serialized.
+ */
+TEST_F(TestSubscription, take_serialized) {
+  initialize();
+  using test_msgs::msg::Empty;
+  auto do_nothing = [](std::shared_ptr<const rcl_serialized_message_t>) { FAIL(); };
+  {
+    auto sub = node->create_subscription<test_msgs::msg::Empty>("~/test_take", 1, do_nothing);
+    std::shared_ptr<rcl_serialized_message_t> msg = sub->create_serialized_message();
+    rclcpp::MessageInfo msg_info;
+    EXPECT_FALSE(sub->take_serialized(*msg, msg_info));
+  }
+  {
+    rclcpp::SubscriptionOptions so;
+    so.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
+    auto sub = node->create_subscription<test_msgs::msg::Empty>("~/test_take", 1, do_nothing, so);
+    rclcpp::PublisherOptions po;
+    po.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
+    auto pub = node->create_publisher<test_msgs::msg::Empty>("~/test_take", 1, po);
+    {
+      test_msgs::msg::Empty msg;
+      pub->publish(msg);
+    }
+    std::shared_ptr<rcl_serialized_message_t> msg = sub->create_serialized_message();
+    rclcpp::MessageInfo msg_info;
+    bool message_recieved = false;
+    auto start = std::chrono::steady_clock::now();
+    do {
+      message_recieved = sub->take_serialized(*msg, msg_info);
+      std::this_thread::sleep_for(100ms);
+    } while (!message_recieved && std::chrono::steady_clock::now() - start < 10s);
+    EXPECT_TRUE(message_recieved);
+  }
 }
 
 /*

--- a/rclcpp/test/test_subscription.cpp
+++ b/rclcpp/test/test_subscription.cpp
@@ -266,7 +266,7 @@ TEST_F(TestSubscription, take) {
   {
     auto sub = node->create_subscription<test_msgs::msg::Empty>("~/test_take", 1, do_nothing);
     test_msgs::msg::Empty msg;
-    rmw_message_info_t msg_info;
+    rclcpp::MessageInfo msg_info;
     EXPECT_FALSE(sub->take(msg, msg_info));
   }
   {
@@ -281,7 +281,7 @@ TEST_F(TestSubscription, take) {
       pub->publish(msg);
     }
     test_msgs::msg::Empty msg;
-    rmw_message_info_t msg_info;
+    rclcpp::MessageInfo msg_info;
     bool message_recieved = false;
     auto start = std::chrono::steady_clock::now();
     do {

--- a/rclcpp/test/test_wait_set.cpp
+++ b/rclcpp/test/test_wait_set.cpp
@@ -200,22 +200,6 @@ TEST_F(TestWaitSet, add_remove_guard_condition) {
       wait_set.remove_guard_condition(gc);
     }, std::runtime_error);
   }
-
-  // remove after delete, checking weak ownership behavior
-  // {
-  //   auto gc = std::make_shared<rclcpp::GuardCondition>();
-  //   rclcpp::WaitSet wait_set;
-  //   wait_set.add_guard_condition(gc);
-  //   gc.reset();
-  //   ASSERT_THROW(
-  //   {
-  //     // gc should be missing at this point
-  //     wait_set.remove_guard_condition(gc);
-  //   }, std::runtime_error);
-  // }
-  // Note this case does not fail because you cannot pass a "reset" shared pointer to gc
-  // and expect it to try and find the original pointer.
-  // Instead it throws due to gc being nullptr.
 }
 
 /*

--- a/rclcpp/test/test_wait_set.cpp
+++ b/rclcpp/test/test_wait_set.cpp
@@ -39,7 +39,7 @@ TEST_F(TestWaitSet, construction_and_destruction) {
 
   {
     rclcpp::WaitSet wait_set(
-      std::vector<rclcpp::SubscriptionBase::SharedPtr>{},
+      std::vector<rclcpp::WaitSet::SubscriptionEntry>{},
       std::vector<rclcpp::GuardCondition::SharedPtr>{},
       std::vector<rclcpp::TimerBase::SharedPtr>{},
       std::vector<rclcpp::WaitSet::WaitableEntry>{});
@@ -65,7 +65,7 @@ TEST_F(TestWaitSet, construction_and_destruction) {
     ASSERT_THROW(
     {
       rclcpp::WaitSet wait_set(
-        std::vector<rclcpp::SubscriptionBase::SharedPtr>{},
+        std::vector<rclcpp::WaitSet::SubscriptionEntry>{},
         std::vector<rclcpp::GuardCondition::SharedPtr>{},
         std::vector<rclcpp::TimerBase::SharedPtr>{},
         std::vector<rclcpp::WaitSet::WaitableEntry>{},
@@ -80,7 +80,7 @@ TEST_F(TestWaitSet, construction_and_destruction) {
     ASSERT_THROW(
     {
       rclcpp::WaitSet wait_set(
-        std::vector<rclcpp::SubscriptionBase::SharedPtr>{},
+        std::vector<rclcpp::WaitSet::SubscriptionEntry>{},
         std::vector<rclcpp::GuardCondition::SharedPtr>{},
         std::vector<rclcpp::TimerBase::SharedPtr>{},
         std::vector<rclcpp::WaitSet::WaitableEntry>{},

--- a/rclcpp/test/test_wait_set.cpp
+++ b/rclcpp/test/test_wait_set.cpp
@@ -1,0 +1,197 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+
+class TestWaitSet : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+};
+
+/*
+ * Testing normal construction and destruction.
+ */
+TEST_F(TestWaitSet, construction_and_destruction) {
+  {
+    rclcpp::WaitSet wait_set;
+    (void)wait_set;
+  }
+
+  {
+    rclcpp::WaitSet wait_set(std::vector<rclcpp::GuardCondition::SharedPtr>{});
+    (void)wait_set;
+  }
+
+  {
+    auto gc = std::make_shared<rclcpp::GuardCondition>();
+    rclcpp::WaitSet wait_set({gc});
+    (void)wait_set;
+  }
+
+  {
+    auto context = std::make_shared<rclcpp::Context>();
+    context->init(0, nullptr);
+    auto gc = std::make_shared<rclcpp::GuardCondition>(context);
+    rclcpp::WaitSet wait_set({gc}, context);
+    (void)wait_set;
+  }
+
+  {
+    // invalid context (nullptr)
+    ASSERT_THROW(
+    {
+      rclcpp::WaitSet wait_set(std::vector<rclcpp::GuardCondition::SharedPtr>{}, nullptr);
+      (void)wait_set;
+    }, std::invalid_argument);
+  }
+
+  {
+    // invalid context (uninitialized)
+    auto context = std::make_shared<rclcpp::Context>();
+    ASSERT_THROW(
+    {
+      rclcpp::WaitSet wait_set(std::vector<rclcpp::GuardCondition::SharedPtr>{}, context);
+      (void)wait_set;
+    }, rclcpp::exceptions::RCLInvalidArgument);
+  }
+}
+
+/*
+ * Testing rcl wait set accessor.
+ */
+TEST_F(TestWaitSet, get_rcl_wait_set) {
+  {
+    rclcpp::WaitSet wait_set;
+    wait_set.get_rcl_wait_set();
+  }
+}
+
+/*
+ * Testing add/remove for guard condition methods.
+ */
+TEST_F(TestWaitSet, add_remove_guard_condition) {
+  // normal, mixed initialization
+  {
+    auto gc = std::make_shared<rclcpp::GuardCondition>();
+    auto gc2 = std::make_shared<rclcpp::GuardCondition>();
+    rclcpp::WaitSet wait_set({gc});
+    wait_set.add_guard_condition(gc2);
+    wait_set.remove_guard_condition(gc2);
+    wait_set.remove_guard_condition(gc);
+  }
+
+  // out of order removal
+  {
+    auto gc = std::make_shared<rclcpp::GuardCondition>();
+    auto gc2 = std::make_shared<rclcpp::GuardCondition>();
+    rclcpp::WaitSet wait_set({gc});
+    wait_set.add_guard_condition(gc2);
+    wait_set.remove_guard_condition(gc);
+    wait_set.remove_guard_condition(gc2);
+  }
+
+  // start empty, normal
+  {
+    auto gc = std::make_shared<rclcpp::GuardCondition>();
+    rclcpp::WaitSet wait_set;
+    wait_set.add_guard_condition(gc);
+    wait_set.remove_guard_condition(gc);
+  }
+
+  // add invalid (nullptr)
+  {
+    rclcpp::WaitSet wait_set;
+    ASSERT_THROW(
+    {
+      wait_set.add_guard_condition(nullptr);
+    }, std::invalid_argument);
+  }
+
+  // double add
+  {
+    auto gc = std::make_shared<rclcpp::GuardCondition>();
+    rclcpp::WaitSet wait_set;
+    wait_set.add_guard_condition(gc);
+    ASSERT_THROW(
+    {
+      wait_set.add_guard_condition(gc);
+    }, std::runtime_error);
+  }
+
+  // remove invalid (nullptr)
+  {
+    rclcpp::WaitSet wait_set;
+    ASSERT_THROW(
+    {
+      wait_set.remove_guard_condition(nullptr);
+    }, std::invalid_argument);
+  }
+
+  // remove unrelated
+  {
+    auto gc = std::make_shared<rclcpp::GuardCondition>();
+    auto gc2 = std::make_shared<rclcpp::GuardCondition>();
+    rclcpp::WaitSet wait_set({gc});
+    ASSERT_THROW(
+    {
+      wait_set.remove_guard_condition(gc2);
+    }, std::runtime_error);
+  }
+
+  // double remove
+  {
+    auto gc = std::make_shared<rclcpp::GuardCondition>();
+    rclcpp::WaitSet wait_set({gc});
+    wait_set.remove_guard_condition(gc);
+    ASSERT_THROW(
+    {
+      wait_set.remove_guard_condition(gc);
+    }, std::runtime_error);
+  }
+
+  // remove from empty
+  {
+    auto gc = std::make_shared<rclcpp::GuardCondition>();
+    rclcpp::WaitSet wait_set;
+    ASSERT_THROW(
+    {
+      wait_set.remove_guard_condition(gc);
+    }, std::runtime_error);
+  }
+
+  // remove after delete, checking weak ownership behavior
+  // {
+  //   auto gc = std::make_shared<rclcpp::GuardCondition>();
+  //   rclcpp::WaitSet wait_set;
+  //   wait_set.add_guard_condition(gc);
+  //   gc.reset();
+  //   ASSERT_THROW(
+  //   {
+  //     // gc should be missing at this point
+  //     wait_set.remove_guard_condition(gc);
+  //   }, std::runtime_error);
+  // }
+  // Note this case does not fail because you cannot pass a "reset" shared pointer to gc
+  // and expect it to try and find the original pointer.
+  // Instead it throws due to gc being nullptr.
+}

--- a/rclcpp/test/test_wait_set.cpp
+++ b/rclcpp/test/test_wait_set.cpp
@@ -42,6 +42,8 @@ TEST_F(TestWaitSet, construction_and_destruction) {
       std::vector<rclcpp::WaitSet::SubscriptionEntry>{},
       std::vector<rclcpp::GuardCondition::SharedPtr>{},
       std::vector<rclcpp::TimerBase::SharedPtr>{},
+      std::vector<rclcpp::ClientBase::SharedPtr>{},
+      std::vector<rclcpp::ServiceBase::SharedPtr>{},
       std::vector<rclcpp::WaitSet::WaitableEntry>{});
     (void)wait_set;
   }
@@ -56,7 +58,7 @@ TEST_F(TestWaitSet, construction_and_destruction) {
     auto context = std::make_shared<rclcpp::Context>();
     context->init(0, nullptr);
     auto gc = std::make_shared<rclcpp::GuardCondition>(context);
-    rclcpp::WaitSet wait_set({}, {gc}, {}, {}, context);
+    rclcpp::WaitSet wait_set({}, {gc}, {}, {}, {}, {}, context);
     (void)wait_set;
   }
 
@@ -68,6 +70,8 @@ TEST_F(TestWaitSet, construction_and_destruction) {
         std::vector<rclcpp::WaitSet::SubscriptionEntry>{},
         std::vector<rclcpp::GuardCondition::SharedPtr>{},
         std::vector<rclcpp::TimerBase::SharedPtr>{},
+        std::vector<rclcpp::ClientBase::SharedPtr>{},
+        std::vector<rclcpp::ServiceBase::SharedPtr>{},
         std::vector<rclcpp::WaitSet::WaitableEntry>{},
         nullptr);
       (void)wait_set;
@@ -83,6 +87,8 @@ TEST_F(TestWaitSet, construction_and_destruction) {
         std::vector<rclcpp::WaitSet::SubscriptionEntry>{},
         std::vector<rclcpp::GuardCondition::SharedPtr>{},
         std::vector<rclcpp::TimerBase::SharedPtr>{},
+        std::vector<rclcpp::ClientBase::SharedPtr>{},
+        std::vector<rclcpp::ServiceBase::SharedPtr>{},
         std::vector<rclcpp::WaitSet::WaitableEntry>{},
         context);
       (void)wait_set;

--- a/rclcpp/test/test_wait_set.cpp
+++ b/rclcpp/test/test_wait_set.cpp
@@ -38,13 +38,17 @@ TEST_F(TestWaitSet, construction_and_destruction) {
   }
 
   {
-    rclcpp::WaitSet wait_set(std::vector<rclcpp::GuardCondition::SharedPtr>{});
+    rclcpp::WaitSet wait_set(
+      std::vector<rclcpp::SubscriptionBase::SharedPtr>{},
+      std::vector<rclcpp::GuardCondition::SharedPtr>{},
+      std::vector<rclcpp::TimerBase::SharedPtr>{},
+      std::vector<rclcpp::WaitSet::WaitableEntry>{});
     (void)wait_set;
   }
 
   {
     auto gc = std::make_shared<rclcpp::GuardCondition>();
-    rclcpp::WaitSet wait_set({gc});
+    rclcpp::WaitSet wait_set({}, {gc});
     (void)wait_set;
   }
 
@@ -52,7 +56,7 @@ TEST_F(TestWaitSet, construction_and_destruction) {
     auto context = std::make_shared<rclcpp::Context>();
     context->init(0, nullptr);
     auto gc = std::make_shared<rclcpp::GuardCondition>(context);
-    rclcpp::WaitSet wait_set({gc}, context);
+    rclcpp::WaitSet wait_set({}, {gc}, {}, {}, context);
     (void)wait_set;
   }
 
@@ -60,7 +64,12 @@ TEST_F(TestWaitSet, construction_and_destruction) {
     // invalid context (nullptr)
     ASSERT_THROW(
     {
-      rclcpp::WaitSet wait_set(std::vector<rclcpp::GuardCondition::SharedPtr>{}, nullptr);
+      rclcpp::WaitSet wait_set(
+        std::vector<rclcpp::SubscriptionBase::SharedPtr>{},
+        std::vector<rclcpp::GuardCondition::SharedPtr>{},
+        std::vector<rclcpp::TimerBase::SharedPtr>{},
+        std::vector<rclcpp::WaitSet::WaitableEntry>{},
+        nullptr);
       (void)wait_set;
     }, std::invalid_argument);
   }
@@ -70,7 +79,12 @@ TEST_F(TestWaitSet, construction_and_destruction) {
     auto context = std::make_shared<rclcpp::Context>();
     ASSERT_THROW(
     {
-      rclcpp::WaitSet wait_set(std::vector<rclcpp::GuardCondition::SharedPtr>{}, context);
+      rclcpp::WaitSet wait_set(
+        std::vector<rclcpp::SubscriptionBase::SharedPtr>{},
+        std::vector<rclcpp::GuardCondition::SharedPtr>{},
+        std::vector<rclcpp::TimerBase::SharedPtr>{},
+        std::vector<rclcpp::WaitSet::WaitableEntry>{},
+        context);
       (void)wait_set;
     }, rclcpp::exceptions::RCLInvalidArgument);
   }
@@ -94,7 +108,7 @@ TEST_F(TestWaitSet, add_remove_guard_condition) {
   {
     auto gc = std::make_shared<rclcpp::GuardCondition>();
     auto gc2 = std::make_shared<rclcpp::GuardCondition>();
-    rclcpp::WaitSet wait_set({gc});
+    rclcpp::WaitSet wait_set({}, {gc});
     wait_set.add_guard_condition(gc2);
     wait_set.remove_guard_condition(gc2);
     wait_set.remove_guard_condition(gc);
@@ -104,7 +118,7 @@ TEST_F(TestWaitSet, add_remove_guard_condition) {
   {
     auto gc = std::make_shared<rclcpp::GuardCondition>();
     auto gc2 = std::make_shared<rclcpp::GuardCondition>();
-    rclcpp::WaitSet wait_set({gc});
+    rclcpp::WaitSet wait_set({}, {gc});
     wait_set.add_guard_condition(gc2);
     wait_set.remove_guard_condition(gc);
     wait_set.remove_guard_condition(gc2);
@@ -151,7 +165,7 @@ TEST_F(TestWaitSet, add_remove_guard_condition) {
   {
     auto gc = std::make_shared<rclcpp::GuardCondition>();
     auto gc2 = std::make_shared<rclcpp::GuardCondition>();
-    rclcpp::WaitSet wait_set({gc});
+    rclcpp::WaitSet wait_set({}, {gc});
     ASSERT_THROW(
     {
       wait_set.remove_guard_condition(gc2);
@@ -161,7 +175,7 @@ TEST_F(TestWaitSet, add_remove_guard_condition) {
   // double remove
   {
     auto gc = std::make_shared<rclcpp::GuardCondition>();
-    rclcpp::WaitSet wait_set({gc});
+    rclcpp::WaitSet wait_set({}, {gc});
     wait_set.remove_guard_condition(gc);
     ASSERT_THROW(
     {


### PR DESCRIPTION
This closes https://github.com/ros2/rclcpp/issues/520 or at the very least lays the ground work for closing it. This pull request adds a few new `rclcpp::*WaitSet` classes which can be used with all the "waitable" entities to wait on sets of them at the same time, using `rcl_wait_set_t` under the hood.

This pull request does these things:

- add guard condition class
  - replaces use of rcl_guard_condition_t directly
  - this pull request will probably not update all instances just yet, but examples can use it
- add message info class
  - replaces use of rmw_message_info_t, and updated all cases where it was being used before
- add wait set classes
  - main wait set class has synchronization and storage policies as template arguments
    - Policy based design, see: https://en.wikipedia.org/wiki/Modern_C%2B%2B_Design#Policy-based_design
  - add static and dynamic storage policy options
  - add thread-safe and sequential (not thread-safe) synchronization policy options
- update `Subscription` to have `take`, `take_type_erased`, and `take_serialized`
  - update `Executor` to use these rather than call rcl directly
  - user can now use these to take data without an executor
- update `Client` to have `take_response`
  - update `Executor` to use this instead
- update `Service` to have `take_request` and `send_response`
  - update `Executor` to use this instead

One thing mentioned in https://github.com/ros2/rclcpp/issues/520, which may not be in the first pass, is the ability to mix use of the executor and waitset together (like some subscriptions from a node are in an executor while others are not and instead use a waitset directly). This will be part of my other pull request to address https://github.com/ros2/rclcpp/issues/519.

What this pull request will _not_ do:

- update executor to use new wait set classes
  - I will do that in a follow up pr which also incorporates the use of time stamps from rcl
- change executors so more than one can be used with a node at a time

Things I would like to do, but will most likely have to be follow up work:

- add "algorithms" (utility functions) for working with `rclcpp::WaitSetResult`
  - in the spirit of `#include <algorithm>`, like `rclcpp::find_next_ready_subscription` kind of stuff
- support an allocator argument for the wait set
  - I spent a lot of time trying to integrate it, but it's complicated to support, but if we fell back to only supporting the polymorphic allocator it would be easier, but since we don't have c++17 and we haven't back ported the polymorphic allocator API to c++14 I couldn't easily do that yet.

----

TODO:

- [x] update to support client and service
- [x] finish thread-safe policy
- [x] add check to ensure entities are only added to one wait set at a time

I'm going move this out of draft mode so reviews can start while I finish the last few sets of changes.

Also, test coverage is missing in a few places, but I do have this example to exercise the main use cases:

https://github.com/ros2/examples/pull/262

I would appreciate help with adding more tests, but they are also something that I can add after the API freeze, so I'm de-prioritizing them now, as much as I hate to do that.