### PR TITLE
[rclcpp_action] Action client holds weak pointers to goal handles

### DIFF
--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -331,7 +331,9 @@ public:
    * If the goal is accepted by an action server, the returned future is set to a `ClientGoalHandle`.
    * If the goal is rejected by an action server, then the future is set to a `nullptr`.
    *
-   * The goal handle is used to monitor the status of the goal and get the final result.
+   * The returned goal handle is used to monitor the status of the goal and get the final result.
+   * It is valid as long as you hold a reference to the shared pointer or until the
+   * rclcpp_action::Client is destroyed at which point the goal status will become UNKNOWN.
    *
    * \param[in] goal The goal request.
    * \param[in] options Options for sending the goal request. Contains references to callbacks for

--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -387,6 +387,8 @@ public:
         }
       });
 
+    // TODO(jacobperron): Encapsulate into it's own function and
+    //                    consider exposing an option to disable this cleanup
     // To prevent the list from growing out of control, forget about any goals
     // with no more user references
     {

--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -396,6 +396,9 @@ public:
       auto goal_handle_it = goal_handles_.begin();
       while (goal_handle_it != goal_handles_.end()) {
         if (!goal_handle_it->second.lock()) {
+          RCLCPP_DEBUG(
+            this->get_logger(),
+            "Dropping weak reference to goal handle during send_goal()");
           goal_handle_it = goal_handles_.erase(goal_handle_it);
         } else {
           ++goal_handle_it;
@@ -569,6 +572,9 @@ private:
     typename GoalHandle::SharedPtr goal_handle = goal_handles_[goal_id].lock();
     // Forget about the goal if there are no more user references
     if (!goal_handle) {
+      RCLCPP_DEBUG(
+        this->get_logger(),
+        "Dropping weak reference to goal handle during feedback callback");
       goal_handles_.erase(goal_id);
       return;
     }
@@ -603,6 +609,9 @@ private:
       typename GoalHandle::SharedPtr goal_handle = goal_handles_[goal_id].lock();
       // Forget about the goal if there are no more user references
       if (!goal_handle) {
+        RCLCPP_DEBUG(
+          this->get_logger(),
+          "Dropping weak reference to goal handle during status callback");
         goal_handles_.erase(goal_id);
         continue;
       }


### PR DESCRIPTION
Fixes #861

It is against the design of ROS actions to rely on the status topic for the core implementation,
instead it should just be used for introspection.

Rather than relying on the status topic to remove references to goal handles, the action client
instead holds weak pointers to the goal handles. This way, as long as a user holds a reference to
the goal handle they can use it to interact with the action client.

~~Draft PR for now as I try to determine if this actually fixes the issue (hopefully with a reliable reproduction of the bug).~~

For a reproduction, see https://github.com/ros2/rclcpp/issues/861#issuecomment-631762189