### PR TITLE
Deprecate set_on_parameters_set_callback

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -277,7 +277,7 @@ public:
    * If `ignore_override` is `true`, the parameter override will be ignored.
    *
    * This method, if successful, will result in any callback registered with
-   * set_on_parameters_set_callback to be called.
+   * add_on_set_parameters_callback to be called.
    * If that callback prevents the initial value for the parameter from being
    * set then rclcpp::exceptions::InvalidParameterValueException is thrown.
    *
@@ -359,7 +359,7 @@ public:
    * by the function call will be ignored.
    *
    * This method, if successful, will result in any callback registered with
-   * set_on_parameters_set_callback to be called, once for each parameter.
+   * add_on_set_parameters_callback to be called, once for each parameter.
    * If that callback prevents the initial value for any parameter from being
    * set then rclcpp::exceptions::InvalidParameterValueException is thrown.
    *
@@ -401,7 +401,7 @@ public:
   /// Undeclare a previously declared parameter.
   /**
    * This method will not cause a callback registered with
-   * set_on_parameters_set_callback to be called.
+   * add_on_set_parameters_callback to be called.
    *
    * \param[in] name The name of the parameter to be undeclared.
    * \throws rclcpp::exceptions::ParameterNotDeclaredException if the parameter
@@ -435,7 +435,7 @@ public:
    * Parameter overrides are ignored by set_parameter.
    *
    * This method will result in any callback registered with
-   * set_on_parameters_set_callback to be called.
+   * add_on_set_parameters_callback to be called.
    * If the callback prevents the parameter from being set, then it will be
    * reflected in the SetParametersResult that is returned, but no exception
    * will be thrown.
@@ -476,7 +476,7 @@ public:
    * corresponding SetParametersResult in the vector returned by this function.
    *
    * This method will result in any callback registered with
-   * set_on_parameters_set_callback to be called, once for each parameter.
+   * add_on_set_parameters_callback to be called, once for each parameter.
    * If the callback prevents the parameter from being set, then, as mentioned
    * before, it will be reflected in the corresponding SetParametersResult
    * that is returned, but no exception will be thrown.
@@ -507,7 +507,7 @@ public:
    * If the exception is thrown then none of the parameters will have been set.
    *
    * This method will result in any callback registered with
-   * set_on_parameters_set_callback to be called, just one time.
+   * add_on_set_parameters_callback to be called, just one time.
    * If the callback prevents the parameters from being set, then it will be
    * reflected in the SetParametersResult which is returned, but no exception
    * will be thrown.
@@ -787,7 +787,7 @@ public:
    * of the {get,list,describe}_parameter() methods), but may *not* modify
    * other parameters (by calling any of the {set,declare}_parameter() methods)
    * or modify the registered callback itself (by calling the
-   * set_on_parameters_set_callback() method).  If a callback tries to do any
+   * add_on_set_parameters_callback() method).  If a callback tries to do any
    * of the latter things,
    * rclcpp::exceptions::ParameterModifiedInCallbackException will be thrown.
    *

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -852,7 +852,7 @@ public:
    * \return The previous callback that was registered, if there was one,
    *   otherwise nullptr.
    */
-  [[deprecate("use add_on_set_parameters_callback(OnParametersSetCallbackType callback) instead")]]
+  [[deprecated("use add_on_set_parameters_callback(OnParametersSetCallbackType callback) instead")]]
   RCLCPP_PUBLIC
   OnParametersSetCallbackType
   set_on_parameters_set_callback(rclcpp::Node::OnParametersSetCallbackType callback);

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -839,6 +839,7 @@ public:
 
   /// Register a callback to be called anytime a parameter is about to be changed.
   /**
+   * \deprecated Use add_on_set_parameters_callback instead.
    * With this method, only one callback can be set at a time. The callback that was previously
    * set by this method is returned or `nullptr` if no callback was previously set.
    *
@@ -851,6 +852,7 @@ public:
    * \return The previous callback that was registered, if there was one,
    *   otherwise nullptr.
    */
