### PR TITLE
Add `take_data` to `Waitable` and `data` to `AnyExecutable`

### DIFF
--- a/rclcpp/include/rclcpp/any_executable.hpp
+++ b/rclcpp/include/rclcpp/any_executable.hpp
@@ -47,6 +47,7 @@ struct AnyExecutable
   // These are used to keep the scope on the containing items
   rclcpp::CallbackGroup::SharedPtr callback_group;
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base;
+  std::shared_ptr<void> data;
 };
 
 namespace executor

--- a/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
@@ -77,7 +77,11 @@ public:
   void
   execute(std::shared_ptr<void> & data) override;
 
-  /// Prepare the waitable for execution.
+  /// Take the data so that it can be consumed with `execute`.
+  /**
+   * For `StaticExecutorEntitiesCollector`, this always return `nullptr`.
+   * \sa rclcpp::Waitable::take_data()
+   */
   RCLCPP_PUBLIC
   std::shared_ptr<void>
   take_data() override;

--- a/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
@@ -72,9 +72,15 @@ public:
   void
   fini();
 
+  /// Execute the waitable.
   RCLCPP_PUBLIC
   void
-  execute() override;
+  execute(std::shared_ptr<void> & data) override;
+
+  /// Prepare the waitable for execution.
+  RCLCPP_PUBLIC
+  void
+  take_data(std::shared_ptr<void> & data) override;
 
   /// Function to add_handles_to_wait_set and wait for work and
   /**

--- a/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
@@ -79,8 +79,8 @@ public:
 
   /// Prepare the waitable for execution.
   RCLCPP_PUBLIC
-  void
-  take_data(std::shared_ptr<void> & data) override;
+  std::shared_ptr<void>
+  take_data() override;
 
   /// Function to add_handles_to_wait_set and wait for work and
   /**

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
@@ -20,6 +20,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
@@ -198,7 +198,7 @@ private:
       data);
 
     if (any_callback_.use_take_shared_method()) {
-      ConstMessageSharedPtr shared_msg = (*shared_ptr).first;
+      ConstMessageSharedPtr shared_msg = shared_ptr->first;
       any_callback_.dispatch_intra_process(shared_msg, msg_info);
     } else {
       MessageUniquePtr unique_msg = std::move((*shared_ptr).second);

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
@@ -178,6 +178,7 @@ private:
   typename std::enable_if<std::is_same<T, rcl_serialized_message_t>::value, void>::type
   execute_impl(std::shared_ptr<void> & data)
   {
+    (void)data;
     throw std::runtime_error("Subscription intra-process can't handle serialized messages");
   }
 

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
@@ -121,12 +121,9 @@ public:
     return buffer_->has_data();
   }
 
-  void take_data(std::shared_ptr<void> & data)
+  std::shared_ptr<void>
+  take_data()
   {
-    if (data) {
-      throw std::runtime_error("'data' is not empty");
-    }
-
     ConstMessageSharedPtr shared_msg;
     MessageUniquePtr unique_msg;
 
@@ -135,7 +132,7 @@ public:
     } else {
       unique_msg = buffer_->consume_unique();
     }
-    data = std::static_pointer_cast<void>(
+    return std::static_pointer_cast<void>(
       std::make_shared<std::pair<ConstMessageSharedPtr, MessageUniquePtr>>(
         std::pair<ConstMessageSharedPtr, MessageUniquePtr>(
           shared_msg, std::move(unique_msg)))

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
@@ -201,7 +201,7 @@ private:
       ConstMessageSharedPtr shared_msg = shared_ptr->first;
       any_callback_.dispatch_intra_process(shared_msg, msg_info);
     } else {
-      MessageUniquePtr unique_msg = std::move((*shared_ptr).second);
+      MessageUniquePtr unique_msg = std::move(shared_ptr->second);
       any_callback_.dispatch_intra_process(std::move(unique_msg), msg_info);
     }
     shared_ptr.reset();

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -56,8 +56,9 @@ public:
   virtual bool
   is_ready(rcl_wait_set_t * wait_set) = 0;
 
-  virtual void
-  take_data(std::shared_ptr<void> & data) = 0;
+  virtual
+  std::shared_ptr<void>
+  take_data() = 0;
 
   virtual void
   execute(std::shared_ptr<void> & data) = 0;

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -57,7 +57,10 @@ public:
   is_ready(rcl_wait_set_t * wait_set) = 0;
 
   virtual void
-  execute() = 0;
+  take_data(std::shared_ptr<void> & data) = 0;
+
+  virtual void
+  execute(std::shared_ptr<void> & data) = 0;
 
   virtual bool
   use_take_shared_method() const = 0;

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -17,6 +17,7 @@
 
 #include <functional>
 #include <memory>
+#include <stdexcept>
 #include <string>
 
 #include "rcl/error_handling.h"
@@ -137,7 +138,7 @@ public:
   take_data(std::shared_ptr<void> & data) override
   {
     if (data) {
-      throw std::runtime_error("Should not be data in the pointer");
+      throw std::runtime_error("'data' is not empty");
     }
 
     EventCallbackInfoT callback_info;

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -145,9 +145,7 @@ public:
         "Couldn't take event info: %s", rcl_get_error_string().str);
       return nullptr;
     }
-    return std::static_pointer_cast<void>(
-      std::make_shared<EventCallbackInfoT>(
-        callback_info));
+    return std::static_pointer_cast<void>(std::make_shared<EventCallbackInfoT>(callback_info));
   }
 
   /// Execute any entities of the Waitable that are ready.

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -158,7 +158,7 @@ public:
   execute(std::shared_ptr<void> & data) override
   {
     if (!data) {
-      throw std::runtime_error("Data is empty");
+      throw std::runtime_error("'data' is empty");
     }
     auto callback_ptr = std::static_pointer_cast<EventCallbackInfoT>(data);
     event_callback_(*callback_ptr);

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -132,7 +132,7 @@ public:
     }
   }
 
-  /// Take data so that the callback cannot be called again
+  /// Take data so that the callback cannot be scheduled again
   void
   take_data(std::shared_ptr<void> & data) override
   {

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -134,22 +134,18 @@ public:
   }
 
   /// Take data so that the callback cannot be scheduled again
-  void
-  take_data(std::shared_ptr<void> & data) override
+  std::shared_ptr<void>
+  take_data() override
   {
-    if (data) {
-      throw std::runtime_error("'data' is not empty");
-    }
-
     EventCallbackInfoT callback_info;
     rcl_ret_t ret = rcl_take_event(&event_handle_, &callback_info);
     if (ret != RCL_RET_OK) {
       RCUTILS_LOG_ERROR_NAMED(
         "rclcpp",
         "Couldn't take event info: %s", rcl_get_error_string().str);
-      return;
+      return nullptr;
     }
-    data = std::static_pointer_cast<void>(
+    return std::static_pointer_cast<void>(
       std::make_shared<EventCallbackInfoT>(
         callback_info));
   }

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -16,6 +16,7 @@
 #define RCLCPP__QOS_EVENT_HPP_
 
 #include <functional>
+#include <memory>
 #include <string>
 
 #include "rcl/error_handling.h"
@@ -131,12 +132,15 @@ public:
     }
   }
 
-  /// Execute any entities of the Waitable that are ready.
+  /// Take data so that the callback cannot be called again
   void
-  execute() override
+  take_data(std::shared_ptr<void> & data) override
   {
-    EventCallbackInfoT callback_info;
+    if (data) {
+      throw std::runtime_error("Should not be data in the pointer");
+    }
 
+    EventCallbackInfoT callback_info;
     rcl_ret_t ret = rcl_take_event(&event_handle_, &callback_info);
     if (ret != RCL_RET_OK) {
       RCUTILS_LOG_ERROR_NAMED(
@@ -144,8 +148,21 @@ public:
         "Couldn't take event info: %s", rcl_get_error_string().str);
       return;
     }
+    data = std::static_pointer_cast<void>(
+      std::make_shared<EventCallbackInfoT>(
+        callback_info));
+  }
 
-    event_callback_(callback_info);
+  /// Execute any entities of the Waitable that are ready.
+  void
+  execute(std::shared_ptr<void> & data) override
+  {
+    if (!data) {
+      throw std::runtime_error("Data is empty");
+    }
+    auto callback_ptr = std::static_pointer_cast<EventCallbackInfoT>(data);
+    event_callback_(*callback_ptr);
+    callback_ptr.reset();
   }
 
 private:

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -153,14 +153,13 @@ public:
    * // Update the Waitable
    * waitable.update(wait_set);
    * // Execute any entities of the Waitable that may be ready
-   * std::shared_ptr<void> data;
-   * waitable.take_data(data);
+   * std::shared_ptr<void> data = waitable.take_data();
    * ```
    */
   RCLCPP_PUBLIC
   virtual
