### PR TITLE
Check if context is valid when looping in spin_some

### DIFF
--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -234,7 +234,7 @@ Executor::spin_some(std::chrono::nanoseconds max_duration)
   RCLCPP_SCOPE_EXIT(this->spinning.store(false); );
   // non-blocking call to pre-load all available work
   wait_for_work(std::chrono::milliseconds::zero());
-  while (spinning.load() && max_duration_not_elapsed()) {
+  while (rclcpp::ok(context_) && spinning.load() && max_duration_not_elapsed()) {
     AnyExecutable any_exec;
     if (get_next_ready_executable(any_exec)) {
       execute_any_executable(any_exec);


### PR DESCRIPTION
Taken from https://github.com/ros2/rclcpp/pull/1156#discussion_r438432897, so we can backport this change.