### PR TITLE
rmw_publisher_options should be initialized

### DIFF
--- a/rclcpp/include/rclcpp/publisher_options.hpp
+++ b/rclcpp/include/rclcpp/publisher_options.hpp
@@ -71,7 +71,7 @@ struct PublisherOptionsWithAllocator : public PublisherOptionsBase
   rcl_publisher_options_t
   to_rcl_publisher_options(const rclcpp::QoS & qos) const
   {
-    rcl_publisher_options_t result;
+    rcl_publisher_options_t result = rcl_publisher_get_default_options();
     using AllocatorTraits = std::allocator_traits<Allocator>;
     using MessageAllocatorT = typename AllocatorTraits::template rebind_alloc<MessageT>;
     auto message_alloc = std::make_shared<MessageAllocatorT>(*this->get_allocator().get());


### PR DESCRIPTION
In function `to_rcl_publisher_options`, the member `rmw_publisher_options` of `rcl_publisher_options_t result` is not initialized to default. This will cause the problem for rmw layer to parse `rmw_specific_publisher_payload`, because I don't know whether the payload is available or not.