### PR TITLE
Fix conversion of negative durations to messages

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -23,7 +23,11 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wconversion -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
+  # About -Wno-sign-conversion: With Clang, -Wconversion implies -Wsign-conversion. There are a number of
+  # implicit sign conversions in rclcpp and gtest.cc, see https://ci.ros2.org/job/ci_osx/9265/.
+  # Hence disabling -Wsign-conversion for now until all those have eventually been fixed.
+  # (from https://github.com/ros2/rclcpp/pull/1188#issuecomment-650229140)
+  add_compile_options(-Wall -Wextra -Wconversion -Wno-sign-conversion -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
 endif()
 
 set(${PROJECT_NAME}_SRCS

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -23,7 +23,7 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
+  add_compile_options(-Wall -Wextra -Wconversion -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
 endif()
 
 set(${PROJECT_NAME}_SRCS

--- a/rclcpp/include/rclcpp/duration.hpp
+++ b/rclcpp/include/rclcpp/duration.hpp
@@ -72,7 +72,7 @@ public:
   operator=(const Duration & rhs);
 
   Duration &
-  operator=(const builtin_interfaces::msg::Duration & Duration_msg);
+  operator=(const builtin_interfaces::msg::Duration & duration_msg);
 
   bool
   operator==(const rclcpp::Duration & rhs) const;

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -48,10 +48,10 @@ public:
   /// Time constructor
   /**
    * \param nanoseconds since time epoch
-   * \param clock clock type
+   * \param clock_type clock type
    */
   RCLCPP_PUBLIC
-  explicit Time(int64_t nanoseconds = 0, rcl_clock_type_t clock = RCL_SYSTEM_TIME);
+  explicit Time(int64_t nanoseconds = 0, rcl_clock_type_t clock_type = RCL_SYSTEM_TIME);
 
   /// Copy constructor
   RCLCPP_PUBLIC
@@ -60,13 +60,13 @@ public:
   /// Time constructor
   /**
    * \param time_msg builtin_interfaces time message to copy
-   * \param ros_time clock type
+   * \param clock_type clock type
    * \throws std::runtime_error if seconds are negative
    */
   RCLCPP_PUBLIC
   Time(
     const builtin_interfaces::msg::Time & time_msg,
-    rcl_clock_type_t ros_time = RCL_ROS_TIME);
+    rcl_clock_type_t clock_type = RCL_ROS_TIME);
 
   /// Time constructor
   /**
@@ -90,6 +90,12 @@ public:
   Time &
   operator=(const Time & rhs);
 
+  /**
+   * Assign Time from a builtin_interfaces::msg::Time instance.
+   * The clock_type will be reset to RCL_ROS_TIME.
+   * Equivalent to *this = Time(time_msg, RCL_ROS_TIME).
+   * \throws std::runtime_error if seconds are negative
+   */
   RCLCPP_PUBLIC
   Time &
   operator=(const builtin_interfaces::msg::Time & time_msg);

--- a/rclcpp/src/rclcpp/duration.cpp
+++ b/rclcpp/src/rclcpp/duration.cpp
@@ -66,14 +66,14 @@ Duration::Duration(const rcl_duration_t & duration)
 Duration::operator builtin_interfaces::msg::Duration() const
 {
   builtin_interfaces::msg::Duration msg_duration;
-  constexpr rcl_duration_value_t kRemainder = RCL_S_TO_NS(1);
-  const auto result = std::div(rcl_duration_.nanoseconds, kRemainder);
+  constexpr rcl_duration_value_t kDivisor = RCL_S_TO_NS(1);
+  const auto result = std::div(rcl_duration_.nanoseconds, kDivisor);
   if (result.rem >= 0) {
     msg_duration.sec = static_cast<std::int32_t>(result.quot);
     msg_duration.nanosec = static_cast<std::uint32_t>(result.rem);
   } else {
     msg_duration.sec = static_cast<std::int32_t>(result.quot - 1);
-    msg_duration.nanosec = static_cast<std::uint32_t>(kRemainder + result.rem);
+    msg_duration.nanosec = static_cast<std::uint32_t>(kDivisor + result.rem);
   }
   return msg_duration;
 }
@@ -84,8 +84,7 @@ Duration::operator=(const Duration & rhs) = default;
 Duration &
 Duration::operator=(const builtin_interfaces::msg::Duration & duration_msg)
 {
-  rcl_duration_.nanoseconds = RCL_S_TO_NS(static_cast<rcl_duration_value_t>(duration_msg.sec));
-  rcl_duration_.nanoseconds += static_cast<rcl_duration_value_t>(duration_msg.nanosec);
+  *this = Duration(duration_msg);
   return *this;
 }
 

--- a/rclcpp/src/rclcpp/duration.cpp
+++ b/rclcpp/src/rclcpp/duration.cpp
@@ -47,17 +47,14 @@ Duration::Duration(std::chrono::nanoseconds nanoseconds)
   rcl_duration_.nanoseconds = nanoseconds.count();
 }
 
-Duration::Duration(const Duration & rhs)
-{
-  rcl_duration_.nanoseconds = rhs.rcl_duration_.nanoseconds;
-}
+Duration::Duration(const Duration & rhs) = default;
 
 Duration::Duration(
   const builtin_interfaces::msg::Duration & duration_msg)
 {
   rcl_duration_.nanoseconds =
-    static_cast<rcl_duration_value_t>(RCL_S_TO_NS(duration_msg.sec));
-  rcl_duration_.nanoseconds += duration_msg.nanosec;
+    RCL_S_TO_NS(static_cast<rcl_duration_value_t>(duration_msg.sec));
+  rcl_duration_.nanoseconds += static_cast<rcl_duration_value_t>(duration_msg.nanosec);
 }
 
 Duration::Duration(const rcl_duration_t & duration)
@@ -69,24 +66,26 @@ Duration::Duration(const rcl_duration_t & duration)
 Duration::operator builtin_interfaces::msg::Duration() const
 {
   builtin_interfaces::msg::Duration msg_duration;
-  msg_duration.sec = static_cast<std::int32_t>(RCL_NS_TO_S(rcl_duration_.nanoseconds));
-  msg_duration.nanosec =
-    static_cast<std::uint32_t>(rcl_duration_.nanoseconds % (1000 * 1000 * 1000));
+  constexpr rcl_duration_value_t kRemainder = RCL_S_TO_NS(1);
+  const auto result = std::div(rcl_duration_.nanoseconds, kRemainder);
+  if (result.rem >= 0) {
+    msg_duration.sec = static_cast<std::int32_t>(result.quot);
+    msg_duration.nanosec = static_cast<std::uint32_t>(result.rem);
+  } else {
+    msg_duration.sec = static_cast<std::int32_t>(result.quot - 1);
+    msg_duration.nanosec = static_cast<std::uint32_t>(kRemainder + result.rem);
+  }
   return msg_duration;
 }
 
 Duration &
-Duration::operator=(const Duration & rhs)
-{
-  rcl_duration_.nanoseconds = rhs.rcl_duration_.nanoseconds;
-  return *this;
-}
+Duration::operator=(const Duration & rhs) = default;
 
 Duration &
 Duration::operator=(const builtin_interfaces::msg::Duration & duration_msg)
 {
-  rcl_duration_.nanoseconds = RCL_S_TO_NS(static_cast<int64_t>(duration_msg.sec));
-  rcl_duration_.nanoseconds += duration_msg.nanosec;
+  rcl_duration_.nanoseconds = RCL_S_TO_NS(static_cast<rcl_duration_value_t>(duration_msg.sec));
+  rcl_duration_.nanoseconds += static_cast<rcl_duration_value_t>(duration_msg.nanosec);
   return *this;
 }
 
@@ -230,6 +229,10 @@ Duration::seconds() const
 rmw_time_t
 Duration::to_rmw_time() const
 {
+  if (rcl_duration_.nanoseconds < 0) {
+    throw std::runtime_error("rmw_time_t cannot be negative");
+  }
+
   // reuse conversion logic from msg creation
   builtin_interfaces::msg::Duration msg = *this;
   rmw_time_t result;

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -159,7 +159,7 @@ __lockless_has_parameter(
 // see https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
 RCLCPP_LOCAL
 bool
-__are_doubles_equal(double x, double y, size_t ulp = 100)
+__are_doubles_equal(double x, double y, double ulp = 100.0)
 {
   return std::abs(x - y) <= std::numeric_limits<double>::epsilon() * std::abs(x + y) * ulp;
 }

--- a/rclcpp/src/rclcpp/node_options.cpp
+++ b/rclcpp/src/rclcpp/node_options.cpp
@@ -338,7 +338,7 @@ NodeOptions::get_domain_id_from_env() const
   _dupenv_s(&ros_domain_id, &ros_domain_id_size, env_var);
 #endif
   if (ros_domain_id) {
-    uint32_t number = strtoul(ros_domain_id, NULL, 0);
+    uint32_t number = static_cast<uint32_t>(strtoul(ros_domain_id, NULL, 0));
     if (number == (std::numeric_limits<uint32_t>::max)()) {
 #ifdef _WIN32
       // free the ros_domain_id before throwing, if getenv was used on Windows

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -67,9 +67,9 @@ Time::Time(const Time & rhs) = default;
 
 Time::Time(
   const builtin_interfaces::msg::Time & time_msg,
-  rcl_clock_type_t ros_time)
+  rcl_clock_type_t clock_type)
+: rcl_time_(init_time_point(clock_type))
 {
-  rcl_time_ = init_time_point(ros_time);
   if (time_msg.sec < 0) {
     throw std::runtime_error("cannot store a negative time point in rclcpp::Time");
   }
@@ -109,16 +109,7 @@ Time::operator=(const Time & rhs) = default;
 Time &
 Time::operator=(const builtin_interfaces::msg::Time & time_msg)
 {
-  if (time_msg.sec < 0) {
-    throw std::runtime_error("cannot store a negative time point in rclcpp::Time");
-  }
-
-
-  rcl_clock_type_t ros_time = RCL_ROS_TIME;
-  rcl_time_ = init_time_point(ros_time);  // TODO(tfoote) hard coded ROS here
-
-  rcl_time_.nanoseconds = RCL_S_TO_NS(static_cast<int64_t>(time_msg.sec));
-  rcl_time_.nanoseconds += time_msg.nanosec;
+  *this = Time(time_msg);
   return *this;
 }
 

--- a/rclcpp/test/rclcpp/executors/test_multi_threaded_executor.cpp
+++ b/rclcpp/test/rclcpp/executors/test_multi_threaded_executor.cpp
@@ -83,7 +83,7 @@ TEST_F(TestMultiThreadedExecutor, timer_over_take) {
 
       {
         std::lock_guard<std::mutex> lock(last_mutex);
-        double diff = std::abs((now - last).nanoseconds()) / 1.0e9;
+        double diff = static_cast<double>(std::abs((now - last).nanoseconds())) / 1.0e9;
         last = now;
 
         if (diff < PERIOD - TOLERANCE) {

--- a/rclcpp/test/rclcpp/test_duration.cpp
+++ b/rclcpp/test/rclcpp/test_duration.cpp
@@ -204,7 +204,7 @@ TEST(TestDuration, conversions) {
     EXPECT_EQ(duration_msg.nanosec, HALF_SEC_IN_NS);
     EXPECT_EQ(rclcpp::Duration(duration_msg).nanoseconds(), -HALF_SEC_IN_NS);
 
-    EXPECT_THROW(duration.to_rmw_time(), std::overflow_error);
+    EXPECT_THROW(duration.to_rmw_time(), std::runtime_error);
 
     auto chrono_duration = duration.to_chrono<std::chrono::nanoseconds>();
     EXPECT_EQ(chrono_duration.count(), -HALF_SEC_IN_NS);
@@ -217,7 +217,7 @@ TEST(TestDuration, conversions) {
     EXPECT_EQ(duration_msg.nanosec, 0u);
     EXPECT_EQ(rclcpp::Duration(duration_msg).nanoseconds(), -ONE_SEC_IN_NS);
 
-    EXPECT_THROW(duration.to_rmw_time(), std::overflow_error);
+    EXPECT_THROW(duration.to_rmw_time(), std::runtime_error);
 
     auto chrono_duration = duration.to_chrono<std::chrono::nanoseconds>();
     EXPECT_EQ(chrono_duration.count(), -ONE_SEC_IN_NS);
@@ -230,7 +230,7 @@ TEST(TestDuration, conversions) {
     EXPECT_EQ(duration_msg.nanosec, HALF_SEC_IN_NS);
     EXPECT_EQ(rclcpp::Duration(duration_msg).nanoseconds(), -ONE_AND_HALF_SEC_IN_NS);
 
-    EXPECT_THROW(duration.to_rmw_time(), std::overflow_error);
+    EXPECT_THROW(duration.to_rmw_time(), std::runtime_error);
 
     auto chrono_duration = duration.to_chrono<std::chrono::nanoseconds>();
     EXPECT_EQ(chrono_duration.count(), -ONE_AND_HALF_SEC_IN_NS);

--- a/rclcpp/test/rclcpp/test_duration.cpp
+++ b/rclcpp/test/rclcpp/test_duration.cpp
@@ -32,7 +32,7 @@ class TestDuration : public ::testing::Test
 {
 };
 
-TEST(TestDuration, operators) {
+TEST_F(TestDuration, operators) {
   rclcpp::Duration old(1, 0);
   rclcpp::Duration young(2, 0);
 
@@ -63,7 +63,7 @@ TEST(TestDuration, operators) {
   EXPECT_TRUE(time == assignment_op_duration);
 }
 
-TEST(TestDuration, chrono_overloads) {
+TEST_F(TestDuration, chrono_overloads) {
   int64_t ns = 123456789l;
   auto chrono_ns = std::chrono::nanoseconds(ns);
   auto d1 = rclcpp::Duration(ns);
@@ -82,7 +82,7 @@ TEST(TestDuration, chrono_overloads) {
   EXPECT_EQ(chrono_float_seconds, d5.to_chrono<decltype(chrono_float_seconds)>());
 }
 
-TEST(TestDuration, overflows) {
+TEST_F(TestDuration, overflows) {
   rclcpp::Duration max(std::numeric_limits<rcl_duration_value_t>::max());
   rclcpp::Duration min(std::numeric_limits<rcl_duration_value_t>::min());
 
@@ -103,7 +103,7 @@ TEST(TestDuration, overflows) {
   EXPECT_THROW(base_d_neg * 4, std::underflow_error);
 }
 
-TEST(TestDuration, negative_duration) {
+TEST_F(TestDuration, negative_duration) {
   rclcpp::Duration assignable_duration = rclcpp::Duration(0) - rclcpp::Duration(5, 0);
 
   {
@@ -126,7 +126,7 @@ TEST(TestDuration, negative_duration) {
   }
 }
 
-TEST(TestDuration, maximum_duration) {
+TEST_F(TestDuration, maximum_duration) {
   rclcpp::Duration max_duration = rclcpp::Duration::max();
   rclcpp::Duration max(std::numeric_limits<int32_t>::max(), 999999999);
 
@@ -137,21 +137,21 @@ static const int64_t HALF_SEC_IN_NS = 500 * 1000 * 1000;
 static const int64_t ONE_SEC_IN_NS = 1000 * 1000 * 1000;
 static const int64_t ONE_AND_HALF_SEC_IN_NS = 3 * HALF_SEC_IN_NS;
 
-TEST(TestDuration, from_seconds) {
+TEST_F(TestDuration, from_seconds) {
   EXPECT_EQ(rclcpp::Duration(0), rclcpp::Duration::from_seconds(0.0));
   EXPECT_EQ(rclcpp::Duration(0), rclcpp::Duration::from_seconds(0));
   EXPECT_EQ(rclcpp::Duration(1, HALF_SEC_IN_NS), rclcpp::Duration::from_seconds(1.5));
   EXPECT_EQ(rclcpp::Duration(-ONE_AND_HALF_SEC_IN_NS), rclcpp::Duration::from_seconds(-1.5));
 }
 
-TEST(TestDuration, std_chrono_constructors) {
+TEST_F(TestDuration, std_chrono_constructors) {
   EXPECT_EQ(rclcpp::Duration(0), rclcpp::Duration(0.0s));
   EXPECT_EQ(rclcpp::Duration(0), rclcpp::Duration(0s));
   EXPECT_EQ(rclcpp::Duration(1, HALF_SEC_IN_NS), rclcpp::Duration(1.5s));
   EXPECT_EQ(rclcpp::Duration(-1, 0), rclcpp::Duration(-1s));
 }
 
-TEST(TestDuration, conversions) {
+TEST_F(TestDuration, conversions) {
   {
     const rclcpp::Duration duration(HALF_SEC_IN_NS);
     const auto duration_msg = static_cast<builtin_interfaces::msg::Duration>(duration);

--- a/rclcpp/test/rclcpp/test_parameter.cpp
+++ b/rclcpp/test/rclcpp/test_parameter.cpp
@@ -32,7 +32,7 @@ protected:
   }
 };
 
-TEST(TestParameter, not_set_variant) {
+TEST_F(TestParameter, not_set_variant) {
   // Direct instantiation
   rclcpp::Parameter not_set_variant;
   EXPECT_EQ(rclcpp::PARAMETER_NOT_SET, not_set_variant.get_type());
@@ -58,7 +58,7 @@ TEST(TestParameter, not_set_variant) {
     rclcpp::Parameter::from_parameter_msg(not_set_param).get_type());
 }
 
-TEST(TestParameter, bool_variant) {
+TEST_F(TestParameter, bool_variant) {
   // Direct instantiation
   rclcpp::Parameter bool_variant_true("bool_param", true);
   EXPECT_EQ("bool_param", bool_variant_true.get_name());
@@ -116,7 +116,7 @@ TEST(TestParameter, bool_variant) {
     bool_variant_false.get_value_message().type);
 }
 
-TEST(TestParameter, integer_variant) {
+TEST_F(TestParameter, integer_variant) {
   const int TEST_VALUE {42};
 
   // Direct instantiation
@@ -164,7 +164,7 @@ TEST(TestParameter, integer_variant) {
     from_msg.get_value_message().type);
 }
 
-TEST(TestParameter, long_integer_variant) {
+TEST_F(TestParameter, long_integer_variant) {
   const int64_t TEST_VALUE {std::numeric_limits<int64_t>::max()};
 
   // Direct instantiation
@@ -212,7 +212,7 @@ TEST(TestParameter, long_integer_variant) {
     from_msg.get_value_message().type);
 }
 
-TEST(TestParameter, float_variant) {
+TEST_F(TestParameter, float_variant) {
   const float TEST_VALUE {42.0f};
 
   // Direct instantiation
@@ -260,7 +260,7 @@ TEST(TestParameter, float_variant) {
     from_msg.get_value_message().type);
 }
 
-TEST(TestParameter, double_variant) {
+TEST_F(TestParameter, double_variant) {
   const double TEST_VALUE {-42.1};
 
   // Direct instantiation
@@ -308,7 +308,7 @@ TEST(TestParameter, double_variant) {
     from_msg.get_value_message().type);
 }
 
-TEST(TestParameter, string_variant) {
+TEST_F(TestParameter, string_variant) {
   const std::string TEST_VALUE {"ROS2"};
 
   // Direct instantiation
@@ -354,7 +354,7 @@ TEST(TestParameter, string_variant) {
     from_msg.get_value_message().type);
 }
 
-TEST(TestParameter, byte_array_variant) {
+TEST_F(TestParameter, byte_array_variant) {
   const std::vector<uint8_t> TEST_VALUE {0x52, 0x4f, 0x53, 0x32};
 
   // Direct instantiation
@@ -402,7 +402,7 @@ TEST(TestParameter, byte_array_variant) {
     from_msg.get_value_message().type);
 }
 
-TEST(TestParameter, bool_array_variant) {
+TEST_F(TestParameter, bool_array_variant) {
   const std::vector<bool> TEST_VALUE {false, true, true, false, false, true};
 
   // Direct instantiation
@@ -450,7 +450,7 @@ TEST(TestParameter, bool_array_variant) {
     from_msg.get_value_message().type);
 }
 
-TEST(TestParameter, integer_array_variant) {
+TEST_F(TestParameter, integer_array_variant) {
   const std::vector<int> TEST_VALUE
   {42, -99, std::numeric_limits<int>::max(), std::numeric_limits<int>::lowest(), 0};
 
@@ -529,7 +529,7 @@ TEST(TestParameter, integer_array_variant) {
     rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER_ARRAY);
 }
 
-TEST(TestParameter, long_integer_array_variant) {
+TEST_F(TestParameter, long_integer_array_variant) {
   const std::vector<int64_t> TEST_VALUE
   {42, -99, std::numeric_limits<int64_t>::max(), std::numeric_limits<int64_t>::lowest(), 0};
 
@@ -583,7 +583,7 @@ TEST(TestParameter, long_integer_array_variant) {
     from_msg.get_value_message().type);
 }
 
-TEST(TestParameter, float_array_variant) {
+TEST_F(TestParameter, float_array_variant) {
   const std::vector<float> TEST_VALUE
   {42.1f, -99.1f, std::numeric_limits<float>::max(), std::numeric_limits<float>::lowest(), 0.1f};
 
@@ -662,7 +662,7 @@ TEST(TestParameter, float_array_variant) {
     from_msg.get_value_message().type);
 }
 
-TEST(TestParameter, double_array_variant) {
+TEST_F(TestParameter, double_array_variant) {
   const std::vector<double> TEST_VALUE
   {42.1, -99.1, std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest(), 0.1};
 
@@ -716,7 +716,7 @@ TEST(TestParameter, double_array_variant) {
     from_msg.get_value_message().type);
 }
 
-TEST(TestParameter, string_array_variant) {
+TEST_F(TestParameter, string_array_variant) {
   const std::vector<std::string> TEST_VALUE {"R", "O", "S2"};
 
   // Direct instantiation

--- a/rclcpp/test/rclcpp/test_time.cpp
+++ b/rclcpp/test/rclcpp/test_time.cpp
@@ -278,8 +278,8 @@ TEST(TestTime, overflow_detectors) {
   // 256 * 256 = 64K total loops, should be pretty fast on everything
   for (big_type_t y = min_val; y <= max_val; ++y) {
     for (big_type_t x = min_val; x <= max_val; ++x) {
-      const big_type_t sum = x + y;
-      const big_type_t diff = x - y;
+      const big_type_t sum = static_cast<big_type_t>(x + y);
+      const big_type_t diff = static_cast<big_type_t>(x - y);
 
       const bool add_will_overflow =
         rclcpp::add_will_overflow(test_type_t(x), test_type_t(y));

--- a/rclcpp/test/rclcpp/test_time.cpp
+++ b/rclcpp/test/rclcpp/test_time.cpp
@@ -45,7 +45,7 @@ protected:
   }
 };
 
-TEST(TestTime, clock_type_access) {
+TEST_F(TestTime, clock_type_access) {
   rclcpp::Clock ros_clock(RCL_ROS_TIME);
   EXPECT_EQ(RCL_ROS_TIME, ros_clock.get_clock_type());
 
@@ -57,7 +57,7 @@ TEST(TestTime, clock_type_access) {
 }
 
 // Check that the clock may go out of the scope before the jump callback without leading in UB.
-TEST(TestTime, clock_jump_callback_destruction_order) {
+TEST_F(TestTime, clock_jump_callback_destruction_order) {
   rclcpp::JumpHandler::SharedPtr handler;
   {
     rclcpp::Clock ros_clock(RCL_ROS_TIME);
@@ -68,7 +68,7 @@ TEST(TestTime, clock_jump_callback_destruction_order) {
   }
 }
 
-TEST(TestTime, time_sources) {
+TEST_F(TestTime, time_sources) {
   using builtin_interfaces::msg::Time;
   rclcpp::Clock ros_clock(RCL_ROS_TIME);
   Time ros_now = ros_clock.now();
@@ -90,7 +90,7 @@ static const int64_t HALF_SEC_IN_NS = 500 * 1000 * 1000;
 static const int64_t ONE_SEC_IN_NS = 1000 * 1000 * 1000;
 static const int64_t ONE_AND_HALF_SEC_IN_NS = 3 * HALF_SEC_IN_NS;
 
-TEST(TestTime, conversions) {
+TEST_F(TestTime, conversions) {
   rclcpp::Clock system_clock(RCL_SYSTEM_TIME);
 
   {
@@ -203,7 +203,7 @@ TEST(TestTime, conversions) {
   }
 }
 
-TEST(TestTime, operators) {
+TEST_F(TestTime, operators) {
   rclcpp::Time old(1, 0);
   rclcpp::Time young(2, 0);
 
@@ -258,7 +258,7 @@ TEST(TestTime, operators) {
   }
 }
 
-TEST(TestTime, overflow_detectors) {
+TEST_F(TestTime, overflow_detectors) {
   /////////////////////////////////////////////////////////////////////////////
   // Test logical_eq call first:
   EXPECT_TRUE(logical_eq(false, false));
@@ -315,7 +315,7 @@ TEST(TestTime, overflow_detectors) {
   EXPECT_TRUE(rclcpp::sub_will_underflow<int64_t>(INT64_MIN, 1));
 }
 
-TEST(TestTime, overflows) {
+TEST_F(TestTime, overflows) {
   rclcpp::Time max_time(std::numeric_limits<rcl_time_point_value_t>::max());
   rclcpp::Time min_time(std::numeric_limits<rcl_time_point_value_t>::min());
   rclcpp::Duration one(1);
@@ -347,7 +347,7 @@ TEST(TestTime, overflows) {
   EXPECT_NO_THROW(one_time - two_time);
 }
 
-TEST(TestTime, seconds) {
+TEST_F(TestTime, seconds) {
   EXPECT_DOUBLE_EQ(0.0, rclcpp::Time(0, 0).seconds());
   EXPECT_DOUBLE_EQ(4.5, rclcpp::Time(4, 500000000).seconds());
   EXPECT_DOUBLE_EQ(2.5, rclcpp::Time(0, 2500000000).seconds());


### PR DESCRIPTION
This pull request is a follow-up on https://github.com/ros2/rclcpp/pull/901, to fix conversions of negative `Duration` (and `Time`) instances to the respective message times in `builtin_interfaces`, where the `nanosec` part is represented as an unsigned `uint32` integer type.

The implicit conversion from `rclcpp::Duration` to `builtin_interfaces::msg::Duration` was actually wrong for negative values, because the default integer division in C/C++ rounds towards zero and the modulo operator returns a negative remainder for negative numerators. With the previous implementation this negative remainder was then cast to `uint32_t` without a range check, which then results in timestamps that are 2³² nanoseconds or 4.294967296 seconds too big if converted back to `rclcpp::Duration`.

For
```cpp
rclcpp::Duration duration(-1);
builtin_interfaces::msg::Duration msg_duration = duration;
std::cout
  << "sec: " << msg_duration.sec << '\n'
  << "nanosec: " << msg_duration.nanosec << '\n'
  << "back to Duration(msg_duration).nanoseconds(): " << Duration(msg_duration).nanoseconds() << '\n';
```
the output was
```
sec: 0
nanosec: 4294967295
back to Duration(msg_duration).nanoseconds(): 4294967295
```
instead of
```
sec: -1
nanosec: 999999999
back to Duration(msg_duration).nanoseconds(): -1
```

The conversion from `rclcpp::Duration` to `rmw_time_t` had a similar problem. In `rmw_time_t` both, the `sec` and `nsec` parts are unsigned 64 bit types:
```cpp
typedef struct RMW_PUBLIC_TYPE rmw_time_t
{
  uint64_t sec;
  uint64_t nsec;
} rmw_time_t;
```
So the type cannot represent negative values. Was it intentional to represent `rmw_time_t` with 128 bits in total, or should it have been `uint32_t` instead? I added a check that throws `std::runtime_error` when trying to call `Duration::to_rmw_time()` for negative values.

For `rclcpp::Time` I am not sure whether it is supposed to have negative values (times before the epoch) or not. There was a discussion about that in https://github.com/ros2/rclcpp/issues/525. Some constructors and assignment operators throw, others don't. For example it is possible to construct a negative `rclcpp::Time` instance from a negative `int64_t` nanosecond value:

https://github.com/ros2/rclcpp/blob/79d1ba1cceab26791496b3ead9873dee5232ea9a/rclcpp/src/rclcpp/time.cpp#L60-L64

Because of that, and because also the internal storage type `rcl_time_point_value_t` and [`builtin_interfaces/Time`](https://github.com/ros2/rcl_interfaces/blob/5a4a3bd4da4cfc35ad377f2966714321b2951c89/builtin_interfaces/msg/Time.msg) can also hold negative values, I applied the same patch for the conversion to the message type as in `rclcpp::Duration`. If negative values should be forbidden for `rclcpp::Time`, which is the conclusion of https://github.com/ros2/rclcpp/issues/525#issuecomment-414425011 if I understand correctly, then in my opinion this should be addressed in a separate pull request and the added checks (and unit test) can be removed again.

All other changes are mainly cosmetic, either to make implicit casts between signed and unsigned integer types explicit, or to match the implementation of constructors and respective assignment operators. In order to at least emit a warning and to avoid similar problems with unintended integer or floating point conversions that may alter the value, I suggest to add `-Wconversion` to the compiler options of `rclcpp`. It is not included in `-Wall` or `-Wextra`. But this warning option would not have helped in case of the buggy `Duration` conversions because the bad casts without checking for over- or underflow were explicit. Also the explicit casts added in https://github.com/ros2/rclcpp/pull/901 might hide problems in case the argument is out of range of the target type.

The copy constructors and assignment operators are equivalent to the default implementations, in the sense that they just copy the one and only member of the `Duration` or `Time` instance. Maybe this used to be different in an earlier version? The assignment of `rcl_time_.nanoseconds = rhs.rcl_time_.nanoseconds` in the copy constructor `Time::Time(const Time &)` was redundant because `rcl_time_` is already copied in the initializer list.

There is another problem with the definition of time-related macros defined in [rcutils/time.h](https://github.com/ros2/rcutils/blob/8c1d190fc5e6425f83c3e8716a5ee861bbf82cf1/include/rcutils/time.h) which are also indirectly used for the `Duration` and `Time` implementations in `rclcpp`: They don't have parentheses around the macro argument:

```cpp
/// Convenience macro to convert seconds to nanoseconds.
#define RCUTILS_S_TO_NS(seconds) (seconds * (1000LL * 1000LL * 1000LL))
/// Convenience macro to convert milliseconds to nanoseconds.
#define RCUTILS_MS_TO_NS(milliseconds) (milliseconds * (1000LL * 1000LL))
/// Convenience macro to convert microseconds to nanoseconds.
#define RCUTILS_US_TO_NS(microseconds) (microseconds * 1000LL)

/// Convenience macro to convert nanoseconds to seconds.
#define RCUTILS_NS_TO_S(nanoseconds) (nanoseconds / (1000LL * 1000LL * 1000LL))
/// Convenience macro to convert nanoseconds to milliseconds.
#define RCUTILS_NS_TO_MS(nanoseconds) (nanoseconds / (1000LL * 1000LL))
/// Convenience macro to convert nanoseconds to microseconds.
#define RCUTILS_NS_TO_US(nanoseconds) (nanoseconds / 1000LL)
```

So `RCUTILS_S_TO_NS(1 + 1)` is not `2000000000LL` as one might expect, but `1000000001LL`, because of operator precedence rules. This case is not triggered in `rclcpp`. I will open a separate pull request in https://github.com/ros2/rcutils for that.

Last but not least, new unit test cases have been added to `test_duration.cpp` and `test_time.cpp` to cover all the conversions and potential failure cases above. Without the patches in `time.cpp` and `duration.cpp` the new tests would fail as follows:
```
root@c610b7e4c97e:/ros2_ws# ./build/rclcpp/test/test_duration 
Running main() from /opt/ros/foxy/src/gtest_vendor/src/gtest_main.cc
[==========] Running 8 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 8 tests from TestDuration
[ RUN      ] TestDuration.operators
[       OK ] TestDuration.operators (0 ms)
[ RUN      ] TestDuration.chrono_overloads
[       OK ] TestDuration.chrono_overloads (0 ms)
[ RUN      ] TestDuration.overflows
[       OK ] TestDuration.overflows (1 ms)
[ RUN      ] TestDuration.negative_duration
[       OK ] TestDuration.negative_duration (0 ms)
[ RUN      ] TestDuration.maximum_duration
[       OK ] TestDuration.maximum_duration (0 ms)
[ RUN      ] TestDuration.from_seconds
[       OK ] TestDuration.from_seconds (0 ms)
[ RUN      ] TestDuration.std_chrono_constructors
[       OK ] TestDuration.std_chrono_constructors (0 ms)
[ RUN      ] TestDuration.conversions
/ros2_ws/src/rclcpp/rclcpp/test/rclcpp/test_duration.cpp:203: Failure
Expected equality of these values:
  duration_msg.sec
    Which is: 0
  -1
/ros2_ws/src/rclcpp/rclcpp/test/rclcpp/test_duration.cpp:204: Failure
Expected equality of these values:
  duration_msg.nanosec
    Which is: 3794967296
  HALF_SEC_IN_NS
    Which is: 500000000
/ros2_ws/src/rclcpp/rclcpp/test/rclcpp/test_duration.cpp:205: Failure
Expected equality of these values:
  rclcpp::Duration(duration_msg).nanoseconds()
    Which is: 3794967296
  -HALF_SEC_IN_NS
    Which is: -500000000
/ros2_ws/src/rclcpp/rclcpp/test/rclcpp/test_duration.cpp:207: Failure
Expected: duration.to_rmw_time() throws an exception of type std::overflow_error.
  Actual: it throws nothing.
/ros2_ws/src/rclcpp/rclcpp/test/rclcpp/test_duration.cpp:220: Failure
Expected: duration.to_rmw_time() throws an exception of type std::overflow_error.
  Actual: it throws nothing.
/ros2_ws/src/rclcpp/rclcpp/test/rclcpp/test_duration.cpp:229: Failure
Expected equality of these values:
  duration_msg.sec
    Which is: -1
  -2
/ros2_ws/src/rclcpp/rclcpp/test/rclcpp/test_duration.cpp:230: Failure
Expected equality of these values:
  duration_msg.nanosec
    Which is: 3794967296
  HALF_SEC_IN_NS
    Which is: 500000000
/ros2_ws/src/rclcpp/rclcpp/test/rclcpp/test_duration.cpp:231: Failure
Expected equality of these values:
  rclcpp::Duration(duration_msg).nanoseconds()
    Which is: 2794967296
  -ONE_AND_HALF_SEC_IN_NS
    Which is: -1500000000
/ros2_ws/src/rclcpp/rclcpp/test/rclcpp/test_duration.cpp:233: Failure
Expected: duration.to_rmw_time() throws an exception of type std::overflow_error.
  Actual: it throws nothing.
[  FAILED  ] TestDuration.conversions (1 ms)
[----------] 8 tests from TestDuration (2 ms total)

[----------] Global test environment tear-down
[==========] 8 tests from 1 test case ran. (2 ms total)
[  PASSED  ] 7 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] TestDuration.conversions

 1 FAILED TEST

root@c610b7e4c97e:/ros2_ws# ./build/rclcpp/test/test_time
Running main() from /opt/ros/foxy/src/gtest_vendor/src/gtest_main.cc
[==========] Running 8 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 8 tests from TestTime
[ RUN      ] TestTime.clock_type_access
[       OK ] TestTime.clock_type_access (0 ms)
[ RUN      ] TestTime.clock_jump_callback_destruction_order
[       OK ] TestTime.clock_jump_callback_destruction_order (0 ms)
[ RUN      ] TestTime.time_sources
[       OK ] TestTime.time_sources (0 ms)
[ RUN      ] TestTime.conversions
/ros2_ws/src/rclcpp/rclcpp/test/rclcpp/test_time.cpp:167: Failure
Expected equality of these values:
  time_msg.sec
    Which is: 0
  -1
/ros2_ws/src/rclcpp/rclcpp/test/rclcpp/test_time.cpp:168: Failure
Expected equality of these values:
  time_msg.nanosec
    Which is: 3794967296
  HALF_SEC_IN_NS
    Which is: 500000000
/ros2_ws/src/rclcpp/rclcpp/test/rclcpp/test_time.cpp:171: Failure
Expected: { rclcpp::Time negative_time(time_msg); } throws an exception.
  Actual: it doesn't.
/ros2_ws/src/rclcpp/rclcpp/test/rclcpp/test_time.cpp:193: Failure
Expected equality of these values:
  time_msg.sec
    Which is: -1
  -2
/ros2_ws/src/rclcpp/rclcpp/test/rclcpp/test_time.cpp:194: Failure
Expected equality of these values:
  time_msg.nanosec
    Which is: 3794967296
  HALF_SEC_IN_NS
    Which is: 500000000
[  FAILED  ] TestTime.conversions (2 ms)
[ RUN      ] TestTime.operators
[       OK ] TestTime.operators (1 ms)
[ RUN      ] TestTime.overflow_detectors
[       OK ] TestTime.overflow_detectors (0 ms)
[ RUN      ] TestTime.overflows
[       OK ] TestTime.overflows (1 ms)
[ RUN      ] TestTime.seconds
[       OK ] TestTime.seconds (0 ms)
[----------] 8 tests from TestTime (4 ms total)

[----------] Global test environment tear-down
[==========] 8 tests from 1 test case ran. (4 ms total)
[  PASSED  ] 7 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] TestTime.conversions

 1 FAILED TEST
 ```
