### PR TITLE
Make Component Manager public

### DIFF
--- a/rclcpp_components/CMakeLists.txt
+++ b/rclcpp_components/CMakeLists.txt
@@ -32,7 +32,7 @@ ament_target_dependencies(component_manager
   "rcpputils"
 )
 target_compile_definitions(component_manager
-  PRIVATE "RCLCPP_COMPONENT_BUILDING_LIBRARY")
+  PRIVATE "RCLCPP_COMPONENTS_BUILDING_LIBRARY")
 
 add_executable(
   component_container

--- a/rclcpp_components/CMakeLists.txt
+++ b/rclcpp_components/CMakeLists.txt
@@ -89,7 +89,6 @@ if(BUILD_TESTING)
     APPEND_LIBRARY_DIRS "${append_library_dirs}")
   if(TARGET test_component_manager)
     target_link_libraries(test_component_manager component_manager)
-    target_include_directories(test_component_manager PRIVATE src)
   endif()
 
   ament_add_gtest(test_component_manager_api test/test_component_manager_api.cpp
@@ -97,7 +96,6 @@ if(BUILD_TESTING)
     APPEND_LIBRARY_DIRS "${append_library_dirs}")
   if(TARGET test_component_manager_api)
     target_link_libraries(test_component_manager_api component_manager)
-    target_include_directories(test_component_manager_api PRIVATE src)
   endif()
 endif()
 

