### PR TITLE
Throw exception if rcl_timer_init fails

### DIFF
--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -61,15 +61,11 @@ TimerBase::TimerBase(
   rcl_clock_t * clock_handle = clock_->get_clock_handle();
   {
     std::lock_guard<std::mutex> clock_guard(clock_->get_clock_mutex());
-    if (
-      rcl_timer_init(
-        timer_handle_.get(), clock_handle, rcl_context.get(), period.count(), nullptr,
-        rcl_get_default_allocator()) != RCL_RET_OK)
-    {
-      RCUTILS_LOG_ERROR_NAMED(
-        "rclcpp",
-        "Couldn't initialize rcl timer handle: %s\n", rcl_get_error_string().str);
-      rcl_reset_error();
+    rcl_ret_t ret = rcl_timer_init(
+      timer_handle_.get(), clock_handle, rcl_context.get(), period.count(), nullptr,
+      rcl_get_default_allocator());
+    if (ret != RCL_RET_OK) {
+      rclcpp::exceptions::throw_from_rcl_error(ret, "Couldn't initialize rcl timer handle");
     }
   }
 }

--- a/rclcpp/test/rclcpp/test_timer.cpp
+++ b/rclcpp/test/rclcpp/test_timer.cpp
@@ -162,37 +162,33 @@ TEST_F(TestTimer, test_bad_arguments) {
 
   // Negative period
   EXPECT_THROW(
-    rclcpp::GenericTimer<decltype(callback)>(
-      steady_clock, -1ms, std::forward<decltype(callback)>(callback), context),
+    rclcpp::GenericTimer<decltype(callback)>(steady_clock, -1ms, std::move(callback), context),
     rclcpp::exceptions::RCLInvalidArgument);
 
   // Very negative period
   constexpr auto nanoseconds_min = std::chrono::nanoseconds::min();
   EXPECT_THROW(
     rclcpp::GenericTimer<decltype(callback)>(
-      steady_clock, nanoseconds_min, std::forward<decltype(callback)>(callback), context),
+      steady_clock, nanoseconds_min, std::move(callback), context),
     rclcpp::exceptions::RCLInvalidArgument);
 
   // nanoseconds max, should be ok
   constexpr auto nanoseconds_max = std::chrono::nanoseconds::max();
   EXPECT_NO_THROW(
     rclcpp::GenericTimer<decltype(callback)>(
-      steady_clock, nanoseconds_max, std::forward<decltype(callback)>(callback), context));
+      steady_clock, nanoseconds_max, std::move(callback), context));
 
   // 0 duration period, should be ok
   EXPECT_NO_THROW(
-    rclcpp::GenericTimer<decltype(callback)>(
-      steady_clock, 0ms, std::forward<decltype(callback)>(callback), context));
+    rclcpp::GenericTimer<decltype(callback)>(steady_clock, 0ms, std::move(callback), context));
 
   // context is null, which resorts to default
   EXPECT_NO_THROW(
-    rclcpp::GenericTimer<decltype(callback)>(
-      steady_clock, 1ms, std::forward<decltype(callback)>(callback), nullptr));
+    rclcpp::GenericTimer<decltype(callback)>(steady_clock, 1ms, std::move(callback), nullptr));
 
   // Clock is unitialized
   auto unitialized_clock = std::make_shared<rclcpp::Clock>(RCL_CLOCK_UNINITIALIZED);
   EXPECT_THROW(
-    rclcpp::GenericTimer<decltype(callback)>(
-      unitialized_clock, 1us, std::forward<decltype(callback)>(callback), context),
+    rclcpp::GenericTimer<decltype(callback)>(unitialized_clock, 1us, std::move(callback), context),
     rclcpp::exceptions::RCLError);
 }

