### PR TITLE
Toggle Guard Condition Feature

### DIFF
--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -94,6 +94,20 @@ public:
     return _find_ptrs_if_impl<rclcpp::Waitable, Function>(func, waitable_ptrs_);
   }
 
+   /**
+   * Returns size of callback group which includes
+   * subscriptions, timers, clients, services, and
+   * waitable
+   *
+   * \return size of callback group
+   */
+  size_t
+  size() const
+  {
+    return subscription_ptrs_.size() + timer_ptrs_.size() +
+           client_ptrs_.size() + service_ptrs_.size() + waitable_ptrs_.size();
+  }
+
   RCLCPP_PUBLIC
   std::atomic_bool &
   can_be_taken_from();

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -263,6 +263,15 @@ public:
   void
   set_memory_strategy(memory_strategy::MemoryStrategy::SharedPtr memory_strategy);
 
+  /**
+   * Returns wake_after_execute_ flag
+   *
+   * \return wake_after_execute_ flag
+   */
+  RCLCPP_PUBLIC
+  bool
+  get_wake_after_executor_flag() {return wake_after_execute_.load();}
+
 protected:
   RCLCPP_PUBLIC
   void
@@ -279,6 +288,17 @@ protected:
   RCLCPP_PUBLIC
   void
   execute_any_executable(AnyExecutable & any_exec);
+
+  /**
+   * After executing an executable, this function determines
+   * if it should wake the wait in rcl_wait so that the executor
+   * can process any pending executable
+   *
+   * \return wake_after_execute_ flag
+   */
+  RCLCPP_PUBLIC
+  virtual bool
+  set_wake_after_execute_flag() {return wake_after_execute_.load();}
 
   RCLCPP_PUBLIC
   static void
@@ -324,6 +344,9 @@ protected:
 
   /// Spinning state, used to prevent multi threaded calls to spin and to cancel blocking spins.
   std::atomic_bool spinning;
+
+  /// boolean to control whether guard condition is triggered after executing
+  std::atomic_bool wake_after_execute_;
 
   /// Guard condition for signaling the rmw layer to wake up for special events.
   rcl_guard_condition_t interrupt_guard_condition_ = rcl_get_zero_initialized_guard_condition();

--- a/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
@@ -78,6 +78,17 @@ protected:
   void
   run(size_t this_thread_number);
 
+  /**
+   * After executing an executable, this function determines
+   * if it should wake the wait in rcl_wait so that the executor
+   * can process any pending executable
+   *
+   * \return wake_after_execute_ flag
+   */
+  RCLCPP_PUBLIC
+  bool
+  set_wake_after_execute_flag();
+
 private:
   RCLCPP_DISABLE_COPY(MultiThreadedExecutor)
 

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -36,6 +36,7 @@ using rclcpp::FutureReturnCode;
 
 Executor::Executor(const rclcpp::ExecutorOptions & options)
 : spinning(false),
+  wake_after_execute_(false),
   memory_strategy_(options.memory_strategy)
 {
   rcl_guard_condition_options_t guard_condition_options = rcl_guard_condition_get_default_options();
@@ -304,9 +305,13 @@ Executor::execute_any_executable(AnyExecutable & any_exec)
   }
   // Reset the callback_group, regardless of type
   any_exec.callback_group->can_be_taken_from().store(true);
+
+  // Check whether triggering a guard condition is necessary
+  // (will depend on the type of executor and callback groups)
   // Wake the wait, because it may need to be recalculated or work that
   // was previously blocked is now available.
-  if (rcl_trigger_guard_condition(&interrupt_guard_condition_) != RCL_RET_OK) {
+  if (set_wake_after_execute_flag() &&
+      rcl_trigger_guard_condition(&interrupt_guard_condition_) != RCL_RET_OK) {
     throw std::runtime_error(rcl_get_error_string().str);
   }
 }

--- a/rclcpp/test/CMakeLists.txt
+++ b/rclcpp/test/CMakeLists.txt
@@ -391,6 +391,12 @@ if(TARGET test_multi_threaded_executor)
   target_link_libraries(test_multi_threaded_executor ${PROJECT_NAME})
 endif()
 
+ament_add_gtest(test_wake_after_execute_flag rclcpp/test_wake_after_execute_flag.cpp
+  APPEND_LIBRARY_DIRS "${append_library_dirs}")
+if(TARGET test_wake_after_execute_flag)
+  target_link_libraries(test_wake_after_execute_flag ${PROJECT_NAME})
+endif()
+
 ament_add_gtest(test_guard_condition rclcpp/test_guard_condition.cpp
   APPEND_LIBRARY_DIRS "${append_library_dirs}")
 if(TARGET test_guard_condition)

