### PR TITLE
Add missing header in logging_mutex.cpp

### DIFF
--- a/rclcpp/src/rclcpp/logging_mutex.cpp
+++ b/rclcpp/src/rclcpp/logging_mutex.cpp
@@ -17,6 +17,8 @@
 
 #include "rcutils/macros.h"
 
+#include "./logging_mutex.hpp"
+
 std::shared_ptr<std::recursive_mutex>
 get_global_logging_mutex()
 {


### PR DESCRIPTION
Addresses good observation in https://github.com/ros2/rclcpp/pull/1125#discussion_r432203724.