### PR TITLE
`SubscriptionBase::get_subscription_handle() const` should return a shared pointer to const value

### DIFF
--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -91,7 +91,7 @@ public:
   get_subscription_handle();
 
   RCLCPP_PUBLIC
-  const std::shared_ptr<rcl_subscription_t>
+  std::shared_ptr<const rcl_subscription_t>
   get_subscription_handle() const;
 
   /// Get all the QoS event handlers associated with this subscription.

--- a/rclcpp/src/rclcpp/subscription_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_base.cpp
@@ -109,7 +109,7 @@ SubscriptionBase::get_subscription_handle()
   return subscription_handle_;
 }
 
-const std::shared_ptr<rcl_subscription_t>
+std::shared_ptr<const rcl_subscription_t>
 SubscriptionBase::get_subscription_handle() const
 {
   return subscription_handle_;


### PR DESCRIPTION
In https://github.com/ros2/rclcpp/pull/431, `const rcl_subscription_t *` was incorrectly modified to `const std::shared_ptr<rcl_subscription_t>`.

This fixes the issue.