### PR TITLE
Add spin_all method to Executor

### DIFF
--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -185,7 +185,7 @@ public:
    * become ready, this method will execute work repeatedly until `max_duration` has elapsed.
    *
    * \param[in] max_duration The maximum amount of time to spend executing work. Must be positive.
-   * Note that spin_some() may take longer than this time as it only returns once max_duration has
+   * Note that spin_all() may take longer than this time as it only returns once max_duration has
    * been exceeded.
    */
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -160,7 +160,7 @@ public:
   void
   spin_node_some(std::shared_ptr<rclcpp::Node> node);
 
-  /// Complete all available queued work without blocking.
+  /// Complete some available queued work without blocking.
   /**
    * This function can be overridden. The default implementation is suitable for a
    * single-threaded model of execution.
@@ -174,6 +174,26 @@ public:
   RCLCPP_PUBLIC
   virtual void
   spin_some(std::chrono::nanoseconds max_duration = std::chrono::nanoseconds(0));
+
+  /// Complete all available queued work without blocking.
+  /**
+   * This function can be overridden. The default implementation is suitable for a
+   * single-threaded model of execution.
+   * Adding subscriptions, timers, services, etc. with blocking callbacks will cause this function
+   * to block (which may have unintended consequences).
+   *
+   * To ensure all available queued work is executed, this function have to check if there is
+   * available work repeatedly.
+   * Thus, if the time that waitables take to be executed is longer than the period on which new waitables
+   * become ready, this will execute work repeatedly until `max_duration` has elapsed.
+   *
+   * \param[in] max_duration The maximum amount of time to spend executing work. Must be positive.
+   * Note that spin_some() may take longer than this time as it only returns once max_duration has
+   * been exceeded.
+   */
+  RCLCPP_PUBLIC
+  virtual void
+  spin_all(std::chrono::nanoseconds max_duration);
 
   RCLCPP_PUBLIC
   virtual void
@@ -269,6 +289,10 @@ protected:
   spin_node_once_nanoseconds(
     rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node,
     std::chrono::nanoseconds timeout);
+
+  RCLCPP_PUBLIC
+  void
+  spin_some_impl(std::chrono::nanoseconds max_duration, bool exhaustive);
 
   /// Find the next available executable and do the work associated with it.
   /**

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -160,7 +160,7 @@ public:
   void
   spin_node_some(std::shared_ptr<rclcpp::Node> node);
 
-  /// Complete some available queued work without blocking.
+  /// Collect work once and execute all available work, optionally within a duration.
   /**
    * This function can be overridden. The default implementation is suitable for a
    * single-threaded model of execution.
@@ -175,17 +175,14 @@ public:
   virtual void
   spin_some(std::chrono::nanoseconds max_duration = std::chrono::nanoseconds(0));
 
-  /// Complete all available queued work without blocking.
+  /// Collect and execute work repeatedly within a duration or until no more work is available.
   /**
    * This function can be overridden. The default implementation is suitable for a
    * single-threaded model of execution.
    * Adding subscriptions, timers, services, etc. with blocking callbacks will cause this function
    * to block (which may have unintended consequences).
-   *
-   * To ensure all available queued work is executed, this function has to check if there is
-   * available work repeatedly.
-   * Thus, if the time that waitables take to be executed is longer than the period on which new waitables
-   * become ready, this will execute work repeatedly until `max_duration` has elapsed.
+   * If the time that waitables take to be executed is longer than the period on which new waitables
+   * become ready, this method will execute work repeatedly until `max_duration` has elapsed.
    *
    * \param[in] max_duration The maximum amount of time to spend executing work. Must be positive.
    * Note that spin_some() may take longer than this time as it only returns once max_duration has

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -182,7 +182,7 @@ public:
    * Adding subscriptions, timers, services, etc. with blocking callbacks will cause this function
    * to block (which may have unintended consequences).
    *
-   * To ensure all available queued work is executed, this function have to check if there is
+   * To ensure all available queued work is executed, this function has to check if there is
    * available work repeatedly.
    * Thus, if the time that waitables take to be executed is longer than the period on which new waitables
    * become ready, this will execute work repeatedly until `max_duration` has elapsed.

--- a/rclcpp/test/rclcpp/test_executor.cpp
+++ b/rclcpp/test/rclcpp/test_executor.cpp
@@ -119,7 +119,6 @@ TEST_F(TestExecutors, testSpinUntilFutureCompleteSharedFuture) {
 class TestWaitable : public rclcpp::Waitable
 {
 public:
-
   TestWaitable()
   {
     rcl_guard_condition_options_t guard_condition_options =
@@ -168,6 +167,7 @@ public:
   {
     return count_;
   }
+
 private:
   size_t count_ = 0;
   rcl_guard_condition_t gc_;


### PR DESCRIPTION
This is a midpoint between the old implementation of `spin_some` and the one after https://github.com/ros2/rclcpp/pull/844.

The old `spin_some` implementation waited on entities when getting each executable.
That created starvation and other problems as described in https://github.com/ros2/rclcpp/pull/844.

Now, it only collects entities once and then executes all the ones that are ready.
The problem is that executing "all ready" entities doesn't actually execute all of them.

e.g.: If a subscription have a queue of 100 messages ready, it will only take one.

This proposes to wait on entities and execute all the ready executables repeatedly, until all of them are executed or the specified time has elapsed.