### PR TITLE
Add received message age metric to topic statistics

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -619,10 +619,6 @@ if(BUILD_TESTING)
     target_link_libraries(test_wait_set ${PROJECT_NAME})
   endif()
 
-  set(append_library_dirs "${CMAKE_CURRENT_BINARY_DIR}")
-  if(WIN32)
-    set(append_library_dirs "${append_library_dirs}/$<CONFIG>")
-  endif()
   ament_add_gtest(test_subscription_topic_statistics test/topic_statistics/test_subscription_topic_statistics.cpp
     APPEND_LIBRARY_DIRS "${append_library_dirs}"
   )

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -229,6 +229,7 @@ if(BUILD_TESTING)
     test/msg/MessageWithHeader.msg
     DEPENDENCIES builtin_interfaces
     LIBRARY_NAME ${PROJECT_NAME}
+    SKIP_INSTALL
   )
 
   ament_add_gtest(test_client test/test_client.cpp)

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -217,6 +217,7 @@ if(BUILD_TESTING)
 
   find_package(rmw_implementation_cmake REQUIRED)
 
+  find_package(sensor_msgs REQUIRED)
   find_package(test_msgs REQUIRED)
 
   include(cmake/rclcpp_add_build_failure_test.cmake)
@@ -614,11 +615,13 @@ if(BUILD_TESTING)
   if(TARGET test_subscription_topic_statistics)
     ament_target_dependencies(test_subscription_topic_statistics
       "libstatistics_collector"
+      "rcl"
       "rcl_interfaces"
       "rcutils"
       "rmw"
       "rosidl_runtime_cpp"
       "rosidl_typesupport_cpp"
+      "sensor_msgs"
       "statistics_msgs"
       "test_msgs")
     target_link_libraries(test_subscription_topic_statistics ${PROJECT_NAME})

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rosgraph_msgs REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
 find_package(rosidl_runtime_cpp REQUIRED)
 find_package(rosidl_typesupport_c REQUIRED)
 find_package(rosidl_typesupport_cpp REQUIRED)
@@ -222,6 +223,13 @@ if(BUILD_TESTING)
   include(cmake/rclcpp_add_build_failure_test.cmake)
 
   add_definitions(-DTEST_RESOURCES_DIRECTORY="${CMAKE_CURRENT_BINARY_DIR}/test/resources")
+
+  rosidl_generate_interfaces(${PROJECT_NAME}_test_msgs
+    test/msg/Header.msg
+    test/msg/MessageWithHeader.msg
+    DEPENDENCIES builtin_interfaces
+    LIBRARY_NAME ${PROJECT_NAME}
+  )
 
   ament_add_gtest(test_client test/test_client.cpp)
   if(TARGET test_client)
@@ -613,6 +621,7 @@ if(BUILD_TESTING)
   ament_add_gtest(test_subscription_topic_statistics test/topic_statistics/test_subscription_topic_statistics.cpp)
   if(TARGET test_subscription_topic_statistics)
     ament_target_dependencies(test_subscription_topic_statistics
+      "builtin_interfaces"
       "libstatistics_collector"
       "rcl_interfaces"
       "rcutils"
@@ -621,8 +630,10 @@ if(BUILD_TESTING)
       "rosidl_typesupport_cpp"
       "statistics_msgs"
       "test_msgs")
+    rosidl_target_interfaces(test_subscription_topic_statistics ${PROJECT_NAME}_test_msgs "rosidl_typesupport_cpp")
     target_link_libraries(test_subscription_topic_statistics ${PROJECT_NAME})
   endif()
+
 
   ament_add_gtest(test_subscription_options test/test_subscription_options.cpp)
   if(TARGET test_subscription_options)

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -619,8 +619,12 @@ if(BUILD_TESTING)
     target_link_libraries(test_wait_set ${PROJECT_NAME})
   endif()
 
