### PR TITLE
Increase coverage rclcpp_action to 95%

### DIFF
--- a/rclcpp_action/CMakeLists.txt
+++ b/rclcpp_action/CMakeLists.txt
@@ -77,6 +77,7 @@ if(BUILD_TESTING)
   ament_add_gtest(test_client test/test_client.cpp TIMEOUT 180)
   if(TARGET test_client)
     ament_target_dependencies(test_client
+      "rcutils"
       "test_msgs"
     )
     target_link_libraries(test_client
@@ -88,6 +89,7 @@ if(BUILD_TESTING)
   ament_add_gtest(test_server test/test_server.cpp)
   if(TARGET test_server)
     ament_target_dependencies(test_server
+      "rcutils"
       "test_msgs"
     )
     target_link_libraries(test_server
@@ -99,6 +101,7 @@ if(BUILD_TESTING)
   ament_add_gtest(test_server_goal_handle test/test_server_goal_handle.cpp)
   if(TARGET test_server_goal_handle)
     ament_target_dependencies(test_server_goal_handle
+      "rcutils"
       "test_msgs"
     )
     target_link_libraries(test_server_goal_handle

--- a/rclcpp_action/CMakeLists.txt
+++ b/rclcpp_action/CMakeLists.txt
@@ -81,6 +81,7 @@ if(BUILD_TESTING)
     )
     target_link_libraries(test_client
       ${PROJECT_NAME}
+      mimick
     )
   endif()
 
@@ -91,6 +92,18 @@ if(BUILD_TESTING)
     )
     target_link_libraries(test_server
       ${PROJECT_NAME}
+      mimick
+    )
+  endif()
+
+  ament_add_gtest(test_server_goal_handle test/test_server_goal_handle.cpp)
+  if(TARGET test_server_goal_handle)
+    ament_target_dependencies(test_server_goal_handle
+      "test_msgs"
+    )
+    target_link_libraries(test_server_goal_handle
+      ${PROJECT_NAME}
+      mimick
     )
   endif()
 

--- a/rclcpp_action/package.xml
+++ b/rclcpp_action/package.xml
@@ -22,6 +22,7 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>mimick_vendor</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>

--- a/rclcpp_action/test/mocking_utils/patch.hpp
+++ b/rclcpp_action/test/mocking_utils/patch.hpp
@@ -1,0 +1,393 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Original file taken from:
+// https://github.com/ros2/rcutils/blob/master/test/mocking_utils/patch.hpp
+
+#ifndef MOCKING_UTILS__PATCH_HPP_
+#define MOCKING_UTILS__PATCH_HPP_
+
+#define MOCKING_UTILS_SUPPORT_VA_LIST
+#if (defined(__aarch64__) || defined(__arm__) || defined(_M_ARM) || defined(__thumb__))
+// In ARM machines, va_list does not define comparison operators
+// nor the compiler allows defining them via operator overloads.
+// Thus, Mimick argument matching code will not compile.
+#undef MOCKING_UTILS_SUPPORT_VA_LIST
+#endif
+
+#ifdef MOCKING_UTILS_SUPPORT_VA_LIST
+#include <cstdarg>
+#endif
+
+#include <functional>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include "mimick/mimick.h"
+#include "rcutils/macros.h"
+
+namespace mocking_utils
+{
+
+/// Mimick specific traits for each mocking_utils::Patch instance.
+/**
+ * \tparam ID Numerical identifier of the patch. Ought to be unique.
+ * \tparam SignatureT Type of the symbol to be patched.
+*/
+template<size_t ID, typename SignatureT>
+struct PatchTraits;
+
+/// Traits specialization for ReturnT(void) free functions.
+/**
+ * \tparam ID Numerical identifier of the patch. Ought to be unique.
+ * \tparam ReturnT Return value type.
+ */
+template<size_t ID, typename ReturnT>
+struct PatchTraits<ID, ReturnT(void)>
+{
+  mmk_mock_define(mock_type, ReturnT);
+};
+
+/// Traits specialization for ReturnT(ArgT0) free functions.
+/**
+ * \tparam ID Numerical identifier of the patch. Ought to be unique.
+ * \tparam ReturnT Return value type.
+ * \tparam ArgT0 Argument type.
+ */
+template<size_t ID, typename ReturnT, typename ArgT0>
+struct PatchTraits<ID, ReturnT(ArgT0)>
+{
+  mmk_mock_define(mock_type, ReturnT, ArgT0);
+};
+
+/// Traits specialization for ReturnT(ArgT0, ArgT1) free functions.
+/**
+ * \tparam ID Numerical identifier of the patch. Ought to be unique.
+ * \tparam ReturnT Return value type.
+ * \tparam ArgTx Argument types.
+ */
+template<size_t ID, typename ReturnT,
+  typename ArgT0, typename ArgT1>
+struct PatchTraits<ID, ReturnT(ArgT0, ArgT1)>
+{
+  mmk_mock_define(mock_type, ReturnT, ArgT0, ArgT1);
+};
+
+/// Traits specialization for ReturnT(ArgT0, ArgT1, ArgT2) free functions.
+/**
+ * \tparam ID Numerical identifier of the patch. Ought to be unique.
+ * \tparam ReturnT Return value type.
+ * \tparam ArgTx Argument types.
+ */
+template<size_t ID, typename ReturnT,
+  typename ArgT0, typename ArgT1, typename ArgT2>
+struct PatchTraits<ID, ReturnT(ArgT0, ArgT1, ArgT2)>
+{
+  mmk_mock_define(mock_type, ReturnT, ArgT0, ArgT1, ArgT2);
+};
+
+/// Traits specialization for ReturnT(ArgT0, ArgT1, ArgT2, ArgT3) free functions.
+/**
+ * \tparam ID Numerical identifier of the patch. Ought to be unique.
+ * \tparam ReturnT Return value type.
+ * \tparam ArgTx Argument types.
+ */
+template<size_t ID, typename ReturnT,
+  typename ArgT0, typename ArgT1,
+  typename ArgT2, typename ArgT3>
+struct PatchTraits<ID, ReturnT(ArgT0, ArgT1, ArgT2, ArgT3)>
+{
+  mmk_mock_define(mock_type, ReturnT, ArgT0, ArgT1, ArgT2, ArgT3);
+};
+
+/// Traits specialization for ReturnT(ArgT0, ArgT1, ArgT2, ArgT3, ArgT4)
+/// free functions.
+/**
+ * \tparam ID Numerical identifier of the patch. Ought to be unique.
+ * \tparam ReturnT Return value type.
+ * \tparam ArgTx Argument types.
+ */
+template<size_t ID, typename ReturnT,
+  typename ArgT0, typename ArgT1,
+  typename ArgT2, typename ArgT3, typename ArgT4>
+struct PatchTraits<ID, ReturnT(ArgT0, ArgT1, ArgT2, ArgT3, ArgT4)>
+{
+  mmk_mock_define(mock_type, ReturnT, ArgT0, ArgT1, ArgT2, ArgT3, ArgT4);
+};
+
+/// Traits specialization for ReturnT(ArgT0, ArgT1, ArgT2, ArgT3, ArgT4, ArgT5)
+/// free functions.
+/**
+ * \tparam ID Numerical identifier of the patch. Ought to be unique.
+ * \tparam ReturnT Return value type.
+ * \tparam ArgTx Argument types.
+ */
+template<size_t ID, typename ReturnT,
+  typename ArgT0, typename ArgT1,
+  typename ArgT2, typename ArgT3,
+  typename ArgT4, typename ArgT5>
+struct PatchTraits<ID, ReturnT(ArgT0, ArgT1, ArgT2, ArgT3, ArgT4, ArgT5)>
+{
+  mmk_mock_define(
+    mock_type, ReturnT, ArgT0, ArgT1, ArgT2, ArgT3, ArgT4, ArgT5);
+};
+
+/// Traits specialization for ReturnT(ArgT0, ArgT1, ArgT2, ArgT3, ArgT4, ArgT5, ArgT6)
+/// free functions.
+/**
+ * \tparam ID Numerical identifier of the patch. Ought to be unique.
+ * \tparam ReturnT Return value type.
+ * \tparam ArgTx Argument types.
+ */
+template<size_t ID, typename ReturnT,
+  typename ArgT0, typename ArgT1,
+  typename ArgT2, typename ArgT3,
+  typename ArgT4, typename ArgT5, typename ArgT6>
+struct PatchTraits<ID, ReturnT(ArgT0, ArgT1, ArgT2, ArgT3, ArgT4, ArgT5, ArgT6)>
+{
+  mmk_mock_define(
+    mock_type, ReturnT, ArgT0, ArgT1, ArgT2, ArgT3, ArgT4, ArgT5, ArgT6);
+};
+
+/// Generic trampoline to wrap generalized callables in plain functions.
+/**
+ * \tparam ID Numerical identifier of this trampoline. Ought to be unique.
+ * \tparam SignatureT Type of the symbol this trampoline replaces.
+ */
+template<size_t ID, typename SignatureT>
+struct Trampoline;
+
+/// Trampoline specialization for free functions.
+template<size_t ID, typename ReturnT, typename ... ArgTs>
+struct Trampoline<ID, ReturnT(ArgTs...)>
+{
+  static ReturnT base(ArgTs... args)
+  {
+    return target(std::forward<ArgTs>(args)...);
+  }
+
+  static std::function<ReturnT(ArgTs...)> target;
+};
+
+template<size_t ID, typename ReturnT, typename ... ArgTs>
+std::function<ReturnT(ArgTs...)>
+Trampoline<ID, ReturnT(ArgTs...)>::target;
+
+/// Setup trampoline with the given @p target.
+/**
+ * \param[in] target Callable that this trampoline will target.
+ * \return the plain base function of this trampoline.
+ *
+ * \tparam ID Numerical identifier of this trampoline. Ought to be unique.
+ * \tparam SignatureT Type of the symbol this trampoline replaces.
+ */
+template<size_t ID, typename SignatureT>
+auto prepare_trampoline(std::function<SignatureT> target)
+{
+  Trampoline<ID, SignatureT>::target = target;
+  return Trampoline<ID, SignatureT>::base;
+}
+
+/// Patch class for binary API mocking
+/**
+ * Built on top of Mimick, to enable symbol mocking on a per dynamically
+ * linked binary object basis.
+ *
+ * \tparam ID Numerical identifier for this patch. Ought to be unique.
+ * \tparam SignatureT Type of the symbol to be patched.
+ */
+template<size_t ID, typename SignatureT>
+class Patch;
+
+/// Patch specialization for ReturnT(ArgTs...) free functions.
+/**
+ * \tparam ID Numerical identifier for this patch. Ought to be unique.
+ * \tparam ReturnT Return value type.
+ * \tparam ArgTs Argument types.
+ */
+template<size_t ID, typename ReturnT, typename ... ArgTs>
+class Patch<ID, ReturnT(ArgTs...)>
+{
+public:
+  using mock_type = typename PatchTraits<ID, ReturnT(ArgTs...)>::mock_type;
+
+  /// Construct a patch.
+  /**
+   * \param[in] target Symbol target string, using Mimick syntax
+   *   i.e. "symbol(@scope)?", where scope may be "self" to target the current
+   *   binary, "lib:library_name" to target a given library, "file:path/to/library"
+   *   to target a given file, or "sym:other_symbol" to target the first library
+   *   that defines said symbol.
+   * \param[in] proxy An indirection to call the target function.
+   *   This indirection must ensure this call goes through the function's
+   *   trampoline, as setup by the dynamic linker.
+   * \return a mocking_utils::Patch instance.
+   */
+  explicit Patch(const std::string & target, std::function<ReturnT(ArgTs...)> proxy)
+  : target_(target), proxy_(proxy)
+  {
+  }
+
+  // Copy construction and assignment are disabled.
+  Patch(const Patch &) = delete;
+  Patch & operator=(const Patch &) = delete;
+
+  Patch(Patch && other)
+  {
+    mock_ = other.mock_;
+    other.mock_ = nullptr;
+  }
+
+  Patch & operator=(Patch && other)
+  {
+    if (mock_) {
+      mmk_reset(mock_);
+    }
+    mock_ = other.mock_;
+    other.mock_ = nullptr;
+  }
+
+  ~Patch()
+  {
+    if (mock_) {
+      mmk_reset(mock_);
+    }
+  }
+
+  /// Inject a @p replacement for the patched function.
+  Patch & then_call(std::function<ReturnT(ArgTs...)> replacement) &
+  {
+    replace_with(replacement);
+    return *this;
+  }
+
+  /// Inject a @p replacement for the patched function.
+  Patch && then_call(std::function<ReturnT(ArgTs...)> replacement) &&
+  {
+    replace_with(replacement);
+    return std::move(*this);
+  }
+
+private:
+  // Helper for template parameter pack expansion using `mmk_any`
+  // macro as pattern.
+  template<typename T>
+  T any() {return mmk_any(T);}
+
+  void replace_with(std::function<ReturnT(ArgTs...)> replacement)
+  {
+    if (mock_) {
+      throw std::logic_error("Cannot configure patch more than once");
+    }
+    auto type_erased_trampoline =
+      reinterpret_cast<mmk_fn>(prepare_trampoline<ID>(replacement));
+    auto MMK_MANGLE(mock_type, create) =
+      PatchTraits<ID, ReturnT(ArgTs...)>::MMK_MANGLE(mock_type, create);
+    mock_ = mmk_mock(target_.c_str(), mock_type);
+    mmk_when(proxy_(any<ArgTs>()...), .then_call = type_erased_trampoline);
+  }
+
+  mock_type mock_{nullptr};
+  std::string target_;
+  std::function<ReturnT(ArgTs...)> proxy_;
+};
+
+/// Make a patch for a `target` function.
+/**
+ * Useful for type deduction during \ref mocking_utils::Patch construction.
+ *
+ * \param[in] target Symbol target string, using Mimick syntax.
+ * \param[in] proxy An indirection to call the target function.
+ * \return a mocking_utils::Patch instance.
+ *
+ * \tparam ID Numerical identifier for this patch. Ought to be unique.
+ * \tparam SignatureT Type of the function to be patched.
+ *
+ * \sa mocking_utils::Patch for further reference.
+ */
+template<size_t ID, typename SignatureT>
+auto make_patch(const std::string & target, std::function<SignatureT> proxy)
+{
+  return Patch<ID, SignatureT>(target, proxy);
+}
+
+/// Define a dummy operator `op` for a given `type`.
+/**
+ * Useful to enable patching functions that take arguments whose types
+ * do not define basic comparison operators, as required by Mimick.
+*/
+#define MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(type_, op) \
+  template<typename T> \
+  typename std::enable_if<std::is_same<T, type_>::value, bool>::type \
+  operator op(const T &, const T &) { \
+    return false; \
+  }
+
+/// Get the exact \ref mocking_utils::Patch type for a given `id` and `function`.
+/**
+ * Useful to avoid ignored attribute warnings when using the \b decltype operator.
+ */
+#define MOCKING_UTILS_PATCH_TYPE(id, function) \
+  decltype(mocking_utils::make_patch<id, decltype(function)>("", nullptr))
+
+/// A transparent forwarding proxy to a given `function`.
+/**
+ * Useful to ensure a call to `function` goes through its trampoline.
+ */
+#define MOCKING_UTILS_PATCH_PROXY(function) \
+  [] (auto && ... args)->decltype(auto) { \
+    return function(std::forward<decltype(args)>(args)...); \
+  }
+
+/// Compute a Mimick symbol target string based on which `function` is to be patched
+/// in which `scope`.
+#define MOCKING_UTILS_PATCH_TARGET(scope, function) \
+  (std::string(RCUTILS_STRINGIFY(function)) + "@" + (scope))
+
+/// Prepare a mocking_utils::Patch for patching a `function` in a given `scope`
+/// but defer applying any changes.
+#define prepare_patch(scope, function) \
+  make_patch<__COUNTER__, decltype(function)>( \
+    MOCKING_UTILS_PATCH_TARGET(scope, function), MOCKING_UTILS_PATCH_PROXY(function) \
+  )
+
+/// Patch a `function` with a used-provided `replacement` in a given `scope`.
+#define patch(scope, function, replacement) \
+  prepare_patch(scope, function).then_call(replacement)
+
+/// Patch a `function` to always yield a given `return_code` in a given `scope`.
+#define patch_and_return(scope, function, return_code) \
+  patch(scope, function, [&](auto && ...) {return return_code;})
+
+/// Patch a `function` to execute normally but always yield a given `return_code`
+/// in a given `scope`.
+#define inject_on_return(scope, function, return_code) \
+  patch( \
+    scope, function, ([&, base = function](auto && ... __args) { \
+      static_cast<void>(base(std::forward<decltype(__args)>(__args)...)); \
+      return return_code; \
+    }))
+
+}  // namespace mocking_utils
+
+#ifdef MOCKING_UTILS_SUPPORT_VA_LIST
+// Define dummy comparison operators for C standard va_list type
+MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(va_list, ==)
+MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(va_list, !=)
+MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(va_list, <)
+MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(va_list, >)
+#endif
+
+#endif  // MOCKING_UTILS__PATCH_HPP_

--- a/rclcpp_action/test/test_client.cpp
+++ b/rclcpp_action/test/test_client.cpp
@@ -357,6 +357,8 @@ TEST_F(TestClient, construction_and_destruction_rcl_errors)
 TEST_F(TestClient, wait_for_action_server)
 {
   auto action_client = rclcpp_action::create_client<ActionType>(client_node, action_name);
+  EXPECT_FALSE(action_client->wait_for_action_server(0ms));
+  EXPECT_FALSE(action_client->wait_for_action_server(10ms));
   SetUpServer();
   ASSERT_TRUE(action_client->wait_for_action_server(WAIT_FOR_SERVER_TIMEOUT));
   TearDownServer();

--- a/rclcpp_action/test/test_client.cpp
+++ b/rclcpp_action/test/test_client.cpp
@@ -876,9 +876,8 @@ TEST_F(TestClientAgainstServer, send_rcl_errors)
       "lib:rclcpp_action", rcl_action_send_result_request, RCL_RET_ERROR);
     auto future_goal_handle = action_client->async_send_goal(goal, send_goal_ops);
     dual_spin_until_future_complete(future_goal_handle);
-    EXPECT_THROW(
-      future_goal_handle.get(),
-      rclcpp::exceptions::RCLError);
+    auto goal_handle = future_goal_handle.get();
+    EXPECT_EQ(rclcpp_action::GoalStatus::STATUS_UNKNOWN, goal_handle->get_status());
   }
   {
     ActionGoal goal;

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -983,36 +983,99 @@ TEST_F(TestServer, deferred_execution)
   EXPECT_TRUE(received_handle->is_executing());
 }
 
