### PR TITLE
Remove usage of domain id in node options

### DIFF
--- a/rclcpp/include/rclcpp/node_options.hpp
+++ b/rclcpp/include/rclcpp/node_options.hpp
@@ -327,11 +327,6 @@ public:
   NodeOptions &
   allocator(rcl_allocator_t allocator);
 
-protected:
-  /// Retrieve the ROS_DOMAIN_ID environment variable and populate options.
-  size_t
-  get_domain_id_from_env() const;
-
 private:
   // This is mutable to allow for a const accessor which lazily creates the node options instance.
   /// Underlying rcl_node_options structure.

--- a/rclcpp/src/rclcpp/node_options.cpp
+++ b/rclcpp/src/rclcpp/node_options.cpp
@@ -92,7 +92,6 @@ NodeOptions::get_rcl_node_options() const
     *node_options_ = rcl_node_get_default_options();
     node_options_->allocator = this->allocator_;
     node_options_->use_global_arguments = this->use_global_arguments_;
-    node_options_->domain_id = this->get_domain_id_from_env();
     node_options_->enable_rosout = this->enable_rosout_;
 
     int c_argc = 0;
@@ -320,38 +319,6 @@ NodeOptions::allocator(rcl_allocator_t allocator)
   this->node_options_.reset();  // reset node options to make it be recreated on next access.
   this->allocator_ = allocator;
   return *this;
-}
-
-// TODO(wjwwood): reuse rcutils_get_env() to avoid code duplication.
-//   See also: https://github.com/ros2/rcl/issues/119
-size_t
-NodeOptions::get_domain_id_from_env() const
-{
-  // Determine the domain id based on the options and the ROS_DOMAIN_ID env variable.
-  size_t domain_id = std::numeric_limits<size_t>::max();
-  char * ros_domain_id = nullptr;
-  const char * env_var = "ROS_DOMAIN_ID";
-#ifndef _WIN32
-  ros_domain_id = getenv(env_var);
-#else
-  size_t ros_domain_id_size;
-  _dupenv_s(&ros_domain_id, &ros_domain_id_size, env_var);
-#endif
-  if (ros_domain_id) {
-    uint32_t number = static_cast<uint32_t>(strtoul(ros_domain_id, NULL, 0));
-    if (number == (std::numeric_limits<uint32_t>::max)()) {
-#ifdef _WIN32
-      // free the ros_domain_id before throwing, if getenv was used on Windows
-      free(ros_domain_id);
-#endif
-      throw std::runtime_error("failed to interpret ROS_DOMAIN_ID as integral number");
-    }
-    domain_id = static_cast<size_t>(number);
-#ifdef _WIN32
-    free(ros_domain_id);
-#endif
-  }
-  return domain_id;
 }
 
 }  // namespace rclcpp


### PR DESCRIPTION
This code isn't doing anything:

- https://github.com/ros2/rcl/blob/b9cfc243bf018091b5c5bcb5585d19591daf4ae6/rcl/src/rcl/node_options.c#L32
- https://github.com/ros2/rcl/blob/b9cfc243bf018091b5c5bcb5585d19591daf4ae6/rcl/src/rcl/node.c#L257-L264

I'm planning to completely remove domain id from `node options`, and use the one in `init options` instead.
That was agreed during the implementation of https://github.com/ros2/rmw/issues/183, but we never finished that API change.

It isn't much of an issue currently, as there's no API in `rclpy` or `rclcpp` to modify the domain id.