+  set(append_library_dirs "${CMAKE_CURRENT_BINARY_DIR}")
+  if(WIN32)
+    set(append_library_dirs "${append_library_dirs}/$<CONFIG>")
+  endif()
   ament_add_gtest(test_subscription_topic_statistics test/topic_statistics/test_subscription_topic_statistics.cpp
-    APPEND_LIBRARY_DIRS "${CMAKE_CURRENT_BINARY_DIR}"
+    APPEND_LIBRARY_DIRS "${append_library_dirs}"
   )
   if(TARGET test_subscription_topic_statistics)
     ament_target_dependencies(test_subscription_topic_statistics

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -634,7 +634,6 @@ if(BUILD_TESTING)
     target_link_libraries(test_subscription_topic_statistics ${PROJECT_NAME})
   endif()
 
-
   ament_add_gtest(test_subscription_options test/test_subscription_options.cpp)
   if(TARGET test_subscription_options)
     ament_target_dependencies(test_subscription_options "rcl")

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -217,7 +217,6 @@ if(BUILD_TESTING)
 
   find_package(rmw_implementation_cmake REQUIRED)
 
-  find_package(sensor_msgs REQUIRED)
   find_package(test_msgs REQUIRED)
 
   include(cmake/rclcpp_add_build_failure_test.cmake)
@@ -615,13 +614,11 @@ if(BUILD_TESTING)
   if(TARGET test_subscription_topic_statistics)
     ament_target_dependencies(test_subscription_topic_statistics
       "libstatistics_collector"
-      "rcl"
       "rcl_interfaces"
       "rcutils"
       "rmw"
       "rosidl_runtime_cpp"
       "rosidl_typesupport_cpp"
-      "sensor_msgs"
       "statistics_msgs"
       "test_msgs")
     target_link_libraries(test_subscription_topic_statistics ${PROJECT_NAME})

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -619,7 +619,9 @@ if(BUILD_TESTING)
     target_link_libraries(test_wait_set ${PROJECT_NAME})
   endif()
 
-  ament_add_gtest(test_subscription_topic_statistics test/topic_statistics/test_subscription_topic_statistics.cpp)
+  ament_add_gtest(test_subscription_topic_statistics test/topic_statistics/test_subscription_topic_statistics.cpp
+    APPEND_LIBRARY_DIRS "${CMAKE_CURRENT_BINARY_DIR}"
+  )
   if(TARGET test_subscription_topic_statistics)
     ament_target_dependencies(test_subscription_topic_statistics
       "builtin_interfaces"

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -271,8 +271,8 @@ public:
 
     if (subscription_topic_statistics_) {
       const auto nanos = std::chrono::time_point_cast<std::chrono::nanoseconds>(
-        std::chrono::steady_clock::now());
-      const auto time = rclcpp::Time(nanos.time_since_epoch().count(), RCL_STEADY_TIME);
+        std::chrono::system_clock::now());
+      const auto time = rclcpp::Time(nanos.time_since_epoch().count());
       subscription_topic_statistics_->handle_message(*typed_message, time);
     }
   }

--- a/rclcpp/include/rclcpp/topic_statistics/subscription_topic_statistics.hpp
+++ b/rclcpp/include/rclcpp/topic_statistics/subscription_topic_statistics.hpp
@@ -23,6 +23,7 @@
 #include "libstatistics_collector/collector/generate_statistics_message.hpp"
 #include "libstatistics_collector/moving_average_statistics/types.hpp"
 #include "libstatistics_collector/topic_statistics_collector/constants.hpp"
+#include "libstatistics_collector/topic_statistics_collector/received_message_age.hpp"
 #include "libstatistics_collector/topic_statistics_collector/received_message_period.hpp"
 
 #include "rcl/time.h"