-class TestValidServer : public TestServer
+class TestBasicServer : public TestServer
 {
 public:
-  TestValidServer()
-  : node_(nullptr), action_server_(nullptr), current_goal_handle_(nullptr) {}
-
   void SetUp()
   {
-    node_ = std::make_shared<rclcpp::Node>("is_ready_error", "/rclcpp_action/construct");
-    using GoalHandle = rclcpp_action::ServerGoalHandle<Fibonacci>;
+    node_ = std::make_shared<rclcpp::Node>("goal_request", "/rclcpp_action/goal_request");
+    uuid_ = {{1, 2, 3, 4, 5, 6, 70, 8, 9, 1, 11, 120, 13, 140, 15, 160}};
     action_server_ = rclcpp_action::create_server<Fibonacci>(
       node_, "fibonacci",
       [](const GoalUUID &, std::shared_ptr<const Fibonacci::Goal>) {
-        return rclcpp_action::GoalResponse::ACCEPT_AND_DEFER;
+        return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
       },
       [](std::shared_ptr<GoalHandle>) {
-        return rclcpp_action::CancelResponse::REJECT;
+        return rclcpp_action::CancelResponse::ACCEPT;
       },
       [this](std::shared_ptr<GoalHandle> handle) {
-        current_goal_handle_ = handle;
+        goal_handle_ = handle;
       });
   }
 
+  void SendClientGoalRequest(
+    std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
+  {
+    send_goal_request(node_, uuid_, timeout);
+    auto result_client = node_->create_client<Fibonacci::Impl::GetResultService>(
+      "fibonacci/_action/get_result");
+    if (!result_client->wait_for_service(std::chrono::seconds(20))) {
+      throw std::runtime_error("get result service didn't become available");
+    }
+    auto request = std::make_shared<Fibonacci::Impl::GetResultService::Request>();
+    request->goal_id.uuid = uuid_;
+    auto future = result_client->async_send_request(request);
+
+    // Send a result
+    auto result = std::make_shared<Fibonacci::Result>();
+    result->sequence = {5, 8, 13, 21};
+    goal_handle_->succeed(result);
+
+    // Wait for the result request to be received
+    ASSERT_EQ(
+      rclcpp::FutureReturnCode::SUCCESS,
+      rclcpp::spin_until_future_complete(node_, future));
+
+    auto response = future.get();
+    EXPECT_EQ(action_msgs::msg::GoalStatus::STATUS_SUCCEEDED, response->status);
+    EXPECT_EQ(result->sequence, response->result.sequence);
+
+    // Wait for goal expiration
+    rclcpp::sleep_for(std::chrono::milliseconds(100));
+
+    // Allow for expiration to take place
+    rclcpp::spin_some(node_);
+
+    // Send and wait for another result request
+    future = result_client->async_send_request(request);
+    ASSERT_EQ(
+      rclcpp::FutureReturnCode::SUCCESS,
+      rclcpp::spin_until_future_complete(node_, future));
+  }
+
 protected:
+  GoalUUID uuid_;
   std::shared_ptr<rclcpp::Node> node_;
   std::shared_ptr<rclcpp_action::Server<Fibonacci>> action_server_;
-  std::shared_ptr<rclcpp_action::ServerGoalHandle<Fibonacci>> current_goal_handle_;
+
+  using GoalHandle = rclcpp_action::ServerGoalHandle<Fibonacci>;
+  std::shared_ptr<GoalHandle> goal_handle_;
 };
 
-TEST_F(TestValidServer, is_ready_rcl_error) {
+class TestGoalRequestServer : public TestBasicServer {};
+
+TEST_F(TestGoalRequestServer, execute_goal_request_received_take_goal)
+{
+  EXPECT_NO_THROW(SendClientGoalRequest());
+}
+
+class TestCancelRequestServer : public TestBasicServer
+{
+public:
+  void SendClientCancelRequest(
+    std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
+  {
+    send_goal_request(node_, uuid_, timeout);
+    send_cancel_request(node_, uuid_, timeout);
+  }
+};
+
+TEST_F(TestCancelRequestServer, execute_goal_request_received_take_goal)
+{
+  EXPECT_NO_THROW(SendClientCancelRequest());
+}
+
+TEST_F(TestGoalRequestServer, is_ready_rcl_error) {
   rcl_wait_set_t wait_set = rcl_get_zero_initialized_wait_set();
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   auto rcl_context = node_->get_node_base_interface()->get_context()->get_rcl_context().get();
@@ -1031,89 +1094,36 @@ TEST_F(TestValidServer, is_ready_rcl_error) {
   EXPECT_THROW(action_server_->is_ready(&wait_set), rclcpp::exceptions::RCLError);
 }
 
-class TestBasicServer : public TestServer
-{
-public:
-  void SetUp()
-  {
-    node_ = std::make_shared<rclcpp::Node>("goal_request", "/rclcpp_action/goal_request");
-    uuid_ = {{1, 2, 3, 4, 5, 6, 70, 8, 9, 1, 11, 120, 13, 140, 15, 160}};
-    action_server_ = rclcpp_action::create_server<Fibonacci>(
-      node_, "fibonacci",
-      [](const GoalUUID &, std::shared_ptr<const Fibonacci::Goal>) {
-        return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
-      },
-      [](std::shared_ptr<GoalHandle>) {
-        return rclcpp_action::CancelResponse::REJECT;
-      },
-      [this](std::shared_ptr<GoalHandle> handle) {
-        goal_handle_ = handle;
-      });
-  }
-
-  virtual void SendClientRequest(
-    std::chrono::milliseconds timeout = std::chrono::milliseconds(-1)) = 0;
-
-protected:
-  GoalUUID uuid_;
-  std::shared_ptr<rclcpp::Node> node_;
-  std::shared_ptr<rclcpp_action::Server<Fibonacci>> action_server_;
-
-  using GoalHandle = rclcpp_action::ServerGoalHandle<Fibonacci>;
-  std::shared_ptr<GoalHandle> goal_handle_;
-};
-
-class TestGoalRequestServer : public TestBasicServer
-{
-public:
-  void SendClientRequest(
-    std::chrono::milliseconds timeout = std::chrono::milliseconds(-1)) override
-  {
-    send_goal_request(node_, uuid_, timeout);
-    goal_handle_->execute();
-    auto result = std::make_shared<Fibonacci::Result>();
-    result->sequence = {5, 8, 13, 21};
-    goal_handle_->succeed(result);
-  }
-};
-
-class TestCancelRequestServer : public TestBasicServer
-{
-public:
-  void SendClientRequest(
-    std::chrono::milliseconds timeout = std::chrono::milliseconds(-1)) override
-  {
-    send_cancel_request(node_, uuid_, timeout);
-  }
-};
-
 TEST_F(TestGoalRequestServer, execute_goal_request_received_take_goal_request_errors)
 {
   auto mock = mocking_utils::patch_and_return(
     "lib:rclcpp_action", rcl_action_take_goal_request, RCL_RET_ERROR);
 
-  EXPECT_THROW(SendClientRequest(), rclcpp::exceptions::RCLError);
+  EXPECT_THROW(SendClientGoalRequest(), rclcpp::exceptions::RCLError);
 }
+
 TEST_F(TestGoalRequestServer, execute_goal_request_received_send_goal_response_errors)
 {
   auto mock = mocking_utils::patch_and_return(
     "lib:rclcpp_action", rcl_action_send_goal_response, RCL_RET_ERROR);
 
-  EXPECT_THROW(SendClientRequest(), rclcpp::exceptions::RCLError);
+  EXPECT_THROW(SendClientGoalRequest(), rclcpp::exceptions::RCLError);
 }
+
 TEST_F(TestGoalRequestServer, execute_goal_request_received_accept_new_goal_errors)
 {
   auto mock = mocking_utils::patch_and_return(
     "lib:rclcpp_action", rcl_action_accept_new_goal, nullptr);
 
-  EXPECT_THROW(SendClientRequest(), std::runtime_error);
+  EXPECT_THROW(SendClientGoalRequest(), std::runtime_error);
 }
+
 TEST_F(TestGoalRequestServer, execute_goal_request_received_update_goal_state_errors)
 {
   auto mock = mocking_utils::patch_and_return(
     "lib:rclcpp_action", rcl_action_update_goal_state, RCL_RET_ERROR);
 
-  EXPECT_THROW(SendClientRequest(), rclcpp::exceptions::RCLError);
+  EXPECT_THROW(SendClientGoalRequest(), rclcpp::exceptions::RCLError);
 }
 
 TEST_F(TestGoalRequestServer, publish_status_server_get_goal_handles_errors)
@@ -1121,7 +1131,7 @@ TEST_F(TestGoalRequestServer, publish_status_server_get_goal_handles_errors)
   auto mock = mocking_utils::patch_and_return(
     "lib:rclcpp_action", rcl_action_server_get_goal_handles, RCL_RET_ERROR);
 
-  EXPECT_THROW(SendClientRequest(), rclcpp::exceptions::RCLError);
+  EXPECT_THROW(SendClientGoalRequest(), rclcpp::exceptions::RCLError);
 }
 
 TEST_F(TestGoalRequestServer, publish_status_get_goal_status_array_errors)
@@ -1129,7 +1139,7 @@ TEST_F(TestGoalRequestServer, publish_status_get_goal_status_array_errors)
   auto mock = mocking_utils::patch_and_return(
     "lib:rclcpp_action", rcl_action_get_goal_status_array, RCL_RET_ERROR);
 
-  EXPECT_THROW(SendClientRequest(), rclcpp::exceptions::RCLError);
+  EXPECT_THROW(SendClientGoalRequest(), rclcpp::exceptions::RCLError);
 }
 
 TEST_F(TestGoalRequestServer, publish_status_publish_status_errors)
@@ -1137,15 +1147,7 @@ TEST_F(TestGoalRequestServer, publish_status_publish_status_errors)
   auto mock = mocking_utils::patch_and_return(
     "lib:rclcpp_action", rcl_action_publish_status, RCL_RET_ERROR);
 
-  EXPECT_THROW(SendClientRequest(), std::runtime_error);
-}
-
-TEST_F(TestGoalRequestServer, publish_result_send_result_response_errors)
-{
-  auto mock = mocking_utils::patch_and_return(
-    "lib:rclcpp_action", rcl_action_send_result_response, RCL_RET_ERROR);
-
-  EXPECT_THROW(SendClientRequest(), rclcpp::exceptions::RCLError);
+  EXPECT_THROW(SendClientGoalRequest(), std::runtime_error);
 }
 
 TEST_F(TestGoalRequestServer, execute_goal_request_received_take_failed)
@@ -1153,7 +1155,7 @@ TEST_F(TestGoalRequestServer, execute_goal_request_received_take_failed)
   auto mock = mocking_utils::inject_on_return(
     "lib:rclcpp_action", rcl_action_take_goal_request, RCL_RET_ACTION_SERVER_TAKE_FAILED);
   try {
-    SendClientRequest(std::chrono::milliseconds(100));
+    SendClientGoalRequest(std::chrono::milliseconds(100));
     ADD_FAILURE() << "SetupActionServerAndSpin did not throw, but was expected to";
   } catch (const std::runtime_error & e) {
     EXPECT_STREQ("send goal future timed out", e.what());
@@ -1162,27 +1164,28 @@ TEST_F(TestGoalRequestServer, execute_goal_request_received_take_failed)
   }
 }
 
