### PR TITLE
Added rclcpp lifecycle Doxyfile

### DIFF
--- a/rclcpp_lifecycle/Doxyfile
+++ b/rclcpp_lifecycle/Doxyfile
@@ -1,0 +1,35 @@
+# All settings not listed here will use the Doxygen default values.
+
+PROJECT_NAME           = "rclcpp_lifecycle"
+PROJECT_NUMBER         = master
+PROJECT_BRIEF          = "C++ ROS Lifecycle Library API"
+
+# Use these lines to include the generated logging.hpp (update install path if needed)
+# Otherwise just generate for the local (non-generated header files)
+
+
+INPUT                  = ./include
+
+RECURSIVE              = YES
+OUTPUT_DIRECTORY       = doc_output
+
+EXTRACT_ALL            = YES
+SORT_MEMBER_DOCS       = NO
+
+GENERATE_LATEX         = NO
+
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+EXPAND_ONLY_PREDEF     = YES
+PREDEFINED             = RCLCPP_PUBLIC=
+
+# Tag files that do not exist will produce a warning and cross-project linking will not work.
+TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
+# Consider changing "latest" to the version you want to reference (e.g. beta1 or 1.0.0)
+TAGFILES += "../../../../doxygen_tag_files/rclcpp.tag=http://docs.ros2.org//api/rclcpp/"
+TAGFILES += "../../../../doxygen_tag_files/rcl_lifecycle.tag=http://docs.ros2.org//api/rcl_lifecycle/"
+TAGFILES += "../../../../doxygen_tag_files/rcl.tag=http://docs.ros2.org//api/rcl/"
+TAGFILES += "../../../../doxygen_tag_files/rmw.tag=http://docs.ros2.org//api/rmw/"
+TAGFILES += "../../../../doxygen_tag_files/rcutils.tag=http://docs.ros2.org//api/rcutils/"
+# Uncomment to generate tag files for cross-project linking.
+GENERATE_TAGFILE = "../../../../doxygen_tag_files/rclcpp_lifecycle.tag"

--- a/rclcpp_lifecycle/Doxyfile
+++ b/rclcpp_lifecycle/Doxyfile
@@ -21,15 +21,13 @@ GENERATE_LATEX         = NO
 ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
-PREDEFINED             = RCLCPP_PUBLIC=
+PREDEFINED             = RCLCPP_LIFECYCLE_PUBLIC=
 
 # Tag files that do not exist will produce a warning and cross-project linking will not work.
 TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
 # Consider changing "latest" to the version you want to reference (e.g. beta1 or 1.0.0)
-TAGFILES += "../../../../doxygen_tag_files/rclcpp.tag=http://docs.ros2.org//api/rclcpp/"
-TAGFILES += "../../../../doxygen_tag_files/rcl_lifecycle.tag=http://docs.ros2.org//api/rcl_lifecycle/"
-TAGFILES += "../../../../doxygen_tag_files/rcl.tag=http://docs.ros2.org//api/rcl/"
-TAGFILES += "../../../../doxygen_tag_files/rmw.tag=http://docs.ros2.org//api/rmw/"
-TAGFILES += "../../../../doxygen_tag_files/rcutils.tag=http://docs.ros2.org//api/rcutils/"
+TAGFILES += "../../../../doxygen_tag_files/rclcpp.tag=http://docs.ros2.org/latest/api/rclcpp/"
+TAGFILES += "../../../../doxygen_tag_files/rcl_lifecycle.tag=http://docs.ros2.org/latest/api/rcl_lifecycle/"
+TAGFILES += "../../../../doxygen_tag_files/rmw.tag=http://docs.ros2.org/latest/api/rmw/"
 # Uncomment to generate tag files for cross-project linking.
 GENERATE_TAGFILE = "../../../../doxygen_tag_files/rclcpp_lifecycle.tag"


### PR DESCRIPTION
Added Doxyfile to rcl_lifecycle in the process of reaching Quality Level 1.

In the repo [docs.ros2.org](https://github.com/ros2/docs.ros2.org/) branch `gen_doc`. The [documentation](https://github.com/ros2/docs.ros2.org/blob/doc_gen/Makefile#L12) of `rclcpp_lifecycle` is trying to be build but there is no Doxyfile.

Signed-off-by: ahcorde <ahcorde@gmail.com>