### PR TITLE
link against thread library where necessary

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rclcpp)
 
+find_package(Threads REQUIRED)
+
 find_package(ament_cmake_ros REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(libstatistics_collector REQUIRED)
@@ -170,6 +172,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
   "$<INSTALL_INTERFACE:include>")
+target_link_libraries(${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
 # specific order: dependents before dependencies
 ament_target_dependencies(${PROJECT_NAME}
   "libstatistics_collector"


### PR DESCRIPTION
Add missing link against the thread library which fails: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=nightly_linux_clang_libcxx&build=467)](https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/467/)

Clang-libcxx build (also skipping `intra_process_demo` from ros2/ci#491): [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11351)](https://ci.ros2.org/job/ci_linux/11351/)

The usual set of CI builds:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11354)](http://ci.ros2.org/job/ci_linux/11354/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6584)](http://ci.ros2.org/job/ci_linux-aarch64/6584/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9309)](http://ci.ros2.org/job/ci_osx/9309/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11245)](http://ci.ros2.org/job/ci_windows/11245/)