### PR TITLE
Adding tests basic getters

### DIFF
--- a/rclcpp/test/CMakeLists.txt
+++ b/rclcpp/test/CMakeLists.txt
@@ -373,6 +373,7 @@ if(TARGET test_service)
     "rmw"
     "rosidl_runtime_cpp"
     "rosidl_typesupport_cpp"
+    "test_msgs"
   )
   target_link_libraries(test_service ${PROJECT_NAME})
 endif()

--- a/rclcpp/test/rclcpp/test_publisher.cpp
+++ b/rclcpp/test/rclcpp/test_publisher.cpp
@@ -231,11 +231,13 @@ TEST_F(TestPublisher, basic_getters) {
   initialize();
   using test_msgs::msg::Empty;
   {
-    auto publisher = node->create_publisher<Empty>("topic", 42);
+    using rclcpp::QoS;
+    using rclcpp::KeepLast;
+    const size_t qos_depth_size = 10u;
+    auto publisher = node->create_publisher<Empty>("topic", QoS(KeepLast(qos_depth_size)));
 
     size_t publisher_queue_size = publisher->get_queue_size();
-    // TODO(blast545): get default rmw qos options to compare here
-    EXPECT_NE(800u, publisher_queue_size);
+    EXPECT_EQ(qos_depth_size, publisher_queue_size);
 
     const rmw_gid_t & publisher_rmw_gid = publisher->get_gid();
     EXPECT_NE(nullptr, publisher_rmw_gid.implementation_identifier);

--- a/rclcpp/test/rclcpp/test_publisher.cpp
+++ b/rclcpp/test/rclcpp/test_publisher.cpp
@@ -204,7 +204,7 @@ TEST_F(TestPublisherSub, construction_and_destruction) {
   }
 }
 
-// Auxiliar class used to test getter for const PublisherBase
+// Auxiliary class used to test getter for const PublisherBase
 const rosidl_message_type_support_t EmptyTypeSupport()
 {
   return *rosidl_typesupport_cpp::get_message_type_support_handle<test_msgs::msg::Empty>();

--- a/rclcpp/test/rclcpp/test_publisher.cpp
+++ b/rclcpp/test/rclcpp/test_publisher.cpp
@@ -237,15 +237,23 @@ TEST_F(TestPublisher, basic_getters) {
     // TODO(blast545): get default rmw qos options to compare here
     EXPECT_NE(800u, publisher_queue_size);
 
-    const rmw_gid_t & publisher_rmw_gid_t = publisher->get_gid();
-    EXPECT_NE(nullptr, publisher_rmw_gid_t.implementation_identifier);
+    const rmw_gid_t & publisher_rmw_gid = publisher->get_gid();
+    EXPECT_NE(nullptr, publisher_rmw_gid.implementation_identifier);
 
     std::shared_ptr<rcl_publisher_t> publisher_handle = publisher->get_publisher_handle();
     EXPECT_NE(nullptr, publisher_handle);
+
+    EXPECT_TRUE(publisher->assert_liveliness());
   }
   {
     const TestPublisherBase publisher = TestPublisherBase(node.get());
     std::shared_ptr<const rcl_publisher_t> publisher_handle = publisher.get_publisher_handle();
     EXPECT_NE(nullptr, publisher_handle);
+
+    const rmw_gid_t & publisher_rmw_gid = publisher.get_gid();
+    EXPECT_NE(nullptr, publisher_rmw_gid.implementation_identifier);
+
+    // Test == operator of publisher with rmw_gid_t
+    EXPECT_EQ(publisher, publisher_rmw_gid);
   }
 }

--- a/rclcpp/test/rclcpp/test_publisher.cpp
+++ b/rclcpp/test/rclcpp/test_publisher.cpp
@@ -203,3 +203,49 @@ TEST_F(TestPublisherSub, construction_and_destruction) {
     }, rclcpp::exceptions::InvalidTopicNameError);
   }
 }
+
+// Auxiliar class used to test getter for const PublisherBase
+const rosidl_message_type_support_t EmptyTypeSupport()
+{
+  return *rosidl_typesupport_cpp::get_message_type_support_handle<test_msgs::msg::Empty>();
+}
+
+const rcl_publisher_options_t PublisherOptions()
+{
+  return rclcpp::PublisherOptionsWithAllocator<std::allocator<void>>().template
+         to_rcl_publisher_options<test_msgs::msg::Empty>(rclcpp::QoS(10));
+}
+
+class TestPublisherBase : public rclcpp::PublisherBase
+{
+public:
+  explicit TestPublisherBase(rclcpp::Node * node)
+  : rclcpp::PublisherBase(
+      node->get_node_base_interface().get(), "topic", EmptyTypeSupport(), PublisherOptions()) {}
+};
+
+/*
+   Testing some publisher getters
+ */
+TEST_F(TestPublisher, basic_getters) {
+  initialize();
+  using test_msgs::msg::Empty;
+  {
+    auto publisher = node->create_publisher<Empty>("topic", 42);
+
+    size_t publisher_queue_size = publisher->get_queue_size();
+    // TODO(blast545): get default rmw qos options to compare here
+    EXPECT_NE(800u, publisher_queue_size);
+
+    const rmw_gid_t & publisher_rmw_gid_t = publisher->get_gid();
+    EXPECT_NE(nullptr, publisher_rmw_gid_t.implementation_identifier);
+
+    std::shared_ptr<rcl_publisher_t> publisher_handle = publisher->get_publisher_handle();
+    EXPECT_NE(nullptr, publisher_handle);
+  }
+  {
+    const TestPublisherBase publisher = TestPublisherBase(node.get());
+    std::shared_ptr<const rcl_publisher_t> publisher_handle = publisher.get_publisher_handle();
+    EXPECT_NE(nullptr, publisher_handle);
+  }
+}