+TEST_F(TestGoalRequestServer, get_result_rcl_errors)
+{
+  auto mock = mocking_utils::patch_and_return(
+    "lib:rclcpp_action", rcl_action_take_result_request, RCL_RET_ERROR);
+
+  EXPECT_THROW(SendClientGoalRequest(), rclcpp::exceptions::RCLError);
+}
+
+TEST_F(TestGoalRequestServer, send_result_rcl_errors)
+{
+  auto mock = mocking_utils::patch_and_return(
+    "lib:rclcpp_action", rcl_action_send_result_response, RCL_RET_ERROR);
+
+  EXPECT_THROW(SendClientGoalRequest(), rclcpp::exceptions::RCLError);
+}
+
 TEST_F(TestCancelRequestServer, execute_cancel_request_received_take_cancel_request_errors)
 {
   auto mock = mocking_utils::patch_and_return(
     "lib:rclcpp_action", rcl_action_take_cancel_request, RCL_RET_ERROR);
 
-  EXPECT_THROW(SendClientRequest(), rclcpp::exceptions::RCLError);
-}
-
-TEST_F(TestGoalRequestServer, publish_status_rcl_errors)
-{
-  auto mock = mocking_utils::patch_and_return(
-    "lib:rclcpp_action", rcl_action_process_cancel_request, RCL_RET_ERROR);
-
-  EXPECT_THROW(SendClientRequest(), rclcpp::exceptions::RCLError);
-}
-TEST_F(TestGoalRequestServer, publish_status_send_cancel_response_errors)
-{
-  auto mock = mocking_utils::patch_and_return(
-    "lib:rclcpp_action", rcl_action_send_cancel_response, RCL_RET_ERROR);
-
-  EXPECT_THROW(SendClientRequest(), std::runtime_error);
+  EXPECT_THROW(SendClientCancelRequest(), rclcpp::exceptions::RCLError);
 }
 
 TEST_F(TestCancelRequestServer, execute_cancel_request_received_take_failed)
