### PR TITLE
Avoid multiple type topics in tests.

### DIFF
--- a/rclcpp/test/topic_statistics/test_subscription_topic_statistics.cpp
+++ b/rclcpp/test/topic_statistics/test_subscription_topic_statistics.cpp
@@ -210,21 +210,20 @@ protected:
   void SetUp()
   {
     rclcpp::init(0 /* argc */, nullptr /* argv */);
-    empty_subscriber = std::make_shared<EmptySubscriber>(
-      kTestSubNodeName,
-      kTestSubStatsTopic);
   }
 
   void TearDown()
   {
     rclcpp::shutdown();
-    empty_subscriber.reset();
   }
-  std::shared_ptr<EmptySubscriber> empty_subscriber;
 };
 
 TEST_F(TestSubscriptionTopicStatisticsFixture, test_manual_construction)
 {
+  auto empty_subscriber = std::make_shared<EmptySubscriber>(
+      kTestSubNodeName,
+      kTestSubStatsTopic);
+
   // Manually create publisher tied to the node
   auto topic_stats_publisher =
     empty_subscriber->create_publisher<MetricsMessage>(
@@ -260,6 +259,10 @@ TEST_F(TestSubscriptionTopicStatisticsFixture, test_receive_stats_for_message_no
     "test_receive_single_empty_stats_message_listener",
     "/statistics",
     2);
+
+  auto empty_subscriber = std::make_shared<EmptySubscriber>(
+      kTestSubNodeName,
+      kTestSubStatsTopic);
 
   rclcpp::executors::SingleThreadedExecutor ex;
   ex.add_node(empty_publisher);

--- a/rclcpp/test/topic_statistics/test_subscription_topic_statistics.cpp
+++ b/rclcpp/test/topic_statistics/test_subscription_topic_statistics.cpp
@@ -221,8 +221,8 @@ protected:
 TEST_F(TestSubscriptionTopicStatisticsFixture, test_manual_construction)
 {
   auto empty_subscriber = std::make_shared<EmptySubscriber>(
-      kTestSubNodeName,
-      kTestSubStatsTopic);
+    kTestSubNodeName,
+    kTestSubStatsTopic);
 
   // Manually create publisher tied to the node
   auto topic_stats_publisher =
@@ -261,8 +261,8 @@ TEST_F(TestSubscriptionTopicStatisticsFixture, test_receive_stats_for_message_no
     2);
 
   auto empty_subscriber = std::make_shared<EmptySubscriber>(
-      kTestSubNodeName,
-      kTestSubStatsTopic);
+    kTestSubNodeName,
+    kTestSubStatsTopic);
 
   rclcpp::executors::SingleThreadedExecutor ex;
   ex.add_node(empty_publisher);

--- a/rclcpp/test/topic_statistics/test_subscription_topic_statistics.cpp
+++ b/rclcpp/test/topic_statistics/test_subscription_topic_statistics.cpp
@@ -46,6 +46,7 @@ namespace
 constexpr const char kTestPubNodeName[]{"test_pub_stats_node"};
 constexpr const char kTestSubNodeName[]{"test_sub_stats_node"};
 constexpr const char kTestSubStatsTopic[]{"/test_sub_stats_topic"};
+constexpr const char kTestSubStatsEmptyTopic[]{"/test_sub_stats_empty_topic"};
 constexpr const char kTestTopicStatisticsTopic[]{"/test_topic_statistics_topic"};
 constexpr const uint64_t kNoSamples{0};
 constexpr const std::chrono::seconds kTestDuration{10};
@@ -222,7 +223,7 @@ TEST_F(TestSubscriptionTopicStatisticsFixture, test_manual_construction)
 {
   auto empty_subscriber = std::make_shared<EmptySubscriber>(
     kTestSubNodeName,
-    kTestSubStatsTopic);
+    kTestSubStatsEmptyTopic);
 
   // Manually create publisher tied to the node
   auto topic_stats_publisher =
@@ -250,7 +251,7 @@ TEST_F(TestSubscriptionTopicStatisticsFixture, test_receive_stats_for_message_no
   // Create an empty publisher
   auto empty_publisher = std::make_shared<EmptyPublisher>(
     kTestPubNodeName,
-    kTestSubStatsTopic);
+    kTestSubStatsEmptyTopic);
   // empty_subscriber has a topic statistics instance as part of its subscription
   // this will listen to and generate statistics for the empty message
 
@@ -262,7 +263,7 @@ TEST_F(TestSubscriptionTopicStatisticsFixture, test_receive_stats_for_message_no
 
   auto empty_subscriber = std::make_shared<EmptySubscriber>(
     kTestSubNodeName,
-    kTestSubStatsTopic);
+    kTestSubStatsEmptyTopic);
 
   rclcpp::executors::SingleThreadedExecutor ex;
   ex.add_node(empty_publisher);


### PR DESCRIPTION
Precisely what the title says, as RMW implementation may but are not bound to support it. This is making these tests fail on nightlies running with RMW implementations other than Fast-RTPS (see http://build.ros2.org/view/Fci/job/Fci__nightly-cyclonedds_ubuntu_focal_amd64/128/testReport/junit/(root)/rclcpp/test_subscription_topic_statistics_gtest_missing_result/)