### PR TITLE
Remove warning message for failing to register default incompatible QoS callback

### DIFF
--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -97,11 +97,7 @@ public:
           },
           RCL_PUBLISHER_OFFERED_INCOMPATIBLE_QOS);
       } catch (UnsupportedEventTypeException & /*exc*/) {
-        RCLCPP_WARN_ONCE(
-          rclcpp::get_logger(rcl_node_get_logger_name(rcl_node_handle_.get())),
-          "This rmw implementation does not support ON_OFFERED_INCOMPATIBLE_QOS "
-          "events, you will not be notified when Publishers offer an incompatible "
-          "QoS profile to Subscriptions on the same topic.");
+        // pass
       }
     }
     // Setup continues in the post construction method, post_init_setup().

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -132,11 +132,7 @@ public:
           },
           RCL_SUBSCRIPTION_REQUESTED_INCOMPATIBLE_QOS);
       } catch (UnsupportedEventTypeException & /*exc*/) {
-        RCLCPP_WARN_ONCE(
-          rclcpp::get_logger(rcl_node_get_logger_name(node_handle_.get())),
-          "This rmw implementation does not support ON_REQUESTED_INCOMPATIBLE_QOS "
-          "events, you will not be notified when Subscriptions request an incompatible "
-          "QoS profile from Publishers on the same topic.");
+        // pass
       }
     }
 


### PR DESCRIPTION
This is to synchronize `rclcpp` with the change being made to `rclpy` in https://github.com/ros2/rclpy/pull/544.