### PR TITLE
add operator!= for duration

### DIFF
--- a/rclcpp/include/rclcpp/duration.hpp
+++ b/rclcpp/include/rclcpp/duration.hpp
@@ -78,6 +78,9 @@ public:
   operator==(const rclcpp::Duration & rhs) const;
 
   bool
+  operator!=(const rclcpp::Duration & rhs) const;
+
+  bool
   operator<(const rclcpp::Duration & rhs) const;
 
   bool

--- a/rclcpp/src/rclcpp/duration.cpp
+++ b/rclcpp/src/rclcpp/duration.cpp
@@ -95,6 +95,12 @@ Duration::operator==(const rclcpp::Duration & rhs) const
 }
 
 bool
+Duration::operator!=(const rclcpp::Duration & rhs) const
+{
+  return rcl_duration_.nanoseconds != rhs.rcl_duration_.nanoseconds;
+}
+
+bool
 Duration::operator<(const rclcpp::Duration & rhs) const
 {
   return rcl_duration_.nanoseconds < rhs.rcl_duration_.nanoseconds;

--- a/rclcpp/test/rclcpp/test_duration.cpp
+++ b/rclcpp/test/rclcpp/test_duration.cpp
@@ -41,6 +41,7 @@ TEST_F(TestDuration, operators) {
   EXPECT_TRUE(old <= young);
   EXPECT_TRUE(young >= old);
   EXPECT_FALSE(young == old);
+  EXPECT_TRUE(young != old);
 
   rclcpp::Duration add = old + young;
   EXPECT_EQ(add.nanoseconds(), old.nanoseconds() + young.nanoseconds());


### PR DESCRIPTION
I'm not sure why it wasn't there in the first place and couldn't find an (obvious) reason.

Unfortunately I cannot build/test the current master branch (still running melodic and eloquent) so PR against "eloquent" 