### PR TITLE
Rename rclcpp library target

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -162,10 +162,12 @@ endforeach()
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/include")
 
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME}_library
   ${${PROJECT_NAME}_SRCS})
+set_target_properties(${PROJECT_NAME}_library
+  PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 # specific order: dependents before dependencies
-ament_target_dependencies(${PROJECT_NAME}
+ament_target_dependencies(${PROJECT_NAME}_library
   "libstatistics_collector"
   "rcl"
   "rcl_yaml_param_parser"
@@ -181,11 +183,11 @@ ament_target_dependencies(${PROJECT_NAME}
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
-target_compile_definitions(${PROJECT_NAME}
+target_compile_definitions(${PROJECT_NAME}_library
   PRIVATE "RCLCPP_BUILDING_LIBRARY")
 
 install(
-  TARGETS ${PROJECT_NAME}
+  TARGETS ${PROJECT_NAME}_library
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -193,7 +195,7 @@ install(
 
 # specific order: dependents before dependencies
 ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME})
+ament_export_libraries(${PROJECT_NAME}_library)
 
 ament_export_dependencies(libstatistics_collector)
 ament_export_dependencies(rcl)
@@ -229,7 +231,7 @@ if(BUILD_TESTING)
       "rosidl_runtime_cpp"
       "rosidl_typesupport_cpp"
     )
-    target_link_libraries(test_client ${PROJECT_NAME})
+    target_link_libraries(test_client ${PROJECT_NAME}_library)
   endif()
   ament_add_gtest(test_create_timer test/test_create_timer.cpp)
   if(TARGET test_create_timer)
@@ -240,7 +242,7 @@ if(BUILD_TESTING)
       "rosidl_runtime_cpp"
       "rosidl_typesupport_cpp"
     )
-    target_link_libraries(test_create_timer ${PROJECT_NAME})
+    target_link_libraries(test_create_timer ${PROJECT_NAME}_library)
     target_include_directories(test_create_timer PRIVATE test/)
   endif()
   ament_add_gtest(test_expand_topic_or_service_name test/test_expand_topic_or_service_name.cpp)
@@ -251,7 +253,7 @@ if(BUILD_TESTING)
       "rosidl_runtime_cpp"
       "rosidl_typesupport_cpp"
     )
-    target_link_libraries(test_expand_topic_or_service_name ${PROJECT_NAME})
+    target_link_libraries(test_expand_topic_or_service_name ${PROJECT_NAME}_library)
   endif()
   ament_add_gtest(test_function_traits test/test_function_traits.cpp)
   if(TARGET test_function_traits)
@@ -271,7 +273,7 @@ if(BUILD_TESTING)
       "rosidl_runtime_cpp"
       "rosidl_typesupport_cpp"
     )
-    target_link_libraries(test_intra_process_manager ${PROJECT_NAME})
+    target_link_libraries(test_intra_process_manager ${PROJECT_NAME}_library)
   endif()
   ament_add_gtest(test_ring_buffer_implementation test/test_ring_buffer_implementation.cpp)
   if(TARGET test_ring_buffer_implementation)
@@ -281,7 +283,7 @@ if(BUILD_TESTING)
       "rosidl_runtime_cpp"
       "rosidl_typesupport_cpp"
     )
-    target_link_libraries(test_ring_buffer_implementation ${PROJECT_NAME})
+    target_link_libraries(test_ring_buffer_implementation ${PROJECT_NAME}_library)
   endif()
   ament_add_gtest(test_intra_process_buffer test/test_intra_process_buffer.cpp)
   if(TARGET test_intra_process_buffer)
@@ -291,14 +293,14 @@ if(BUILD_TESTING)
       "rosidl_runtime_cpp"
       "rosidl_typesupport_cpp"
     )
-    target_link_libraries(test_intra_process_buffer ${PROJECT_NAME})
+    target_link_libraries(test_intra_process_buffer ${PROJECT_NAME}_library)
   endif()
 
   ament_add_gtest(test_loaned_message test/test_loaned_message.cpp)
   ament_target_dependencies(test_loaned_message
     "test_msgs"
   )
