### PR TITLE
[eloquent] Ensure rcl_clock accesses are thread-safe (ABI-safe version).

### DIFF
--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -152,6 +152,8 @@ private:
 extern std::shared_timed_mutex g_clock_map_mutex;
 extern std::unordered_map<rclcpp::Clock *, std::mutex> g_clock_mutex_map;
 
+std::mutex & get_clock_mutex(rclcpp::Clock * clock);
+
 }  // namespace rclcpp
 
 #endif  // RCLCPP__CLOCK_HPP_

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -43,7 +43,7 @@ TimerBase::TimerBase(
     new rcl_timer_t, [ = ](rcl_timer_t * timer) mutable
     {
       {
-        std::lock_guard<std::mutex> clock_guard(get_clock_mutex(this->clock_.get()));
+        std::lock_guard<std::mutex> clock_guard(get_clock_mutex(clock.get()));
         if (rcl_timer_fini(timer) != RCL_RET_OK) {
           RCUTILS_LOG_ERROR_NAMED(
             "rclcpp",

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -42,10 +42,8 @@ TimerBase::TimerBase(
   timer_handle_ = std::shared_ptr<rcl_timer_t>(
     new rcl_timer_t, [ = ](rcl_timer_t * timer) mutable
     {
-      // Lookup the per-object mutex
-      std::mutex & clock_mutex = get_clock_mutex(this->clock_.get());
       {
-        std::lock_guard<std::mutex> clock_guard(clock_mutex);
+        std::lock_guard<std::mutex> clock_guard(get_clock_mutex(this->clock_.get()));
         if (rcl_timer_fini(timer) != RCL_RET_OK) {
           RCUTILS_LOG_ERROR_NAMED(
             "rclcpp",
@@ -63,8 +61,7 @@ TimerBase::TimerBase(
 
   rcl_clock_t * clock_handle = clock_->get_clock_handle();
   {
-    std::mutex & clock_mutex = get_clock_mutex(this->clock_.get());
-    std::lock_guard<std::mutex> clock_guard(clock_mutex);
+    std::lock_guard<std::mutex> clock_guard(get_clock_mutex(this->clock_.get()));
     if (
       rcl_timer_init(
         timer_handle_.get(), clock_handle, rcl_context.get(), period.count(), nullptr,

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -43,9 +43,7 @@ TimerBase::TimerBase(
     new rcl_timer_t, [ = ](rcl_timer_t * timer) mutable
     {
       // Lookup the per-object mutex
-      g_clock_map_mutex.lock_shared();
-      std::mutex & clock_mutex = g_clock_mutex_map.at(this->clock_.get());
-      g_clock_map_mutex.unlock_shared();
+      std::mutex & clock_mutex = get_clock_mutex(this->clock_.get());
       {
         std::lock_guard<std::mutex> clock_guard(clock_mutex);
         if (rcl_timer_fini(timer) != RCL_RET_OK) {
@@ -65,9 +63,7 @@ TimerBase::TimerBase(
 
   rcl_clock_t * clock_handle = clock_->get_clock_handle();
   {
-    g_clock_map_mutex.lock_shared();
-    std::mutex & clock_mutex = g_clock_mutex_map.at(this->clock_.get());
-    g_clock_map_mutex.unlock_shared();
+    std::mutex & clock_mutex = get_clock_mutex(this->clock_.get());
     std::lock_guard<std::mutex> clock_guard(clock_mutex);
     if (
       rcl_timer_init(


### PR DESCRIPTION
This is an alternative PR to https://github.com/ros2/rclcpp/pull/999
The code in this one is less nice, but it is ABI-safe.  Thus,
it can be used as a short-term workaround for users hurt by
the problem now, and/or used as the solution for Eloquent.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

I'm still testing this, so consider this a request for comment on the approach.  Once I run a full CI on it, I'll be more confident in it.