### PR TITLE
Update comment about return value in Executor::get_next_ready_executable

### DIFF
--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -603,7 +603,7 @@ Executor::get_next_ready_executable(AnyExecutable & any_executable)
       any_executable.callback_group->can_be_taken_from().store(false);
     }
   }
-  // If there is no ready executable, return a null ptr
+  // If there is no ready executable, return false
   return success;
 }
 


### PR DESCRIPTION
Goes back to when `get_next_ready_executable()` was changed to return a `bool` instead of a `SharedPtr` here: https://github.com/ros2/rclcpp/commit/1610fc3973541d7064d2592ba5555ee99b45e128#diff-97193a162153796658f8e485ff3f9d5aR563