-  target_link_libraries(test_loaned_message ${PROJECT_NAME})
+  target_link_libraries(test_loaned_message ${PROJECT_NAME}_library)
 
   ament_add_gtest(test_node test/test_node.cpp TIMEOUT 240)
   if(TARGET test_node)
@@ -310,35 +312,35 @@ if(BUILD_TESTING)
       "rosidl_typesupport_cpp"
       "test_msgs"
     )
-    target_link_libraries(test_node ${PROJECT_NAME})
+    target_link_libraries(test_node ${PROJECT_NAME}_library)
   endif()
 
   ament_add_gtest(test_node_interfaces__get_node_interfaces
     test/node_interfaces/test_get_node_interfaces.cpp)
   if(TARGET test_node_interfaces__get_node_interfaces)
-    target_link_libraries(test_node_interfaces__get_node_interfaces ${PROJECT_NAME})
+    target_link_libraries(test_node_interfaces__get_node_interfaces ${PROJECT_NAME}_library)
   endif()
 
   # TODO(wjwwood): reenable these build failure tests when I can get Jenkins to ignore their output
   # rclcpp_add_build_failure_test(build_failure__get_node_topics_interface_const_ref_rclcpp_node
   #   test/node_interfaces/test_does_not_compile/get_node_topics_interface_const_ref_rclcpp_node.cpp)
   # target_link_libraries(build_failure__get_node_topics_interface_const_ref_rclcpp_node
-  #   ${PROJECT_NAME})
+  #   ${PROJECT_NAME}_library)
 
   # rclcpp_add_build_failure_test(build_failure__get_node_topics_interface_const_ptr_rclcpp_node
   #   test/node_interfaces/test_does_not_compile/get_node_topics_interface_const_ptr_rclcpp_node.cpp)
   # target_link_libraries(build_failure__get_node_topics_interface_const_ptr_rclcpp_node
-  #   ${PROJECT_NAME})
+  #   ${PROJECT_NAME}_library)
 
   # rclcpp_add_build_failure_test(build_failure__get_node_topics_interface_const_ref_wrapped_node
   #   test/node_interfaces/test_does_not_compile/get_node_topics_interface_const_ref_wrapped_node.cpp)
   # target_link_libraries(build_failure__get_node_topics_interface_const_ref_rclcpp_node
-  #   ${PROJECT_NAME})
+  #   ${PROJECT_NAME}_library)
 
   # rclcpp_add_build_failure_test(build_failure__get_node_topics_interface_const_ptr_wrapped_node
   #   test/node_interfaces/test_does_not_compile/get_node_topics_interface_const_ptr_wrapped_node.cpp)
   # target_link_libraries(build_failure__get_node_topics_interface_const_ptr_rclcpp_node
-  #   ${PROJECT_NAME})
+  #   ${PROJECT_NAME}_library)
 
   ament_add_gtest(test_node_global_args test/test_node_global_args.cpp)
   if(TARGET test_node_global_args)
@@ -348,19 +350,19 @@ if(BUILD_TESTING)
       "rosidl_runtime_cpp"
       "rosidl_typesupport_cpp"
     )
-    target_link_libraries(test_node_global_args ${PROJECT_NAME})
+    target_link_libraries(test_node_global_args ${PROJECT_NAME}_library)
   endif()
   ament_add_gtest(test_node_options test/test_node_options.cpp)
   if(TARGET test_node_options)
     ament_target_dependencies(test_node_options "rcl")
-    target_link_libraries(test_node_options ${PROJECT_NAME})
+    target_link_libraries(test_node_options ${PROJECT_NAME}_library)
   endif()
   ament_add_gtest(test_parameter_client test/test_parameter_client.cpp)
   if(TARGET test_parameter_client)
     ament_target_dependencies(test_parameter_client
       "rcl_interfaces"
     )
-    target_link_libraries(test_parameter_client ${PROJECT_NAME})
+    target_link_libraries(test_parameter_client ${PROJECT_NAME}_library)
   endif()
   ament_add_gtest(test_parameter_events_filter test/test_parameter_events_filter.cpp)
   if(TARGET test_parameter_events_filter)
