### PR TITLE
Add missing RCLCPP_PUBLIC to ~StaticExecutorEntitiesCollector

### DIFF
--- a/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
@@ -45,6 +45,7 @@ public:
   StaticExecutorEntitiesCollector() = default;
 
   // Destructor
+  RCLCPP_PUBLIC
   ~StaticExecutorEntitiesCollector();
 
   /// Initialize StaticExecutorEntitiesCollector


### PR DESCRIPTION
The destructor for StaticExecutorEntitiesCollector needs the RCLCPP_PUBLIC flag otherwise it fails to build on Windows when it's used.

Example:
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11309)](https://ci.ros2.org/job/ci_windows/11309/)

Unit test is being added in #1221.

Signed-off-by: Stephen Brawner <brawner@gmail.com>