-  void
-  take_data(std::shared_ptr<void> & data) = 0;
+  std::shared_ptr<void>
+  take_data() = 0;
 
   /// Execute data that is passed in.
   /**
@@ -181,8 +180,7 @@ public:
    * // Update the Waitable
    * waitable.update(wait_set);
    * // Execute any entities of the Waitable that may be ready
-   * std::shared_ptr<void> data;
-   * waitable.take_data(data);
+   * std::shared_ptr<void> data = waitable.take_data();
    * waitable.execute(data);
    * ```
    */

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -16,6 +16,7 @@
 #define RCLCPP__WAITABLE_HPP_
 
 #include <atomic>
+#include <memory>
 
 #include "rclcpp/macros.hpp"
 #include "rclcpp/visibility_control.hpp"
@@ -125,8 +126,17 @@ public:
   bool
   is_ready(rcl_wait_set_t * wait_set) = 0;
 
-  /// Execute any entities of the Waitable that are ready.
+  /// Take the data so that it can be consumed with `execute`.
   /**
+   * NOTE: take_data is a partial fix to a larger design issue with the
+   * multithreaded executor. This method is likely to be removed when
+   * a more permanent fix is implemented. A longterm fix is currently
+   * being discussed here: https://github.com/ros2/rclcpp/pull/1276
+   *
+   * This method takes the data from the underlying data structure and
+   * writes it to the void shared pointer `data` that is passed into the
+   * method. The `data` can then be executed with the `execute` method.
+   *
    * Before calling this method, the Waitable should be added to a wait set,
    * waited on, and then updated.
    *
@@ -143,13 +153,43 @@ public:
    * // Update the Waitable
    * waitable.update(wait_set);
    * // Execute any entities of the Waitable that may be ready
-   * waitable.execute();
+   * std::shared_ptr<void> data;
+   * waitable.take_data(data);
    * ```
    */
   RCLCPP_PUBLIC
   virtual
   void
