### PR TITLE
Pass shared pointer by value instead than by const & when possible

### DIFF
--- a/rclcpp/include/rclcpp/wait_set_policies/dynamic_storage.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/dynamic_storage.hpp
@@ -52,9 +52,9 @@ public:
 
     /// Conversion constructor, which is intentionally not marked explicit.
     SubscriptionEntry(
-      const std::shared_ptr<rclcpp::SubscriptionBase> & subscription_in = nullptr,
+      std::shared_ptr<rclcpp::SubscriptionBase> subscription_in = nullptr,
       const rclcpp::SubscriptionWaitSetMask & mask_in = {})
-    : subscription(subscription_in),
+    : subscription(std::move(subscription_in)),
       mask(mask_in)
     {}
 
@@ -117,10 +117,10 @@ public:
 
     /// Conversion constructor, which is intentionally not marked explicit.
     WaitableEntry(
-      const std::shared_ptr<rclcpp::Waitable> & waitable_in = nullptr,
-      const std::shared_ptr<void> & associated_entity_in = nullptr) noexcept
-    : waitable(waitable_in),
-      associated_entity(associated_entity_in)
+      std::shared_ptr<rclcpp::Waitable> waitable_in = nullptr,
+      std::shared_ptr<void> associated_entity_in = nullptr) noexcept
+    : waitable(std::move(waitable_in)),
+      associated_entity(std::move(associated_entity_in))
     {}
 
     void

--- a/rclcpp/include/rclcpp/wait_set_policies/static_storage.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/static_storage.hpp
@@ -17,6 +17,7 @@
 
 #include <array>
 #include <memory>
+#include <utility>
 
 #include "rclcpp/client.hpp"
 #include "rclcpp/guard_condition.hpp"

--- a/rclcpp/include/rclcpp/wait_set_policies/static_storage.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/static_storage.hpp
@@ -60,9 +60,9 @@ public:
 
     /// Conversion constructor, which is intentionally not marked explicit.
     SubscriptionEntry(
-      const std::shared_ptr<rclcpp::SubscriptionBase> & subscription_in = nullptr,
-      const rclcpp::SubscriptionWaitSetMask & mask_in = {})
-    : subscription(subscription_in),
+      std::shared_ptr<rclcpp::SubscriptionBase> subscription_in = nullptr,
+      rclcpp::SubscriptionWaitSetMask mask_in = {})
+    : subscription(std::move(subscription_in)),
       mask(mask_in)
     {}
   };
@@ -100,10 +100,10 @@ public:
   {
     /// Conversion constructor, which is intentionally not marked explicit.
     WaitableEntry(
-      const std::shared_ptr<rclcpp::Waitable> & waitable_in = nullptr,
-      const std::shared_ptr<void> & associated_entity_in = nullptr) noexcept
-    : waitable(waitable_in),
-      associated_entity(associated_entity_in)
+      std::shared_ptr<rclcpp::Waitable> waitable_in = nullptr,
+      std::shared_ptr<void> associated_entity_in = nullptr) noexcept
+    : waitable(std::move(waitable_in)),
+      associated_entity(std::move(associated_entity_in))
     {}
 
     std::shared_ptr<rclcpp::Waitable> waitable;


### PR DESCRIPTION
According to the cpp core guidelines (which imo is the best guideline about smart pointer signatures), if the function always retains shared ownership of a `std::shared_ptr`, then it must be passed by value.
See [R.34](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r34-take-a-shared_ptrwidget-parameter-to-express-that-a-function-is-part-owner) and [R.36](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r36-take-a-const-shared_ptrwidget-parameter-to-express-that-it-might-retain-a-reference-count-to-the-object-).

This breaks ABI and not API, so I don't think there are much chances of breaking downstream packages (this functionality is also pretty new and there is not much external usage, it was never part of a ros distribution).