+  [[deprecate("use add_on_set_parameters_callback(OnParametersSetCallbackType callback) instead")]]
   RCLCPP_PUBLIC
   OnParametersSetCallbackType
   set_on_parameters_set_callback(rclcpp::Node::OnParametersSetCallbackType callback);

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
@@ -167,6 +167,7 @@ public:
   void
   remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * const handler) override;
 
+  [[deprecate("use add_on_set_parameters_callback(OnParametersSetCallbackType callback) instead")]]
   RCLCPP_PUBLIC
   OnParametersSetCallbackType
   set_on_parameters_set_callback(OnParametersSetCallbackType callback) override;

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
@@ -167,7 +167,7 @@ public:
   void
   remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * const handler) override;
 
-  [[deprecate("use add_on_set_parameters_callback(OnParametersSetCallbackType callback) instead")]]
+  [[deprecated("use add_on_set_parameters_callback(OnParametersSetCallbackType callback) instead")]]
   RCLCPP_PUBLIC
   OnParametersSetCallbackType
   set_on_parameters_set_callback(OnParametersSetCallbackType callback) override;

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -193,8 +193,10 @@ public:
 
   /// Register a callback for when parameters are being set, return an existing one.
   /**
+   * \deprecated Use add_on_set_parameters_callback instead.
    * \sa rclcpp::Node::set_on_parameters_set_callback
    */
+  [[deprecate("use add_on_set_parameters_callback(OnParametersSetCallbackType callback) instead")]]
   RCLCPP_PUBLIC
   virtual
   OnParametersSetCallbackType

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -196,7 +196,7 @@ public:
    * \deprecated Use add_on_set_parameters_callback instead.
    * \sa rclcpp::Node::set_on_parameters_set_callback
    */
-  [[deprecate("use add_on_set_parameters_callback(OnParametersSetCallbackType callback) instead")]]
+  [[deprecated("use add_on_set_parameters_callback(OnParametersSetCallbackType callback) instead")]]
   RCLCPP_PUBLIC
   virtual
   OnParametersSetCallbackType

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -328,11 +328,27 @@ Node::remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * co
   return node_parameters_->remove_on_set_parameters_callback(callback);
 }
 
+// suppress deprecated function warning
+#if !defined(_WIN32)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else  // !defined(_WIN32)
+# pragma warning(push)
+# pragma warning(disable: 4996)
+#endif
+
 rclcpp::Node::OnParametersSetCallbackType
 Node::set_on_parameters_set_callback(rclcpp::Node::OnParametersSetCallbackType callback)
 {
   return node_parameters_->set_on_parameters_set_callback(callback);
 }
+
+// remove warning suppression
+#if !defined(_WIN32)
+# pragma GCC diagnostic pop
+#else  // !defined(_WIN32)
+# pragma warning(pop)
+#endif
 
 std::vector<std::string>
 Node::get_node_names() const

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -366,7 +366,7 @@ TEST_F(TestNode, declare_parameter_with_no_initial_values) {
         return result;
       };
     auto handler = node->add_on_set_parameters_callback(on_set_parameters);
-    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler);});   // always reset
+    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(*handler);});   // always reset
     EXPECT_THROW(
       {node->declare_parameter<std::string>(name, "not an int");},
       rclcpp::exceptions::InvalidParameterValueException);
@@ -565,7 +565,7 @@ TEST_F(TestNode, declare_parameter_with_overrides) {
         return result;
       };
     auto handler = node->add_on_set_parameters_callback(on_set_parameters);
-    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler);});    // always reset
+    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(*handler);});    // always reset
     EXPECT_THROW(
       {node->declare_parameter<int>(name, 43);},
       rclcpp::exceptions::InvalidParameterValueException);
@@ -676,7 +676,7 @@ TEST_F(TestNode, declare_parameters_with_no_initial_values) {
         return result;
       };
     auto handler = node->add_on_set_parameters_callback(on_set_parameters);
-    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler);});    // always reset
+    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(*handler);});    // always reset
     EXPECT_THROW(
       {node->declare_parameters<std::string>("", {{name, "not an int"}});},
       rclcpp::exceptions::InvalidParameterValueException);
@@ -864,7 +864,7 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     auto handler = node->add_on_set_parameters_callback(on_set_parameters);
 
     EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, 43)).successful);
