### PR TITLE
Serialized message move constructor

### DIFF
--- a/rclcpp/src/rclcpp/serialization.cpp
+++ b/rclcpp/src/rclcpp/serialization.cpp
@@ -55,8 +55,11 @@ void SerializationBase::deserialize_message(
   rcpputils::check_true(nullptr != type_support_, "Typesupport is nullpointer.");
   rcpputils::check_true(nullptr != serialized_message, "Serialized message is nullpointer.");
   rcpputils::check_true(
-    0 != serialized_message->capacity() && 0 != serialized_message->size(),
-    "Serialized message is wrongly initialized.");
+    0u != serialized_message->capacity(),
+    "Wrongly initialized. Serializaed message has a capacity of zero.");
+  rcpputils::check_true(
+    0u != serialized_message->size(),
+    "Wrongly initialized. Serialized message has a size of zero.");
   rcpputils::check_true(nullptr != ros_message, "ROS message is a nullpointer.");
 
   const auto ret = rmw_deserialize(

--- a/rclcpp/src/rclcpp/serialization.cpp
+++ b/rclcpp/src/rclcpp/serialization.cpp
@@ -56,7 +56,7 @@ void SerializationBase::deserialize_message(
   rcpputils::check_true(nullptr != serialized_message, "Serialized message is nullpointer.");
   rcpputils::check_true(
     0u != serialized_message->capacity(),
-    "Wrongly initialized. Serializaed message has a capacity of zero.");
+    "Wrongly initialized. Serialized message has a capacity of zero.");
   rcpputils::check_true(
     0u != serialized_message->size(),
     "Wrongly initialized. Serialized message has a size of zero.");

--- a/rclcpp/src/rclcpp/serialized_message.cpp
+++ b/rclcpp/src/rclcpp/serialized_message.cpp
@@ -66,7 +66,7 @@ SerializedMessage::SerializedMessage(const rcl_serialized_message_t & other)
 }
 
 SerializedMessage::SerializedMessage(SerializedMessage && other)
-: SerializedMessage(other.serialized_message_)
+: SerializedMessage(static_cast<rcl_serialized_message_t &&>(other.serialized_message_))
 {
   other.serialized_message_ = rmw_get_zero_initialized_serialized_message();
 }

--- a/rclcpp/src/rclcpp/serialized_message.cpp
+++ b/rclcpp/src/rclcpp/serialized_message.cpp
@@ -66,50 +66,51 @@ SerializedMessage::SerializedMessage(const rcl_serialized_message_t & other)
 }
 
 SerializedMessage::SerializedMessage(SerializedMessage && other)
-: SerializedMessage(static_cast<rcl_serialized_message_t &&>(other.serialized_message_))
-{
-  other.serialized_message_ = rmw_get_zero_initialized_serialized_message();
-}
+: serialized_message_(
+    std::exchange(other.serialized_message_, rmw_get_zero_initialized_serialized_message()))
+{}
 
 SerializedMessage::SerializedMessage(rcl_serialized_message_t && other)
-: serialized_message_(other)
-{
-  // reset buffer to prevent double free
-  other = rmw_get_zero_initialized_serialized_message();
-}
+: serialized_message_(
+    std::exchange(other, rmw_get_zero_initialized_serialized_message()))
+{}
 
 SerializedMessage & SerializedMessage::operator=(const SerializedMessage & other)
 {
-  serialized_message_ = rmw_get_zero_initialized_serialized_message();
-  copy_rcl_message(other.serialized_message_, serialized_message_);
+  if (this != &other) {
+    serialized_message_ = rmw_get_zero_initialized_serialized_message();
+    copy_rcl_message(other.serialized_message_, serialized_message_);
+  }
 
   return *this;
 }
 
 SerializedMessage & SerializedMessage::operator=(const rcl_serialized_message_t & other)
 {
-  serialized_message_ = rmw_get_zero_initialized_serialized_message();
-  copy_rcl_message(other, serialized_message_);
+  if (&serialized_message_ != &other) {
+    serialized_message_ = rmw_get_zero_initialized_serialized_message();
+    copy_rcl_message(other, serialized_message_);
+  }
 
   return *this;
 }
 
 SerializedMessage & SerializedMessage::operator=(SerializedMessage && other)
 {
-  *this = other.serialized_message_;
-  other.serialized_message_ = rmw_get_zero_initialized_serialized_message();
+  if (this != &other) {
+    serialized_message_ =
+      std::exchange(other.serialized_message_, rmw_get_zero_initialized_serialized_message());
+  }
 
   return *this;
 }
 
 SerializedMessage & SerializedMessage::operator=(rcl_serialized_message_t && other)
 {
-  serialized_message_ = rmw_get_zero_initialized_serialized_message();
-  serialized_message_ = other;
-
-  // reset original to prevent double free
-  other = rmw_get_zero_initialized_serialized_message();
-
+  if (&serialized_message_ != &other) {
+    serialized_message_ =
+      std::exchange(other, rmw_get_zero_initialized_serialized_message());
+  }
   return *this;
 }
 

