### PR TITLE
Fix tests that were not properly torn down

### DIFF
--- a/rclcpp/test/test_publisher_subscription_count_api.cpp
+++ b/rclcpp/test/test_publisher_subscription_count_api.cpp
@@ -55,6 +55,7 @@ public:
   {
     rclcpp::shutdown();
   }
+
 protected:
   void SetUp() {}
 

--- a/rclcpp/test/test_publisher_subscription_count_api.cpp
+++ b/rclcpp/test/test_publisher_subscription_count_api.cpp
@@ -15,8 +15,8 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
-#include <string>
 #include <memory>
+#include <string>
 
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/publisher.hpp"
@@ -51,7 +51,10 @@ public:
   {
     rclcpp::init(0, nullptr);
   }
-
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
 protected:
   void SetUp() {}
 

--- a/rclcpp/test/test_subscription_publisher_count_api.cpp
+++ b/rclcpp/test/test_subscription_publisher_count_api.cpp
@@ -48,6 +48,7 @@ public:
   {
     rclcpp::shutdown();
   }
+
 protected:
   void SetUp() {}
   void TearDown() {}

--- a/rclcpp/test/test_subscription_publisher_count_api.cpp
+++ b/rclcpp/test/test_subscription_publisher_count_api.cpp
@@ -44,7 +44,10 @@ public:
   {
     rclcpp::init(0, nullptr);
   }
-
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
 protected:
   void SetUp() {}
   void TearDown() {}


### PR DESCRIPTION
Attempting to run the `test_publisher_subscription_count_api` and `test_subscription_publisher_count_api` with the following gtest flags

- --gtest_repeat=-1
- --gtest_break_on_failure

failed. Manually verified on Linux that adding the `TearDownTestCase` allows the tests to be repeated.

Signed-off-by: Devin Bonnie <dbbonnie@amazon.com>