@@ -1190,7 +1193,7 @@ TEST_F(TestCancelRequestServer, execute_cancel_request_received_take_failed)
   auto mock = mocking_utils::patch_and_return(
     "lib:rclcpp_action", rcl_action_take_cancel_request, RCL_RET_ACTION_SERVER_TAKE_FAILED);
   try {
-    SendClientRequest(std::chrono::milliseconds(100));
+    SendClientCancelRequest(std::chrono::milliseconds(100));
     ADD_FAILURE() << "SetupActionServerAndSpin did not throw, but it was expected to";
   } catch (const std::runtime_error & e) {
     EXPECT_STREQ("cancel request future timed out", e.what());
@@ -1199,42 +1202,18 @@ TEST_F(TestCancelRequestServer, execute_cancel_request_received_take_failed)
   }
 }
 
-TEST_F(TestGoalRequestServer, get_result_rcl_errors)
+TEST_F(TestCancelRequestServer, publish_status_rcl_errors)
 {
-  auto take_result_request_error = [this]() {
-      this->SendClientRequest();
-      // Send result request
-      auto result_client = node_->create_client<Fibonacci::Impl::GetResultService>(
-        "fibonacci/_action/get_result");
-      if (!result_client->wait_for_service(std::chrono::seconds(20))) {
-        throw std::runtime_error("get result service didn't become available");
-      }
-      auto request = std::make_shared<Fibonacci::Impl::GetResultService::Request>();
-      request->goal_id.uuid = uuid_;
-      auto mock = mocking_utils::patch_and_return(
-        "lib:rclcpp_action", rcl_action_take_result_request, RCL_RET_ERROR);
-      auto future = result_client->async_send_request(request);
-    };
+  auto mock = mocking_utils::patch_and_return(
+    "lib:rclcpp_action", rcl_action_process_cancel_request, RCL_RET_ERROR);
 
-  EXPECT_THROW(take_result_request_error(), rclcpp::exceptions::RCLError);
+  EXPECT_THROW(SendClientCancelRequest(), rclcpp::exceptions::RCLError);
 }
 
