### PR TITLE
Add missing virtual destructors

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -23,7 +23,7 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
 endif()
 
 set(${PROJECT_NAME}_SRCS

--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -31,6 +31,7 @@ class RateBase
 public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(RateBase)
 
+  virtual ~RateBase() {}
   virtual bool sleep() = 0;
   virtual bool is_steady() const = 0;
   virtual void reset() = 0;

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -62,6 +62,7 @@ public:
 
   /// TimerBase destructor
   RCLCPP_PUBLIC
+  virtual
   ~TimerBase();
 
   /// Cancel the timer.

--- a/rclcpp_action/CMakeLists.txt
+++ b/rclcpp_action/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
 endif()
 
 set(${PROJECT_NAME}_SRCS

--- a/rclcpp_components/CMakeLists.txt
+++ b/rclcpp_components/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
 endif()
 
 find_package(ament_cmake_ros REQUIRED)

--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
 endif()
 
 find_package(ament_cmake_ros REQUIRED)

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_publisher.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_publisher.hpp
@@ -36,7 +36,7 @@ namespace rclcpp_lifecycle
 class LifecyclePublisherInterface
 {
 public:
-  virtual ~LifecyclePublisherInterface() {};
+  virtual ~LifecyclePublisherInterface() {}
   virtual void on_activate() = 0;
   virtual void on_deactivate() = 0;
   virtual bool is_activated() = 0;

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_publisher.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_publisher.hpp
@@ -36,6 +36,7 @@ namespace rclcpp_lifecycle
 class LifecyclePublisherInterface
 {
 public:
+  virtual ~LifecyclePublisherInterface() {};
   virtual void on_activate() = 0;
   virtual void on_deactivate() = 0;
   virtual bool is_activated() = 0;

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
@@ -100,6 +100,10 @@ public:
   RCLCPP_LIFECYCLE_PUBLIC
   virtual CallbackReturn
   on_error(const State & previous_state);
+
+  RCLCPP_LIFECYCLE_PUBLIC
+  virtual
+  ~LifecycleNodeInterface() {}
 };
 
 }  // namespace node_interfaces


### PR DESCRIPTION
Recently, we detected a missing virtual dtor in [QOSEventHandlerBase](https://github.com/ros2/rclcpp/pull/1119#discussion_r428216447).
It sounded like something that the compiler could catch, and after looking a bit I found:

>        -Wnon-virtual-dtor (C++ and Objective-C++ only)
>           Warn when a class has virtual functions and an accessible non-virtual destructor itself or in > an accessible polymorphic base class, in which case it is possible but unsafe to delete an instance
>           of a derived class through a pointer to the class itself or base class.  This warning is automatically enabled if -Weffc++ is specified.

i.e.: if the class has a public non virtual dtor and virtual methods, the compiler will warn.

The new compiler option detected missing virtual dtors in `RateBase` and `TimerBase`, which are fixed in this PR too.

---

I propose also adding `-Woveloaded-virtual`:

>        -Woverloaded-virtual (C++ and Objective-C++ only)
>           Warn when a function declaration hides virtual functions from a base class.

We should probably add both warnings to all cpp packages.

---

I'm planning to rebase and merge, one commit adding the warnings and the other fixing the missing virtual dtors.