### PR TITLE
fix node graph test with Connext and CycloneDDS returning actual data

### DIFF
--- a/rclcpp/test/rclcpp/node_interfaces/test_node_graph.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_graph.cpp
@@ -178,7 +178,7 @@ TEST_F(TestNodeGraph, get_info_by_topic)
       EXPECT_EQ(0u, actual_qos.get_rmw_qos_profile().depth);
       break;
     default:
-      EXPECT_TRUE(false) << "unexpected history";
+      ADD_FAILURE() << "unexpected history";
   }
 
   rclcpp::QoS const_actual_qos = const_publisher_endpoint_info.qos_profile();
@@ -190,7 +190,7 @@ TEST_F(TestNodeGraph, get_info_by_topic)
       EXPECT_EQ(0u, const_actual_qos.get_rmw_qos_profile().depth);
       break;
     default:
-      EXPECT_TRUE(false) << "unexpected history";
+      ADD_FAILURE() << "unexpected history";
   }
 
   auto endpoint_gid = publisher_endpoint_info.endpoint_gid();

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_graph.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_graph.cpp
@@ -170,10 +170,28 @@ TEST_F(TestNodeGraph, get_info_by_topic)
   EXPECT_EQ(rclcpp::EndpointType::Publisher, const_publisher_endpoint_info.endpoint_type());
 
   rclcpp::QoS actual_qos = publisher_endpoint_info.qos_profile();
-  EXPECT_EQ(0u, actual_qos.get_rmw_qos_profile().depth);
+  switch (actual_qos.get_rmw_qos_profile().history) {
+    case RMW_QOS_POLICY_HISTORY_KEEP_LAST:
+      EXPECT_EQ(1u, actual_qos.get_rmw_qos_profile().depth);
+      break;
+    case RMW_QOS_POLICY_HISTORY_UNKNOWN:
+      EXPECT_EQ(0u, actual_qos.get_rmw_qos_profile().depth);
+      break;
+    default:
+      EXPECT_TRUE(false) << "unexpected history";
+  }
 
   rclcpp::QoS const_actual_qos = const_publisher_endpoint_info.qos_profile();
-  EXPECT_EQ(0u, const_actual_qos.get_rmw_qos_profile().depth);
+  switch (const_actual_qos.get_rmw_qos_profile().history) {
+    case RMW_QOS_POLICY_HISTORY_KEEP_LAST:
+      EXPECT_EQ(1u, const_actual_qos.get_rmw_qos_profile().depth);
+      break;
+    case RMW_QOS_POLICY_HISTORY_UNKNOWN:
+      EXPECT_EQ(0u, const_actual_qos.get_rmw_qos_profile().depth);
+      break;
+    default:
+      EXPECT_TRUE(false) << "unexpected history";
+  }
 
   auto endpoint_gid = publisher_endpoint_info.endpoint_gid();
   auto const_endpoint_gid = const_publisher_endpoint_info.endpoint_gid();


### PR DESCRIPTION
The failing test was introduced by #1202.

Failing tests:
* Connext: http://build.ros2.org/view/Rci/job/Rci__nightly-connext_ubuntu_focal_amd64/29/testReport/rclcpp/TestNodeGraph/get_info_by_topic/
* Cyclone DDS: http://build.ros2.org/view/Rci/job/Rci__nightly-cyclonedds_ubuntu_focal_amd64/31/testReport/rclcpp/TestNodeGraph/get_info_by_topic/