--- a/rclcpp_components/CMakeLists.txt
+++ b/rclcpp_components/CMakeLists.txt
@@ -21,7 +21,7 @@ include_directories(include)
 
 add_library(
   component_manager
-  STATIC
+  SHARED
   src/component_manager.cpp
 )
 ament_target_dependencies(component_manager
@@ -31,6 +31,8 @@ ament_target_dependencies(component_manager
   "rclcpp"
   "rcpputils"
 )
+target_compile_definitions(component_manager
+  PRIVATE "RCLCPP_COMPONENT_BUILDING_LIBRARY")
 
 add_executable(
   component_container

--- a/rclcpp_components/cmake/rclcpp_components_package_hook.cmake
+++ b/rclcpp_components/cmake/rclcpp_components_package_hook.cmake
@@ -15,8 +15,6 @@
 # register node plugins
 list(REMOVE_DUPLICATES _RCLCPP_COMPONENTS_PACKAGE_RESOURCE_INDICES)
 foreach(resource_index ${_RCLCPP_COMPONENTS_PACKAGE_RESOURCE_INDICES})
-  #message(WARNING "registered index: ${resource_index}")
-  #message(WARNING "content for index: ${_RCLCPP_COMPONENTS_${resource_index}__NODES}")
   ament_index_register_resource(
     ${resource_index} CONTENT "${_RCLCPP_COMPONENTS_${resource_index}__NODES}")
 endforeach()

--- a/rclcpp_components/cmake/rclcpp_components_package_hook.cmake
+++ b/rclcpp_components/cmake/rclcpp_components_package_hook.cmake
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 # register node plugins
-ament_index_register_resource(
-  "rclcpp_components" CONTENT "${_RCLCPP_COMPONENTS__NODES}")
+list(REMOVE_DUPLICATES _RCLCPP_COMPONENTS_PACKAGE_RESOURCE_INDICES)
+foreach(resource_index ${_RCLCPP_COMPONENTS_PACKAGE_RESOURCE_INDICES})
+  #message(WARNING "registered index: ${resource_index}")
+  #message(WARNING "content for index: ${_RCLCPP_COMPONENTS_${resource_index}__NODES}")
+  ament_index_register_resource(
+    ${resource_index} CONTENT "${_RCLCPP_COMPONENTS_${resource_index}__NODES}")
+endforeach()
 

--- a/rclcpp_components/cmake/rclcpp_components_register_node.cmake
+++ b/rclcpp_components/cmake/rclcpp_components_register_node.cmake
@@ -33,6 +33,12 @@ macro(rclcpp_components_register_node target)
     message(FATAL_ERROR "rclcpp_components_register_node() called with unused "
       "arguments: ${ARGS_UNPARSED_ARGUMENTS}")
   endif()
+  if("${ARGS_PLUGIN}" STREQUAL "")
+    message(FATAL_ERROR "rclcpp_components_register_node macro requires a PLUGIN argument for target ${target}")
+  endif()
+  if("${ARGS_EXECUTABLE}" STREQUAL "")
+    message(FATAL_ERROR "rclcpp_components_register_node macro requires a EXECUTABLE argument for target ${target}")
+  endif()
   # default to rclcpp_components if not specified otherwise
   set(resource_index "rclcpp_components")
   if(NOT "${ARGS_RESOURCE_INDEX}" STREQUAL "")

--- a/rclcpp_components/cmake/rclcpp_components_register_nodes.cmake
+++ b/rclcpp_components/cmake/rclcpp_components_register_nodes.cmake
@@ -21,6 +21,8 @@
 # :type target: string
 # :param ARGN: the unique plugin names being exported using class_loader
 # :type ARGN: list of strings
+# :param RESOURCE_INDEX: the ament resource index to register the components
+# :type RESOURCE_INDEX: string
 #
 macro(rclcpp_components_register_nodes target)
   if(NOT TARGET ${target})
@@ -28,6 +30,17 @@ macro(rclcpp_components_register_nodes target)
       FATAL_ERROR
       "rclcpp_components_register_nodes() first argument "
       "'${target}' is not a target")
+  endif()
+  cmake_parse_arguments(ARGS "" "RESOURCE_INDEX" "" ${ARGN})
+  if(ARGS_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "rclcpp_components_register_node() called with unused "
+      "arguments: ${ARGS_UNPARSED_ARGUMENTS}")
+  endif()
+  # default to rclcpp_components if not specified otherwise
+  set(resource_index "rclcpp_components")
+  if(NOT "${ARGS_RESOURCE_INDEX}" STREQUAL "")
+    set(resource_index ${ARGS_RESOURCE_INDEX})
+    message(STATUS "Setting component resource index to non-default value ${resource_index}")
   endif()
   get_target_property(_target_type ${target} TYPE)
   if(NOT _target_type STREQUAL "SHARED_LIBRARY")
@@ -54,8 +67,9 @@ macro(rclcpp_components_register_nodes target)
       else()
         set(_path "lib")
       endif()
-      set(_RCLCPP_COMPONENTS__NODES
-        "${_RCLCPP_COMPONENTS__NODES}${_arg};${_path}/$<TARGET_FILE_NAME:${target}>\n")
+      set(_RCLCPP_COMPONENTS_${resource_index}__NODES
+        "${_RCLCPP_COMPONENTS_${resource_index}__NODES}${_arg};${_path}/$<TARGET_FILE_NAME:${target}>\n")
+      list(APPEND _RCLCPP_COMPONENTS_PACKAGE_RESOURCE_INDICES ${resource_index})
     endforeach()
   endif()
 endmacro()

--- a/rclcpp_components/cmake/rclcpp_components_register_nodes.cmake
+++ b/rclcpp_components/cmake/rclcpp_components_register_nodes.cmake
@@ -32,10 +32,6 @@ macro(rclcpp_components_register_nodes target)
       "'${target}' is not a target")
   endif()
   cmake_parse_arguments(ARGS "" "RESOURCE_INDEX" "" ${ARGN})
-  if(ARGS_UNPARSED_ARGUMENTS)
-    message(FATAL_ERROR "rclcpp_components_register_node() called with unused "
-      "arguments: ${ARGS_UNPARSED_ARGUMENTS}")
-  endif()
   # default to rclcpp_components if not specified otherwise
   set(resource_index "rclcpp_components")
   if(NOT "${ARGS_RESOURCE_INDEX}" STREQUAL "")
@@ -53,7 +49,7 @@ macro(rclcpp_components_register_nodes target)
   if(${ARGC} GREATER 0)
     _rclcpp_components_register_package_hook()
     set(_unique_names)