-  execute() = 0;
+  take_data(std::shared_ptr<void> & data) = 0;
+
+  /// Execute data that is passed in.
+  /**
+   * Before calling this method, the Waitable should be added to a wait set,
+   * waited on, and then updated - and the `take_data` method should be
+   * called.
+   *
+   * Example usage:
+   *
+   * ```cpp
+   * // ... create a wait set and a Waitable
+   * // Add the Waitable to the wait set
+   * bool add_ret = waitable.add_to_wait_set(wait_set);
+   * // ... error handling
+   * // Wait
+   * rcl_ret_t wait_ret = rcl_wait(wait_set);
+   * // ... error handling
+   * // Update the Waitable
+   * waitable.update(wait_set);
+   * // Execute any entities of the Waitable that may be ready
+   * std::shared_ptr<void> data;
+   * waitable.take_data(data);
+   * waitable.execute(data);
+   * ```
+   */
+  RCLCPP_PUBLIC
+  virtual
+  void
+  execute(std::shared_ptr<void> & data) = 0;
 
   /// Exchange the "in use by wait set" state for this timer.
   /**

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -507,7 +507,7 @@ Executor::execute_any_executable(AnyExecutable & any_exec)
     execute_client(any_exec.client);
   }
   if (any_exec.waitable) {
-    any_exec.waitable->execute();
+    any_exec.waitable->execute(any_exec.data);
   }
   // Reset the callback_group, regardless of type
   any_exec.callback_group->can_be_taken_from().store(true);
@@ -830,6 +830,7 @@ Executor::get_next_ready_executable_from_map(
     // Check the waitables to see if there are any that are ready
     memory_strategy_->get_next_waitable(any_executable, weak_groups_to_nodes);
     if (any_executable.waitable) {
+      any_executable.waitable->take_data(any_executable.data);
       success = true;
     }
   }

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -830,7 +830,7 @@ Executor::get_next_ready_executable_from_map(
     // Check the waitables to see if there are any that are ready
     memory_strategy_->get_next_waitable(any_executable, weak_groups_to_nodes);
     if (any_executable.waitable) {
-      any_executable.waitable->take_data(any_executable.data);
+      any_executable.data = any_executable.waitable->take_data();
       success = true;
     }
   }

--- a/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
@@ -88,10 +88,10 @@ StaticExecutorEntitiesCollector::fini()
   exec_list_.clear();
 }
 
-void
-StaticExecutorEntitiesCollector::take_data(std::shared_ptr<void> & data)
+std::shared_ptr<void>
+StaticExecutorEntitiesCollector::take_data()
 {
-  (void) data;
+  return nullptr;
 }
 
 void

--- a/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
@@ -77,7 +77,8 @@ StaticExecutorEntitiesCollector::init(
   // Add executor's guard condition
   memory_strategy_->add_guard_condition(executor_guard_condition);
   // Get memory strategy and executable list. Prepare wait_set_
-  execute();
+  std::shared_ptr<void> shared_ptr;
+  execute(shared_ptr);
 }
 
 void
@@ -88,8 +89,15 @@ StaticExecutorEntitiesCollector::fini()
 }
 
 void
-StaticExecutorEntitiesCollector::execute()
+StaticExecutorEntitiesCollector::take_data(std::shared_ptr<void> & data)
 {
+  (void) data;
+}
+
+void
+StaticExecutorEntitiesCollector::execute(std::shared_ptr<void> & data)
+{
+  (void) data;
   // Fill memory strategy with entities coming from weak_nodes_
   fill_memory_strategy();
   // Fill exec_list_ with entities coming from weak_nodes_ (same as memory strategy)

--- a/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
@@ -176,7 +176,8 @@ StaticSingleThreadedExecutor::execute_ready_executables()
   // Execute all the ready waitables
   for (size_t i = 0; i < entities_collector_->get_number_of_waitables(); ++i) {
     if (entities_collector_->get_waitable(i)->is_ready(&wait_set_)) {
-      entities_collector_->get_waitable(i)->execute();
+      std::shared_ptr<void> shared_ptr;
+      entities_collector_->get_waitable(i)->execute(shared_ptr);
     }
   }
 }

--- a/rclcpp/test/benchmark/benchmark_executor.cpp
+++ b/rclcpp/test/benchmark/benchmark_executor.cpp
@@ -384,6 +384,8 @@ BENCHMARK_F(
   reset_heap_counters();
 
   for (auto _ : st) {
-    entities_collector_->execute();
+    std::shared_ptr<void> data;
+    entities_collector_->take_data(data);
+    entities_collector_->execute(data);
   }
 }

--- a/rclcpp/test/benchmark/benchmark_executor.cpp
+++ b/rclcpp/test/benchmark/benchmark_executor.cpp
@@ -384,8 +384,7 @@ BENCHMARK_F(
   reset_heap_counters();
 
   for (auto _ : st) {
-    std::shared_ptr<void> data;
-    entities_collector_->take_data(data);
+    std::shared_ptr<void> data = entities_collector_->take_data();
     entities_collector_->execute(data);
   }
 }

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -436,10 +436,10 @@ public:
     return true;
   }
 
-  void
-  take_data(std::shared_ptr<void> & data) override
+  std::shared_ptr<void>
+  take_data() override
   {
-    (void) data;
+    return nullptr;
   }
 
   void

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -437,8 +437,15 @@ public:
   }
 
   void
-  execute() override
+  take_data(std::shared_ptr<void> & data) override
   {
+    (void) data;
+  }
+
+  void
+  execute(std::shared_ptr<void> & data) override
+  {
+    (void) data;
     count_++;
     std::this_thread::sleep_for(1ms);
   }

--- a/rclcpp/test/rclcpp/executors/test_static_executor_entities_collector.cpp
+++ b/rclcpp/test/rclcpp/executors/test_static_executor_entities_collector.cpp
@@ -235,7 +235,14 @@ public:
 
   bool is_ready(rcl_wait_set_t *) override {return true;}
 
-  void execute() override {}
+  void take_data(std::shared_ptr<void> & data) override
+  {
+    (void) data;
+  }
+  void execute(std::shared_ptr<void> & data) override
+  {
+    (void) data;
+  }
 };
 
 TEST_F(TestStaticExecutorEntitiesCollector, add_remove_node_with_entities) {
@@ -363,8 +370,10 @@ TEST_F(TestStaticExecutorEntitiesCollector, prepare_wait_set_rcl_wait_set_clear_
 
   {
     auto mock = mocking_utils::patch_and_return("lib:rclcpp", rcl_wait_set_clear, RCL_RET_ERROR);
+    std::shared_ptr<void> data;
+    entities_collector_->take_data(data);
     RCLCPP_EXPECT_THROW_EQ(
-      entities_collector_->execute(),
+      entities_collector_->execute(data),
       std::runtime_error("Couldn't clear wait set"));
   }
 
@@ -393,8 +402,10 @@ TEST_F(TestStaticExecutorEntitiesCollector, prepare_wait_set_rcl_wait_set_resize
 
   {
     auto mock = mocking_utils::patch_and_return("lib:rclcpp", rcl_wait_set_resize, RCL_RET_ERROR);
+    std::shared_ptr<void> data;
+    entities_collector_->take_data(data);
     RCLCPP_EXPECT_THROW_EQ(
-      entities_collector_->execute(),
+      entities_collector_->execute(data),
       std::runtime_error("Couldn't resize the wait set: error not set"));
   }
 
@@ -616,7 +627,9 @@ TEST_F(
   RCLCPP_SCOPE_EXIT(entities_collector_->fini());
 
   cb_group->get_associated_with_executor_atomic().exchange(false);
-  entities_collector_->execute();
+  std::shared_ptr<void> data;
+  entities_collector_->take_data(data);
+  entities_collector_->execute(data);
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
 }

--- a/rclcpp/test/rclcpp/executors/test_static_executor_entities_collector.cpp
+++ b/rclcpp/test/rclcpp/executors/test_static_executor_entities_collector.cpp
@@ -235,11 +235,13 @@ public:
 
   bool is_ready(rcl_wait_set_t *) override {return true;}
 
-  void take_data(std::shared_ptr<void> & data) override
+  std::shared_ptr<void>
+  take_data() override
   {
-    (void) data;
+    return nullptr;
   }
-  void execute(std::shared_ptr<void> & data) override
+  void
+  execute(std::shared_ptr<void> & data) override
   {
     (void) data;
   }
@@ -370,8 +372,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, prepare_wait_set_rcl_wait_set_clear_
 
   {
     auto mock = mocking_utils::patch_and_return("lib:rclcpp", rcl_wait_set_clear, RCL_RET_ERROR);
-    std::shared_ptr<void> data;
-    entities_collector_->take_data(data);
+    std::shared_ptr<void> data = entities_collector_->take_data();
     RCLCPP_EXPECT_THROW_EQ(
       entities_collector_->execute(data),
       std::runtime_error("Couldn't clear wait set"));
@@ -402,8 +403,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, prepare_wait_set_rcl_wait_set_resize
 
   {
     auto mock = mocking_utils::patch_and_return("lib:rclcpp", rcl_wait_set_resize, RCL_RET_ERROR);
-    std::shared_ptr<void> data;
-    entities_collector_->take_data(data);
+    std::shared_ptr<void> data = entities_collector_->take_data();
     RCLCPP_EXPECT_THROW_EQ(
       entities_collector_->execute(data),
       std::runtime_error("Couldn't resize the wait set: error not set"));
@@ -627,8 +627,7 @@ TEST_F(
   RCLCPP_SCOPE_EXIT(entities_collector_->fini());
 
   cb_group->get_associated_with_executor_atomic().exchange(false);
-  std::shared_ptr<void> data;
-  entities_collector_->take_data(data);
+  std::shared_ptr<void> data = entities_collector_->take_data();
   entities_collector_->execute(data);
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_waitables.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_waitables.cpp
@@ -30,7 +30,14 @@ class TestWaitable : public rclcpp::Waitable
 public:
   bool add_to_wait_set(rcl_wait_set_t *) override {return false;}
   bool is_ready(rcl_wait_set_t *) override {return false;}
-  void execute() override {}
+  void take_data(std::shared_ptr<void> & data) override
+  {
+    (void) data;
+  }
+  void execute(std::shared_ptr<void> & data) override
+  {
+    (void) data;
+  }
 };
 
 class TestNodeWaitables : public ::testing::Test

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_waitables.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_waitables.cpp
@@ -30,10 +30,13 @@ class TestWaitable : public rclcpp::Waitable
 public:
   bool add_to_wait_set(rcl_wait_set_t *) override {return false;}
   bool is_ready(rcl_wait_set_t *) override {return false;}
-  void take_data(std::shared_ptr<void> & data) override
+
+  std::shared_ptr<void>
+  take_data() override
   {
-    (void) data;
+    return nullptr;
   }
+
   void execute(std::shared_ptr<void> & data) override
   {
     (void) data;

--- a/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
@@ -49,7 +49,15 @@ public:
     return test_waitable_result;
   }
 
-  void execute() override {}
+  void take_data(std::shared_ptr<void> & data) override
+  {
+    (void) data;
+  }
+
+  void execute(std::shared_ptr<void> & data) override
+  {
+    (void) data;
+  }
 };
 
 struct RclWaitSetSizes

--- a/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
@@ -49,9 +49,10 @@ public:
     return test_waitable_result;
   }
 
-  void take_data(std::shared_ptr<void> & data) override
+  std::shared_ptr<void>
+  take_data() override
   {
-    (void) data;
+    return nullptr;
   }
 
   void execute(std::shared_ptr<void> & data) override

--- a/rclcpp/test/rclcpp/test_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/test_memory_strategy.cpp
@@ -37,7 +37,14 @@ class TestWaitable : public rclcpp::Waitable
 public:
   bool add_to_wait_set(rcl_wait_set_t *) override {return true;}
   bool is_ready(rcl_wait_set_t *) override {return true;}
-  void execute() override {}
+  void take_data(std::shared_ptr<void> & data) override
+  {
+    (void) data;
+  }
+  void execute(std::shared_ptr<void> & data) override
+  {
+    (void) data;
+  }
 };
 
 class TestMemoryStrategy : public ::testing::Test

--- a/rclcpp/test/rclcpp/test_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/test_memory_strategy.cpp
@@ -37,14 +37,8 @@ class TestWaitable : public rclcpp::Waitable
 public:
   bool add_to_wait_set(rcl_wait_set_t *) override {return true;}
   bool is_ready(rcl_wait_set_t *) override {return true;}
-  void take_data(std::shared_ptr<void> & data) override
-  {
-    (void) data;
-  }
-  void execute(std::shared_ptr<void> & data) override
-  {
-    (void) data;
-  }
+  std::shared_ptr<void> take_data() override {return nullptr;}
+  void execute(std::shared_ptr<void> & data) override {(void)data;}
 };
 
 class TestMemoryStrategy : public ::testing::Test

--- a/rclcpp/test/rclcpp/test_publisher.cpp
+++ b/rclcpp/test/rclcpp/test_publisher.cpp
@@ -491,8 +491,7 @@ TEST_F(TestPublisher, run_event_handlers) {
   auto publisher = node->create_publisher<test_msgs::msg::Empty>("topic", 10);
 
   for (const auto & handler : publisher->get_event_handlers()) {
-    std::shared_ptr<void> data;
-    handler->take_data(data);
+    std::shared_ptr<void> data = handler->take_data();
     EXPECT_THROW(handler->execute(data), std::runtime_error);
   }
 }

--- a/rclcpp/test/rclcpp/test_publisher.cpp
+++ b/rclcpp/test/rclcpp/test_publisher.cpp
@@ -489,7 +489,10 @@ TEST_F(TestPublisher, default_incompatible_qos_callback) {
 TEST_F(TestPublisher, run_event_handlers) {
   initialize();
   auto publisher = node->create_publisher<test_msgs::msg::Empty>("topic", 10);
+
   for (const auto & handler : publisher->get_event_handlers()) {
-    EXPECT_NO_THROW(handler->execute());
+    std::shared_ptr<void> data;
+    handler->take_data(data);
+    EXPECT_NO_THROW(handler->execute(data));
   }
 }

--- a/rclcpp/test/rclcpp/test_publisher.cpp
+++ b/rclcpp/test/rclcpp/test_publisher.cpp
@@ -493,6 +493,6 @@ TEST_F(TestPublisher, run_event_handlers) {
   for (const auto & handler : publisher->get_event_handlers()) {
     std::shared_ptr<void> data;
     handler->take_data(data);
-    EXPECT_NO_THROW(handler->execute(data));
+    EXPECT_THROW(handler->execute(data), std::runtime_error);
   }
 }

--- a/rclcpp/test/rclcpp/test_qos_event.cpp
+++ b/rclcpp/test/rclcpp/test_qos_event.cpp
@@ -296,7 +296,7 @@ TEST_F(TestQosEvent, execute) {
     auto mock = mocking_utils::patch_and_return("lib:rclcpp", rcl_take_event, RCL_RET_ERROR);
     std::shared_ptr<void> data;
     handler.take_data(data);
-    EXPECT_NO_THROW(handler.execute(data));
+    EXPECT_THROW(handler.execute(data), std::runtime_error);
     EXPECT_FALSE(handler_callback_executed);
   }
 }

--- a/rclcpp/test/rclcpp/test_qos_event.cpp
+++ b/rclcpp/test/rclcpp/test_qos_event.cpp
@@ -285,8 +285,7 @@ TEST_F(TestQosEvent, execute) {
   rclcpp::QOSEventHandler<decltype(callback), decltype(rcl_handle)> handler(
     callback, rcl_publisher_event_init, rcl_handle, event_type);
 
-  std::shared_ptr<void> data;
-  handler.take_data(data);
+  std::shared_ptr<void> data = handler.take_data();
   EXPECT_NO_THROW(handler.execute(data));
   EXPECT_TRUE(handler_callback_executed);
 
@@ -294,8 +293,7 @@ TEST_F(TestQosEvent, execute) {
     handler_callback_executed = false;
     // Logs error and returns early
     auto mock = mocking_utils::patch_and_return("lib:rclcpp", rcl_take_event, RCL_RET_ERROR);
-    std::shared_ptr<void> data;
-    handler.take_data(data);
+    std::shared_ptr<void> data = handler.take_data();
     EXPECT_THROW(handler.execute(data), std::runtime_error);
     EXPECT_FALSE(handler_callback_executed);
   }

--- a/rclcpp/test/rclcpp/test_qos_event.cpp
+++ b/rclcpp/test/rclcpp/test_qos_event.cpp
@@ -285,14 +285,18 @@ TEST_F(TestQosEvent, execute) {
   rclcpp::QOSEventHandler<decltype(callback), decltype(rcl_handle)> handler(
     callback, rcl_publisher_event_init, rcl_handle, event_type);
 
-  EXPECT_NO_THROW(handler.execute());
+  std::shared_ptr<void> data;
+  handler.take_data(data);
+  EXPECT_NO_THROW(handler.execute(data));
   EXPECT_TRUE(handler_callback_executed);
 
   {
     handler_callback_executed = false;
     // Logs error and returns early
     auto mock = mocking_utils::patch_and_return("lib:rclcpp", rcl_take_event, RCL_RET_ERROR);
-    EXPECT_NO_THROW(handler.execute());
+    std::shared_ptr<void> data;
+    handler.take_data(data);
+    EXPECT_NO_THROW(handler.execute(data));
     EXPECT_FALSE(handler_callback_executed);
   }
 }

--- a/rclcpp/test/rclcpp/wait_set_policies/test_dynamic_storage.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_dynamic_storage.cpp
@@ -55,11 +55,7 @@ public:
 
   bool is_ready(rcl_wait_set_t *) override {return is_ready_;}
 
-  void
-  take_data(std::shared_ptr<void> & data) override
-  {
-    (void) data;
-  }
+  std::shared_ptr<void> take_data() override {return nullptr;}
 
   void
   execute(std::shared_ptr<void> & data) override {(void)data;}

--- a/rclcpp/test/rclcpp/wait_set_policies/test_dynamic_storage.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_dynamic_storage.cpp
@@ -55,7 +55,14 @@ public:
 
   bool is_ready(rcl_wait_set_t *) override {return is_ready_;}
 
-  void execute() override {}
+  void
+  take_data(std::shared_ptr<void> & data) override
+  {
+    (void) data;
+  }
+
+  void
+  execute(std::shared_ptr<void> & data) override {(void)data;}
 
   void set_is_ready(bool value) {is_ready_ = value;}
 

--- a/rclcpp/test/rclcpp/wait_set_policies/test_static_storage.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_static_storage.cpp
@@ -54,7 +54,14 @@ public:
 
   bool is_ready(rcl_wait_set_t *) override {return is_ready_;}
 
-  void execute() override {}
+  void
+  take_data(std::shared_ptr<void> & data) override
+  {
+    (void) data;
+  }
+
+  void
+  execute(std::shared_ptr<void> & data) override {(void)data;}
 
   void set_is_ready(bool value) {is_ready_ = value;}
 

--- a/rclcpp/test/rclcpp/wait_set_policies/test_static_storage.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_static_storage.cpp
@@ -54,11 +54,7 @@ public:
 
   bool is_ready(rcl_wait_set_t *) override {return is_ready_;}
 
-  void
-  take_data(std::shared_ptr<void> & data) override
-  {
-    (void) data;
-  }
+  std::shared_ptr<void> take_data() override {return nullptr;}
 
   void
   execute(std::shared_ptr<void> & data) override {(void)data;}

--- a/rclcpp/test/rclcpp/wait_set_policies/test_storage_policy_common.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_storage_policy_common.cpp
@@ -54,7 +54,14 @@ public:
 
   bool is_ready(rcl_wait_set_t *) override {return is_ready_;}
 
-  void execute() override {}
+  void
+  take_data(std::shared_ptr<void> & data) override
+  {
+    (void) data;
+  }
+
+  void
+  execute(std::shared_ptr<void> & data) override {(void)data;}
 
   void set_is_ready(bool value) {is_ready_ = value;}
 

--- a/rclcpp/test/rclcpp/wait_set_policies/test_storage_policy_common.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_storage_policy_common.cpp
@@ -54,11 +54,7 @@ public:
 
   bool is_ready(rcl_wait_set_t *) override {return is_ready_;}
 
-  void
-  take_data(std::shared_ptr<void> & data) override
-  {
-    (void) data;
-  }
+  std::shared_ptr<void> take_data() override {return nullptr;}
 
   void
   execute(std::shared_ptr<void> & data) override {(void)data;}

--- a/rclcpp/test/rclcpp/wait_set_policies/test_thread_safe_synchronization.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_thread_safe_synchronization.cpp
@@ -54,7 +54,14 @@ public:
 
   bool is_ready(rcl_wait_set_t *) override {return is_ready_;}
 
-  void execute() override {}
+  void
+  take_data(std::shared_ptr<void> & data) override
+  {
+    (void) data;
+  }
+
+  void
+  execute(std::shared_ptr<void> & data) override {(void)data;}
 
   void set_is_ready(bool value) {is_ready_ = value;}
 

--- a/rclcpp/test/rclcpp/wait_set_policies/test_thread_safe_synchronization.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_thread_safe_synchronization.cpp
@@ -54,11 +54,7 @@ public:
 
   bool is_ready(rcl_wait_set_t *) override {return is_ready_;}
 
-  void
-  take_data(std::shared_ptr<void> & data) override
-  {
-    (void) data;
-  }
+  std::shared_ptr<void> take_data() override {return nullptr;}
 
   void
   execute(std::shared_ptr<void> & data) override {(void)data;}

--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -119,7 +119,12 @@ public:
   /// \internal
   RCLCPP_ACTION_PUBLIC
   void
-  execute() override;
+  take_data(std::shared_ptr<void> & data) override;
+
+  /// \internal
+  RCLCPP_ACTION_PUBLIC
+  void
+  execute(std::shared_ptr<void> & data) override;
 
   // End Waitables API
   // -----------------

--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -118,8 +118,8 @@ public:
 
   /// \internal
   RCLCPP_ACTION_PUBLIC
-  void
-  take_data(std::shared_ptr<void> & data) override;
+  std::shared_ptr<void>
+  take_data() override;
 
   /// \internal
   RCLCPP_ACTION_PUBLIC

--- a/rclcpp_action/include/rclcpp_action/server.hpp
+++ b/rclcpp_action/include/rclcpp_action/server.hpp
@@ -118,11 +118,15 @@ public:
   bool
   is_ready(rcl_wait_set_t *) override;
 
+  RCLCPP_ACTION_PUBLIC
+  void
+  take_data(std::shared_ptr<void> & data) override;
+
   /// Act on entities in the wait set which are ready to be acted upon.
   /// \internal
   RCLCPP_ACTION_PUBLIC
   void
-  execute() override;
+  execute(std::shared_ptr<void> & data) override;
 
   // End Waitables API
   // -----------------
@@ -229,19 +233,19 @@ private:
   /// \internal
   RCLCPP_ACTION_PUBLIC
   void
-  execute_goal_request_received();
+  execute_goal_request_received(std::shared_ptr<void> & data);
 
   /// Handle a request to cancel goals on the server
   /// \internal
   RCLCPP_ACTION_PUBLIC
   void
-  execute_cancel_request_received();
+  execute_cancel_request_received(std::shared_ptr<void> & data);
 
   /// Handle a request to get the result of an action
   /// \internal
   RCLCPP_ACTION_PUBLIC
   void
-  execute_result_request_received();
+  execute_result_request_received(std::shared_ptr<void> & data);
 
   /// Handle a timeout indicating a completed goal should be forgotten by the server
   /// \internal

--- a/rclcpp_action/include/rclcpp_action/server.hpp
+++ b/rclcpp_action/include/rclcpp_action/server.hpp
@@ -119,8 +119,8 @@ public:
   is_ready(rcl_wait_set_t *) override;
 
   RCLCPP_ACTION_PUBLIC
-  void
-  take_data(std::shared_ptr<void> & data) override;
+  std::shared_ptr<void>
+  take_data() override;
 
   /// Act on entities in the wait set which are ready to be acted upon.
   /// \internal

--- a/rclcpp_action/src/client.cpp
+++ b/rclcpp_action/src/client.cpp
@@ -382,25 +382,21 @@ ClientBase::generate_goal_id()
   return goal_id;
 }
 
-void
-ClientBase::take_data(std::shared_ptr<void> & data)
+std::shared_ptr<void>
+ClientBase::take_data()
 {
-  if (data) {
-    throw std::runtime_error("'data' is not empty");
-  }
-
   if (pimpl_->is_feedback_ready) {
     std::shared_ptr<void> feedback_message = this->create_feedback_message();
     rcl_ret_t ret = rcl_action_take_feedback(
       pimpl_->client_handle.get(), feedback_message.get());
-    data = std::static_pointer_cast<void>(
+    return std::static_pointer_cast<void>(
       std::make_shared<std::tuple<rcl_ret_t, std::shared_ptr<void>>>(
         ret, feedback_message));
   } else if (pimpl_->is_status_ready) {
     std::shared_ptr<void> status_message = this->create_status_message();
     rcl_ret_t ret = rcl_action_take_status(
       pimpl_->client_handle.get(), status_message.get());
-    data = std::static_pointer_cast<void>(
+    return std::static_pointer_cast<void>(
       std::make_shared<std::tuple<rcl_ret_t, std::shared_ptr<void>>>(
         ret, status_message));
   } else if (pimpl_->is_goal_response_ready) {
@@ -408,7 +404,7 @@ ClientBase::take_data(std::shared_ptr<void> & data)
     std::shared_ptr<void> goal_response = this->create_goal_response();
     rcl_ret_t ret = rcl_action_take_goal_response(
       pimpl_->client_handle.get(), &response_header, goal_response.get());
-    data = std::static_pointer_cast<void>(
+    return std::static_pointer_cast<void>(
       std::make_shared<std::tuple<rcl_ret_t, rmw_request_id_t, std::shared_ptr<void>>>(
         ret, response_header, goal_response));
   } else if (pimpl_->is_result_response_ready) {
@@ -416,7 +412,7 @@ ClientBase::take_data(std::shared_ptr<void> & data)
     std::shared_ptr<void> result_response = this->create_result_response();
     rcl_ret_t ret = rcl_action_take_result_response(
       pimpl_->client_handle.get(), &response_header, result_response.get());
-    data = std::static_pointer_cast<void>(
+    return std::static_pointer_cast<void>(
       std::make_shared<std::tuple<rcl_ret_t, rmw_request_id_t, std::shared_ptr<void>>>(
         ret, response_header, result_response));
   } else if (pimpl_->is_cancel_response_ready) {
@@ -424,7 +420,7 @@ ClientBase::take_data(std::shared_ptr<void> & data)
     std::shared_ptr<void> cancel_response = this->create_cancel_response();
     rcl_ret_t ret = rcl_action_take_cancel_response(
       pimpl_->client_handle.get(), &response_header, cancel_response.get());
-    data = std::static_pointer_cast<void>(
+    return std::static_pointer_cast<void>(
       std::make_shared<std::tuple<rcl_ret_t, rmw_request_id_t, std::shared_ptr<void>>>(
         ret, response_header, cancel_response));
   } else {

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -190,13 +190,9 @@ ServerBase::is_ready(rcl_wait_set_t * wait_set)
          pimpl_->goal_expired_;
 }
 
-void
-ServerBase::take_data(std::shared_ptr<void> & data)
+std::shared_ptr<void>
+ServerBase::take_data()
 {
-  if (data) {
-    throw std::runtime_error("'data' is not empty");
-  }
-
   if (pimpl_->goal_request_ready_) {
     rcl_ret_t ret;
     rcl_action_goal_info_t goal_info = rcl_action_get_zero_initialized_goal_info();
@@ -210,7 +206,7 @@ ServerBase::take_data(std::shared_ptr<void> & data)
       &request_header,
       message.get());
 
-    data = std::static_pointer_cast<void>(
+    return std::static_pointer_cast<void>(
       std::make_shared
       <std::tuple<rcl_ret_t, rcl_action_goal_info_t, rmw_request_id_t, std::shared_ptr<void>>>(
         ret,
@@ -229,7 +225,7 @@ ServerBase::take_data(std::shared_ptr<void> & data)
       &request_header,
       request.get());
 
-    data = std::static_pointer_cast<void>(
+    return std::static_pointer_cast<void>(
       std::make_shared
       <std::tuple<rcl_ret_t, std::shared_ptr<action_msgs::srv::CancelGoal::Request>,
       rmw_request_id_t>>(ret, request, request_header));
@@ -242,11 +238,11 @@ ServerBase::take_data(std::shared_ptr<void> & data)
     ret = rcl_action_take_result_request(
       pimpl_->action_server_.get(), &request_header, result_request.get());
 
-    data = std::static_pointer_cast<void>(
+    return std::static_pointer_cast<void>(
       std::make_shared<std::tuple<rcl_ret_t, std::shared_ptr<void>, rmw_request_id_t>>(
         ret, result_request, request_header));
   } else if (pimpl_->goal_expired_) {
-    return;
+    return nullptr;
   } else {
     throw std::runtime_error("Taking data from action server but nothing is ready");
   }

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -24,7 +24,9 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <tuple>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 using rclcpp_action::ServerBase;
@@ -189,14 +191,80 @@ ServerBase::is_ready(rcl_wait_set_t * wait_set)
 }
 
 void
-ServerBase::execute()
+ServerBase::take_data(std::shared_ptr<void> & data)
 {
+  if (data) {
+    throw std::runtime_error("'data' is not empty");
+  }
+
   if (pimpl_->goal_request_ready_) {
-    execute_goal_request_received();
+    rcl_ret_t ret;
+    rcl_action_goal_info_t goal_info = rcl_action_get_zero_initialized_goal_info();
+    rmw_request_id_t request_header;
+
+    std::lock_guard<std::recursive_mutex> lock(pimpl_->action_server_reentrant_mutex_);
+
+    std::shared_ptr<void> message = create_goal_request();
+    ret = rcl_action_take_goal_request(
+      pimpl_->action_server_.get(),
+      &request_header,
+      message.get());
+
+    data = std::static_pointer_cast<void>(
+      std::make_shared
+      <std::tuple<rcl_ret_t, rcl_action_goal_info_t, rmw_request_id_t, std::shared_ptr<void>>>(
+        ret,
+        goal_info,
+        request_header, message));
   } else if (pimpl_->cancel_request_ready_) {
-    execute_cancel_request_received();
+    rcl_ret_t ret;
+    rmw_request_id_t request_header;
+
+    // Initialize cancel request
+    auto request = std::make_shared<action_msgs::srv::CancelGoal::Request>();
+
+    std::lock_guard<std::recursive_mutex> lock(pimpl_->action_server_reentrant_mutex_);
+    ret = rcl_action_take_cancel_request(
+      pimpl_->action_server_.get(),
+      &request_header,
+      request.get());
+
+    data = std::static_pointer_cast<void>(
+      std::make_shared
+      <std::tuple<rcl_ret_t, std::shared_ptr<action_msgs::srv::CancelGoal::Request>,
+      rmw_request_id_t>>(ret, request, request_header));
   } else if (pimpl_->result_request_ready_) {
-    execute_result_request_received();
+    rcl_ret_t ret;
+    // Get the result request message
+    rmw_request_id_t request_header;
+    std::shared_ptr<void> result_request = create_result_request();
+    std::lock_guard<std::recursive_mutex> lock(pimpl_->action_server_reentrant_mutex_);
+    ret = rcl_action_take_result_request(
+      pimpl_->action_server_.get(), &request_header, result_request.get());
+
+    data = std::static_pointer_cast<void>(
+      std::make_shared<std::tuple<rcl_ret_t, std::shared_ptr<void>, rmw_request_id_t>>(
+        ret, result_request, request_header));
+  } else if (pimpl_->goal_expired_) {
+    return;
+  } else {
+    throw std::runtime_error("Taking data from action server but nothing is ready");
+  }
+}
+
+void
+ServerBase::execute(std::shared_ptr<void> & data)
+{
+  if (!data && !pimpl_->goal_expired_) {
+    throw std::runtime_error("'data' is empty");
+  }
+
+  if (pimpl_->goal_request_ready_) {
+    execute_goal_request_received(data);
+  } else if (pimpl_->cancel_request_ready_) {
+    execute_cancel_request_received(data);
+  } else if (pimpl_->result_request_ready_) {
+    execute_result_request_received(data);
   } else if (pimpl_->goal_expired_) {
     execute_check_expired_goals();
   } else {
@@ -205,22 +273,11 @@ ServerBase::execute()
 }
 
 void
-ServerBase::execute_goal_request_received()
+ServerBase::execute_goal_request_received(std::shared_ptr<void> & data)
 {
-  rcl_ret_t ret;
-  rcl_action_goal_info_t goal_info = rcl_action_get_zero_initialized_goal_info();
-  rmw_request_id_t request_header;
-
-  std::lock_guard<std::recursive_mutex> lock(pimpl_->action_server_reentrant_mutex_);
-
-  std::shared_ptr<void> message = create_goal_request();
-  ret = rcl_action_take_goal_request(
-    pimpl_->action_server_.get(),
-    &request_header,
-    message.get());
-
-  pimpl_->goal_request_ready_ = false;
-
+  auto shared_ptr = std::static_pointer_cast
+    <std::tuple<rcl_ret_t, rcl_action_goal_info_t, rmw_request_id_t, std::shared_ptr<void>>>(data);
+  rcl_ret_t ret = std::get<0>(*shared_ptr);
   if (RCL_RET_ACTION_SERVER_TAKE_FAILED == ret) {
     // Ignore take failure because connext fails if it receives a sample without valid data.
     // This happens when a client shuts down and connext receives a sample saying the client is
@@ -229,6 +286,14 @@ ServerBase::execute_goal_request_received()
   } else if (RCL_RET_OK != ret) {
     rclcpp::exceptions::throw_from_rcl_error(ret);
   }
+  rcl_action_goal_info_t goal_info = std::get<1>(*shared_ptr);
+  rmw_request_id_t request_header = std::get<2>(*shared_ptr);
+  std::shared_ptr<void> message = std::get<3>(*shared_ptr);
+
+
+  std::lock_guard<std::recursive_mutex> lock(pimpl_->action_server_reentrant_mutex_);
+
+  pimpl_->goal_request_ready_ = false;
 
   GoalUUID uuid = get_goal_id_from_goal_request(message.get());
   convert(uuid, &goal_info);
@@ -288,25 +353,17 @@ ServerBase::execute_goal_request_received()
     // Tell user to start executing action
     call_goal_accepted_callback(handle, uuid, message);
   }
+  data.reset();
 }
 
 void
-ServerBase::execute_cancel_request_received()
+ServerBase::execute_cancel_request_received(std::shared_ptr<void> & data)
 {
-  rcl_ret_t ret;
-  rmw_request_id_t request_header;
-
-  // Initialize cancel request
-  auto request = std::make_shared<action_msgs::srv::CancelGoal::Request>();
-
+  auto shared_ptr = std::static_pointer_cast
+    <std::tuple<rcl_ret_t, std::shared_ptr<action_msgs::srv::CancelGoal::Request>,
+      rmw_request_id_t>>(data);
+  auto ret = std::get<0>(*shared_ptr);
   std::lock_guard<std::recursive_mutex> lock(pimpl_->action_server_reentrant_mutex_);
-  ret = rcl_action_take_cancel_request(
-    pimpl_->action_server_.get(),
-    &request_header,
-    request.get());
-
-  pimpl_->cancel_request_ready_ = false;
-
   if (RCL_RET_ACTION_SERVER_TAKE_FAILED == ret) {
     // Ignore take failure because connext fails if it receives a sample without valid data.
     // This happens when a client shuts down and connext receives a sample saying the client is
@@ -315,6 +372,8 @@ ServerBase::execute_cancel_request_received()
   } else if (RCL_RET_OK != ret) {
     rclcpp::exceptions::throw_from_rcl_error(ret);
   }
+  auto request = std::get<1>(*shared_ptr);
+  auto request_header = std::get<2>(*shared_ptr);
 
   // Convert c++ message to C message
   rcl_action_cancel_request_t cancel_request = rcl_action_get_zero_initialized_cancel_request();
@@ -376,21 +435,16 @@ ServerBase::execute_cancel_request_received()
   if (RCL_RET_OK != ret) {
     rclcpp::exceptions::throw_from_rcl_error(ret);
   }
+  data.reset();
 }
 
 void
-ServerBase::execute_result_request_received()
+ServerBase::execute_result_request_received(std::shared_ptr<void> & data)
 {
-  rcl_ret_t ret;
-  // Get the result request message
-  rmw_request_id_t request_header;
-  std::shared_ptr<void> result_request = create_result_request();
+  auto shared_ptr = std::static_pointer_cast
+    <std::tuple<rcl_ret_t, std::shared_ptr<void>, rmw_request_id_t>>(data);
+  auto ret = std::get<0>(*shared_ptr);
   std::lock_guard<std::recursive_mutex> lock(pimpl_->action_server_reentrant_mutex_);
-  ret = rcl_action_take_result_request(
-    pimpl_->action_server_.get(), &request_header, result_request.get());
-
-  pimpl_->result_request_ready_ = false;
-
   if (RCL_RET_ACTION_SERVER_TAKE_FAILED == ret) {
     // Ignore take failure because connext fails if it receives a sample without valid data.
     // This happens when a client shuts down and connext receives a sample saying the client is
@@ -399,7 +453,10 @@ ServerBase::execute_result_request_received()
   } else if (RCL_RET_OK != ret) {
     rclcpp::exceptions::throw_from_rcl_error(ret);
   }
+  auto result_request = std::get<1>(*shared_ptr);
+  auto request_header = std::get<2>(*shared_ptr);
 
+  pimpl_->result_request_ready_ = false;
   std::shared_ptr<void> result_response;
 
   // check if the goal exists
@@ -421,7 +478,7 @@ ServerBase::execute_result_request_received()
 
   if (result_response) {
     // Send the result now
-    ret = rcl_action_send_result_response(
+    rcl_ret_t ret = rcl_action_send_result_response(
       pimpl_->action_server_.get(), &request_header, result_response.get());
     if (RCL_RET_OK != ret) {
       rclcpp::exceptions::throw_from_rcl_error(ret);
@@ -430,6 +487,7 @@ ServerBase::execute_result_request_received()
     // Store the request so it can be responded to later
     pimpl_->result_requests_[uuid].push_back(request_header);
   }
+  data.reset();
 }
 
 void


### PR DESCRIPTION
Fixes #1212.  This PR extends the `Waitable` class with a `take_data` method and the `AnyExecutable` struct with a `data` field.  `take_data` places the data to be executed in `AnyExecutable.data`, which is then used in the `execute` method.