@@ -370,7 +372,7 @@ if(BUILD_TESTING)
       "rosidl_runtime_cpp"
       "rosidl_typesupport_cpp"
     )
-    target_link_libraries(test_parameter_events_filter ${PROJECT_NAME})
+    target_link_libraries(test_parameter_events_filter ${PROJECT_NAME}_library)
   endif()
   ament_add_gtest(test_parameter test/test_parameter.cpp)
   if(TARGET test_parameter)
@@ -380,11 +382,11 @@ if(BUILD_TESTING)
       "rosidl_runtime_cpp"
       "rosidl_typesupport_cpp"
     )
-    target_link_libraries(test_parameter ${PROJECT_NAME})
+    target_link_libraries(test_parameter ${PROJECT_NAME}_library)
   endif()
   ament_add_gtest(test_parameter_map test/test_parameter_map.cpp)
   if(TARGET test_parameter_map)
-    target_link_libraries(test_parameter_map ${PROJECT_NAME})
+    target_link_libraries(test_parameter_map ${PROJECT_NAME}_library)
   endif()
   ament_add_gtest(test_publisher test/test_publisher.cpp)
   if(TARGET test_publisher)
@@ -394,7 +396,7 @@ if(BUILD_TESTING)
       "rosidl_typesupport_cpp"
       "test_msgs"
     )
-    target_link_libraries(test_publisher ${PROJECT_NAME})
+    target_link_libraries(test_publisher ${PROJECT_NAME}_library)
   endif()
   ament_add_gtest(test_publisher_subscription_count_api test/test_publisher_subscription_count_api.cpp)
   if(TARGET test_publisher_subscription_count_api)
@@ -405,7 +407,7 @@ if(BUILD_TESTING)
       "rosidl_typesupport_cpp"
       "test_msgs"
     )
-    target_link_libraries(test_publisher_subscription_count_api ${PROJECT_NAME})
+    target_link_libraries(test_publisher_subscription_count_api ${PROJECT_NAME}_library)
   endif()
   ament_add_gtest(test_qos test/test_qos.cpp)
   if(TARGET test_qos)
@@ -413,7 +415,7 @@ if(BUILD_TESTING)
       "rmw"
     )
     target_link_libraries(test_qos
-      ${PROJECT_NAME}
+      ${PROJECT_NAME}_library
     )
   endif()
   ament_add_gtest(test_qos_event test/test_qos_event.cpp)
@@ -423,7 +425,7 @@ if(BUILD_TESTING)
       "test_msgs"
     )
     target_link_libraries(test_qos_event
-      ${PROJECT_NAME}
+      ${PROJECT_NAME}_library
     )
   endif()
   ament_add_gtest(test_rate test/test_rate.cpp)
@@ -435,7 +437,7 @@ if(BUILD_TESTING)
       "rosidl_typesupport_cpp"
     )
     target_link_libraries(test_rate
-      ${PROJECT_NAME}
+      ${PROJECT_NAME}_library
     )
   endif()
   ament_add_gtest(test_serialized_message_allocator test/test_serialized_message_allocator.cpp)
@@ -444,7 +446,7 @@ if(BUILD_TESTING)
       test_msgs
     )
     target_link_libraries(test_serialized_message_allocator
-      ${PROJECT_NAME}
+      ${PROJECT_NAME}_library
     )
   endif()
   ament_add_gtest(test_serialized_message test/test_serialized_message.cpp)
@@ -453,7 +455,7 @@ if(BUILD_TESTING)
       test_msgs
     )
     target_link_libraries(test_serialized_message
-      ${PROJECT_NAME}
+      ${PROJECT_NAME}_library
     )
   endif()
   ament_add_gtest(test_service test/test_service.cpp)
@@ -464,7 +466,7 @@ if(BUILD_TESTING)
       "rosidl_runtime_cpp"
       "rosidl_typesupport_cpp"
     )