--- a/rclcpp/test/test_serialized_message.cpp
+++ b/rclcpp/test/test_serialized_message.cpp
@@ -52,6 +52,7 @@ TEST(TestSerializedMessage, various_constructors) {
   rcl_handle.buffer_length = content_size;
   EXPECT_STREQ(content.c_str(), reinterpret_cast<char *>(rcl_handle.buffer));
   EXPECT_EQ(content_size, serialized_message.capacity());
+  EXPECT_EQ(content_size, serialized_message.size());
 
   // Copy Constructor
   rclcpp::SerializedMessage other_serialized_message(serialized_message);

--- a/rclcpp/test/test_serialized_message.cpp
+++ b/rclcpp/test/test_serialized_message.cpp
@@ -159,9 +159,9 @@ TEST(TestSerializedMessage, serialization) {
   }
 }
 
-template<typename MessageT>
-void test_empty_msg_serialize()
+void serialize_default_ros_msg()
 {
+  using MessageT = test_msgs::msg::BasicTypes;
   rclcpp::Serialization<MessageT> serializer;
   MessageT ros_msg;
   rclcpp::SerializedMessage serialized_msg;
@@ -169,12 +169,40 @@ void test_empty_msg_serialize()
   serializer.serialize_message(&ros_msg, &serialized_msg);
 }
 
-template<typename MessageT>
-void test_empty_msg_deserialize()
+void serialize_default_ros_msg_into_nullptr()
 {
+  using MessageT = test_msgs::msg::BasicTypes;
+  rclcpp::Serialization<MessageT> serializer;
+  MessageT ros_msg;
+
+  serializer.serialize_message(&ros_msg, nullptr);
+}
+
+void deserialize_default_serialized_message()
+{
+  using MessageT = test_msgs::msg::BasicTypes;
   rclcpp::Serialization<MessageT> serializer;
   MessageT ros_msg;
   rclcpp::SerializedMessage serialized_msg;
 
   serializer.deserialize_message(&serialized_msg, &ros_msg);
+}
+
+void deserialize_nullptr()
+{
+  using MessageT = test_msgs::msg::BasicTypes;
+  rclcpp::Serialization<MessageT> serializer;
+  MessageT ros_msg;
+  rclcpp::SerializedMessage serialized_msg;
+
+  serializer.deserialize_message(&serialized_msg, &ros_msg);
+}
+
+TEST(TestSerializedMessage, serialization_empty_messages)
+{
+  EXPECT_NO_THROW(serialize_default_ros_msg());
+  EXPECT_THROW(serialize_default_ros_msg_into_nullptr(), rcpputils::IllegalStateException);
+  EXPECT_THROW(serialize_default_ros_msg_into_nullptr(), rcpputils::IllegalStateException);
+  EXPECT_THROW(deserialize_default_serialized_message(), rcpputils::IllegalStateException);
+  EXPECT_THROW(deserialize_nullptr(), rcpputils::IllegalStateException);
 }


### PR DESCRIPTION
Aims at resolving test failures reported in here: https://ci.ros2.org/job/nightly_win_rel/1533/
Namely, `test_communication.TestMessageSerialization.serialized_callback`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10541)](http://ci.ros2.org/job/ci_linux/10541/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5997)](http://ci.ros2.org/job/ci_linux-aarch64/5997/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8587)](http://ci.ros2.org/job/ci_osx/8587/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10414)](http://ci.ros2.org/job/ci_windows/10414/)

It's a bit of a search in the dark as I can't reproduce the test failures locally (tried on OSX as well as Ubuntu 18.04). However, I could see some memory loss with the help of `valgrind`.