### PR TITLE
Fix lock-order-inversion (potential deadlock)

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
@@ -368,9 +368,11 @@ rclcpp::Event::SharedPtr
 NodeGraph::get_graph_event()
 {
   auto event = rclcpp::Event::make_shared();
-  std::lock_guard<std::mutex> graph_changed_lock(graph_mutex_);
-  graph_events_.push_back(event);
-  graph_users_count_++;
+  {
+    std::lock_guard<std::mutex> graph_changed_lock(graph_mutex_);
+    graph_events_.push_back(event);
+    graph_users_count_++;
+  }
   // on first call, add node to graph_listener_
   if (should_add_to_graph_listener_.exchange(false)) {
     graph_listener_->add_node(this);


### PR DESCRIPTION
Signed-off-by: Tomoya.Fujita <Tomoya.Fujita@sony.com>

fix https://github.com/ros2/rclcpp/issues/1121.