--- a/rclcpp/test/rclcpp/test_wake_after_execute_flag.cpp
+++ b/rclcpp/test/rclcpp/test_wake_after_execute_flag.cpp
@@ -1,0 +1,105 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <string>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/executors.hpp"
+#include "rclcpp/executor.hpp"
+
+using namespace std::chrono_literals;
+
+class TestWakeAfterExecuteFlag : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+};
+
+
+constexpr int EXECUTION_COUNT = 5;
+
+/*
+   Test guard condition trigger is set when a node is added and resetted when it is removed
+ */
+TEST_F(TestWakeAfterExecuteFlag, set_wake_after_execute_flag_multi_threaded) {
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+
+  std::shared_ptr<rclcpp::Node> node =
+    std::make_shared<rclcpp::Node>("test_wake_after_execute_flag_multi_threaded");
+
+  auto cbg = node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
+
+  std::atomic_int timer_count {0};
+
+  auto timer_callback = [&executor, &timer_count]() {
+    printf("Timer executed!");
+
+    if(timer_count > 0){
+      ASSERT_EQ(executor.get_wake_after_executor_flag(), true);
+    }
+
+    timer_count++;
+
+    if(timer_count > EXECUTION_COUNT){
+      executor.cancel();
+    }
+  };
+
+  auto timer_ = node->create_wall_timer(
+      2s, timer_callback, cbg);
+
+  executor.add_node(node);
+  executor.spin();
+}
+
+TEST_F(TestWakeAfterExecuteFlag, set_wake_after_execute_flag_single_threaded) {
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+
+  std::shared_ptr<rclcpp::Node> node =
+    std::make_shared<rclcpp::Node>("test_wake_after_execute_flag_single_threaded");
+
+  std::atomic_int timer_count {0};
+
+  auto timer_callback = [&executor, &timer_count]() {
+    printf("Timer executed!");
+
+    if(timer_count > 0){
+      ASSERT_EQ(executor.get_wake_after_executor_flag(), false);
+    }
+
+    timer_count++;
+
+    if(timer_count > EXECUTION_COUNT){
+      executor.cancel();
+    }
+  };
+
+  auto timer_ = node->create_wall_timer(
+      2s, timer_callback);
+
+  executor.add_node(node);
+  executor.spin();
+}


### PR DESCRIPTION
This pull request is related to #1021. Triggering a guard condition is only necessary when the executor is multithreaded and has at least one non-empty `MutualExclusive` callback group. In this PR I added a virtual function with a `trigger_guard_condition_` boolean that by default is set to false and is overriden by the `MultiThreadedExecutor` to set it to true when the conditions are met. The executor sets the trigger when `add_node` or `remove_node` is invoked. 

The tests verify the `SingleThreadedExecutor` sets the trigger to false when `add_node` and `remove_node` are called and `MultiThreadedExecutor` sets it to true when there is a non-empty `MutualExclusive` callback group and false when the node is removed and executor no longer has a node to process:
```
-- run_test.py: extra environment variables to append:
 - LD_LIBRARY_PATH+=/home/peter/ros2_foxy/build/rclcpp
-- run_test.py: invoking following command in '/home/peter/ros2_foxy/build/rclcpp':
 - /home/peter/ros2_foxy/build/rclcpp/test_guard_condition_trigger --gtest_output=xml:/home/peter/ros2_foxy/build/rclcpp/test_results/rclcpp/test_guard_condition_trigger.gtest.xml

Running main() from /home/peter/ros2_foxy/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from TestGuardConditionTrigger
[ RUN      ] TestGuardConditionTrigger.set_trigger_guard_condition_multi_threaded
[       OK ] TestGuardConditionTrigger.set_trigger_guard_condition_multi_threaded (21 ms)
[ RUN      ] TestGuardConditionTrigger.set_trigger_guard_condition_single_threaded
[       OK ] TestGuardConditionTrigger.set_trigger_guard_condition_single_threaded (8 ms)
[----------] 2 tests from TestGuardConditionTrigger (29 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (39 ms total)
[  PASSED  ] 2 tests.


-- run_test.py: return code 0
-- run_test.py: inject classname prefix into gtest result file '/home/peter/ros2_foxy/build/rclcpp/test_results/rclcpp/test_guard_condition_trigger.gtest.xml'
-- run_test.py: verify result file '/home/peter/ros2_foxy/build/rclcpp/test_results/rclcpp/test_guard_condition_trigger.gtest.xml'
```