### PR TITLE
Add SubscriptionOptions for topic statistics

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -535,6 +535,12 @@ if(BUILD_TESTING)
     target_link_libraries(test_wait_set ${PROJECT_NAME})
   endif()
 
+  ament_add_gtest(test_subscription_options test/test_subscription_options.cpp)
+  if(TARGET test_subscription_options)
+    ament_target_dependencies(test_subscription_options "rcl")
+    target_link_libraries(test_subscription_options ${PROJECT_NAME})
+  endif()
+
   # Install test resources
   install(
     DIRECTORY test/resources

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -15,6 +15,7 @@
 #ifndef RCLCPP__SUBSCRIPTION_OPTIONS_HPP_
 #define RCLCPP__SUBSCRIPTION_OPTIONS_HPP_
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -63,6 +64,12 @@ struct SubscriptionOptionsBase
 
     // Enable and disable topic statistics calculation and publication. Defaults to disabled.
     TopicStatisticsState state = TopicStatisticsState::DISABLED;
+
+    // Topic to which topic statistics get published when enabled. Defaults to /system_metrics.
+    std::string publish_topic = "system_metrics";
+
+    // Topic statistics publication period in ms. Defaults to one minute.
+    std::chrono::milliseconds publish_period{60000};
   };
 
   TopicStatisticsOptions topic_stats_options;

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -56,20 +56,20 @@ struct SubscriptionOptionsBase
   std::shared_ptr<rclcpp::detail::RMWImplementationSpecificSubscriptionPayload>
   rmw_implementation_payload = nullptr;
 
-  // Options to configure topic statistics collector in the subscription
+  // Options to configure topic statistics collector in the subscription.
   struct TopicStatisticsOptions
   {
-    // Represent the state of topic statistics collector
+    // Represent the state of topic statistics collector.
     enum class TopicStatisticsState {ENABLED, DISABLED};
 
     // Enable and disable topic statistics calculation and publication. Defaults to disabled.
     TopicStatisticsState state = TopicStatisticsState::DISABLED;
 
-    // Topic to which topic statistics get published when enabled. Defaults to /system_metrics.
-    std::string publish_topic = "system_metrics";
+    // Topic to which topic statistics get published when enabled. Defaults to /statistics.
+    std::string publish_topic = "/statistics";
 
     // Topic statistics publication period in ms. Defaults to one minute.
-    std::chrono::milliseconds publish_period{60000};
+    std::chrono::milliseconds publish_period{std::chrono::minutes(1)};
   };
 
   TopicStatisticsOptions topic_stats_options;

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -54,6 +54,18 @@ struct SubscriptionOptionsBase
   /// Optional RMW implementation specific payload to be used during creation of the subscription.
   std::shared_ptr<rclcpp::detail::RMWImplementationSpecificSubscriptionPayload>
   rmw_implementation_payload = nullptr;
+
+  // Options to configure topic statistics collector in the subscription
+  struct TopicStatisticsOptions
+  {
+    // Represent the state of topic statistics collector
+    enum class TopicStatisticsState {ENABLED, DISABLED};
+
+    // Enable and disable topic statistics calculation and publication. Defaults to disabled.
+    TopicStatisticsState state = TopicStatisticsState::DISABLED;
+  };
+
+  TopicStatisticsOptions topic_stats_options;
 };
 
 /// Structure containing optional configuration for Subscriptions.
@@ -104,6 +116,7 @@ struct SubscriptionOptionsWithAllocator : public SubscriptionOptionsBase
 };
 
 using SubscriptionOptions = SubscriptionOptionsWithAllocator<std::allocator<void>>;
+using TopicStatisticsState = SubscriptionOptionsBase::TopicStatisticsOptions::TopicStatisticsState;
 
 }  // namespace rclcpp
 

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -69,7 +69,7 @@ struct SubscriptionOptionsBase
     std::string publish_topic = "/statistics";
 
     // Topic statistics publication period in ms. Defaults to one minute.
-    std::chrono::milliseconds publish_period{std::chrono::minutes(1)};
+    std::chrono::milliseconds publish_period{std::chrono::seconds(1)};
   };
 
   TopicStatisticsOptions topic_stats_options;

--- a/rclcpp/test/test_subscription_options.cpp
+++ b/rclcpp/test/test_subscription_options.cpp
@@ -1,0 +1,44 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include "rclcpp/subscription_options.hpp"
+
+using namespace std::chrono_literals;
+
+namespace
+{
+constexpr const char defaultPublishTopic[] = "system_metrics";
+}
+
+TEST(TestSubscriptionOptions, topic_statistics_options) {
+  auto options = rclcpp::SubscriptionOptions();
+
+  EXPECT_EQ(options.topic_stats_options.state, rclcpp::TopicStatisticsState::DISABLED);
+  EXPECT_EQ(options.topic_stats_options.publish_topic, defaultPublishTopic);
+  EXPECT_EQ(options.topic_stats_options.publish_period, 1min);
+
+  options.topic_stats_options.state = rclcpp::TopicStatisticsState::ENABLED;
+  options.topic_stats_options.publish_topic = "topic_statistics";
+  options.topic_stats_options.publish_period = 5min;
+
+  EXPECT_EQ(options.topic_stats_options.state, rclcpp::TopicStatisticsState::ENABLED);
+  EXPECT_EQ(options.topic_stats_options.publish_topic, "topic_statistics");
+  EXPECT_EQ(options.topic_stats_options.publish_period, 5min);
+}

--- a/rclcpp/test/test_subscription_options.cpp
+++ b/rclcpp/test/test_subscription_options.cpp
@@ -32,7 +32,7 @@ TEST(TestSubscriptionOptions, topic_statistics_options) {
 
   EXPECT_EQ(options.topic_stats_options.state, rclcpp::TopicStatisticsState::DISABLED);
   EXPECT_EQ(options.topic_stats_options.publish_topic, defaultPublishTopic);
-  EXPECT_EQ(options.topic_stats_options.publish_period, 1min);
+  EXPECT_EQ(options.topic_stats_options.publish_period, 1s);
 
   options.topic_stats_options.state = rclcpp::TopicStatisticsState::ENABLED;
   options.topic_stats_options.publish_topic = "topic_statistics";

--- a/rclcpp/test/test_subscription_options.cpp
+++ b/rclcpp/test/test_subscription_options.cpp
@@ -24,7 +24,7 @@ using namespace std::chrono_literals;
 
 namespace
 {
-constexpr const char defaultPublishTopic[] = "system_metrics";
+constexpr const char defaultPublishTopic[] = "/statistics";
 }
 
 TEST(TestSubscriptionOptions, topic_statistics_options) {


### PR DESCRIPTION
Related to https://github.com/ros-tooling/aws-roadmap/issues/225

* Add a new struct for topic statistics parameters inside SubscriptionOptions
* The struct has 3 options needed for topic statistics
* Added a unit test for new options in `subscription_options`

Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>