### PR TITLE
add add_on and remove_on fn to deprecate set_on_param fn

### DIFF
--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -331,7 +331,7 @@ Node::remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * co
 rclcpp::Node::OnParametersSetCallbackType
 Node::set_on_parameters_set_callback(rclcpp::Node::OnParametersSetCallbackType callback)
 {
-  node_parameters_->set_on_parameters_set_callback(callback);
+  return node_parameters_->set_on_parameters_set_callback(callback);
 }
 
 std::vector<std::string>

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -331,7 +331,7 @@ Node::remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * co
 rclcpp::Node::OnParametersSetCallbackType
 Node::set_on_parameters_set_callback(rclcpp::Node::OnParametersSetCallbackType callback)
 {
-  return node_parameters_->set_on_parameters_set_callback(callback);
+  node_parameters_->set_on_parameters_set_callback(callback);
 }
 
 std::vector<std::string>

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -447,8 +447,28 @@ public:
   rcl_interfaces::msg::ListParametersResult
   list_parameters(const std::vector<std::string> & prefixes, uint64_t depth) const;
 
+  using OnSetParametersCallbackHandle =
+    rclcpp::node_interfaces::OnSetParametersCallbackHandle;
   using OnParametersSetCallbackType =
     rclcpp::node_interfaces::NodeParametersInterface::OnParametersSetCallbackType;
+
+  /// Add a callback for when parameters are being set.
+  /**
+   * \sa rclcpp::Node::add_on_set_parameters_callback
+   */
+  RCLCPP_LIFECYCLE_PUBLIC
+  rclcpp_lifecycle::LifecycleNode::OnSetParametersCallbackHandle::SharedPtr
+  add_on_set_parameters_callback(
+    rclcpp_lifecycle::LifecycleNode::OnParametersSetCallbackType callback);
+
+  /// Remove a callback registered with `add_on_set_parameters_callback`.
+  /**
+   * \sa rclcpp::Node::remove_on_set_parameters_callback
+   */
+  RCLCPP_LIFECYCLE_PUBLIC
+  void
+  remove_on_set_parameters_callback(
+    const rclcpp_lifecycle::LifecycleNode::OnSetParametersCallbackHandle * const handler);
 
   /// Register a callback to be called anytime a parameter is about to be changed.
   /**

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -264,7 +264,7 @@ LifecycleNode::add_on_set_parameters_callback(OnParametersSetCallbackType callba
 void
 LifecycleNode::remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * const callback)
 {
-  return node_parameters_->remove_on_set_parameters_callback(callback);
+  node_parameters_->remove_on_set_parameters_callback(callback);
 }
 
 rclcpp::Node::OnParametersSetCallbackType

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -255,6 +255,17 @@ LifecycleNode::list_parameters(
   return node_parameters_->list_parameters(prefixes, depth);
 }
 
+rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr
+LifecycleNode::add_on_set_parameters_callback(OnParametersSetCallbackType callback)
+{
+  return node_parameters_->add_on_set_parameters_callback(callback);
+}
+
+void
+LifecycleNode::remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * const callback)
+{
+  return node_parameters_->remove_on_set_parameters_callback(callback);
+
 rclcpp::Node::OnParametersSetCallbackType
 LifecycleNode::set_on_parameters_set_callback(rclcpp::Node::OnParametersSetCallbackType callback)
 {

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -265,6 +265,7 @@ void
 LifecycleNode::remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * const callback)
 {
   return node_parameters_->remove_on_set_parameters_callback(callback);
+}
 
 rclcpp::Node::OnParametersSetCallbackType
 LifecycleNode::set_on_parameters_set_callback(rclcpp::Node::OnParametersSetCallbackType callback)

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -262,7 +262,8 @@ LifecycleNode::add_on_set_parameters_callback(OnParametersSetCallbackType callba
 }
 
 void
-LifecycleNode::remove_on_set_parameters_callback(const OnSetParametersCallbackHandle * const callback)
+LifecycleNode::remove_on_set_parameters_callback(
+  const OnSetParametersCallbackHandle * const callback)
 {
   node_parameters_->remove_on_set_parameters_callback(callback);
 }


### PR DESCRIPTION
Part of the effort to deprecate `set_on_parameters_set_callback` function in #1123 . It adds `add_on_set_parameters_callback` and `remove_on_set_parameters_callback` to `lifecycle_node`