### PR TITLE
fix race in test_lifecycle_service_client

### DIFF
--- a/rclcpp_lifecycle/test/test_lifecycle_service_client.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_service_client.cpp
@@ -20,6 +20,7 @@
 #include <gtest/gtest.h>
 #include <chrono>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -217,21 +218,31 @@ private:
 
   void TearDown() override
   {
-    rclcpp::shutdown();
+    {
+      std::lock_guard<std::mutex> guard(shutdown_mutex_);
+      rclcpp::shutdown();
+    }
     spinner_.join();
   }
 
   void spin()
   {
-    while (rclcpp::ok()) {
-      rclcpp::spin_some(lifecycle_node_->get_node_base_interface());
-      rclcpp::spin_some(lifecycle_client_);
+    while (true) {
+      {
+        std::lock_guard<std::mutex> guard(shutdown_mutex_);
+        if (!rclcpp::ok()) {
+          break;
+        }
+        rclcpp::spin_some(lifecycle_node_->get_node_base_interface());
+        rclcpp::spin_some(lifecycle_client_);
+      }
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
   }
 
   std::shared_ptr<EmptyLifecycleNode> lifecycle_node_;
   std::shared_ptr<LifecycleServiceClient> lifecycle_client_;
+  std::mutex shutdown_mutex_;
   std::thread spinner_;
 };
 


### PR DESCRIPTION
Fixes a race between one thread spinning and calling `rclcpp::shutdown()` from another thread by making the critical sections mutually exclusive.

The test has been failing since the first nightly build (https://ci.ros2.org/view/nightly/job/nightly_osx_repeated/1939/testReport/(root)/projectroot/test_lifecycle_service_client/) after being added in #1045.

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9267)](https://ci.ros2.org/job/ci_osx/9267/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9275)](https://ci.ros2.org/job/ci_osx/9275/)