### PR TITLE
[foxy backport] Add missing RCLCPP_PUBLIC to ~StaticExecutorEntitiesCollector (#1227)

### DIFF
--- a/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
@@ -45,6 +45,7 @@ public:
   StaticExecutorEntitiesCollector() = default;
 
   // Destructor
+  RCLCPP_PUBLIC
   ~StaticExecutorEntitiesCollector();
 
   /// Initialize StaticExecutorEntitiesCollector


### PR DESCRIPTION
Signed-off-by: Stephen Brawner <brawner@gmail.com>