-    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler);});    // always reset
+    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(*handler);});    // always reset
   }
   {
     // setting type of rclcpp::PARAMETER_NOT_SET, when already not set, does not undeclare
@@ -1376,7 +1376,7 @@ TEST_F(TestNode, set_parameters_undeclared_parameters_not_allowed) {
     EXPECT_EQ(node->get_parameter(name1).get_value<int>(), 2);
     EXPECT_EQ(node->get_parameter(name2).get_value<bool>(), true);  // old value
     EXPECT_EQ(node->get_parameter(name3).get_value<std::string>(), "red");
-    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler);});    // always reset
+    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(*handler);});    // always reset
   }
   {
     // setting type of rclcpp::PARAMETER_NOT_SET, when already not set, does not undeclare
@@ -1551,7 +1551,7 @@ TEST_F(TestNode, set_parameters_atomically_undeclared_parameters_not_allowed) {
     EXPECT_EQ(node->get_parameter(name1).get_value<int>(), 1);
     EXPECT_EQ(node->get_parameter(name2).get_value<bool>(), true);
     EXPECT_EQ(node->get_parameter(name3).get_value<std::string>(), "blue");
-    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler);});    // always reset
+    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(*handler);});    // always reset
   }
   {
     // setting type of rclcpp::PARAMETER_NOT_SET, when already not set, does not undeclare
@@ -1662,7 +1662,7 @@ TEST_F(TestNode, set_parameters_atomically_undeclared_parameters_allowed) {
     EXPECT_EQ(node->get_parameter(name1).get_value<int>(), 42);
     EXPECT_FALSE(node->has_parameter(name2));  // important! name2 remains undeclared
     EXPECT_EQ(node->get_parameter(name3).get_value<std::string>(), "test");
-    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler);});    // always reset
+    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(*handler);});    // always reset
   }
 }
 

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -2330,13 +2330,14 @@ TEST_F(TestNode, get_parameter_types_undeclared_parameters_allowed) {
 }
 
 // suppress deprecated function test warnings
-#if !defined(_WIN32) 
-# pragma GCC diagnostic push 
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations" 
-#else  // !defined(_WIN32) 
-# pragma warning(push) 
-# pragma warning(disable: 4996) 
+#if !defined(_WIN32)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else  // !defined(_WIN32)
+# pragma warning(push)
+# pragma warning(disable: 4996)
 #endif
+
 // test that it is possible to call get_parameter within the set_callback
 TEST_F(TestNode, set_on_parameters_set_callback_get_parameter) {
   auto node = std::make_shared<rclcpp::Node>("test_set_callback_get_parameter_node"_unq);
@@ -2520,11 +2521,12 @@ TEST_F(TestNode, set_on_parameters_set_callback_set_on_parameters_set_callback) 
     node->set_parameter(rclcpp::Parameter("intparam", 40));
   }, rclcpp::exceptions::ParameterModifiedInCallbackException);
 }
+
 // remove warning suppression
-#if !defined(_WIN32) 
-# pragma GCC diagnostic pop 
-#else  // !defined(_WIN32) 
-# pragma warning(pop) 
+#if !defined(_WIN32)
+# pragma GCC diagnostic pop
+#else  // !defined(_WIN32)
+# pragma warning(pop)
 #endif
 
 void expect_qos_profile_eq(

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -1527,7 +1527,6 @@ TEST_F(TestNode, set_parameters_atomically_undeclared_parameters_not_allowed) {
     node->declare_parameter(name2, true);
     node->declare_parameter<std::string>(name3, "blue");
 
-    RCLCPP_SCOPE_EXIT({node->set_on_parameters_set_callback(nullptr);});    // always reset
     auto on_set_parameters =
       [&name2](const std::vector<rclcpp::Parameter> & ps) {
         rcl_interfaces::msg::SetParametersResult result;
@@ -2330,6 +2329,14 @@ TEST_F(TestNode, get_parameter_types_undeclared_parameters_allowed) {
   }
 }
 
+// suppress deprecated function test warnings
+#if !defined(_WIN32) 
+# pragma GCC diagnostic push 
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations" 
+#else  // !defined(_WIN32) 
+# pragma warning(push) 
+# pragma warning(disable: 4996) 
+#endif
 // test that it is possible to call get_parameter within the set_callback
 TEST_F(TestNode, set_on_parameters_set_callback_get_parameter) {
   auto node = std::make_shared<rclcpp::Node>("test_set_callback_get_parameter_node"_unq);
@@ -2513,6 +2520,12 @@ TEST_F(TestNode, set_on_parameters_set_callback_set_on_parameters_set_callback) 
     node->set_parameter(rclcpp::Parameter("intparam", 40));
   }, rclcpp::exceptions::ParameterModifiedInCallbackException);
 }
