### PR TITLE
[dashing backport] Fix implementation of NodeOptions::use_global_arguments() (#1176)

### DIFF
--- a/rclcpp/src/rclcpp/node_options.cpp
+++ b/rclcpp/src/rclcpp/node_options.cpp
@@ -163,7 +163,7 @@ NodeOptions::parameter_overrides(const std::vector<rclcpp::Parameter> & paramete
 bool
 NodeOptions::use_global_arguments() const
 {
-  return this->node_options_->use_global_arguments;
+  return this->use_global_arguments_;
 }
 
 NodeOptions &

--- a/rclcpp/test/rclcpp/test_node_options.cpp
+++ b/rclcpp/test/rclcpp/test_node_options.cpp
@@ -1,0 +1,57 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "rcl/allocator.h"
+#include "rcl/arguments.h"
+#include "rcl/remap.h"
+
+#include "rclcpp/node_options.hpp"
+
+
+TEST(TestNodeOptions, use_global_arguments) {
+  {
+    auto options = rclcpp::NodeOptions();
+    EXPECT_TRUE(options.use_global_arguments());
+    EXPECT_TRUE(options.get_rcl_node_options()->use_global_arguments);
+  }
+
+  {
+    auto options = rclcpp::NodeOptions().use_global_arguments(false);
+    EXPECT_FALSE(options.use_global_arguments());
+    EXPECT_FALSE(options.get_rcl_node_options()->use_global_arguments);
+  }
+
+  {
+    auto options = rclcpp::NodeOptions().use_global_arguments(true);
+    EXPECT_TRUE(options.use_global_arguments());
+    EXPECT_TRUE(options.get_rcl_node_options()->use_global_arguments);
+  }
+
+  {
+    auto options = rclcpp::NodeOptions();
+    EXPECT_TRUE(options.use_global_arguments());
+    EXPECT_TRUE(options.get_rcl_node_options()->use_global_arguments);
+    options.use_global_arguments(false);
+    EXPECT_FALSE(options.use_global_arguments());
+    EXPECT_FALSE(options.get_rcl_node_options()->use_global_arguments);
+    options.use_global_arguments(true);
+    EXPECT_TRUE(options.use_global_arguments());
+    EXPECT_TRUE(options.get_rcl_node_options()->use_global_arguments);
+  }
+}


### PR DESCRIPTION
`this->node_options_` might still be `nullptr` for a default initialized NodeOptions instance.
`use_global_arguments()` must return `this->use_global_arguments_`, in analogy to `NodeOptions::enable_rosout()`.

Signed-off-by: Johannes Meyer <johannes@intermodalics.eu>