### PR TITLE
Increase timeouts for connext for long tests

### DIFF
--- a/rclcpp/test/CMakeLists.txt
+++ b/rclcpp/test/CMakeLists.txt
@@ -17,17 +17,13 @@ rosidl_generate_interfaces(${PROJECT_NAME}_test_msgs
   SKIP_INSTALL
 )
 
-set(GTEST_TIMEOUT_ARGS "")
+# Increasing timeout because connext can take a long time to destroy nodes
 # TODO(brawner) remove when destroying Node for Connext is resolved. See:
 # https://github.com/ros2/rclcpp/issues/1250
-if(rmw_implementation STREQUAL "rmw_connext_dynamic_cpp" OR rmw_implementation STREQUAL "rmw_connext_cpp")
-  message(STATUS "Increasing test_allocator_memory_strategy test timeout.")
-  set(GTEST_TIMEOUT_ARGS "TIMEOUT 180")
-endif()
 ament_add_gtest(
   test_allocator_memory_strategy
   rclcpp/strategies/test_allocator_memory_strategy.cpp
-  ${GTEST_TIMEOUT_ARGS})
+  TIMEOUT 360)
 if(TARGET test_allocator_memory_strategy)
   ament_target_dependencies(test_allocator_memory_strategy
     "rcl"
@@ -480,18 +476,13 @@ if(TARGET test_interface_traits)
   target_link_libraries(test_interface_traits ${PROJECT_NAME})
 endif()
 
-set(GTEST_TIMEOUT_ARGS "")
 # TODO(brawner) remove when destroying Node for Connext is resolved. See:
 # https://github.com/ros2/rclcpp/issues/1250
-if(rmw_implementation STREQUAL "rmw_connext_dynamic_cpp" OR rmw_implementation STREQUAL "rmw_connext_cpp")
-  message(STATUS "Increasing test_allocator_memory_strategy test timeout.")
-  set(GTEST_TIMEOUT_ARGS "TIMEOUT 180")
-endif()
 ament_add_gtest(
   test_executors
   rclcpp/executors/test_executors.cpp
   APPEND_LIBRARY_DIRS "${append_library_dirs}"
-  ${GTEST_TIMEOUT_ARGS})
+  TIMEOUT 180)
 if(TARGET test_executors)
   ament_target_dependencies(test_executors
     "rcl")

--- a/rclcpp/test/CMakeLists.txt
+++ b/rclcpp/test/CMakeLists.txt
@@ -17,7 +17,17 @@ rosidl_generate_interfaces(${PROJECT_NAME}_test_msgs
   SKIP_INSTALL
 )
 
-ament_add_gtest(test_allocator_memory_strategy rclcpp/strategies/test_allocator_memory_strategy.cpp)
+set(GTEST_TIMEOUT_ARGS "")
+# TODO(brawner) remove when destroying Node for Connext is resolved. See:
+# https://github.com/ros2/rclcpp/issues/1250
+if(rmw_implementation STREQUAL "rmw_connext_dynamic_cpp" OR rmw_implementation STREQUAL "rmw_connext_cpp")
+  message(STATUS "Increasing test_allocator_memory_strategy test timeout.")
+  set(GTEST_TIMEOUT_ARGS "TIMEOUT 180")
+endif()
+ament_add_gtest(
+  test_allocator_memory_strategy
+  rclcpp/strategies/test_allocator_memory_strategy.cpp
+  ${GTEST_TIMEOUT_ARGS})
 if(TARGET test_allocator_memory_strategy)
   ament_target_dependencies(test_allocator_memory_strategy
     "rcl"
@@ -470,8 +480,18 @@ if(TARGET test_interface_traits)
   target_link_libraries(test_interface_traits ${PROJECT_NAME})
 endif()
 
-ament_add_gtest(test_executors rclcpp/executors/test_executors.cpp
-  APPEND_LIBRARY_DIRS "${append_library_dirs}")
+set(GTEST_TIMEOUT_ARGS "")
+# TODO(brawner) remove when destroying Node for Connext is resolved. See:
+# https://github.com/ros2/rclcpp/issues/1250
+if(rmw_implementation STREQUAL "rmw_connext_dynamic_cpp" OR rmw_implementation STREQUAL "rmw_connext_cpp")
+  message(STATUS "Increasing test_allocator_memory_strategy test timeout.")
+  set(GTEST_TIMEOUT_ARGS "TIMEOUT 180")
+endif()
+ament_add_gtest(
+  test_executors
+  rclcpp/executors/test_executors.cpp
+  APPEND_LIBRARY_DIRS "${append_library_dirs}"
+  ${GTEST_TIMEOUT_ARGS})
 if(TARGET test_executors)
   ament_target_dependencies(test_executors
     "rcl")


### PR DESCRIPTION
Destroying nodes takes upwards of 3 seconds, which can cause many unit tests to take inordinate amount of time (#1250) with rmw_connext_cpp. Currently only `test_executors` and `test_allocator_memory_strategy` timeout, so the timeout is being increased here.

Signed-off-by: Stephen Brawner <brawner@gmail.com>