### PR TITLE
Adjust test_static_executor_entities_collector for rmw_connext_cpp

### DIFF
--- a/rclcpp/test/rclcpp/executors/test_static_executor_entities_collector.cpp
+++ b/rclcpp/test/rclcpp/executors/test_static_executor_entities_collector.cpp
@@ -227,7 +227,7 @@ public:
 
 TEST_F(TestStaticExecutorEntitiesCollector, add_remove_node_with_entities) {
   auto node = std::make_shared<rclcpp::Node>("node", "ns");
-  const auto expected_number_of_entities = get_number_of_default_entities(node);
+  auto expected_number_of_entities = get_number_of_default_entities(node);
   EXPECT_NE(nullptr, expected_number_of_entities);
 
   // Create 1 of each entity type
@@ -244,6 +244,10 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_remove_node_with_entities) {
       test_msgs::srv::Empty::Response::SharedPtr) {});
   auto client = node->create_client<test_msgs::srv::Empty>("service");
   auto waitable = std::make_shared<TestWaitable>();
+
+  // Adding a subscription with rmw_connext_cpp adds another waitable, so we need to get the
+  // current number of waitables just before adding the new waitable.
+  expected_number_of_entities->waitables = get_number_of_default_entities(node)->waitables;
   node->get_node_waitables_interface()->add_waitable(waitable, nullptr);
 
   entities_collector_->add_node(node->get_node_base_interface());


### PR DESCRIPTION
It turns out rmw_connext_cpp adds a default waitable that other rmw implementations do not. Adjusting the unit test to take this into account, but in a non-rmw specific manner.

Non connext rmw implementations (testing `--packages-select` rclcpp)
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11734)](http://ci.ros2.org/job/ci_linux/11734/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6815)](http://ci.ros2.org/job/ci_linux-aarch64/6815/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9572)](http://ci.ros2.org/job/ci_osx/9572/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11672)](http://ci.ros2.org/job/ci_windows/11672/)

connext only rmw implementation
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11735)](http://ci.ros2.org/job/ci_linux/11735/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6816)](http://ci.ros2.org/job/ci_linux-aarch64/6816/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9573)](http://ci.ros2.org/job/ci_osx/9573/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11674)](http://ci.ros2.org/job/ci_windows/11674/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>