-TEST_F(TestGoalRequestServer, send_result_rcl_errors)
+TEST_F(TestCancelRequestServer, publish_status_send_cancel_response_errors)
 {
-  auto send_result_error = [this]() {
-      this->SendClientRequest();
-      // Send result request
-      auto result_client = node_->create_client<Fibonacci::Impl::GetResultService>(
-        "fibonacci/_action/get_result");
-      if (!result_client->wait_for_service(std::chrono::seconds(20))) {
-        throw std::runtime_error("get result service didn't become available");
-      }
-      auto request = std::make_shared<Fibonacci::Impl::GetResultService::Request>();
-      request->goal_id.uuid = uuid_;
-      auto mock = mocking_utils::patch_and_return(
-        "lib:rclcpp_action", rcl_action_send_result_response, RCL_RET_ERROR);
-      auto future = result_client->async_send_request(request);
-    };
+  auto mock = mocking_utils::patch_and_return(
+    "lib:rclcpp_action", rcl_action_send_cancel_response, RCL_RET_ERROR);
 
-  EXPECT_THROW(send_result_error(), rclcpp::exceptions::RCLError);
+  EXPECT_THROW(SendClientCancelRequest(), std::runtime_error);
 }

--- a/rclcpp_action/test/test_server_goal_handle.cpp
+++ b/rclcpp_action/test/test_server_goal_handle.cpp
@@ -1,0 +1,159 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rclcpp/exceptions.hpp>
+#include <rclcpp/node.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <test_msgs/action/fibonacci.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "action_msgs/msg/goal_info.h"
+#include "rclcpp_action/server_goal_handle.hpp"
+#include "./mocking_utils/patch.hpp"
+
+class FibonacciServerGoalHandle
+  : public rclcpp_action::ServerGoalHandle<test_msgs::action::Fibonacci>
+{
+public:
+  FibonacciServerGoalHandle(
+    std::shared_ptr<rcl_action_goal_handle_t> rcl_handle,
+    rclcpp_action::GoalUUID uuid,
+    std::shared_ptr<const test_msgs::action::Fibonacci::Goal> goal,
+    std::function<void(
+      const rclcpp_action::GoalUUID &, std::shared_ptr<void>)> on_terminal_state,
+    std::function<void(const rclcpp_action::GoalUUID &)> on_executing,
+    std::function<void(
+      std::shared_ptr<test_msgs::action::Fibonacci::Impl::FeedbackMessage>)> publish_feedback)
+  : rclcpp_action::ServerGoalHandle<test_msgs::action::Fibonacci>(
+      rcl_handle, uuid, goal, on_terminal_state, on_executing, publish_feedback) {}
+
+  bool cancel() {return try_canceling();}
+
+  void cancel_goal() {_cancel_goal();}
+};
+
+class TestServerGoalHandle : public ::testing::Test
+{
+public:
+  TestServerGoalHandle()
+  : handle_(nullptr) {}
+
+  void SetUp()
+  {
+    std::shared_ptr<rcl_action_goal_handle_t> rcl_handle =
+      std::make_shared<rcl_action_goal_handle_t>();
+    *rcl_handle.get() = rcl_action_get_zero_initialized_goal_handle();
+    rcutils_allocator_t allocator = rcutils_get_default_allocator();
+    rcl_action_goal_info_t goal_info = rcl_action_get_zero_initialized_goal_info();
+    ASSERT_EQ(RCL_RET_OK, rcl_action_goal_handle_init(rcl_handle.get(), &goal_info, allocator));
+    rclcpp_action::GoalUUID uuid;
+    std::shared_ptr<const test_msgs::action::Fibonacci::Goal> goal =
+      std::make_shared<const test_msgs::action::Fibonacci::Goal>();
+    auto on_terminal_state = [](const rclcpp_action::GoalUUID &, std::shared_ptr<void>) {};
+    auto on_executing = [](const rclcpp_action::GoalUUID &) {};
+    auto publish_feedback =
+      [](std::shared_ptr<test_msgs::action::Fibonacci::Impl::FeedbackMessage>) {};
+    handle_ = std::make_unique<FibonacciServerGoalHandle>(
+      rcl_handle, uuid, goal, on_terminal_state, on_executing, publish_feedback);
+  }
+
+protected:
+  std::unique_ptr<FibonacciServerGoalHandle> handle_;
+};
+
+TEST_F(TestServerGoalHandle, construct_destruct) {
+  EXPECT_FALSE(handle_->is_canceling());
+  EXPECT_TRUE(handle_->is_active());
+  EXPECT_FALSE(handle_->is_executing());
+}
+
+TEST_F(TestServerGoalHandle, cancel) {
+  handle_->execute();
+  EXPECT_TRUE(handle_->cancel());
+  EXPECT_FALSE(handle_->is_canceling());
+  EXPECT_FALSE(handle_->is_active());
+  EXPECT_FALSE(handle_->is_executing());
+
+  {
+    auto mock_get_status = mocking_utils::patch_and_return(
+      "lib:rclcpp_action", rcl_action_goal_handle_get_status, RCL_RET_ERROR);
+    EXPECT_FALSE(handle_->cancel());
+  }
+
+  {
+    auto mock_update_status = mocking_utils::patch_and_return(
+      "lib:rclcpp_action", rcl_action_update_goal_state, RCL_RET_ERROR);
+    auto mock_is_cancelable = mocking_utils::patch_and_return(
+      "lib:rclcpp_action", rcl_action_goal_handle_is_cancelable, true);
+    EXPECT_FALSE(handle_->cancel());
+    EXPECT_THROW(handle_->cancel_goal(), rclcpp::exceptions::RCLError);
+
+    test_msgs::action::Fibonacci::Result::SharedPtr result =
+      std::make_shared<test_msgs::action::Fibonacci::Result>();
+    EXPECT_THROW(handle_->canceled(result), rclcpp::exceptions::RCLError);
+  }
+}
+
+TEST_F(TestServerGoalHandle, abort) {
+  handle_->execute();
+  test_msgs::action::Fibonacci::Result::SharedPtr result =
+    std::make_shared<test_msgs::action::Fibonacci::Result>();
+  handle_->abort(result);
+  EXPECT_FALSE(handle_->is_canceling());
+  EXPECT_FALSE(handle_->is_active());
+  EXPECT_FALSE(handle_->is_executing());
+
+  auto mock = mocking_utils::patch_and_return(
+    "lib:rclcpp_action", rcl_action_update_goal_state, RCL_RET_ERROR);
+  EXPECT_THROW(handle_->abort(result), rclcpp::exceptions::RCLError);
+}
+
+TEST_F(TestServerGoalHandle, succeed) {
+  handle_->execute();
+  test_msgs::action::Fibonacci::Result::SharedPtr result =
+    std::make_shared<test_msgs::action::Fibonacci::Result>();
+  handle_->succeed(result);
+  EXPECT_FALSE(handle_->is_canceling());
+  EXPECT_FALSE(handle_->is_active());
+  EXPECT_FALSE(handle_->is_executing());
+
+  auto mock = mocking_utils::patch_and_return(
+    "lib:rclcpp_action", rcl_action_update_goal_state, RCL_RET_ERROR);
+  EXPECT_THROW(handle_->succeed(result), rclcpp::exceptions::RCLError);
+}
+
+
+TEST_F(TestServerGoalHandle, execute) {
+  handle_->execute();
+  EXPECT_FALSE(handle_->is_canceling());
+  EXPECT_TRUE(handle_->is_active());
+  EXPECT_TRUE(handle_->is_executing());
+
+  auto mock = mocking_utils::patch_and_return(
+    "lib:rclcpp_action", rcl_action_update_goal_state, RCL_RET_ERROR);
+  EXPECT_THROW(handle_->execute(), rclcpp::exceptions::RCLError);
+}
+
+TEST_F(TestServerGoalHandle, rcl_action_goal_handle_get_status_error) {
+  auto mock = mocking_utils::patch_and_return(
+    "lib:rclcpp_action", rcl_action_goal_handle_get_status, RCL_RET_ERROR);
+
+  EXPECT_THROW(handle_->is_canceling(), rclcpp::exceptions::RCLError);
+  EXPECT_NO_THROW(handle_->is_active());
+  EXPECT_THROW(handle_->is_executing(), rclcpp::exceptions::RCLError);
+}

