### PR TITLE
Remove recreation of entities_collector

### DIFF
--- a/rclcpp/include/rclcpp/executors/static_single_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/static_single_threaded_executor.hpp
@@ -162,7 +162,6 @@ public:
     }
     std::chrono::nanoseconds timeout_left = timeout_ns;
 
-    entities_collector_ = std::make_shared<StaticExecutorEntitiesCollector>();
     entities_collector_->init(&wait_set_, memory_strategy_, &interrupt_guard_condition_);
 
     while (rclcpp::ok(this->context_)) {


### PR DESCRIPTION
In the implementation of `spin_until_future_complete` in static_single_threaded_executor, it recreated the entities_collector. However, due to the logic of the class, this removed the nodes from being considered for work. It's my understanding of this code that the entities collector should only be created in the constructor.

Signed-off-by: Stephen Brawner <brawner@gmail.com>