+// remove warning suppression
+#if !defined(_WIN32) 
+# pragma GCC diagnostic pop 
+#else  // !defined(_WIN32) 
+# pragma warning(pop) 
+#endif
 
 void expect_qos_profile_eq(
   const rmw_qos_profile_t & qos1, const rmw_qos_profile_t & qos2, bool is_publisher)

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -862,9 +862,9 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
         return result;
       };
     auto handler = node->add_on_set_parameters_callback(on_set_parameters);
+    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler.get());});    // always reset
 
     EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, 43)).successful);
-    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler.get());});    // always reset
   }
   {
     // setting type of rclcpp::PARAMETER_NOT_SET, when already not set, does not undeclare
@@ -1361,6 +1361,7 @@ TEST_F(TestNode, set_parameters_undeclared_parameters_not_allowed) {
         return result;
       };
     auto handler = node->add_on_set_parameters_callback(on_set_parameters);
+    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler.get());});    // always reset
 
     auto rets = node->set_parameters(
     {
@@ -1376,7 +1377,6 @@ TEST_F(TestNode, set_parameters_undeclared_parameters_not_allowed) {
     EXPECT_EQ(node->get_parameter(name1).get_value<int>(), 2);
     EXPECT_EQ(node->get_parameter(name2).get_value<bool>(), true);  // old value
     EXPECT_EQ(node->get_parameter(name3).get_value<std::string>(), "red");
-    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler.get());});    // always reset
   }
   {
     // setting type of rclcpp::PARAMETER_NOT_SET, when already not set, does not undeclare
@@ -1538,6 +1538,7 @@ TEST_F(TestNode, set_parameters_atomically_undeclared_parameters_not_allowed) {
         return result;
       };
     auto handler = node->add_on_set_parameters_callback(on_set_parameters);
+    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler.get());});    // always reset
 
     auto ret = node->set_parameters_atomically(
     {
@@ -1550,7 +1551,6 @@ TEST_F(TestNode, set_parameters_atomically_undeclared_parameters_not_allowed) {
     EXPECT_EQ(node->get_parameter(name1).get_value<int>(), 1);
     EXPECT_EQ(node->get_parameter(name2).get_value<bool>(), true);
     EXPECT_EQ(node->get_parameter(name3).get_value<std::string>(), "blue");
-    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler.get());});    // always reset
   }
   {
     // setting type of rclcpp::PARAMETER_NOT_SET, when already not set, does not undeclare
@@ -1649,6 +1649,7 @@ TEST_F(TestNode, set_parameters_atomically_undeclared_parameters_allowed) {
         return result;
       };
     auto handler = node->add_on_set_parameters_callback(on_set_parameters);
+    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler.get());});    // always reset
 
     auto ret = node->set_parameters_atomically(
     {
@@ -1661,7 +1662,6 @@ TEST_F(TestNode, set_parameters_atomically_undeclared_parameters_allowed) {
     EXPECT_EQ(node->get_parameter(name1).get_value<int>(), 42);
     EXPECT_FALSE(node->has_parameter(name2));  // important! name2 remains undeclared
     EXPECT_EQ(node->get_parameter(name3).get_value<std::string>(), "test");
-    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler.get());});    // always reset
   }
 }
 

--- a/rclcpp/test/test_node.cpp
+++ b/rclcpp/test/test_node.cpp
@@ -366,7 +366,7 @@ TEST_F(TestNode, declare_parameter_with_no_initial_values) {
         return result;
       };
     auto handler = node->add_on_set_parameters_callback(on_set_parameters);
