### PR TITLE
Make sure to include what you use.

### DIFF
--- a/rclcpp/src/rclcpp/publisher_base.cpp
+++ b/rclcpp/src/rclcpp/publisher_base.cpp
@@ -35,6 +35,7 @@
 #include "rclcpp/logging.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/node.hpp"
+#include "rclcpp/qos_event.hpp"
 
 using rclcpp::PublisherBase;
 
@@ -246,7 +247,8 @@ PublisherBase::setup_intra_process(
 }
 
 void
-PublisherBase::default_incompatible_qos_callback(QOSOfferedIncompatibleQoSInfo & event) const
+PublisherBase::default_incompatible_qos_callback(
+  rclcpp::QOSOfferedIncompatibleQoSInfo & event) const
 {
   std::string policy_name = qos_policy_name_from_kind(event.last_policy_kind);
   RCLCPP_WARN(

--- a/rclcpp/src/rclcpp/subscription_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_base.cpp
@@ -24,6 +24,7 @@
 #include "rclcpp/experimental/intra_process_manager.hpp"
 #include "rclcpp/logging.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
+#include "rclcpp/qos_event.hpp"
 
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"
@@ -238,7 +239,8 @@ SubscriptionBase::get_intra_process_waitable() const
 }
 
 void
-SubscriptionBase::default_incompatible_qos_callback(QOSRequestedIncompatibleQoSInfo & event) const
+SubscriptionBase::default_incompatible_qos_callback(
+  rclcpp::QOSRequestedIncompatibleQoSInfo & event) const
 {
   std::string policy_name = qos_policy_name_from_kind(event.last_policy_kind);
   RCLCPP_WARN(


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

It won't build for me on Windows without this.  I'm not sure why my Windows VM is different than CI in this instance, but in any case this is the more correct thing to do.