-    foreach(_arg ${ARGN})
+    foreach(_arg ${ARGS_UNPARSED_ARGUMENTS})
       if(_arg IN_LIST _unique_names)
         message(
           FATAL_ERROR

--- a/rclcpp_components/include/rclcpp_components/component_manager.hpp
+++ b/rclcpp_components/include/rclcpp_components/component_manager.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef COMPONENT_MANAGER_HPP__
-#define COMPONENT_MANAGER_HPP__
+#ifndef RCLCPP_COMPONENTS__COMPONENT_MANAGER_HPP__
+#define RCLCPP_COMPONENTS__COMPONENT_MANAGER_HPP__
 
 #include <map>
 #include <memory>
@@ -32,6 +32,11 @@
 #include "composition_interfaces/srv/list_nodes.hpp"
 
 #include "rclcpp_components/node_factory.hpp"
+
+namespace class_loader
+{
+class ClassLoader;
+}  // namespace class_loader
 
 namespace rclcpp_components
 {
@@ -57,31 +62,34 @@ public:
   using ComponentResource = std::pair<std::string, std::string>;
 
   ComponentManager(
-    std::weak_ptr<rclcpp::executor::Executor> executor);
+    std::weak_ptr<rclcpp::executor::Executor> executor,
+    std::string node_name = "ComponentManager");
 
-  ~ComponentManager();
+  virtual ~ComponentManager();
 
   /// Return a list of valid loadable components in a given package.
-  std::vector<ComponentResource>
-  get_component_resources(const std::string & package_name) const;
+  virtual std::vector<ComponentResource>
+  get_component_resources(
+    const std::string & package_name,
+    const std::string & resource_index = "rclcpp_components") const;
 
-  std::shared_ptr<rclcpp_components::NodeFactory>
+  virtual std::shared_ptr<rclcpp_components::NodeFactory>
   create_component_factory(const ComponentResource & resource);
 
-private:
-  void
+protected:
+  virtual void
   OnLoadNode(
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<LoadNode::Request> request,
     std::shared_ptr<LoadNode::Response> response);
 
-  void
+  virtual void
   OnUnloadNode(
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<UnloadNode::Request> request,
     std::shared_ptr<UnloadNode::Response> response);
 
-  void
+  virtual void
   OnListNodes(
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<ListNodes::Request> request,
@@ -90,7 +98,7 @@ private:
 private:
   std::weak_ptr<rclcpp::executor::Executor> executor_;
 
-  uint64_t unique_id {1};
+  uint64_t unique_id_ {1};
   std::map<std::string, std::unique_ptr<class_loader::ClassLoader>> loaders_;
   std::map<uint64_t, rclcpp_components::NodeInstanceWrapper> node_wrappers_;
 
@@ -101,4 +109,4 @@ private:
 
 }  // namespace rclcpp_components
 
-#endif  // COMPONENT_MANAGER_HPP__
+#endif  // RCLCPP_COMPONENTS__COMPONENT_MANAGER_HPP__

--- a/rclcpp_components/include/rclcpp_components/component_manager.hpp
+++ b/rclcpp_components/include/rclcpp_components/component_manager.hpp
@@ -21,8 +21,6 @@
 #include <utility>
 #include <vector>
 
-#include "class_loader/class_loader.hpp"
-
 #include "composition_interfaces/srv/load_node.hpp"
 #include "composition_interfaces/srv/unload_node.hpp"
 #include "composition_interfaces/srv/list_nodes.hpp"

--- a/rclcpp_components/include/rclcpp_components/component_manager.hpp
+++ b/rclcpp_components/include/rclcpp_components/component_manager.hpp
@@ -40,7 +40,7 @@ class ClassLoader;
 namespace rclcpp_components
 {
 
-class RCLCPP_COMPONENTS_PUBLIC_TYPE ComponentManagerException : public std::runtime_error
+class ComponentManagerException : public std::runtime_error
 {
 public:
   explicit ComponentManagerException(const std::string & error_desc)

--- a/rclcpp_components/include/rclcpp_components/component_manager.hpp
+++ b/rclcpp_components/include/rclcpp_components/component_manager.hpp
@@ -23,15 +23,16 @@
 
 #include "class_loader/class_loader.hpp"
 
-#include "rclcpp/executor.hpp"
-#include "rclcpp/node_options.hpp"
-#include "rclcpp/rclcpp.hpp"
-
 #include "composition_interfaces/srv/load_node.hpp"
 #include "composition_interfaces/srv/unload_node.hpp"
 #include "composition_interfaces/srv/list_nodes.hpp"
 
+#include "rclcpp/executor.hpp"
+#include "rclcpp/node_options.hpp"
+#include "rclcpp/rclcpp.hpp"
+
 #include "rclcpp_components/node_factory.hpp"
+#include "rclcpp_components/visibility_control.hpp"
 
 namespace class_loader
 {
@@ -41,7 +42,7 @@ class ClassLoader;
 namespace rclcpp_components
 {
 
-class ComponentManagerException : public std::runtime_error
+class RCLCPP_COMPONENTS_PUBLIC_TYPE ComponentManagerException : public std::runtime_error
 {
 public:
   explicit ComponentManagerException(const std::string & error_desc)
@@ -61,34 +62,42 @@ public:
    */
   using ComponentResource = std::pair<std::string, std::string>;
 
+  RCLCPP_COMPONENTS_PUBLIC
   ComponentManager(
     std::weak_ptr<rclcpp::executor::Executor> executor,
-    std::string node_name = "ComponentManager");
+    std::string node_name = "ComponentManager",
+    const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions());
 
+  RCLCPP_COMPONENTS_PUBLIC
   virtual ~ComponentManager();
 
   /// Return a list of valid loadable components in a given package.
+  RCLCPP_COMPONENTS_PUBLIC
   virtual std::vector<ComponentResource>
   get_component_resources(
     const std::string & package_name,
     const std::string & resource_index = "rclcpp_components") const;
 
+  RCLCPP_COMPONENTS_PUBLIC
   virtual std::shared_ptr<rclcpp_components::NodeFactory>
   create_component_factory(const ComponentResource & resource);
 
 protected:
+  RCLCPP_COMPONENTS_PUBLIC
   virtual void
   OnLoadNode(
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<LoadNode::Request> request,
     std::shared_ptr<LoadNode::Response> response);
 
+  RCLCPP_COMPONENTS_PUBLIC
   virtual void
   OnUnloadNode(
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<UnloadNode::Request> request,
     std::shared_ptr<UnloadNode::Response> response);
 
+  RCLCPP_COMPONENTS_PUBLIC
   virtual void
   OnListNodes(
     const std::shared_ptr<rmw_request_id_t> request_header,

--- a/rclcpp_components/include/rclcpp_components/visibility_control.hpp
+++ b/rclcpp_components/include/rclcpp_components/visibility_control.hpp
@@ -1,0 +1,56 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* This header must be included by all rclcpp headers which declare symbols
+ * which are defined in the rclcpp library. When not building the rclcpp
+ * library, i.e. when using the headers in other package's code, the contents
+ * of this header change the visibility of certain symbols which the rclcpp
+ * library cannot have, but the consuming code must have inorder to link.
+ */
+
+#ifndef RCLCPP_COMPONENTS__VISIBILITY_CONTROL_HPP_
+#define RCLCPP_COMPONENTS__VISIBILITY_CONTROL_HPP_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define RCLCPP_COMPONENTS_EXPORT __attribute__ ((dllexport))
+    #define RCLCPP_COMPONENTS_IMPORT __attribute__ ((dllimport))
+  #else
+    #define RCLCPP_COMPONENTS_EXPORT __declspec(dllexport)
+    #define RCLCPP_COMPONENTS_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef RCLCPP_COMPONENTS_BUILDING_LIBRARY
+    #define RCLCPP_COMPONENTS_PUBLIC RCLCPP_COMPONENTS_EXPORT
+  #else
+    #define RCLCPP_COMPONENTS_PUBLIC RCLCPP_COMPONENTS_IMPORT
+  #endif
+  #define RCLCPP_COMPONENTS_PUBLIC_TYPE RCLCPP_COMPONENTS_PUBLIC
+  #define RCLCPP_COMPONENTS_LOCAL
+#else
+  #define RCLCPP_COMPONENTS_EXPORT __attribute__ ((visibility("default")))
+  #define RCLCPP_COMPONENTS_IMPORT
+  #if __GNUC__ >= 4
+    #define RCLCPP_COMPONENTS_PUBLIC __attribute__ ((visibility("default")))
+    #define RCLCPP_COMPONENTS_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define RCLCPP_COMPONENTS_PUBLIC
+    #define RCLCPP_COMPONENTS_LOCAL
+  #endif
+  #define RCLCPP_COMPONENTS_PUBLIC_TYPE
+#endif
+
+#endif  // RCLCPP_COMPONENTS__VISIBILITY_CONTROL_HPP_

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -16,7 +16,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include "component_manager.hpp"
+#include "rclcpp_components/component_manager.hpp"
 
 int main(int argc, char * argv[])
 {

--- a/rclcpp_components/src/component_container_mt.cpp
+++ b/rclcpp_components/src/component_container_mt.cpp
@@ -16,7 +16,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include "component_manager.hpp"
+#include "rclcpp_components/component_manager.hpp"
 
 int main(int argc, char * argv[])
 {

--- a/rclcpp_components/src/component_manager.cpp
+++ b/rclcpp_components/src/component_manager.cpp
@@ -32,8 +32,9 @@ namespace rclcpp_components
 
 ComponentManager::ComponentManager(
   std::weak_ptr<rclcpp::executor::Executor> executor,
-  std::string node_name)
-: Node(std::move(node_name)),
+  std::string node_name,
+  const rclcpp::NodeOptions & node_options)
+: Node(std::move(node_name), node_options),
   executor_(executor)
 {
   loadNode_srv_ = create_service<LoadNode>(

--- a/rclcpp_components/test/test_component_manager.cpp
+++ b/rclcpp_components/test/test_component_manager.cpp
@@ -16,7 +16,7 @@
 
 #include <memory>
 
-#include "component_manager.hpp"
+#include "rclcpp_components/component_manager.hpp"
 
 #include "rcpputils/filesystem_helper.hpp"
 

--- a/rclcpp_components/test/test_component_manager_api.cpp
+++ b/rclcpp_components/test/test_component_manager_api.cpp
@@ -21,7 +21,7 @@
 #include "composition_interfaces/srv/unload_node.hpp"
 #include "composition_interfaces/srv/list_nodes.hpp"
 
-#include "component_manager.hpp"
+#include "rclcpp_components/component_manager.hpp"
 
 using namespace std::chrono_literals;
 


### PR DESCRIPTION
closes #1010 

The first commit https://github.com/ros2/rclcpp/pull/1065/commits/d81d494ba6af5a8f8dc8c41a6311619eebb5ffa1 basically just turns the `component manager` into public API.

The second commit https://github.com/ros2/rclcpp/pull/1065/commits/156ff16a3722ce671bb655f341f5c32347e41a81 is enhancing the CMake macros for registering nodes with a new option `RESOURCE_INDEX` to specify under which index the file should be written.

With respect to the upcoming work in ros-control (https://github.com/ros-controls/roadmap/pull/7) that enables to not duplicate the CMake macros to adopt to ros-controls, but simply call the existing rclcpp_components macros with a proper resource index, e.g.:
```
rclcpp_components_register_node(timers_library
  PLUGIN "demo_nodes_cpp::OneOffTimerNode"
  EXECUTABLE one_off_timer
  RESOURCE_INDEX "some_proper_index")
```

The controller manager can then look into this exact index to only fetch controllers and no other components.