### PR TITLE
callback should be perfectly-forwarded.

### DIFF
--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -361,7 +361,8 @@ public:
     SharedPromiseWithRequest promise = std::make_shared<PromiseWithRequest>();
     SharedFutureWithRequest future_with_request(promise->get_future());
 
-    auto wrapping_cb = [future_with_request, promise, request, &cb](SharedFuture future) {
+    auto wrapping_cb = [future_with_request, promise, request,
+                        cb=std::forward<CallbackWithRequestType>(cb)](SharedFuture future) {
         auto response = future.get();
         promise->set_value(std::make_pair(request, response));
         cb(future_with_request);

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -362,7 +362,7 @@ public:
     SharedFutureWithRequest future_with_request(promise->get_future());
 
     auto wrapping_cb = [future_with_request, promise, request,
-                        cb=std::forward<CallbackWithRequestType>(cb)](SharedFuture future) {
+        cb = std::forward<CallbackWithRequestType>(cb)](SharedFuture future) {
         auto response = future.get();
         promise->set_value(std::make_pair(request, response));
         cb(future_with_request);


### PR DESCRIPTION
fix https://github.com/ros2/ros2/issues/644

Signed-off-by: Tomoya.Fujita <Tomoya.Fujita@sony.com>