### PR TITLE
Simplify and fix allocator memory strategy unit test for connext

### DIFF
--- a/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
@@ -413,7 +413,7 @@ TEST_F(TestAllocatorMemoryStrategy, add_remove_waitables) {
 TEST_F(TestAllocatorMemoryStrategy, number_of_entities_with_subscription) {
   RclWaitSetSizes expected_sizes = {};
   expected_sizes.size_of_subscriptions = 1;
-  if (strcmp("rmw_connext_cpp", rmw_get_implementation_identifier()) == 0) {
+  if (std::string("rmw_connext_cpp") == rmw_get_implementation_identifier()) {
     // For connext, a subscription will also add an event and waitable
     expected_sizes.size_of_events += 1;
     expected_sizes.size_of_waitables += 1;
@@ -761,6 +761,7 @@ TEST_F(TestAllocatorMemoryStrategy, get_next_waitable_out_of_scope) {
   auto node = create_node_with_disabled_callback_groups("node");
   nodes.push_back(node->get_node_base_interface());
 
+  // Force waitable to go out of scope and cleanup after collecting entities.
   {
     auto callback_group =
       node->create_callback_group(
@@ -769,7 +770,6 @@ TEST_F(TestAllocatorMemoryStrategy, get_next_waitable_out_of_scope) {
     auto waitable = std::make_shared<TestWaitable>();
     node->get_node_waitables_interface()->add_waitable(waitable, callback_group);
     allocator_memory_strategy()->add_waitable_handle(waitable);
-    waitable.reset();
   }
   // Since all callback groups have been locked, except the one we added, this should only be 1
   EXPECT_EQ(1u, allocator_memory_strategy()->number_of_waitables());


### PR DESCRIPTION
Due to a difference between connext and other rmw implementations, this unit test was failing. I decided to modify this test so that all callback groups are set so `group->can_be_taken_from()` is set to false before adding one callback group and the associated entities. This let me remove the logic that tracks how many entities are in the basic nodes, since the memory strategy will only ever find those that belong to the callback_group that can be taken from.

Failing example:
https://ci.ros2.org/job/ci_linux/11735/testReport/junit/projectroot/test/test_allocator_memory_strategy/

FastRTPS (plus others)
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11737)](http://ci.ros2.org/job/ci_linux/11737/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6819)](http://ci.ros2.org/job/ci_linux-aarch64/6819/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9575)](http://ci.ros2.org/job/ci_osx/9575/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11677)](http://ci.ros2.org/job/ci_windows/11677/)

Connext only:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11738)](http://ci.ros2.org/job/ci_linux/11738/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6820)](http://ci.ros2.org/job/ci_linux-aarch64/6820/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9576)](http://ci.ros2.org/job/ci_osx/9576/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11678)](http://ci.ros2.org/job/ci_windows/11678/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>