--- a/rclcpp_action/test/test_server_goal_handle.cpp
+++ b/rclcpp_action/test/test_server_goal_handle.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Open Source Robotics Foundation, Inc.
+// Copyright 2020 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ public:
   : rclcpp_action::ServerGoalHandle<test_msgs::action::Fibonacci>(
       rcl_handle, uuid, goal, on_terminal_state, on_executing, publish_feedback) {}
 
-  bool cancel() {return try_canceling();}
+  bool try_cancel() {return try_canceling();}
 
   void cancel_goal() {_cancel_goal();}
 };
@@ -84,7 +84,7 @@ TEST_F(TestServerGoalHandle, construct_destruct) {
 
 TEST_F(TestServerGoalHandle, cancel) {
   handle_->execute();
-  EXPECT_TRUE(handle_->cancel());
+  EXPECT_TRUE(handle_->try_cancel());
   EXPECT_FALSE(handle_->is_canceling());
   EXPECT_FALSE(handle_->is_active());
   EXPECT_FALSE(handle_->is_executing());
@@ -92,7 +92,7 @@ TEST_F(TestServerGoalHandle, cancel) {
   {
     auto mock_get_status = mocking_utils::patch_and_return(
       "lib:rclcpp_action", rcl_action_goal_handle_get_status, RCL_RET_ERROR);
-    EXPECT_FALSE(handle_->cancel());
+    EXPECT_FALSE(handle_->try_cancel());
   }
 
   {
@@ -100,7 +100,7 @@ TEST_F(TestServerGoalHandle, cancel) {
       "lib:rclcpp_action", rcl_action_update_goal_state, RCL_RET_ERROR);
     auto mock_is_cancelable = mocking_utils::patch_and_return(
       "lib:rclcpp_action", rcl_action_goal_handle_is_cancelable, true);
-    EXPECT_FALSE(handle_->cancel());
+    EXPECT_FALSE(handle_->try_cancel());
     EXPECT_THROW(handle_->cancel_goal(), rclcpp::exceptions::RCLError);
 
     test_msgs::action::Fibonacci::Result::SharedPtr result =


### PR DESCRIPTION
This adds unit tests for rclcpp_action and increases the coverage to just bit over 95%. As part of this work, an issue was found with the client implementation, which is potentially addressed in #1292. This branch is currently targeting that PR branch for easy review.

Testing `--packages-select rclcpp_action`

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12240)](http://ci.ros2.org/job/ci_linux/12240/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7218)](http://ci.ros2.org/job/ci_linux-aarch64/7218/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9960)](http://ci.ros2.org/job/ci_osx/9960/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12134)](http://ci.ros2.org/job/ci_windows/12134/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>