### PR TITLE
Include topic name in QoS mismatch warning messages

### DIFF
--- a/rclcpp/src/rclcpp/publisher_base.cpp
+++ b/rclcpp/src/rclcpp/publisher_base.cpp
@@ -259,10 +259,13 @@ void
 PublisherBase::default_incompatible_qos_callback(
   rclcpp::QOSOfferedIncompatibleQoSInfo & event) const
 {
+  const char *topic_name = rcl_publisher_get_topic_name(publisher_handle_.get());
   std::string policy_name = qos_policy_name_from_kind(event.last_policy_kind);
   RCLCPP_WARN(
     rclcpp::get_logger(rcl_node_get_logger_name(rcl_node_handle_.get())),
-    "New subscription discovered on this topic, requesting incompatible QoS. "
+    "New subscription discovered on topic %s, requesting incompatible QoS. "
     "No messages will be sent to it. "
-    "Last incompatible policy: %s", policy_name.c_str());
+    "Last incompatible policy: %s",
+    topic_name,
+    policy_name.c_str());
 }

--- a/rclcpp/src/rclcpp/publisher_base.cpp
+++ b/rclcpp/src/rclcpp/publisher_base.cpp
@@ -262,7 +262,7 @@ PublisherBase::default_incompatible_qos_callback(
   std::string policy_name = qos_policy_name_from_kind(event.last_policy_kind);
   RCLCPP_WARN(
     rclcpp::get_logger(rcl_node_get_logger_name(rcl_node_handle_.get())),
-    "New subscription discovered on topic %s, requesting incompatible QoS. "
+    "New subscription discovered on topic '%s', requesting incompatible QoS. "
     "No messages will be sent to it. "
     "Last incompatible policy: %s",
     get_topic_name(),

--- a/rclcpp/src/rclcpp/publisher_base.cpp
+++ b/rclcpp/src/rclcpp/publisher_base.cpp
@@ -259,13 +259,12 @@ void
 PublisherBase::default_incompatible_qos_callback(
   rclcpp::QOSOfferedIncompatibleQoSInfo & event) const
 {
-  const char *topic_name = rcl_publisher_get_topic_name(publisher_handle_.get());
   std::string policy_name = qos_policy_name_from_kind(event.last_policy_kind);
   RCLCPP_WARN(
     rclcpp::get_logger(rcl_node_get_logger_name(rcl_node_handle_.get())),
     "New subscription discovered on topic %s, requesting incompatible QoS. "
     "No messages will be sent to it. "
     "Last incompatible policy: %s",
-    topic_name,
+    get_topic_name(),
     policy_name.c_str());
 }

--- a/rclcpp/src/rclcpp/subscription_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_base.cpp
@@ -242,12 +242,15 @@ void
 SubscriptionBase::default_incompatible_qos_callback(
   rclcpp::QOSRequestedIncompatibleQoSInfo & event) const
 {
+  const char *topic_name = rcl_subscription_get_topic_name(subscription_handle_.get());
   std::string policy_name = qos_policy_name_from_kind(event.last_policy_kind);
   RCLCPP_WARN(
     rclcpp::get_logger(rcl_node_get_logger_name(node_handle_.get())),
-    "New publisher discovered on this topic, offering incompatible QoS. "
+    "New publisher discovered on topic %s, offering incompatible QoS. "
     "No messages will be sent to it. "
-    "Last incompatible policy: %s", policy_name.c_str());
+    "Last incompatible policy: %s",
+    topic_name,
+    policy_name.c_str());
 }
 
 bool

--- a/rclcpp/src/rclcpp/subscription_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_base.cpp
@@ -242,14 +242,13 @@ void
 SubscriptionBase::default_incompatible_qos_callback(
   rclcpp::QOSRequestedIncompatibleQoSInfo & event) const
 {
-  const char *topic_name = rcl_subscription_get_topic_name(subscription_handle_.get());
   std::string policy_name = qos_policy_name_from_kind(event.last_policy_kind);
   RCLCPP_WARN(
     rclcpp::get_logger(rcl_node_get_logger_name(node_handle_.get())),
     "New publisher discovered on topic %s, offering incompatible QoS. "
     "No messages will be sent to it. "
     "Last incompatible policy: %s",
-    topic_name,
+    get_topic_name(),
     policy_name.c_str());
 }
 

--- a/rclcpp/src/rclcpp/subscription_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_base.cpp
@@ -245,7 +245,7 @@ SubscriptionBase::default_incompatible_qos_callback(
   std::string policy_name = qos_policy_name_from_kind(event.last_policy_kind);
   RCLCPP_WARN(
     rclcpp::get_logger(rcl_node_get_logger_name(node_handle_.get())),
-    "New publisher discovered on topic %s, offering incompatible QoS. "
+    "New publisher discovered on topic '%s', offering incompatible QoS. "
     "No messages will be sent to it. "
     "Last incompatible policy: %s",
     get_topic_name(),

--- a/rclcpp/test/rclcpp/test_qos_event.cpp
+++ b/rclcpp/test/rclcpp/test_qos_event.cpp
@@ -211,11 +211,11 @@ TEST_F(TestQosEvent, test_default_incompatible_qos_callbacks)
 
   if (!is_fastrtps) {
     EXPECT_EQ(
-      "New subscription discovered on this topic, requesting incompatible QoS. "
+      "New subscription discovered on topic '/ns/test_topic', requesting incompatible QoS. "
       "No messages will be sent to it. Last incompatible policy: DURABILITY_QOS_POLICY",
       pub_log_msg);
     EXPECT_EQ(
-      "New publisher discovered on this topic, offering incompatible QoS. "
+      "New publisher discovered on topic '/ns/test_topic', offering incompatible QoS. "
       "No messages will be sent to it. Last incompatible policy: DURABILITY_QOS_POLICY",
       sub_log_msg);
   }


### PR DESCRIPTION
This small PR adds the topic name to the console warning about QoS mismatch, to help debugging this type of thing.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>