### PR TITLE
Add a QoS profile equality check that ignores all fields that don't affect compatibility

### DIFF
--- a/rclcpp/include/rclcpp/qos.hpp
+++ b/rclcpp/include/rclcpp/qos.hpp
@@ -147,6 +147,13 @@ public:
   QoS &
   avoid_ros_namespace_conventions(bool avoid_ros_namespace_conventions);
 
+  /// Determine if all policies that affect QoS compatibility are equal.
+  /*
+    Note that this method does not check if the QoS policies are compatible.
+    This is a simple check for exact equality in all policies that affect compatibility.
+  */
+  bool compatibility_policies_equal(const QoS & other) const;
+
 private:
   rmw_qos_profile_t rmw_qos_profile_;
 };

--- a/rclcpp/src/rclcpp/qos.cpp
+++ b/rclcpp/src/rclcpp/qos.cpp
@@ -184,6 +184,21 @@ QoS::avoid_ros_namespace_conventions(bool avoid_ros_namespace_conventions)
   return *this;
 }
 
+bool QoS::compatibility_policies_equal(const QoS & other) const
+{
+  // Note that these policies do not affect QoS compatibility
+  // * History + Depth (relevant only for local behavior)
+  // * Lifespan (only relevant locally on Publishers)
+  // * avoid ros namespace conventions (this affects choice of topic names, not quality of service)
+  const auto & pl = get_rmw_qos_profile();
+  const auto & pr = other.get_rmw_qos_profile();
+  return pl.reliability == pr.reliability &&
+         pl.durability == pr.durability &&
+         pl.deadline == pr.deadline &&
+         pl.liveliness == pr.liveliness &&
+         pl.liveliness_lease_duration == pr.liveliness_lease_duration;
+}
+
 namespace
 {
 /// Check if two rmw_time_t have the same values.


### PR DESCRIPTION
Some of the values in our QoS profiles only affect local behavior, or choice of topic names. These don't affect whether a publisher and subscription are compatible. Add a utility check on `rclcpp::QoS` that compares only the compatibility-affecting QoS policies for equality 

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>