### PR TITLE
Fix implementation of NodeOptions::use_global_arguments()

### DIFF
--- a/rclcpp/src/rclcpp/node_options.cpp
+++ b/rclcpp/src/rclcpp/node_options.cpp
@@ -176,7 +176,7 @@ NodeOptions::parameter_overrides(const std::vector<rclcpp::Parameter> & paramete
 bool
 NodeOptions::use_global_arguments() const
 {
-  return this->node_options_->use_global_arguments;
+  return this->use_global_arguments_;
 }
 
 NodeOptions &

--- a/rclcpp/test/rclcpp/test_node_options.cpp
+++ b/rclcpp/test/rclcpp/test_node_options.cpp
@@ -105,6 +105,38 @@ TEST(TestNodeOptions, bad_ros_args) {
     rclcpp::exceptions::UnknownROSArgsError);
 }
 
+TEST(TestNodeOptions, use_global_arguments) {
+  {
+    auto options = rclcpp::NodeOptions();
+    EXPECT_TRUE(options.use_global_arguments());
+    EXPECT_TRUE(options.get_rcl_node_options()->use_global_arguments);
+  }
+
+  {
+    auto options = rclcpp::NodeOptions().use_global_arguments(false);
+    EXPECT_FALSE(options.use_global_arguments());
+    EXPECT_FALSE(options.get_rcl_node_options()->use_global_arguments);
+  }
+
+  {
+    auto options = rclcpp::NodeOptions().use_global_arguments(true);
+    EXPECT_TRUE(options.use_global_arguments());
+    EXPECT_TRUE(options.get_rcl_node_options()->use_global_arguments);
+  }
+
+  {
+    auto options = rclcpp::NodeOptions();
+    EXPECT_TRUE(options.use_global_arguments());
+    EXPECT_TRUE(options.get_rcl_node_options()->use_global_arguments);
+    options.use_global_arguments(false);
+    EXPECT_FALSE(options.use_global_arguments());
+    EXPECT_FALSE(options.get_rcl_node_options()->use_global_arguments);
+    options.use_global_arguments(true);
+    EXPECT_TRUE(options.use_global_arguments());
+    EXPECT_TRUE(options.get_rcl_node_options()->use_global_arguments);
+  }
+}
+
 TEST(TestNodeOptions, enable_rosout) {
   {
     auto options = rclcpp::NodeOptions();


### PR DESCRIPTION
`this->node_options_` might still be `nullptr` for a default initialized NodeOptions instance. Calling `use_global_arguments()` triggers a segmentation fault.

`use_global_arguments()` must return `this->use_global_arguments`, in analogy to [`NodeOptions::enable_rosout()`](https://github.com/meyerj/rclcpp/blob/543d6d18b153ff136c81da312833aee14c58cdf0/rclcpp/src/rclcpp/node_options.cpp#L190-L194):

https://github.com/ros2/rclcpp/blob/543d6d18b153ff136c81da312833aee14c58cdf0/rclcpp/src/rclcpp/node_options.cpp#L190-L194