### PR TITLE
suppress warnings inline

### DIFF
--- a/rclcpp/src/rclcpp/context.cpp
+++ b/rclcpp/src/rclcpp/context.cpp
@@ -317,7 +317,9 @@ Context::shutdown(const std::string & reason)
       rcl_ret_t rcl_ret = rcl_logging_fini();
       if (RCL_RET_OK != rcl_ret) {
         RCUTILS_SAFE_FWRITE_TO_STDERR(
+          // cppcheck-suppress unknownMacro
           RCUTILS_STRINGIFY(__file__) ":"
+          // cppcheck-suppress unknownMacro
           RCUTILS_STRINGIFY(__LINE__)
           " failed to fini logging");
         rcl_reset_error();


### PR DESCRIPTION
This should let `cppcheck` pass with v2.x.

I deliberately opted against the approach taken in https://github.com/ros2/rclpy/pull/577 as it'd increase testing time quite dramatically - it always timeout after 3mins. 