### PR TITLE
Fixes for unit tests that fail under cyclonedds

### DIFF
--- a/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
@@ -413,7 +413,10 @@ TEST_F(TestAllocatorMemoryStrategy, add_remove_waitables) {
 TEST_F(TestAllocatorMemoryStrategy, number_of_entities_with_subscription) {
   RclWaitSetSizes expected_sizes = {};
   expected_sizes.size_of_subscriptions = 1;
-  if (std::string("rmw_connext_cpp") == rmw_get_implementation_identifier()) {
+  const std::string implementation_identifier = rmw_get_implementation_identifier();
+  if (implementation_identifier == "rmw_connext_cpp" ||
+    implementation_identifier == "rmw_cyclonedds_cpp")
+  {
     // For connext, a subscription will also add an event and waitable
     expected_sizes.size_of_events += 1;
     expected_sizes.size_of_waitables += 1;


### PR DESCRIPTION
Addresses #1268 and #1269

Default build/test testing `--packages-select rclcpp`
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11863)](http://ci.ros2.org/job/ci_linux/11863/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6915)](http://ci.ros2.org/job/ci_linux-aarch64/6915/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9667)](http://ci.ros2.org/job/ci_osx/9667/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11806)](http://ci.ros2.org/job/ci_windows/11806/)

* Linux cyclonedds only [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11864)](https://ci.ros2.org/job/ci_linux/11864/)
* Linux connext only [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11865)](https://ci.ros2.org/job/ci_linux/11865/)

Debug builds
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11866)](http://ci.ros2.org/job/ci_linux/11866/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6916)](http://ci.ros2.org/job/ci_linux-aarch64/6916/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9668)](http://ci.ros2.org/job/ci_osx/9668/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11807)](http://ci.ros2.org/job/ci_windows/11807/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>