### PR TITLE
(dashing) Add operator!= to Duration

### DIFF
--- a/rclcpp/include/rclcpp/duration.hpp
+++ b/rclcpp/include/rclcpp/duration.hpp
@@ -61,6 +61,9 @@ public:
   operator==(const rclcpp::Duration & rhs) const;
 
   bool
+  operator!=(const rclcpp::Duration & rhs) const;
+
+  bool
   operator<(const rclcpp::Duration & rhs) const;
 
   bool

--- a/rclcpp/src/rclcpp/duration.cpp
+++ b/rclcpp/src/rclcpp/duration.cpp
@@ -96,6 +96,12 @@ Duration::operator==(const rclcpp::Duration & rhs) const
 }
 
 bool
+Duration::operator!=(const rclcpp::Duration & rhs) const
+{
+  return rcl_duration_.nanoseconds != rhs.rcl_duration_.nanoseconds;
+}
+
+bool
 Duration::operator<(const rclcpp::Duration & rhs) const
 {
   return rcl_duration_.nanoseconds < rhs.rcl_duration_.nanoseconds;

--- a/rclcpp/test/test_duration.cpp
+++ b/rclcpp/test/test_duration.cpp
@@ -45,6 +45,7 @@ TEST(TestDuration, operators) {
   EXPECT_TRUE(old <= young);
   EXPECT_TRUE(young >= old);
   EXPECT_FALSE(young == old);
+  EXPECT_TRUE(young != old);
 
   rclcpp::Duration add = old + young;
   EXPECT_EQ(add.nanoseconds(), (rcl_duration_value_t)(old.nanoseconds() + young.nanoseconds()));


### PR DESCRIPTION
Backports https://github.com/ros2/rclcpp/pull/1236.

This is an addition, not a bug fix.
It makes sense to me to backport this for consistency. It's weird to have all comparison operators except !=.