--- a/rclcpp/test/rclcpp/test_timer.cpp
+++ b/rclcpp/test/rclcpp/test_timer.cpp
@@ -154,7 +154,6 @@ TEST_F(TestTimer, test_run_cancel_timer)
 }
 
 TEST_F(TestTimer, test_bad_arguments) {
-  auto callback = []() {};
   auto node_base = rclcpp::node_interfaces::get_node_base_interface(test_node);
   auto context = node_base->get_context();
 
@@ -162,33 +161,33 @@ TEST_F(TestTimer, test_bad_arguments) {
 
   // Negative period
   EXPECT_THROW(
-    rclcpp::GenericTimer<decltype(callback)>(steady_clock, -1ms, std::move(callback), context),
+    rclcpp::GenericTimer<void (*)()>(steady_clock, -1ms, []() {}, context),
     rclcpp::exceptions::RCLInvalidArgument);
 
   // Very negative period
   constexpr auto nanoseconds_min = std::chrono::nanoseconds::min();
   EXPECT_THROW(
-    rclcpp::GenericTimer<decltype(callback)>(
-      steady_clock, nanoseconds_min, std::move(callback), context),
+    rclcpp::GenericTimer<void (*)()>(
+      steady_clock, nanoseconds_min, []() {}, context),
     rclcpp::exceptions::RCLInvalidArgument);
 
   // nanoseconds max, should be ok
   constexpr auto nanoseconds_max = std::chrono::nanoseconds::max();
   EXPECT_NO_THROW(
-    rclcpp::GenericTimer<decltype(callback)>(
-      steady_clock, nanoseconds_max, std::move(callback), context));
+    rclcpp::GenericTimer<void (*)()>(
+      steady_clock, nanoseconds_max, []() {}, context));
 
   // 0 duration period, should be ok
   EXPECT_NO_THROW(
-    rclcpp::GenericTimer<decltype(callback)>(steady_clock, 0ms, std::move(callback), context));
+    rclcpp::GenericTimer<void (*)()>(steady_clock, 0ms, []() {}, context));
 
   // context is null, which resorts to default
   EXPECT_NO_THROW(
-    rclcpp::GenericTimer<decltype(callback)>(steady_clock, 1ms, std::move(callback), nullptr));
+    rclcpp::GenericTimer<void (*)()>(steady_clock, 1ms, []() {}, nullptr));
 
   // Clock is unitialized
   auto unitialized_clock = std::make_shared<rclcpp::Clock>(RCL_CLOCK_UNINITIALIZED);
   EXPECT_THROW(
-    rclcpp::GenericTimer<decltype(callback)>(unitialized_clock, 1us, std::move(callback), context),
+    rclcpp::GenericTimer<void (*)()>(unitialized_clock, 1us, []() {}, context),
     rclcpp::exceptions::RCLError);
 }

--- a/rclcpp/test/rclcpp/test_timer.cpp
+++ b/rclcpp/test/rclcpp/test_timer.cpp
@@ -160,30 +160,36 @@ TEST_F(TestTimer, test_bad_arguments) {
 
   auto steady_clock = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
 
+  // Negative period
   EXPECT_THROW(
     rclcpp::GenericTimer<decltype(callback)>(
       steady_clock, -1ms, std::forward<decltype(callback)>(callback), context),
     rclcpp::exceptions::RCLInvalidArgument);
 
+  // Very negative period
   constexpr auto nanoseconds_min = std::chrono::nanoseconds::min();
   EXPECT_THROW(
     rclcpp::GenericTimer<decltype(callback)>(
       steady_clock, nanoseconds_min, std::forward<decltype(callback)>(callback), context),
     rclcpp::exceptions::RCLInvalidArgument);
 
+  // nanoseconds max, should be ok
   constexpr auto nanoseconds_max = std::chrono::nanoseconds::max();
   EXPECT_NO_THROW(
     rclcpp::GenericTimer<decltype(callback)>(
       steady_clock, nanoseconds_max, std::forward<decltype(callback)>(callback), context));
 
+  // 0 duration period, should be ok
   EXPECT_NO_THROW(
     rclcpp::GenericTimer<decltype(callback)>(
       steady_clock, 0ms, std::forward<decltype(callback)>(callback), context));
 
+  // context is null, which resorts to default
   EXPECT_NO_THROW(
     rclcpp::GenericTimer<decltype(callback)>(
       steady_clock, 1ms, std::forward<decltype(callback)>(callback), nullptr));
 
+  // Clock is unitialized
   auto unitialized_clock = std::make_shared<rclcpp::Clock>(RCL_CLOCK_UNINITIALIZED);
   EXPECT_THROW(
     rclcpp::GenericTimer<decltype(callback)>(


### PR DESCRIPTION
This is the second PR related to https://github.com/ros2/rclcpp/issues/1177. I believe along with #1178 the issue will be sufficiently addressed. 

Because the initialized `rcl_timer_t` is invalid, no other function calls in TimerBase will be successful. the destructor of `GenericTimer` in fact calls cancel, which will fail. Therefore, I think it's best to just throw the exception up front in the constructor of TimerBase.

The test conflicts with the test in #1178 and whichever is merged second will need to be updated beforehand.