-    target_link_libraries(test_service ${PROJECT_NAME})
+    target_link_libraries(test_service ${PROJECT_NAME}_library)
   endif()
   ament_add_gtest(test_subscription test/test_subscription.cpp)
   if(TARGET test_subscription)
@@ -475,7 +477,7 @@ if(BUILD_TESTING)
       "rosidl_typesupport_cpp"
       "test_msgs"
     )
-    target_link_libraries(test_subscription ${PROJECT_NAME})
+    target_link_libraries(test_subscription ${PROJECT_NAME}_library)
   endif()
   ament_add_gtest(test_subscription_publisher_count_api test/test_subscription_publisher_count_api.cpp)
   if(TARGET test_subscription_publisher_count_api)
@@ -486,7 +488,7 @@ if(BUILD_TESTING)
       "rosidl_typesupport_cpp"
       "test_msgs"
     )
-    target_link_libraries(test_subscription_publisher_count_api ${PROJECT_NAME})
+    target_link_libraries(test_subscription_publisher_count_api ${PROJECT_NAME}_library)
   endif()
   ament_add_gtest(test_subscription_traits test/test_subscription_traits.cpp)
   if(TARGET test_subscription_traits)
@@ -494,14 +496,14 @@ if(BUILD_TESTING)
       "rcl"
       "test_msgs"
     )
-    target_link_libraries(test_subscription_traits ${PROJECT_NAME})
+    target_link_libraries(test_subscription_traits ${PROJECT_NAME}_library)
   endif()
   ament_add_gtest(test_find_weak_nodes test/test_find_weak_nodes.cpp)
   if(TARGET test_find_weak_nodes)
     ament_target_dependencies(test_find_weak_nodes
       "rcl"
     )
-    target_link_libraries(test_find_weak_nodes ${PROJECT_NAME})
+    target_link_libraries(test_find_weak_nodes ${PROJECT_NAME}_library)
   endif()
 
   set(append_library_dirs "${CMAKE_CURRENT_BINARY_DIR}")
@@ -514,14 +516,14 @@ if(BUILD_TESTING)
     "rcl"
     "test_msgs"
   )
-  target_link_libraries(test_externally_defined_services ${PROJECT_NAME})
+  target_link_libraries(test_externally_defined_services ${PROJECT_NAME}_library)
 
   ament_add_gtest(test_duration test/test_duration.cpp
     APPEND_LIBRARY_DIRS "${append_library_dirs}")
   if(TARGET test_duration)
     ament_target_dependencies(test_duration
       "rcl")
