### PR TITLE
Extend the lifetime of rcl_publisher_t by holding onto the shared pointer.

### DIFF
--- a/rclcpp/include/rclcpp/loaned_message.hpp
+++ b/rclcpp/include/rclcpp/loaned_message.hpp
@@ -65,7 +65,7 @@ public:
     if (pub_.can_loan_messages()) {
       void * message_ptr = nullptr;
       auto ret = rcl_borrow_loaned_message(
-        pub_.get_publisher_handle(),
+        pub_.get_publisher_handle().get(),
         rosidl_typesupport_cpp::get_message_type_support_handle<MessageT>(),
         &message_ptr);
       if (RCL_RET_OK != ret) {
@@ -137,7 +137,7 @@ public:
     if (pub_.can_loan_messages()) {
       // return allocated memory to the middleware
       auto ret =
-        rcl_return_loaned_message_from_publisher(pub_.get_publisher_handle(), message_);
+        rcl_return_loaned_message_from_publisher(pub_.get_publisher_handle().get(), message_);
       if (ret != RCL_RET_OK) {
         RCLCPP_ERROR(
           error_logger, "rcl_deallocate_loaned_message failed: %s", rcl_get_error_string().str);

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -279,12 +279,12 @@ protected:
   void
   do_inter_process_publish(const MessageT & msg)
   {
-    auto status = rcl_publish(&publisher_handle_, &msg, nullptr);
+    auto status = rcl_publish(publisher_handle_.get(), &msg, nullptr);
 
     if (RCL_RET_PUBLISHER_INVALID == status) {
       rcl_reset_error();  // next call will reset error message if not context
-      if (rcl_publisher_is_valid_except_context(&publisher_handle_)) {
-        rcl_context_t * context = rcl_publisher_get_context(&publisher_handle_);
+      if (rcl_publisher_is_valid_except_context(publisher_handle_.get())) {
+        rcl_context_t * context = rcl_publisher_get_context(publisher_handle_.get());
         if (nullptr != context && !rcl_context_is_valid(context)) {
           // publisher is invalid due to context being shutdown
           return;
@@ -303,7 +303,7 @@ protected:
       // TODO(Karsten1987): support serialized message passed by intraprocess
       throw std::runtime_error("storing serialized messages in intra process is not supported yet");
     }
-    auto status = rcl_publish_serialized_message(&publisher_handle_, serialized_msg, nullptr);
+    auto status = rcl_publish_serialized_message(publisher_handle_.get(), serialized_msg, nullptr);
     if (RCL_RET_OK != status) {
       rclcpp::exceptions::throw_from_rcl_error(status, "failed to publish serialized message");
     }
@@ -312,12 +312,12 @@ protected:
   void
   do_loaned_message_publish(MessageT * msg)
   {
-    auto status = rcl_publish_loaned_message(&publisher_handle_, msg, nullptr);
+    auto status = rcl_publish_loaned_message(publisher_handle_.get(), msg, nullptr);
 
     if (RCL_RET_PUBLISHER_INVALID == status) {
       rcl_reset_error();  // next call will reset error message if not context
-      if (rcl_publisher_is_valid_except_context(&publisher_handle_)) {
-        rcl_context_t * context = rcl_publisher_get_context(&publisher_handle_);
+      if (rcl_publisher_is_valid_except_context(publisher_handle_.get())) {
+        rcl_context_t * context = rcl_publisher_get_context(publisher_handle_.get());
         if (nullptr != context && !rcl_context_is_valid(context)) {
           // publisher is invalid due to context being shutdown
           return;

--- a/rclcpp/include/rclcpp/publisher_base.hpp
+++ b/rclcpp/include/rclcpp/publisher_base.hpp
@@ -200,10 +200,11 @@ protected:
     const EventCallbackT & callback,
     const rcl_publisher_event_type_t event_type)
   {
-    auto handler = std::make_shared<QOSEventHandler<EventCallbackT>>(
+    auto handler = std::make_shared<QOSEventHandler<EventCallbackT,
+        std::shared_ptr<rcl_publisher_t>>>(
       callback,
       rcl_publisher_event_init,
-      publisher_handle_.get(),
+      publisher_handle_,
       event_type);
     event_handlers_.emplace_back(handler);
   }

--- a/rclcpp/include/rclcpp/publisher_base.hpp
+++ b/rclcpp/include/rclcpp/publisher_base.hpp
@@ -99,13 +99,13 @@ public:
   /// Get the rcl publisher handle.
   /** \return The rcl publisher handle. */
   RCLCPP_PUBLIC
-  rcl_publisher_t *
+  std::shared_ptr<rcl_publisher_t>
   get_publisher_handle();
 
   /// Get the rcl publisher handle.
   /** \return The rcl publisher handle. */
   RCLCPP_PUBLIC
-  const rcl_publisher_t *
+  std::shared_ptr<const rcl_publisher_t>
   get_publisher_handle() const;
 
   /// Get all the QoS event handlers associated with this publisher.
@@ -203,7 +203,7 @@ protected:
     auto handler = std::make_shared<QOSEventHandler<EventCallbackT>>(
       callback,
       rcl_publisher_event_init,
-      &publisher_handle_,
+      publisher_handle_.get(),
       event_type);
     event_handlers_.emplace_back(handler);
   }
@@ -213,7 +213,7 @@ protected:
 
   std::shared_ptr<rcl_node_t> rcl_node_handle_;
 
-  rcl_publisher_t publisher_handle_ = rcl_get_zero_initialized_publisher();
+  std::shared_ptr<rcl_publisher_t> publisher_handle_;
 
   std::vector<std::shared_ptr<rclcpp::QOSEventHandlerBase>> event_handlers_;
 

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -102,11 +102,11 @@ protected:
   size_t wait_set_event_index_;
 };
 
-template<typename EventCallbackT>
+template<typename EventCallbackT, typename ParentHandleT>
 class QOSEventHandler : public QOSEventHandlerBase
 {
 public:
-  template<typename InitFuncT, typename ParentHandleT, typename EventTypeEnum>
+  template<typename InitFuncT, typename EventTypeEnum>
   QOSEventHandler(
     const EventCallbackT & callback,
     InitFuncT init_func,
@@ -114,8 +114,9 @@ public:
     EventTypeEnum event_type)
   : event_callback_(callback)
   {
+    parent_handle_ = parent_handle;
     event_handle_ = rcl_get_zero_initialized_event();
-    rcl_ret_t ret = init_func(&event_handle_, parent_handle, event_type);
+    rcl_ret_t ret = init_func(&event_handle_, parent_handle.get(), event_type);
     if (ret != RCL_RET_OK) {
       if (ret == RCL_RET_UNSUPPORTED) {
         UnsupportedEventTypeException exc(ret, rcl_get_error_state(), "Failed to initialize event");
@@ -148,6 +149,7 @@ private:
   using EventCallbackInfoT = typename std::remove_reference<typename
       rclcpp::function_traits::function_traits<EventCallbackT>::template argument_type<0>>::type;
 
+  ParentHandleT parent_handle_;
   EventCallbackT event_callback_;
 };
 

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -261,10 +261,11 @@ protected:
     const EventCallbackT & callback,
     const rcl_subscription_event_type_t event_type)
   {
-    auto handler = std::make_shared<QOSEventHandler<EventCallbackT>>(
+    auto handler = std::make_shared<QOSEventHandler<EventCallbackT,
+        std::shared_ptr<rcl_subscription_t>>>(
       callback,
       rcl_subscription_event_init,
-      get_subscription_handle().get(),
+      get_subscription_handle(),
       event_type);
     qos_events_in_use_by_wait_set_.insert(std::make_pair(handler.get(), false));
     event_handlers_.emplace_back(handler);

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -30,6 +30,9 @@ class Waitable
 public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(Waitable)
 
+  RCLCPP_PUBLIC
+  virtual ~Waitable() = default;
+
   /// Get the number of ready subscriptions
   /**
    * Returns a value of 0 by default.


### PR DESCRIPTION
This PR aims to fix a crash that can be seen while using the code in https://github.com/clalancette/rclcpp_event_crash.   That code creates a node, then creates a thread to create publishers in the thread.  The default executor is then run in the main thread.  If you build that code against latest master, put a lot of CPU stress on the machine, and run that code using Connext, it will crash almost every time.

After some debugging, some advice from @wjwwood and @ivanpauno below, we determined that the problem is that the publisher handle (`rcl_publisher_t`, via `PublisherBase` class) could be freed while the executor was still working on QOSEvent handles.  The fix here is to hold onto a shared pointer to the underlying `rcl_{publisher,subscription}_t` structure in QOSEvent, which keeps those structures around until the executor is done with them.

The downside to this change is that it changes the API of `rclcpp`, making `get_publisher_handle` return a shared_ptr rather than a raw pointer.  This also requires https://github.com/ros2/demos/pull/448 and https://github.com/ros2/rosbag2/pull/420 to compile successfully.