### PR TITLE
Include original exception in ComponentManagerException

### DIFF
--- a/rclcpp_components/src/component_manager.cpp
+++ b/rclcpp_components/src/component_manager.cpp
@@ -196,6 +196,11 @@ ComponentManager::OnLoadNode(
 
       try {
         node_wrappers_[node_id] = factory->create_node_instance(options);
+      } catch (const std::exception &ex) {
+        // In the case that the component constructor throws an exception,
+        // rethrow into the following catch block.
+        throw ComponentManagerException(
+                "Component constructor threw an exception: " + std::string(ex.what()));
       } catch (...) {
         // In the case that the component constructor throws an exception,
         // rethrow into the following catch block.

--- a/rclcpp_components/src/component_manager.cpp
+++ b/rclcpp_components/src/component_manager.cpp
@@ -196,7 +196,7 @@ ComponentManager::OnLoadNode(
 
       try {
         node_wrappers_[node_id] = factory->create_node_instance(options);
-      } catch (const std::exception &ex) {
+      } catch (const std::exception & ex) {
         // In the case that the component constructor throws an exception,
         // rethrow into the following catch block.
         throw ComponentManagerException(


### PR DESCRIPTION
When a component throws an exception in the constructor (e.g. when declaring a parameter) during loading, there's no other feedback than `Component constructor threw an exception`. This change introduces a similar construction to what is done earlier in the same file for constructing `class_loader::ClassLoader`: try to catch `std::exception` and append it's `what()` to the new `ComponentManagerException`.