### PR TITLE
Install the component_manager library

### DIFF
--- a/rclcpp_components/CMakeLists.txt
+++ b/rclcpp_components/CMakeLists.txt
@@ -101,6 +101,13 @@ if(BUILD_TESTING)
   endif()
 endif()
 
+install(
+  TARGETS component_manager
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
 # Install executables
 install(
   TARGETS component_container component_container_mt


### PR DESCRIPTION
Fixes new nightly test failures in ros2/build_farmer#272

Signed-off-by: Michael Carroll <michael@openrobotics.org>