-    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(*handler);});   // always reset
+    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler.get());});   // always reset
     EXPECT_THROW(
       {node->declare_parameter<std::string>(name, "not an int");},
       rclcpp::exceptions::InvalidParameterValueException);
@@ -565,7 +565,7 @@ TEST_F(TestNode, declare_parameter_with_overrides) {
         return result;
       };
     auto handler = node->add_on_set_parameters_callback(on_set_parameters);
-    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(*handler);});    // always reset
+    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler.get());});    // always reset
     EXPECT_THROW(
       {node->declare_parameter<int>(name, 43);},
       rclcpp::exceptions::InvalidParameterValueException);
@@ -676,7 +676,7 @@ TEST_F(TestNode, declare_parameters_with_no_initial_values) {
         return result;
       };
     auto handler = node->add_on_set_parameters_callback(on_set_parameters);
-    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(*handler);});    // always reset
+    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler.get());});    // always reset
     EXPECT_THROW(
       {node->declare_parameters<std::string>("", {{name, "not an int"}});},
       rclcpp::exceptions::InvalidParameterValueException);
@@ -864,7 +864,7 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     auto handler = node->add_on_set_parameters_callback(on_set_parameters);
 
     EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, 43)).successful);
-    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(*handler);});    // always reset
+    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler.get());});    // always reset
   }
   {
     // setting type of rclcpp::PARAMETER_NOT_SET, when already not set, does not undeclare
@@ -1376,7 +1376,7 @@ TEST_F(TestNode, set_parameters_undeclared_parameters_not_allowed) {
     EXPECT_EQ(node->get_parameter(name1).get_value<int>(), 2);
     EXPECT_EQ(node->get_parameter(name2).get_value<bool>(), true);  // old value
     EXPECT_EQ(node->get_parameter(name3).get_value<std::string>(), "red");
-    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(*handler);});    // always reset
+    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler.get());});    // always reset
   }
   {
     // setting type of rclcpp::PARAMETER_NOT_SET, when already not set, does not undeclare
@@ -1551,7 +1551,7 @@ TEST_F(TestNode, set_parameters_atomically_undeclared_parameters_not_allowed) {
     EXPECT_EQ(node->get_parameter(name1).get_value<int>(), 1);
     EXPECT_EQ(node->get_parameter(name2).get_value<bool>(), true);
     EXPECT_EQ(node->get_parameter(name3).get_value<std::string>(), "blue");
-    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(*handler);});    // always reset
+    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler.get());});    // always reset
   }
   {
     // setting type of rclcpp::PARAMETER_NOT_SET, when already not set, does not undeclare
@@ -1662,7 +1662,7 @@ TEST_F(TestNode, set_parameters_atomically_undeclared_parameters_allowed) {
     EXPECT_EQ(node->get_parameter(name1).get_value<int>(), 42);
     EXPECT_FALSE(node->has_parameter(name2));  // important! name2 remains undeclared
     EXPECT_EQ(node->get_parameter(name3).get_value<std::string>(), "test");
-    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(*handler);});    // always reset
+    RCLCPP_SCOPE_EXIT({node->remove_on_set_parameters_callback(handler.get());});    // always reset
   }
 }
 

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -447,13 +447,33 @@ public:
   rcl_interfaces::msg::ListParametersResult
   list_parameters(const std::vector<std::string> & prefixes, uint64_t depth) const;
 
+  using OnSetParametersCallbackHandle =
+    rclcpp::node_interfaces::OnSetParametersCallbackHandle;
   using OnParametersSetCallbackType =
     rclcpp::node_interfaces::NodeParametersInterface::OnParametersSetCallbackType;
 
+  /// Add a callback for when parameters are being set.
+  /**
+   * \sa rclcpp::Node::add_on_set_parameters_callback
+   */
+  RCLCPP_LIFECYLE_PUBLIC
+  rclcpp_lifecycle::lifecycleNode::OnSetParametersCallbackHandle::SharedPtr
+  add_on_set_parameters_callback(OnParametersSetCallbackType callback);
+
+  /// Remove a callback registered with `add_on_set_parameters_callback`.
+  /**
+   * \sa rclcpp::Node::remove_on_set_parameters_callback
+   */
+  RCLCPP_LIFECYLE_PUBLIC
+  void
+  remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * const handler);
+
   /// Register a callback to be called anytime a parameter is about to be changed.
   /**
+   * \deprecated Use add_on_set_parameters_callback instead.
    * \sa rclcpp::Node::set_on_parameters_set_callback
    */