--- a/rclcpp/test/rclcpp/test_serialized_message.cpp
+++ b/rclcpp/test/rclcpp/test_serialized_message.cpp
@@ -180,8 +180,7 @@ TEST(TestSerializedMessage, assignment_operators) {
   ASSERT_EQ(RCL_RET_OK, ret);
 
   // manually copy some content
-  std::memcpy(rcl_serialized_msg.buffer, content.c_str(), content.size());
-  rcl_serialized_msg.buffer[content.size()] = '\0';
+  std::memcpy(rcl_serialized_msg.buffer, content.c_str(), content_size);
   rcl_serialized_msg.buffer_length = content_size;
   EXPECT_EQ(13u, rcl_serialized_msg.buffer_capacity);
   rclcpp::SerializedMessage serialized_message_to_assign(rcl_serialized_msg);

--- a/rclcpp/test/rclcpp/test_serialized_message.cpp
+++ b/rclcpp/test/rclcpp/test_serialized_message.cpp
@@ -149,7 +149,9 @@ TEST(TestSerializedMessage, reserve) {
   EXPECT_EQ(15u, serialized_msg.capacity());
 
   // Use invalid value throws exception
-  EXPECT_ANY_THROW(serialized_msg.reserve(-1));
+  EXPECT_THROW(
+    {serialized_msg.reserve(-1);},
+    rclcpp::exceptions::RCLBadAlloc);
 }
 
 TEST(TestSerializedMessage, serialization) {
@@ -231,7 +233,9 @@ TEST(TestSerializedMessage, failed_init_throws) {
   EXPECT_EQ(13u, serialized_msg.capacity());
 
   // Constructor with invalid size throws exception
-  EXPECT_ANY_THROW(rclcpp::SerializedMessage serialized_msg_fail(-1););
+  EXPECT_THROW(
+    {rclcpp::SerializedMessage serialized_msg_fail(-1);},
+    rclcpp::exceptions::RCLBadAlloc);
 
   // Constructor copy with rmw_serialized bad msg throws
   auto default_allocator = rcl_get_default_allocator();
@@ -240,7 +244,9 @@ TEST(TestSerializedMessage, failed_init_throws) {
   ASSERT_EQ(RCL_RET_OK, ret);
   EXPECT_EQ(13u, rcl_serialized_msg.buffer_capacity);
   rcl_serialized_msg.buffer_capacity = -1;
-  EXPECT_ANY_THROW(rclcpp::SerializedMessage serialized_msg_fail_2(rcl_serialized_msg););
+  EXPECT_THROW(
+    {rclcpp::SerializedMessage serialized_msg_fail_2(rcl_serialized_msg);},
+    rclcpp::exceptions::RCLBadAlloc);
 
   rcl_serialized_msg.buffer_capacity = 13;
   EXPECT_EQ(RCL_RET_OK, rmw_serialized_message_fini(&rcl_serialized_msg));

--- a/rclcpp/test/rclcpp/test_serialized_message.cpp
+++ b/rclcpp/test/rclcpp/test_serialized_message.cpp
@@ -140,6 +140,18 @@ TEST(TestSerializedMessage, release) {
   EXPECT_EQ(RCL_RET_OK, rmw_serialized_message_fini(&released_handle));
 }
 
+TEST(TestSerializedMessage, reserve) {
+  rclcpp::SerializedMessage serialized_msg(13);
+  EXPECT_EQ(13u, serialized_msg.capacity());
+
+  // Resize using reserve method
+  serialized_msg.reserve(15);
+  EXPECT_EQ(15u, serialized_msg.capacity());
+
+  // Use invalid value throws exception
+  EXPECT_ANY_THROW(serialized_msg.reserve(-1));
+}
+
 TEST(TestSerializedMessage, serialization) {
   using MessageT = test_msgs::msg::BasicTypes;
 
@@ -157,6 +169,82 @@ TEST(TestSerializedMessage, serialization) {
 
     EXPECT_EQ(*ros_msg, deserialized_ros_msg);
   }
+}
+
+TEST(TestSerializedMessage, assignment_operators) {
+  const std::string content = "Hello World";
+  const auto content_size = content.size() + 1;  // accounting for null terminator
+  auto default_allocator = rcl_get_default_allocator();
+  auto rcl_serialized_msg = rmw_get_zero_initialized_serialized_message();
+  auto ret = rmw_serialized_message_init(&rcl_serialized_msg, 13, &default_allocator);
+  ASSERT_EQ(RCL_RET_OK, ret);
+
+  // manually copy some content
+  std::memcpy(rcl_serialized_msg.buffer, content.c_str(), content.size());
+  rcl_serialized_msg.buffer[content.size()] = '\0';
+  rcl_serialized_msg.buffer_length = content_size;
+  EXPECT_EQ(13u, rcl_serialized_msg.buffer_capacity);
+  rclcpp::SerializedMessage serialized_message_to_assign(rcl_serialized_msg);
+  EXPECT_EQ(13u, serialized_message_to_assign.capacity());
+  EXPECT_EQ(content_size, serialized_message_to_assign.size());
+
+  // Test copy assignment with = operator, on another rclcpp::SerializedMessage
+  rclcpp::SerializedMessage serialized_msg_copy(2);
+  EXPECT_EQ(2u, serialized_msg_copy.capacity());
+  EXPECT_EQ(0u, serialized_msg_copy.size());
+  serialized_msg_copy = serialized_message_to_assign;
+  EXPECT_EQ(13u, serialized_msg_copy.capacity());
+  EXPECT_EQ(content_size, serialized_msg_copy.size());
+
+  // Test copy assignment with = operator, with a rcl_serialized_message_t
+  rclcpp::SerializedMessage serialized_msg_copy_rcl(2);
+  EXPECT_EQ(2u, serialized_msg_copy_rcl.capacity());
+  EXPECT_EQ(0u, serialized_msg_copy_rcl.size());
+  serialized_msg_copy_rcl = rcl_serialized_msg;
+  EXPECT_EQ(13u, serialized_msg_copy_rcl.capacity());
+  EXPECT_EQ(content_size, serialized_msg_copy_rcl.size());
+
+  // Test move assignment with = operator
+  rclcpp::SerializedMessage serialized_msg_move(2);
+  EXPECT_EQ(2u, serialized_msg_move.capacity());
+  EXPECT_EQ(0u, serialized_msg_move.size());
+  serialized_msg_move = std::move(serialized_message_to_assign);
+  EXPECT_EQ(13u, serialized_msg_move.capacity());
+  EXPECT_EQ(content_size, serialized_msg_move.size());
+  EXPECT_EQ(0u, serialized_message_to_assign.capacity());
+  EXPECT_EQ(0u, serialized_message_to_assign.size());
+
+  // Test move assignment with = operator, with a rcl_serialized_message_t
+  rclcpp::SerializedMessage serialized_msg_move_rcl(2);
+  EXPECT_EQ(2u, serialized_msg_move_rcl.capacity());
+  EXPECT_EQ(0u, serialized_msg_move_rcl.size());
+  serialized_msg_move_rcl = std::move(rcl_serialized_msg);
+  EXPECT_EQ(13u, serialized_msg_move_rcl.capacity());
+  EXPECT_EQ(content_size, serialized_msg_move_rcl.size());
+  EXPECT_EQ(0u, rcl_serialized_msg.buffer_capacity);
+
+  // Error because it was moved
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, rmw_serialized_message_fini(&rcl_serialized_msg));
+}
+
+TEST(TestSerializedMessage, failed_init_throws) {
+  rclcpp::SerializedMessage serialized_msg(13);
+  EXPECT_EQ(13u, serialized_msg.capacity());
+
+  // Constructor with invalid size throws exception
+  EXPECT_ANY_THROW(rclcpp::SerializedMessage serialized_msg_fail(-1););
+
+  // Constructor copy with rmw_serialized bad msg throws
+  auto default_allocator = rcl_get_default_allocator();
+  auto rcl_serialized_msg = rmw_get_zero_initialized_serialized_message();
+  auto ret = rmw_serialized_message_init(&rcl_serialized_msg, 13, &default_allocator);
+  ASSERT_EQ(RCL_RET_OK, ret);
+  EXPECT_EQ(13u, rcl_serialized_msg.buffer_capacity);
+  rcl_serialized_msg.buffer_capacity = -1;
+  EXPECT_ANY_THROW(rclcpp::SerializedMessage serialized_msg_fail_2(rcl_serialized_msg););
+
+  rcl_serialized_msg.buffer_capacity = 13;
+  EXPECT_EQ(RCL_RET_OK, rmw_serialized_message_fini(&rcl_serialized_msg));
 }
 
 void serialize_default_ros_msg()


### PR DESCRIPTION
First round of tests for increasing coverage of `rclcpp`, those are tackling some basic getter functions, let me know if you think I can easily improve those tests.

In particular, I added this test:

``` cpp
size_t publisher_queue_size = publisher->get_queue_size();
// TODO(blast545): get default rmw qos options to compare here
EXPECT_NE(800u, publisher_queue_size);
```

If you guys know to get default QOS configuration please let me know, otherwise I'll check this out before merging.