### PR TITLE
Make sure to include what you use.

### DIFF
--- a/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
@@ -15,6 +15,7 @@
 #ifndef RCLCPP__EXECUTORS__STATIC_EXECUTOR_ENTITIES_COLLECTOR_HPP_
 #define RCLCPP__EXECUTORS__STATIC_EXECUTOR_ENTITIES_COLLECTOR_HPP_
 
+#include <chrono>
 #include <list>
 #include <memory>
 

--- a/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
@@ -14,9 +14,12 @@
 
 #include "rclcpp/executors/static_executor_entities_collector.hpp"
 
-#include <string>
+#include <algorithm>
 #include <memory>
+#include <stdexcept>
+#include <string>
 
+#include "rclcpp/memory_strategy.hpp"
 #include "rclcpp/executors/static_single_threaded_executor.hpp"
 
 using rclcpp::executors::StaticExecutorEntitiesCollector;
@@ -39,7 +42,7 @@ StaticExecutorEntitiesCollector::~StaticExecutorEntitiesCollector()
 void
 StaticExecutorEntitiesCollector::init(
   rcl_wait_set_t * p_wait_set,
-  memory_strategy::MemoryStrategy::SharedPtr & memory_strategy,
+  rclcpp::memory_strategy::MemoryStrategy::SharedPtr & memory_strategy,
   rcl_guard_condition_t * executor_guard_condition)
 {
   // Empty initialize executable list


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

For reasons I don't understand, I could not build on Windows without these includes, even though CI seems OK with it.  Regardless, this seems to be the right thing to do, and with this in place I can now build on Windows again.