@@ -55,6 +56,9 @@ class SubscriptionTopicStatistics
 {
   using TopicStatsCollector =
     libstatistics_collector::topic_statistics_collector::TopicStatisticsCollector<
+    CallbackMessageT>;
+  using ReceivedMessageAge =
+    libstatistics_collector::topic_statistics_collector::ReceivedMessageAgeCollector<
     CallbackMessageT>;
   using ReceivedMessagePeriod =
     libstatistics_collector::topic_statistics_collector::ReceivedMessagePeriodCollector<
@@ -173,7 +177,11 @@ private:
    */
   void bring_up()
   {
-    auto received_message_period = std::make_unique<ReceivedMessagePeriod>();
+    const auto received_message_age = std::make_unique<ReceivedMessageAge>();
+    received_message_age->Start();
+    subscriber_statistics_collectors_.emplace_back(std::move(received_message_age));
+
+    const auto received_message_period = std::make_unique<ReceivedMessagePeriod>();
     received_message_period->Start();
     {
       std::lock_guard<std::mutex> lock(mutex_);

--- a/rclcpp/include/rclcpp/topic_statistics/subscription_topic_statistics.hpp
+++ b/rclcpp/include/rclcpp/topic_statistics/subscription_topic_statistics.hpp
@@ -177,11 +177,11 @@ private:
    */
   void bring_up()
   {
-    const auto received_message_age = std::make_unique<ReceivedMessageAge>();
+    auto received_message_age = std::make_unique<ReceivedMessageAge>();
     received_message_age->Start();
     subscriber_statistics_collectors_.emplace_back(std::move(received_message_age));
 
-    const auto received_message_period = std::make_unique<ReceivedMessagePeriod>();
+    auto received_message_period = std::make_unique<ReceivedMessagePeriod>();
     received_message_period->Start();
     {
       std::lock_guard<std::mutex> lock(mutex_);

--- a/rclcpp/package.xml
+++ b/rclcpp/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="3">
+<package format="2">
   <name>rclcpp</name>
   <version>0.8.3</version>
   <description>The ROS client library in C++.</description>
@@ -39,8 +39,6 @@
   <test_depend>rmw_implementation_cmake</test_depend>
   <test_depend>rosidl_default_generators</test_depend>
   <test_depend>test_msgs</test_depend>
-
-  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rclcpp/package.xml
+++ b/rclcpp/package.xml
@@ -37,7 +37,6 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rmw</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>
-  <test_depend>sensor_msgs</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>

--- a/rclcpp/package.xml
+++ b/rclcpp/package.xml
@@ -37,6 +37,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rmw</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>
+  <test_depend>sensor_msgs</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>

--- a/rclcpp/package.xml
+++ b/rclcpp/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<package format="3">
   <name>rclcpp</name>
   <version>0.8.3</version>
   <description>The ROS client library in C++.</description>
@@ -37,7 +37,10 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rmw</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>
+  <test_depend>rosidl_default_generators</test_depend>
   <test_depend>test_msgs</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rclcpp/test/msg/Header.msg
+++ b/rclcpp/test/msg/Header.msg
@@ -1,0 +1,3 @@
+# Simple Header message with a timestamp field.
+
+builtin_interfaces/Time stamp

--- a/rclcpp/test/msg/MessageWithHeader.msg
+++ b/rclcpp/test/msg/MessageWithHeader.msg
@@ -1,0 +1,3 @@
+# Message containing a simple Header field.
+
+Header header

--- a/rclcpp/test/topic_statistics/test_subscription_topic_statistics.cpp
+++ b/rclcpp/test/topic_statistics/test_subscription_topic_statistics.cpp
@@ -25,6 +25,7 @@
 #include "libstatistics_collector/moving_average_statistics/types.hpp"
 
 #include "rclcpp/create_publisher.hpp"
+#include "rclcpp/msg/message_with_header.hpp"
 #include "rclcpp/node.hpp"
 #include "rclcpp/qos.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -36,7 +37,6 @@
 #include "statistics_msgs/msg/statistic_data_point.hpp"
 #include "statistics_msgs/msg/statistic_data_type.hpp"
 
-#include "test_msgs/msg/message_with_header.hpp"
 #include "test_msgs/msg/empty.hpp"
 
 #include "test_topic_stats_utils.hpp"
@@ -51,7 +51,7 @@ constexpr const uint64_t kNoSamples{0};
 constexpr const std::chrono::seconds kTestDuration{10};
 }  // namespace
 
-using test_msgs::msg::MessageWithHeader;
+using rclcpp::msg::MessageWithHeader;
 using test_msgs::msg::Empty;
 using rclcpp::topic_statistics::SubscriptionTopicStatistics;
 using statistics_msgs::msg::MetricsMessage;

--- a/rclcpp/test/topic_statistics/test_subscription_topic_statistics.cpp
+++ b/rclcpp/test/topic_statistics/test_subscription_topic_statistics.cpp
@@ -102,13 +102,11 @@ public:
 private:
   void publish_message()
   {
-    ++number_published_;
     auto msg = Empty{};
     publisher_->publish(msg);
   }
 
   rclcpp::Publisher<Empty>::SharedPtr publisher_;
-  std::atomic<size_t> number_published_{0};
   rclcpp::TimerBase::SharedPtr publish_timer_;
 };
 
@@ -135,7 +133,6 @@ public:
 private:
   void publish_message()
   {
-    ++number_published_;
     auto msg = MessageWithHeader{};
     auto now = this->now();
     auto nanos = now.nanoseconds() - 1000 * 1000;
@@ -145,7 +142,6 @@ private:
   }
 
   rclcpp::Publisher<MessageWithHeader>::SharedPtr publisher_;
-  std::atomic<size_t> number_published_{0};
   rclcpp::TimerBase::SharedPtr publish_timer_;
 };
 
@@ -302,8 +298,6 @@ TEST_F(TestSubscriptionTopicStatisticsFixture, test_receive_stats_for_message_no
   // Message age statistics will not be calculated because Empty messages
   // don't have a `header` with timestamp.
 
-  // TODO(prajakta-gokhale): Change Empty message type to something with a `header`,
-  // and have below assertions work for all collectors.
   for (const auto & msg : received_messages) {
     if (msg.metrics_source == "message_period") {
       for (const auto & stats_point : msg.statistics) {

--- a/rclcpp/test/topic_statistics/test_subscription_topic_statistics.cpp
+++ b/rclcpp/test/topic_statistics/test_subscription_topic_statistics.cpp
@@ -225,9 +225,6 @@ protected:
     empty_subscriber = std::make_shared<EmptySubscriber>(
       kTestSubNodeName,
       kTestSubStatsTopic);
-    imu_subscriber = std::make_shared<ImuSubscriber>(
-      kTestSubNodeName,
-      kTestSubStatsTopic);
   }
 
   void TearDown()
@@ -236,7 +233,6 @@ protected:
     empty_subscriber.reset();
   }
   std::shared_ptr<EmptySubscriber> empty_subscriber;
-  std::shared_ptr<ImuSubscriber> imu_subscriber;
 };
 
 TEST_F(TestSubscriptionTopicStatisticsFixture, test_manual_construction)
@@ -351,6 +347,10 @@ TEST_F(TestSubscriptionTopicStatisticsFixture, test_receive_stats_for_message_wi
     "test_receive_stats_for_message_with_header",
     "/statistics",
     2);
+
+  auto imu_subscriber = std::make_shared<ImuSubscriber>(
+    kTestSubNodeName,
+    kTestSubStatsTopic);
 
   rclcpp::executors::SingleThreadedExecutor ex;
   ex.add_node(imu_publisher);


### PR DESCRIPTION
Waiting on #1072 for unit testing. 

Update: This includes part of changes from #1072 for unit tests. Once #1072 gets merged this will be rebased for CI.

Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>