### PR TITLE
Set promise value after try-catch

### DIFF
--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -370,14 +370,6 @@ public:
         // Do not use std::make_shared as friendship cannot be forwarded.
         std::shared_ptr<GoalHandle> goal_handle(
           new GoalHandle(goal_info, options.feedback_callback, options.result_callback));
-        {
-          std::lock_guard<std::mutex> guard(goal_handles_mutex_);
-          goal_handles_[goal_handle->get_goal_id()] = goal_handle;
-        }
-        promise->set_value(goal_handle);
-        if (options.goal_response_callback) {
-          options.goal_response_callback(future);
-        }
 
         if (options.result_callback) {
           try {
@@ -386,6 +378,16 @@ public:
             promise->set_exception(std::current_exception());
             return;
           }
+        }
+
+        {
+          std::lock_guard<std::mutex> guard(goal_handles_mutex_);
+          goal_handles_[goal_handle->get_goal_id()] = goal_handle;
+        }
+
+        promise->set_value(goal_handle);
+        if (options.goal_response_callback) {
+          options.goal_response_callback(future);
         }
       });
 

--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -262,7 +262,7 @@ public:
   using GoalHandle = ClientGoalHandle<ActionT>;
   using WrappedResult = typename GoalHandle::WrappedResult;
   using GoalResponseCallback =
-    std::function<void (std::shared_future<typename GoalHandle::SharedPtr>)>;
+    std::function<void (typename GoalHandle::SharedPtr)>;
   using FeedbackCallback = typename GoalHandle::FeedbackCallback;
   using ResultCallback = typename GoalHandle::ResultCallback;
   using CancelRequest = typename ActionT::Impl::CancelGoalService::Request;
@@ -360,7 +360,7 @@ public:
         if (!goal_response->accepted) {
           promise->set_value(nullptr);
           if (options.goal_response_callback) {
-            options.goal_response_callback(future);
+            options.goal_response_callback(nullptr);
           }
           return;
         }
@@ -370,6 +370,10 @@ public:
         // Do not use std::make_shared as friendship cannot be forwarded.
         std::shared_ptr<GoalHandle> goal_handle(
           new GoalHandle(goal_info, options.feedback_callback, options.result_callback));
+
+        if (options.goal_response_callback) {
+          options.goal_response_callback(goal_handle);
+        }
 
         if (options.result_callback) {
           try {
@@ -386,9 +390,6 @@ public:
         }
 
         promise->set_value(goal_handle);
-        if (options.goal_response_callback) {
-          options.goal_response_callback(future);
-        }
       });
 
     // TODO(jacobperron): Encapsulate into it's own function and

--- a/rclcpp_action/test/test_client.cpp
+++ b/rclcpp_action/test/test_client.cpp
@@ -435,9 +435,8 @@ TEST_F(TestClientAgainstServer, async_send_goal_with_goal_response_callback_wait
   auto send_goal_ops = rclcpp_action::Client<ActionType>::SendGoalOptions();
   send_goal_ops.goal_response_callback =
     [&goal_response_received]
-      (std::shared_future<typename ActionGoalHandle::SharedPtr> future) mutable
+      (typename ActionGoalHandle::SharedPtr goal_handle) mutable
     {
-      auto goal_handle = future.get();
       if (goal_handle) {
         goal_response_received = true;
       }


### PR DESCRIPTION
This PR fixes a potential issue, where `promise->set_value` is called before a potential call to `promise->set_exception`. Only one can be called, otherwise a `std::future_error` is thrown. This was the original ordering in https://github.com/ros2/rclcpp/pull/594, but it was rearranged in https://github.com/ros2/rclcpp/pull/738. @jacobperron @hidmic if this is breaking something unintentionally, please let me know. It should pass current unit tests as is. This patch is required in order to pass tests in #1290.

Signed-off-by: Stephen Brawner <brawner@gmail.com>