### PR TITLE
Avoid calling Windows max() and min() macros

### DIFF
--- a/rclcpp/include/rclcpp/duration.hpp
+++ b/rclcpp/include/rclcpp/duration.hpp
@@ -80,9 +80,11 @@ public:
   Duration
   operator-(const rclcpp::Duration & rhs) const;
 
+  /* *INDENT-OFF* */
   static
   Duration
   (max)();  // Wrap in parenthesis to avoid confusion with Windows macro
+  /* *INDENT-ON* */
 
   Duration
   operator*(double scale) const;

--- a/rclcpp/include/rclcpp/duration.hpp
+++ b/rclcpp/include/rclcpp/duration.hpp
@@ -80,6 +80,11 @@ public:
   Duration
   operator-(const rclcpp::Duration & rhs) const;
 
+// Avoid confusing max() for Windows macro
+#ifdef _WIN32
+# define NOMINMAX
+#endif
+
   static
   Duration
   max();

--- a/rclcpp/include/rclcpp/duration.hpp
+++ b/rclcpp/include/rclcpp/duration.hpp
@@ -80,14 +80,9 @@ public:
   Duration
   operator-(const rclcpp::Duration & rhs) const;
 
-// Avoid confusing max() for Windows macro
-#ifdef _WIN32
-# define NOMINMAX
-#endif
-
   static
   Duration
-  max();
+  (max)();  // Wrap in parenthesis to avoid confusion with Windows macro
 
   Duration
   operator*(double scale) const;

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -110,9 +110,11 @@ public:
   rcl_time_point_value_t
   nanoseconds() const;
 
+  /* *INDENT-OFF* */
   RCLCPP_PUBLIC
   static Time
   (max)();  // Wrap in parenthesis to avoid confusion with Windows macro
+  /* *INDENT-ON* */
 
   /// \return the seconds since epoch as a floating point number.
   /// \warning Depending on sizeof(double) there could be significant precision loss.

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -110,6 +110,11 @@ public:
   rcl_time_point_value_t
   nanoseconds() const;
 
+// Avoid confusing max() for Windows macro
+#ifdef _WIN32
+# define NOMINMAX
+#endif
+
   RCLCPP_PUBLIC
   static Time
   max();

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -110,14 +110,9 @@ public:
   rcl_time_point_value_t
   nanoseconds() const;
 
-// Avoid confusing max() for Windows macro
-#ifdef _WIN32
-# define NOMINMAX
-#endif
-
   RCLCPP_PUBLIC
   static Time
-  max();
+  (max)();  // Wrap in parenthesis to avoid confusion with Windows macro
 
   /// \return the seconds since epoch as a floating point number.
   /// \warning Depending on sizeof(double) there could be significant precision loss.

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -229,7 +229,7 @@ template<typename T>
 bool
 add_will_overflow(const T x, const T y)
 {
-  return (y > 0) && (x > (std::numeric_limits<T>::max() - y));
+  return (y > 0) && (x > ((std::numeric_limits<T>::max)() - y));
 }
 
 /// Safely check if addition will underflow.
@@ -246,7 +246,7 @@ template<typename T>
 bool
 add_will_underflow(const T x, const T y)
 {
-  return (y < 0) && (x < (std::numeric_limits<T>::min() - y));
+  return (y < 0) && (x < ((std::numeric_limits<T>::min)() - y));
 }
 
 /// Safely check if subtraction will overflow.
@@ -263,7 +263,7 @@ template<typename T>
 bool
 sub_will_overflow(const T x, const T y)
 {
-  return (y < 0) && (x > (std::numeric_limits<T>::max() + y));
+  return (y < 0) && (x > ((std::numeric_limits<T>::max)() + y));
 }
 
 /// Safely check if subtraction will underflow.
@@ -280,7 +280,7 @@ template<typename T>
 bool
 sub_will_underflow(const T x, const T y)
 {
-  return (y > 0) && (x < (std::numeric_limits<T>::min() + y));
+  return (y > 0) && (x < ((std::numeric_limits<T>::min)() + y));
 }
 
 /// Return the given string.

--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -132,7 +132,7 @@ ClientBase::wait_for_service_nanoseconds(std::chrono::nanoseconds timeout)
   std::chrono::nanoseconds time_to_wait =
     timeout > std::chrono::nanoseconds(0) ?
     timeout - (std::chrono::steady_clock::now() - start) :
-    std::chrono::nanoseconds::max();
+    (std::chrono::nanoseconds::max)();
   if (time_to_wait < std::chrono::nanoseconds(0)) {
     // Do not allow the time_to_wait to become negative when timeout was originally positive.
     // Setting time_to_wait to 0 will allow one non-blocking wait because of the do-while.

--- a/rclcpp/src/rclcpp/duration.cpp
+++ b/rclcpp/src/rclcpp/duration.cpp
@@ -143,7 +143,7 @@ Duration::operator+(const rclcpp::Duration & rhs) const
   bounds_check_duration_sum(
     this->rcl_duration_.nanoseconds,
     rhs.rcl_duration_.nanoseconds,
-    std::numeric_limits<rcl_duration_value_t>::max());
+    (std::numeric_limits<rcl_duration_value_t>::max)());
   return Duration(
     rcl_duration_.nanoseconds + rhs.rcl_duration_.nanoseconds);
 }
