### PR TITLE
Fix reference to rclcpp in its QD

### DIFF
--- a/rclcpp/QUALITY_DECLARATION.md
+++ b/rclcpp/QUALITY_DECLARATION.md
@@ -191,7 +191,7 @@ It is **Quality Level 4**, see its [Quality Declaration document](https://github
 
 #### `tracetools`
 
-The `tracetools` package provides utilities for instrumenting the code in `rcl` so that it may be traced for debugging and performance analysis.
+The `tracetools` package provides utilities for instrumenting the code in `rclcpp` so that it may be traced for debugging and performance analysis.
 
 It is **Quality Level 4**, see its [Quality Declaration document](https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing/-/blob/master/tracetools/QUALITY_DECLARATION.md).
 


### PR DESCRIPTION
I assume it was simply copy-pasted from `rcl`'s QD: https://github.com/ros2/rcl/blob/9e5bcd2965626b04e5ccc626d97b83b73231e913/rcl/QUALITY_DECLARATION.md#L186 