-    target_link_libraries(test_duration ${PROJECT_NAME})
+    target_link_libraries(test_duration ${PROJECT_NAME}_library)
   endif()
 
   ament_add_gtest(test_executor test/test_executor.cpp
@@ -529,21 +531,21 @@ if(BUILD_TESTING)
   if(TARGET test_executor)
     ament_target_dependencies(test_executor
       "rcl")
-    target_link_libraries(test_executor ${PROJECT_NAME})
+    target_link_libraries(test_executor ${PROJECT_NAME}_library)
   endif()
 
   ament_add_gtest(test_logger test/test_logger.cpp)
-  target_link_libraries(test_logger ${PROJECT_NAME})
+  target_link_libraries(test_logger ${PROJECT_NAME}_library)
 
   ament_add_gmock(test_logging test/test_logging.cpp)
-  target_link_libraries(test_logging ${PROJECT_NAME})
+  target_link_libraries(test_logging ${PROJECT_NAME}_library)
 
   ament_add_gtest(test_time test/test_time.cpp
     APPEND_LIBRARY_DIRS "${append_library_dirs}")
   if(TARGET test_time)
     ament_target_dependencies(test_time
       "rcl")
-    target_link_libraries(test_time ${PROJECT_NAME})
+    target_link_libraries(test_time ${PROJECT_NAME}_library)
   endif()
 
   ament_add_gtest(test_timer test/test_timer.cpp
@@ -551,7 +553,7 @@ if(BUILD_TESTING)
   if(TARGET test_timer)
     ament_target_dependencies(test_timer
       "rcl")
-    target_link_libraries(test_timer ${PROJECT_NAME})
+    target_link_libraries(test_timer ${PROJECT_NAME}_library)
   endif()
 
   ament_add_gtest(test_time_source test/test_time_source.cpp
@@ -559,7 +561,7 @@ if(BUILD_TESTING)
   if(TARGET test_time_source)
     ament_target_dependencies(test_time_source
       "rcl")
-    target_link_libraries(test_time_source ${PROJECT_NAME})
+    target_link_libraries(test_time_source ${PROJECT_NAME}_library)
   endif()
 
   ament_add_gtest(test_utilities test/test_utilities.cpp
@@ -567,7 +569,7 @@ if(BUILD_TESTING)
   if(TARGET test_utilities)
     ament_target_dependencies(test_utilities
       "rcl")
-    target_link_libraries(test_utilities ${PROJECT_NAME})
+    target_link_libraries(test_utilities ${PROJECT_NAME}_library)
   endif()
 
   ament_add_gtest(test_init test/test_init.cpp
@@ -575,7 +577,7 @@ if(BUILD_TESTING)
   if(TARGET test_init)
     ament_target_dependencies(test_init
       "rcl")
-    target_link_libraries(test_init ${PROJECT_NAME})
+    target_link_libraries(test_init ${PROJECT_NAME}_library)
   endif()
 
   ament_add_gtest(test_interface_traits test/test_interface_traits.cpp
@@ -583,7 +585,7 @@ if(BUILD_TESTING)
   if(TARGET test_interface_traits)
     ament_target_dependencies(test_interface_traits
       "rcl")
-    target_link_libraries(test_interface_traits ${PROJECT_NAME})
+    target_link_libraries(test_interface_traits ${PROJECT_NAME}_library)
   endif()
 
   ament_add_gtest(test_multi_threaded_executor test/executors/test_multi_threaded_executor.cpp
@@ -591,20 +593,20 @@ if(BUILD_TESTING)
   if(TARGET test_multi_threaded_executor)
     ament_target_dependencies(test_multi_threaded_executor
       "rcl")
-    target_link_libraries(test_multi_threaded_executor ${PROJECT_NAME})
+    target_link_libraries(test_multi_threaded_executor ${PROJECT_NAME}_library)
   endif()
 
   ament_add_gtest(test_guard_condition test/test_guard_condition.cpp
     APPEND_LIBRARY_DIRS "${append_library_dirs}")
   if(TARGET test_guard_condition)
-    target_link_libraries(test_guard_condition ${PROJECT_NAME})
+    target_link_libraries(test_guard_condition ${PROJECT_NAME}_library)
   endif()
 
   ament_add_gtest(test_wait_set test/test_wait_set.cpp
     APPEND_LIBRARY_DIRS "${append_library_dirs}")
   if(TARGET test_wait_set)
     ament_target_dependencies(test_wait_set "test_msgs")
-    target_link_libraries(test_wait_set ${PROJECT_NAME})
+    target_link_libraries(test_wait_set ${PROJECT_NAME}_library)
   endif()
 
   ament_add_gtest(test_subscription_topic_statistics test/topic_statistics/test_subscription_topic_statistics.cpp)
@@ -618,13 +620,13 @@ if(BUILD_TESTING)
       "rosidl_typesupport_cpp"
       "statistics_msgs"
       "test_msgs")
-    target_link_libraries(test_subscription_topic_statistics ${PROJECT_NAME})
+    target_link_libraries(test_subscription_topic_statistics ${PROJECT_NAME}_library)
   endif()
 
   ament_add_gtest(test_subscription_options test/test_subscription_options.cpp)
   if(TARGET test_subscription_options)
     ament_target_dependencies(test_subscription_options "rcl")
-    target_link_libraries(test_subscription_options ${PROJECT_NAME})
+    target_link_libraries(test_subscription_options ${PROJECT_NAME}_library)
   endif()
 
   # Install test resources


### PR DESCRIPTION
This is a workaround so that interfaces generated in rclcpp can use a target name
matching the project name.

Unblocks https://github.com/ros2/rclcpp/pull/1080

@dirk-thomas FYI