### PR TITLE
avoid callback_group deprecation

### DIFF
--- a/rclcpp_lifecycle/test/test_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_node.cpp
@@ -536,7 +536,7 @@ TEST_F(TestDefaultStateMachine, test_callback_groups) {
   EXPECT_EQ(groups.size(), 1u);
 
   auto group = test_node->create_callback_group(
-    rclcpp::callback_group::CallbackGroupType::MutuallyExclusive);
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   EXPECT_NE(nullptr, group);
 
   groups = test_node->get_callback_groups();


### PR DESCRIPTION
I got a deprecation warning when building on OSX.