### PR TITLE
Fix potential Construction/Destruction order problem between global contexts vector and Context of static lifetime

### DIFF
--- a/rclcpp/include/rclcpp/context.hpp
+++ b/rclcpp/include/rclcpp/context.hpp
@@ -44,6 +44,9 @@ public:
   : std::runtime_error("context is already initialized") {}
 };
 
+/// Forward declare WeakContextsWrapper
+class WeakContextsWrapper;
+
 /// Context which encapsulates shared state between nodes and other similar entities.
 /**
  * A context also represents the lifecycle between init and shutdown of rclcpp.
@@ -358,6 +361,9 @@ private:
   std::mutex interrupt_guard_cond_handles_mutex_;
   /// Guard conditions for interrupting of associated wait sets on interrupt_all_wait_sets().
   std::unordered_map<rcl_wait_set_t *, rcl_guard_condition_t> interrupt_guard_cond_handles_;
+
+  /// Keep shared ownership of global vector of weak contexts
+  std::shared_ptr<WeakContextsWrapper> weak_contexts_;
 };
 
 /// Return a copy of the list of context shared pointers.

--- a/rclcpp/src/rclcpp/context.cpp
+++ b/rclcpp/src/rclcpp/context.cpp
@@ -40,7 +40,7 @@ using rclcpp::Context;
 namespace rclcpp
 {
 /// Class to manage vector of weak pointers to all created contexts
-struct WeakContextsWrapper
+class WeakContextsWrapper
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(WeakContextsWrapper)
@@ -65,9 +65,8 @@ public:
           if (!locked_context) {
             // take advantage and removed expired contexts
             return true;
-          } else {
-            return locked_context.get() == context;
           }
+          return locked_context.get() == context;
         }
       ),
       weak_contexts_.end());


### PR DESCRIPTION
I had this idea after working on https://github.com/ros2/rclcpp/pull/1125 ...

Not a great deal, but it would be nice to merge this before Foxy release.