### PR TITLE
Export component manager

### DIFF
--- a/rclcpp_components/CMakeLists.txt
+++ b/rclcpp_components/CMakeLists.txt
@@ -130,5 +130,6 @@ install(
 ament_export_include_directories(include)
 ament_export_libraries(component_manager)
 ament_export_dependencies(class_loader)
+ament_export_dependencies(composition_interfaces)
 ament_export_dependencies(rclcpp)
 ament_package(CONFIG_EXTRAS rclcpp_components-extras.cmake.in)

--- a/rclcpp_components/CMakeLists.txt
+++ b/rclcpp_components/CMakeLists.txt
@@ -128,6 +128,7 @@ install(
 
 # specific order: dependents before dependencies
 ament_export_include_directories(include)
+ament_export_libraries(component_manager)
 ament_export_dependencies(class_loader)
 ament_export_dependencies(rclcpp)
 ament_package(CONFIG_EXTRAS rclcpp_components-extras.cmake.in)


### PR DESCRIPTION
Exporting the component manger library and the dependency to composition interfaces is missing.