### PR TITLE
Primary state error transitions

### DIFF
--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -615,6 +615,14 @@ public:
 
   RCLCPP_LIFECYCLE_PUBLIC
   const State &
+  raise_error();
+
+  RCLCPP_LIFECYCLE_PUBLIC
+  const State &
+  raise_error(LifecycleNodeInterface::CallbackReturn & cb_return_code);
+
+  RCLCPP_LIFECYCLE_PUBLIC
+  const State &
   shutdown();
 
   RCLCPP_LIFECYCLE_PUBLIC

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -556,6 +556,28 @@ LifecycleNode::deactivate(LifecycleNodeInterface::CallbackReturn & cb_return_cod
 }
 
 const State &
+LifecycleNode::raise_error()
+{
+  if(get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+    return impl_->trigger_transition(
+        lifecycle_msgs::msg::Transition::TRANSITION_ACTIVE_ERROR);
+  else
+    return impl_->trigger_transition(
+        lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_ERROR);
+}
+
+const State &
+LifecycleNode::raise_error(LifecycleNodeInterface::CallbackReturn & cb_return_code)
+{
+  if(get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+    return impl_->trigger_transition(
+        lifecycle_msgs::msg::Transition::TRANSITION_ACTIVE_ERROR, cb_return_code);
+  else
+    return impl_->trigger_transition(
+        lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_ERROR, cb_return_code);
+}
+
+const State &
 LifecycleNode::shutdown()
 {
   return impl_->trigger_transition(


### PR DESCRIPTION
This PR (built on top of required PRs [ros2/rcl_interfaces#97](https://github.com/ros2/rcl_interfaces/pull/97) and [ros2/rcl#618](https://github.com/ros2/rcl/pull/618)) provides convenience functions for lifecycle nodes to self-trigger the error transitions created in the previous PRs.

This also addresses issue #547 