### PR TITLE
Redesigning the MultiThreadedExecutor

### DIFF
--- a/rclcpp/doc/multi_threaded_executor_redesign.rst
+++ b/rclcpp/doc/multi_threaded_executor_redesign.rst
@@ -1,0 +1,60 @@
+======================================
+:code:`MultiThreadedExecutor` Redesign
+======================================
+
+The :code:`MultiThreadedExecutor` may attempt to execute different types of executables multiple times. 
+This occurs because one executable object can be identified as ready in two threads and both threads will attempt to execute it. 
+To fix this, a general solution should do the following:
+ * Work for all the types of executable objects: timers, subscriptions, services, clients, and waitables
+ * Avoid spurious wake ups (which can be costly)
+
+Summary of discussion so far
+----------------------------
+
+Broadly speaking, two approaches were discussed:
+
+1. **Handle no data in the executor**: If more than one thread is trying to execute the same object and that object is consumed after it is executed once, check for the executable before trying to execute it:
+
+    .. code-block:: c++
+
+        void execute() {
+          if(buffer->has_data()) {
+            auto data = buffer->consume_data();
+            run_any_callback(data);
+          } else {
+            // do nothing
+          }
+        }
+
+   :Advantages: 
+     * simplicity
+     * doesn't extend interface in a way that doesn't generalize well for all other types of executable objects (i.e., timers)
+   :Disadvantages: 
+     * spurious wake up calls
+     * needs to be documented well so every class that executes :code:`AnyExecutable` objects is thread-safe and doesn't hide a race condition
+
+
+2. **Take the data**: When an executable is ready, take it and store it so that it can be executed when execute is called:
+
+    .. code-block:: c++
+
+        void take_data(std::shared_ptr<void> & data) {
+          data = buffer->consume_data();
+        }
+
+        void execute(std::shared_ptr<void> & data) {
+          run_any_callback(data_);
+        }
+
+   :Advantages:
+     * no spurious wake ups
+   :Disadvantages:
+     * more complex
+     * extends the interface in a way that doesn't generalize well for all other types of executable objects (i.e., timers)
+     * type erasure of data
+
+Ideas
+-----------------------
+ * Add a preparation method to get the event after :code:`take_data`
+ * Take a lambda that can be executed later
+ * Store conditions in the waitset (like DDS)

--- a/rclcpp/doc/multi_threaded_executor_redesign.rst
+++ b/rclcpp/doc/multi_threaded_executor_redesign.rst
@@ -56,9 +56,26 @@ Broadly speaking, two approaches were discussed:
      * extends the interface in a way that doesn't generalize well for all other types of executable objects (i.e., timers)
      * type erasure of data
 
+.. note::
+
+   To avoid erasing the type of the data, :code:`take_data` could be replaced with a :code:`get_handle` method that would return a lambda function.
+
+   .. code-block:: c++
+
+      // called first
+      std::function<void()> get_handle() {
+        return [data=buffer->consume_data()]() {
+          run_any_callback(data);
+        };
+      }
+
+      // called second
+      void execute(std::function<void()> handle) {
+        handle();
+      }
+
 Ideas
 -----------------------
 
 * Add a preparation method to get the event after :code:`take_data`
-* Take a lambda that can be executed later
 * Store conditions in the waitset (like DDS)

--- a/rclcpp/doc/multi_threaded_executor_redesign.rst
+++ b/rclcpp/doc/multi_threaded_executor_redesign.rst
@@ -5,8 +5,9 @@
 The :code:`MultiThreadedExecutor` may attempt to execute different types of executables multiple times. 
 This occurs because one executable object can be identified as ready in two threads and both threads will attempt to execute it. 
 To fix this, a general solution should do the following:
- * Work for all the types of executable objects: timers, subscriptions, services, clients, and waitables
- * Avoid spurious wake ups (which can be costly)
+
+* Work for all the types of executable objects: timers, subscriptions, services, clients, and waitables
+* Avoid spurious wake ups (which can be costly)
 
 Summary of discussion so far
 ----------------------------
@@ -55,6 +56,7 @@ Broadly speaking, two approaches were discussed:
 
 Ideas
 -----------------------
- * Add a preparation method to get the event after :code:`take_data`
- * Take a lambda that can be executed later
- * Store conditions in the waitset (like DDS)
+
+* Add a preparation method to get the event after :code:`take_data`
+* Take a lambda that can be executed later
+* Store conditions in the waitset (like DDS)

--- a/rclcpp/doc/multi_threaded_executor_redesign.rst
+++ b/rclcpp/doc/multi_threaded_executor_redesign.rst
@@ -77,5 +77,26 @@ Broadly speaking, two approaches were discussed:
 Ideas
 -----------------------
 