+  [[deprecate("use add_on_set_parameters_callback(OnParametersSetCallbackType callback) instead")]]
   RCLCPP_LIFECYCLE_PUBLIC
   rclcpp_lifecycle::LifecycleNode::OnParametersSetCallbackType
   set_on_parameters_set_callback(

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -456,7 +456,7 @@ public:
   /**
    * \sa rclcpp::Node::add_on_set_parameters_callback
    */
-  RCLCPP_LIFECYLE_PUBLIC
+  RCLCPP_LIFECYCLE_PUBLIC
   rclcpp_lifecycle::lifecycleNode::OnSetParametersCallbackHandle::SharedPtr
   add_on_set_parameters_callback(OnParametersSetCallbackType callback);
 
@@ -464,7 +464,7 @@ public:
   /**
    * \sa rclcpp::Node::remove_on_set_parameters_callback
    */
-  RCLCPP_LIFECYLE_PUBLIC
+  RCLCPP_LIFECYCLE_PUBLIC
   void
   remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * const handler);
 

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -455,7 +455,7 @@ public:
    * \deprecated Use add_on_set_parameters_callback instead.
    * \sa rclcpp::Node::set_on_parameters_set_callback
    */
-  [[deprecate("use add_on_set_parameters_callback(OnParametersSetCallbackType callback) instead")]]
+  [[deprecated("use add_on_set_parameters_callback(OnParametersSetCallbackType callback) instead")]]
   RCLCPP_LIFECYCLE_PUBLIC
   rclcpp_lifecycle::LifecycleNode::OnParametersSetCallbackType
   set_on_parameters_set_callback(

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -447,26 +447,8 @@ public:
   rcl_interfaces::msg::ListParametersResult
   list_parameters(const std::vector<std::string> & prefixes, uint64_t depth) const;
 
-  using OnSetParametersCallbackHandle =
-    rclcpp::node_interfaces::OnSetParametersCallbackHandle;
   using OnParametersSetCallbackType =
     rclcpp::node_interfaces::NodeParametersInterface::OnParametersSetCallbackType;
-
-  /// Add a callback for when parameters are being set.
-  /**
-   * \sa rclcpp::Node::add_on_set_parameters_callback
-   */
-  RCLCPP_LIFECYCLE_PUBLIC
-  rclcpp_lifecycle::LifecycleNode::OnSetParametersCallbackHandle::SharedPtr
-  add_on_set_parameters_callback(OnParametersSetCallbackType callback);
-
-  /// Remove a callback registered with `add_on_set_parameters_callback`.
-  /**
-   * \sa rclcpp::Node::remove_on_set_parameters_callback
-   */
-  RCLCPP_LIFECYCLE_PUBLIC
-  void
-  remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * const handler);
 
   /// Register a callback to be called anytime a parameter is about to be changed.
   /**

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -457,7 +457,7 @@ public:
    * \sa rclcpp::Node::add_on_set_parameters_callback
    */
   RCLCPP_LIFECYCLE_PUBLIC
-  rclcpp_lifecycle::lifecycleNode::OnSetParametersCallbackHandle::SharedPtr
+  rclcpp_lifecycle::LifecycleNode::OnSetParametersCallbackHandle::SharedPtr
   add_on_set_parameters_callback(OnParametersSetCallbackType callback);
 
   /// Remove a callback registered with `add_on_set_parameters_callback`.

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -268,11 +268,27 @@ LifecycleNode::remove_on_set_parameters_callback(
   node_parameters_->remove_on_set_parameters_callback(callback);
 }
 
