### PR TITLE
Add -DNOMINMAX compiler definition for Windows

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -24,6 +24,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+# Avoid confusing max() and min() for Windows macros
+if(WIN32)
+  add_definitions(-DNOMINMAX)
+endif()
+
 include_directories(include)
 
 set(${PROJECT_NAME}_SRCS

--- a/rclcpp_action/CMakeLists.txt
+++ b/rclcpp_action/CMakeLists.txt
@@ -16,6 +16,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+# Avoid confusing max() and min() for Windows macros
+if(WIN32)
+  add_definitions(-DNOMINMAX)
+endif()
+
 include_directories(include)
 
 set(${PROJECT_NAME}_SRCS

--- a/rclcpp_components/CMakeLists.txt
+++ b/rclcpp_components/CMakeLists.txt
@@ -10,6 +10,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+# Avoid confusing max() and min() for Windows macros
+if(WIN32)
+  add_definitions(-DNOMINMAX)
+endif()
+
 find_package(ament_cmake_ros REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(class_loader REQUIRED)

--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -10,6 +10,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+# Avoid confusing max() and min() for Windows macros
+if(WIN32)
+  add_definitions(-DNOMINMAX)
+endif()
+
 find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcl_lifecycle REQUIRED)


### PR DESCRIPTION
This fixes an issue where max() and min() are treated as macros defined in windows.h

Alternative to https://github.com/ros2/rclcpp/pull/1053

Windows: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9921)](https://ci.ros2.org/job/ci_windows/9921/)