-* Add a preparation method to get the event after :code:`take_data`
+* Add a preparation method to get the event after :code:`take_data`:
+
+  .. code-block:: c++
+
+     std::shared_ptr<void> & data_;
+
+     // called first
+     void take_data() {
+       data_ = buffer->consume_data();
+     }
+
+     // called second
+     std::shared_ptr<void> get_prepared() {
+       return data_;
+     }
+
+     // called third, with the data returned in the previous step
+     void execute(std::shared_ptr<void> & data) {
+       run_any_callback(data);
+     }
+
+
 * Store conditions in the waitset (like DDS)

--- a/rclcpp/doc/multi_threaded_executor_redesign.rst
+++ b/rclcpp/doc/multi_threaded_executor_redesign.rst
@@ -35,20 +35,22 @@ Broadly speaking, two approaches were discussed:
      * needs to be documented well so every class that executes :code:`AnyExecutable` objects is thread-safe and doesn't hide a race condition
 
 
-2. **Take the data**: When an executable is ready, take it and store it so that it can be executed when execute is called:
+2. **Take the data**: This approach takes the data when collecting the ready entities, and that process is done in a mutually exclusive fashion. Thus, this approach may avoid spurious wake ups.
 
     .. code-block:: c++
 
+        // called first
         void take_data(std::shared_ptr<void> & data) {
           data = buffer->consume_data();
         }
 
+        // called second
         void execute(std::shared_ptr<void> & data) {
           run_any_callback(data_);
         }
 
    :Advantages:
-     * no spurious wake ups
+     * fixes spurious wake ups for events where :code:`take_data` has a meaning (i.e., not timers)
    :Disadvantages:
      * more complex
      * extends the interface in a way that doesn't generalize well for all other types of executable objects (i.e., timers)

--- a/rclcpp/doc/multi_threaded_executor_redesign.rst
+++ b/rclcpp/doc/multi_threaded_executor_redesign.rst
@@ -29,7 +29,7 @@ Broadly speaking, two approaches were discussed:
 
    :Advantages: 
      * simplicity
-     * doesn't extend interface in a way that doesn't generalize well for all other types of executable objects (i.e., timers)
+     * extends interface in a way that generalizes well for all other types of executable objects (i.e., timers)
    :Disadvantages: 
      * spurious wake up calls
      * needs to be documented well so every class that executes :code:`AnyExecutable` objects is thread-safe and doesn't hide a race condition

--- a/rclcpp/doc/multi_threaded_executor_redesign.rst
+++ b/rclcpp/doc/multi_threaded_executor_redesign.rst
@@ -2,8 +2,8 @@
 :code:`MultiThreadedExecutor` Redesign
 ======================================
 
-The :code:`MultiThreadedExecutor` may attempt to execute different types of executables multiple times. 
-This occurs because one executable object can be identified as ready in two threads and both threads will attempt to execute it. 
+:code:`MultiThreadedExecutor` may attempt to execute one executable object multiple times. 
+This occurs because an executable object can be identified as ready in multiple threads before it has been executed, and each of these threads will then try to execute it.
 To fix this, a general solution should do the following:
 
 * Work for all the types of executable objects: timers, subscriptions, services, clients, and waitables

--- a/rclcpp/doc/multi_threaded_executor_redesign.rst
+++ b/rclcpp/doc/multi_threaded_executor_redesign.rst
@@ -2,7 +2,7 @@
 :code:`MultiThreadedExecutor` Redesign
 ======================================
 
-:code:`MultiThreadedExecutor` may attempt to execute one executable object multiple times. 
+:code:`MultiThreadedExecutor` may attempt to execute one executable object multiple times.
 This occurs because an executable object can be identified as ready in multiple threads before it has been executed, and each of these threads will then try to execute it.
 To fix this, a general solution should do the following:
 
@@ -14,7 +14,7 @@ Summary of discussion so far
 
 Broadly speaking, two approaches were discussed:
 
-1. **Handle no data in the executor**: If more than one thread is trying to execute the same object and that object is consumed after it is executed once, check for the executable before trying to execute it:
+1. **Handle no data in the executor**: If more than one thread is trying to execute the same entity and that entity is consumed after it is executed once, check for the executable before trying to execute it:
 
     .. code-block:: c++
 
@@ -27,10 +27,10 @@ Broadly speaking, two approaches were discussed:
           }
         }
 
-   :Advantages: 
+   :Advantages:
      * simplicity
      * extends interface in a way that generalizes well for all other types of executable objects (i.e., timers)
-   :Disadvantages: 
+   :Disadvantages:
      * spurious wake up calls
      * needs to be documented well so every class that executes :code:`AnyExecutable` objects is thread-safe and doesn't hide a race condition
 


### PR DESCRIPTION
Adds a document for discussing how the `MultiThreadedExecutor` should be redesigned to avoid calling execute more than one time on one executable object. This discussion was prompted by #1241 and #1275.