@@ -171,7 +171,7 @@ Duration::operator-(const rclcpp::Duration & rhs) const
   bounds_check_duration_difference(
     this->rcl_duration_.nanoseconds,
     rhs.rcl_duration_.nanoseconds,
-    std::numeric_limits<rcl_duration_value_t>::max());
+    (std::numeric_limits<rcl_duration_value_t>::max)());
 
   return Duration(
     rcl_duration_.nanoseconds - rhs.rcl_duration_.nanoseconds);
@@ -202,7 +202,7 @@ Duration::operator*(double scale) const
   bounds_check_duration_scale(
     this->rcl_duration_.nanoseconds,
     scale,
-    std::numeric_limits<rcl_duration_value_t>::max());
+    (std::numeric_limits<rcl_duration_value_t>::max)());
   long double scale_ld = static_cast<long double>(scale);
   return Duration(
     static_cast<rcl_duration_value_t>(
@@ -216,9 +216,9 @@ Duration::nanoseconds() const
 }
 
 Duration
-Duration::max()
+(Duration::max)()
 {
-  return Duration(std::numeric_limits<int32_t>::max(), 999999999);
+  return Duration((std::numeric_limits<int32_t>::max)(), 999999999);
 }
 
 double

--- a/rclcpp/src/rclcpp/duration.cpp
+++ b/rclcpp/src/rclcpp/duration.cpp
@@ -215,11 +215,13 @@ Duration::nanoseconds() const
   return rcl_duration_.nanoseconds;
 }
 
+/* *INDENT-OFF* */
 Duration
 (Duration::max)()
 {
   return Duration((std::numeric_limits<int32_t>::max)(), 999999999);
 }
+/* *INDENT-ON* */
 
 double
 Duration::seconds() const