+// suppress deprecated function warning
+#if !defined(_WIN32)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else  // !defined(_WIN32)
+# pragma warning(push)
+# pragma warning(disable: 4996)
+#endif
+
 rclcpp::Node::OnParametersSetCallbackType
 LifecycleNode::set_on_parameters_set_callback(rclcpp::Node::OnParametersSetCallbackType callback)
 {
   return node_parameters_->set_on_parameters_set_callback(callback);
 }
+
+// remove warning suppression
+#if !defined(_WIN32)
+# pragma GCC diagnostic pop
+#else  // !defined(_WIN32)
+# pragma warning(pop)
+#endif
 
 std::vector<std::string>
 LifecycleNode::get_node_names() const

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -255,6 +255,18 @@ LifecycleNode::list_parameters(
   return node_parameters_->list_parameters(prefixes, depth);
 }
 
+rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr
+LifecycleNode::add_on_set_parameters_callback(OnParametersSetCallbackType callback)
+{
+  return node_parameters_->add_on_set_parameters_callback(callback);
+}
+
+void
+Node::remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * const callback)
+{
+  return node_parameters_->remove_on_set_parameters_callback(callback);
+}
+
 rclcpp::Node::OnParametersSetCallbackType
 LifecycleNode::set_on_parameters_set_callback(rclcpp::Node::OnParametersSetCallbackType callback)
 {

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -262,7 +262,8 @@ LifecycleNode::add_on_set_parameters_callback(OnParametersSetCallbackType callba
 }
 
 void
-LifecycleNode::remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * const callback)
+LifecycleNode::remove_on_set_parameters_callback(
+  const OnSetParametersCallbackHandle * const callback)
 {
   return node_parameters_->remove_on_set_parameters_callback(callback);
 }

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -262,7 +262,7 @@ LifecycleNode::add_on_set_parameters_callback(OnParametersSetCallbackType callba
 }
 
 void
-Node::remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * const callback)
+LifecycleNode::remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * const callback)
 {
   return node_parameters_->remove_on_set_parameters_callback(callback);
 }

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -255,19 +255,6 @@ LifecycleNode::list_parameters(
   return node_parameters_->list_parameters(prefixes, depth);
 }
 
-rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr
-LifecycleNode::add_on_set_parameters_callback(OnParametersSetCallbackType callback)
-{
-  return node_parameters_->add_on_set_parameters_callback(callback);
-}
-
-void
-LifecycleNode::remove_on_set_parameters_callback(
-  const OnSetParametersCallbackHandle * const callback)
-{
-  return node_parameters_->remove_on_set_parameters_callback(callback);
-}
-
 rclcpp::Node::OnParametersSetCallbackType
 LifecycleNode::set_on_parameters_set_callback(rclcpp::Node::OnParametersSetCallbackType callback)
 {

--- a/rclcpp_lifecycle/test/test_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_node.cpp
@@ -427,7 +427,7 @@ TEST_F(TestDefaultStateMachine, check_parameters) {
       return result;
     };
 
-  test_node->set_on_parameters_set_callback(callback);
+  test_node->add_on_set_parameters_callback(callback);
   rclcpp::Parameter bool_parameter(bool_name, rclcpp::ParameterValue(false));
   EXPECT_TRUE(test_node->set_parameter(bool_parameter).successful);
   EXPECT_EQ(parameters_set, 1u);

--- a/rclcpp_lifecycle/test/test_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_node.cpp
@@ -427,7 +427,7 @@ TEST_F(TestDefaultStateMachine, check_parameters) {
       return result;
     };
 
-  test_node->add_on_set_parameters_callback(callback);
+  test_node->set_on_parameters_set_callback(callback);
   rclcpp::Parameter bool_parameter(bool_name, rclcpp::ParameterValue(false));
   EXPECT_TRUE(test_node->set_parameter(bool_parameter).successful);
   EXPECT_EQ(parameters_set, 1u);


### PR DESCRIPTION
This PR deprecates `set_on_parameters_set_callback` and replaces it with the new `add_on_set_parameters_callback` and `remove_on_set_parameters_callback` functions. Closes #791 . 

P.S. I added `add_on_set_parameters_callback` and `remove_on_set_parameters_callback` to `lifecycle_node` cuz they weren't there, and I assumed we'd want to deprecate `set_on_parameters_set_callback` in there as well. #1134 needs to merged first.