### PR TITLE
Check period duration in create_wall_timer

### DIFF
--- a/rclcpp/include/rclcpp/create_timer.hpp
+++ b/rclcpp/include/rclcpp/create_timer.hpp
@@ -76,14 +76,14 @@ create_timer(
  * \tparam DurationRepT
  * \tparam DurationT
  * \tparam CallbackT
- * \param period period to execute callback
+ * \param period period to execute callback. This duration must be 0 <= period < nanoseconds::max()
  * \param callback callback to execute via the timer period
  * \param group
  * \param node_base
  * \param node_timers
  * \return
  * \throws std::invalid argument if either node_base or node_timers
- * are null
+ * are null, or period is negative or too large
  */
 template<typename DurationRepT, typename DurationT, typename CallbackT>
 typename rclcpp::WallTimer<CallbackT>::SharedPtr
@@ -106,6 +106,11 @@ create_wall_timer(
     throw std::invalid_argument{"timer period cannot be negative"};
   }
 
+  // Casting to a double representation might lose precision and allow the check below to succeed
+  // but the actual cast to nanoseconds fail. Using 1 DurationT worth of nanoseconds less than max.
+  constexpr auto maximum_safe_cast_ns =
+    std::chrono::nanoseconds::max() - std::chrono::duration<DurationRepT, DurationT>(1);
+
   // If period is greater than nanoseconds::max(), the duration_cast to nanoseconds will overflow
   // a signed integer, which is undefined behavior. Checking whether any std::chrono::duration is
   // greater than nanoseconds::max() is a difficult general problem. This is a more conservative
@@ -114,18 +119,21 @@ create_wall_timer(
   // However, this doesn't solve the issue for all possible duration types of period.
   // Follow-up issue: https://github.com/ros2/rclcpp/issues/1177
   constexpr auto ns_max_as_double =
-    std::chrono::duration_cast<
-    std::chrono::duration<double, std::chrono::nanoseconds::period>
-    >(std::chrono::nanoseconds::max() - std::chrono::duration<DurationRepT, DurationT>(1));
+    std::chrono::duration_cast<std::chrono::duration<double, std::chrono::nanoseconds::period>>(
+    maximum_safe_cast_ns);
   if (period > ns_max_as_double) {
     throw std::invalid_argument{
-            "timer period cannot be greater than std::chrono::nanoseconds::max()"};
+            "timer period must be less than std::chrono::nanoseconds::max()"};
+  }
+
+  const auto period_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(period);
+  if (period_ns < std::chrono::nanoseconds::zero()) {
+    throw std::runtime_error{
+            "Casting timer period to nanoseconds resulted in integer overflow."};
   }
 
   auto timer = rclcpp::WallTimer<CallbackT>::make_shared(
-    std::chrono::duration_cast<std::chrono::nanoseconds>(period),
-    std::move(callback),
-    node_base->get_context());
+    period_ns, std::move(callback), node_base->get_context());
   node_timers->add_timer(timer, group);
   return timer;
 }

--- a/rclcpp/test/rclcpp/test_create_timer.cpp
+++ b/rclcpp/test/rclcpp/test_create_timer.cpp
@@ -73,26 +73,44 @@ TEST(TestCreateTimer, call_wall_timer_with_bad_arguments)
   auto timers_interface =
     rclcpp::node_interfaces::get_node_timers_interface(node).get();
 
+  // Negative period
   EXPECT_THROW(
     rclcpp::create_wall_timer(-1ms, callback, group, node_interface, timers_interface),
     std::invalid_argument);
 
+  // Very negative period
   constexpr auto nanoseconds_min = std::chrono::nanoseconds::min();
   EXPECT_THROW(
     rclcpp::create_wall_timer(
       nanoseconds_min, callback, group, node_interface, timers_interface),
     std::invalid_argument);
+
+  // Period must be less than nanoseconds::max()
+  constexpr auto nanoseconds_max = std::chrono::nanoseconds::min();
+  EXPECT_THROW(
+    rclcpp::create_wall_timer(
+      nanoseconds_max, callback, group, node_interface, timers_interface),
+    std::invalid_argument);
+
+  EXPECT_NO_THROW(
+    rclcpp::create_wall_timer(
+      nanoseconds_max - 1us, callback, group, node_interface, timers_interface));
+
   EXPECT_NO_THROW(
     rclcpp::create_wall_timer(0ms, callback, group, node_interface, timers_interface));
 
+  // Period must be less than nanoseconds::max()
   constexpr auto hours_max = std::chrono::hours::max();
   EXPECT_THROW(
     rclcpp::create_wall_timer(hours_max, callback, group, node_interface, timers_interface),
     std::invalid_argument);
 
+  // node_interface is null
   EXPECT_THROW(
     rclcpp::create_wall_timer(1ms, callback, group, nullptr, timers_interface),
     std::invalid_argument);
+
+  // timers_interface is null
   EXPECT_THROW(
     rclcpp::create_wall_timer(1ms, callback, group, node_interface, nullptr),
     std::invalid_argument);


### PR DESCRIPTION
This is the first of the fixes related to #1177. It adds checks for negative duration values and duration values larger than nanoseconds::max(). As described in the included comment, it's difficult to solve the general problem of comparing one duration value to another for safe casting. I intend to follow up with a PR, (though not immediately) to rcpputils to provide a more general solution.

Signed-off-by: Stephen Brawner <brawner@gmail.com>