--- a/rclcpp/src/rclcpp/node_options.cpp
+++ b/rclcpp/src/rclcpp/node_options.cpp
@@ -97,7 +97,7 @@ NodeOptions::get_rcl_node_options() const
     int c_argc = 0;
     std::unique_ptr<const char *[]> c_argv;
     if (!this->arguments_.empty()) {
-      if (this->arguments_.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+      if (this->arguments_.size() > static_cast<size_t>((std::numeric_limits<int>::max)())) {
         throw_from_rcl_error(RCL_RET_INVALID_ARGUMENT, "Too many args");
       }
 
@@ -314,7 +314,7 @@ size_t
 NodeOptions::get_domain_id_from_env() const
 {
   // Determine the domain id based on the options and the ROS_DOMAIN_ID env variable.
-  size_t domain_id = std::numeric_limits<size_t>::max();
+  size_t domain_id = (std::numeric_limits<size_t>::max)();
   char * ros_domain_id = nullptr;
   const char * env_var = "ROS_DOMAIN_ID";
 #ifndef _WIN32

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -286,9 +286,9 @@ Time::operator-=(const rclcpp::Duration & rhs)
 }
 
 Time
-Time::max()
+(Time::max)()
 {
-  return Time(std::numeric_limits<int32_t>::max(), 999999999);
+  return Time((std::numeric_limits<int32_t>::max)(), 999999999);
 }
 
 

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -285,8 +285,10 @@ Time::operator-=(const rclcpp::Duration & rhs)
   return *this;
 }
 
+/* *INDENT-OFF* */
 Time
 (Time::max)()
+/* *INDENT-ON* */
 {
   return Time((std::numeric_limits<int32_t>::max)(), 999999999);
 }

--- a/rclcpp/test/test_duration.cpp
+++ b/rclcpp/test/test_duration.cpp
@@ -87,8 +87,8 @@ TEST(TestDuration, chrono_overloads) {
 }
 
 TEST(TestDuration, overflows) {
-  rclcpp::Duration max(std::numeric_limits<rcl_duration_value_t>::max());
-  rclcpp::Duration min(std::numeric_limits<rcl_duration_value_t>::min());
+  rclcpp::Duration max((std::numeric_limits<rcl_duration_value_t>::max)());
+  rclcpp::Duration min((std::numeric_limits<rcl_duration_value_t>::min)());
 
   rclcpp::Duration one(1);
   rclcpp::Duration negative_one(-1);
@@ -131,8 +131,8 @@ TEST(TestDuration, negative_duration) {
 }
 
 TEST(TestDuration, maximum_duration) {
-  rclcpp::Duration max_duration = rclcpp::Duration::max();
-  rclcpp::Duration max(std::numeric_limits<int32_t>::max(), 999999999);
+  rclcpp::Duration max_duration = (rclcpp::Duration::max)();
+  rclcpp::Duration max((std::numeric_limits<int32_t>::max)(), 999999999);
 
   EXPECT_EQ(max_duration, max);
 }

--- a/rclcpp/test/test_parameter.cpp
+++ b/rclcpp/test/test_parameter.cpp
@@ -165,7 +165,7 @@ TEST(TestParameter, integer_variant) {
 }
 
 TEST(TestParameter, long_integer_variant) {
-  const int64_t TEST_VALUE {std::numeric_limits<int64_t>::max()};
+  const int64_t TEST_VALUE {(std::numeric_limits<int64_t>::max)()};
 
   // Direct instantiation
   rclcpp::Parameter long_variant("long_integer_param", TEST_VALUE);
@@ -452,7 +452,7 @@ TEST(TestParameter, bool_array_variant) {
 
 TEST(TestParameter, integer_array_variant) {
   const std::vector<int> TEST_VALUE
-  {42, -99, std::numeric_limits<int>::max(), std::numeric_limits<int>::lowest(), 0};
+  {42, -99, (std::numeric_limits<int>::max)(), std::numeric_limits<int>::lowest(), 0};
 
   // Direct instantiation
   rclcpp::Parameter integer_array_variant("integer_array_param", TEST_VALUE);
@@ -531,7 +531,7 @@ TEST(TestParameter, integer_array_variant) {
 
 TEST(TestParameter, long_integer_array_variant) {
   const std::vector<int64_t> TEST_VALUE
-  {42, -99, std::numeric_limits<int64_t>::max(), std::numeric_limits<int64_t>::lowest(), 0};
+  {42, -99, (std::numeric_limits<int64_t>::max)(), std::numeric_limits<int64_t>::lowest(), 0};
 
   rclcpp::Parameter long_array_variant("long_integer_array_param", TEST_VALUE);
   EXPECT_EQ("long_integer_array_param", long_array_variant.get_name());
@@ -585,7 +585,7 @@ TEST(TestParameter, long_integer_array_variant) {
 
 TEST(TestParameter, float_array_variant) {
   const std::vector<float> TEST_VALUE
-  {42.1f, -99.1f, std::numeric_limits<float>::max(), std::numeric_limits<float>::lowest(), 0.1f};
+  {42.1f, -99.1f, (std::numeric_limits<float>::max)(), std::numeric_limits<float>::lowest(), 0.1f};
 
   // Direct instantiation
   rclcpp::Parameter float_array_variant("float_array_param", TEST_VALUE);
@@ -664,7 +664,7 @@ TEST(TestParameter, float_array_variant) {
 
 TEST(TestParameter, double_array_variant) {
   const std::vector<double> TEST_VALUE
-  {42.1, -99.1, std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest(), 0.1};
+  {42.1, -99.1, (std::numeric_limits<double>::max)(), std::numeric_limits<double>::lowest(), 0.1};
 
   rclcpp::Parameter double_array_variant("double_array_param", TEST_VALUE);
   EXPECT_EQ("double_array_param", double_array_variant.get_name());

--- a/rclcpp/test/test_time.cpp
+++ b/rclcpp/test/test_time.cpp
@@ -193,8 +193,8 @@ TEST(TestTime, overflow_detectors) {
   //  big_type_t::min < test_type_t::min
   //  big_type_t::max > test_type_t::max
   using big_type_t = int16_t;
-  const big_type_t min_val = std::numeric_limits<test_type_t>::min();
-  const big_type_t max_val = std::numeric_limits<test_type_t>::max();
+  const big_type_t min_val = (std::numeric_limits<test_type_t>::min)();
+  const big_type_t max_val = (std::numeric_limits<test_type_t>::max)();
   // 256 * 256 = 64K total loops, should be pretty fast on everything
   for (big_type_t y = min_val; y <= max_val; ++y) {
     for (big_type_t x = min_val; x <= max_val; ++x) {
@@ -236,8 +236,8 @@ TEST(TestTime, overflow_detectors) {
 }
 
 TEST(TestTime, overflows) {
-  rclcpp::Time max_time(std::numeric_limits<rcl_time_point_value_t>::max());
-  rclcpp::Time min_time(std::numeric_limits<rcl_time_point_value_t>::min());
+  rclcpp::Time max_time((std::numeric_limits<rcl_time_point_value_t>::max)());
+  rclcpp::Time min_time((std::numeric_limits<rcl_time_point_value_t>::min)());
   rclcpp::Duration one(1);
   rclcpp::Duration two(2);
 

--- a/rclcpp_action/src/client.cpp
+++ b/rclcpp_action/src/client.cpp
@@ -179,7 +179,7 @@ ClientBase::wait_for_action_server_nanoseconds(std::chrono::nanoseconds timeout)
   std::chrono::nanoseconds time_to_wait =
     timeout > std::chrono::nanoseconds(0) ?
     timeout - (std::chrono::steady_clock::now() - start) :
-    std::chrono::nanoseconds::max();
+    (std::chrono::nanoseconds::max)();
   if (time_to_wait < std::chrono::nanoseconds(0)) {
     // Do not allow the time_to_wait to become negative when timeout was originally positive.
     // Setting time_to_wait to 0 will allow one non-blocking wait because of the do-while.


### PR DESCRIPTION
Previously Windows CI was failing: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9903)](https://ci.ros2.org/job/ci_windows/9903/)
With this change: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9920)](https://ci.ros2.org/job/ci_windows/9920/)