### PR TITLE
Add serialized_message.hpp header

### DIFF
--- a/rclcpp/include/rclcpp/message_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/message_memory_strategy.hpp
@@ -23,6 +23,7 @@
 #include "rclcpp/allocator/allocator_common.hpp"
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/macros.hpp"
+#include "rclcpp/serialized_message.hpp"
 #include "rclcpp/visibility_control.hpp"
 
 #include "rcutils/logging_macros.h"


### PR DESCRIPTION
Compiling theora_image_transport resulted in a compile error where SerializedMessage was not a member of rclcpp.

```
from /home/brawner/workspace/ros2_ws/src/ros-perception/image_transport_plugins/theora_image_transport/src/theora_subscriber.cpp:35:
/home/brawner/workspace/ros2_master/install/rclcpp/include/rclcpp/message_memory_strategy.hpp:49:71: error: ‘SerializedMessage’ is not a member of ‘rclcpp’
   using SerializedMessageAllocTraits = allocator::AllocRebind<rclcpp::SerializedMessage, Alloc>;
```
Signed-off-by: Stephen Brawner <brawner@gmail.com>