### PR TITLE
Update tracetools' QL to 2 in rclcpp's QD

### DIFF
--- a/rclcpp/QUALITY_DECLARATION.md
+++ b/rclcpp/QUALITY_DECLARATION.md
@@ -193,7 +193,7 @@ It is **Quality Level 4**, see its [Quality Declaration document](https://github
 
 The `tracetools` package provides utilities for instrumenting the code in `rclcpp` so that it may be traced for debugging and performance analysis.
 
-It is **Quality Level 4**, see its [Quality Declaration document](https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing/-/blob/master/tracetools/QUALITY_DECLARATION.md).
+It is **Quality Level 2**, see its [Quality Declaration document](https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing/-/blob/master/tracetools/QUALITY_DECLARATION.md).
 
 ### Direct Runtime non-ROS Dependency [5.iii]
 


### PR DESCRIPTION
`tracetools`' QL was just bumped to 2: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing/-/merge_requests/179