### PR TITLE
Remove rmw-dependent unit-test checks

### DIFF
--- a/rclcpp_lifecycle/test/test_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_node.cpp
@@ -492,31 +492,51 @@ TEST_F(TestDefaultStateMachine, test_getters) {
 TEST_F(TestDefaultStateMachine, test_graph) {
   auto test_node = std::make_shared<EmptyLifecycleNode>("testnode");
   auto names = test_node->get_node_names();
-  EXPECT_EQ(names.size(), 1u);
-  EXPECT_STREQ(names[0].c_str(), "/testnode");
+
+  EXPECT_NE(names.end(), std::find(names.begin(), names.end(), std::string("/testnode")));
 
   // parameter_events, rosout, /testnode/transition_event
   auto topic_names_and_types = test_node->get_topic_names_and_types();
-  EXPECT_EQ(topic_names_and_types.size(), 3u);
+  EXPECT_NE(
+    topic_names_and_types.end(),
+    topic_names_and_types.find(std::string("/testnode/transition_event")));
   EXPECT_STREQ(
     topic_names_and_types["/testnode/transition_event"][0].c_str(),
     "lifecycle_msgs/msg/TransitionEvent");
 
   auto service_names_and_types = test_node->get_service_names_and_types();
-  EXPECT_EQ(service_names_and_types.size(), 11u);
   // These are specific to lifecycle nodes, other services are provided by rclcpp::Node
+  EXPECT_NE(
+    service_names_and_types.end(),
+    service_names_and_types.find(std::string("/testnode/change_state")));
   EXPECT_STREQ(
     service_names_and_types["/testnode/change_state"][0].c_str(),
     "lifecycle_msgs/srv/ChangeState");
+
+  EXPECT_NE(
+    service_names_and_types.end(),
+    service_names_and_types.find(std::string("/testnode/get_available_states")));
   EXPECT_STREQ(
     service_names_and_types["/testnode/get_available_states"][0].c_str(),
     "lifecycle_msgs/srv/GetAvailableStates");
+
+  EXPECT_NE(
+    service_names_and_types.end(),
+    service_names_and_types.find(std::string("/testnode/get_available_transitions")));
   EXPECT_STREQ(
     service_names_and_types["/testnode/get_available_transitions"][0].c_str(),
     "lifecycle_msgs/srv/GetAvailableTransitions");
+
+  EXPECT_NE(
+    service_names_and_types.end(),
+    service_names_and_types.find(std::string("/testnode/get_state")));
   EXPECT_STREQ(
     service_names_and_types["/testnode/get_state"][0].c_str(),
     "lifecycle_msgs/srv/GetState");
+
+  EXPECT_NE(
+    service_names_and_types.end(),
+    service_names_and_types.find(std::string("/testnode/get_transition_graph")));
   EXPECT_STREQ(
     service_names_and_types["/testnode/get_transition_graph"][0].c_str(),
     "lifecycle_msgs/srv/GetAvailableTransitions");

--- a/rclcpp_lifecycle/test/test_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_node.cpp
@@ -493,11 +493,11 @@ TEST_F(TestDefaultStateMachine, test_graph) {
   auto test_node = std::make_shared<EmptyLifecycleNode>("testnode");
   auto names = test_node->get_node_names();
 
-  EXPECT_NE(names.end(), std::find(names.begin(), names.end(), std::string("/testnode")));
+  ASSERT_NE(names.end(), std::find(names.begin(), names.end(), std::string("/testnode")));
 
   // parameter_events, rosout, /testnode/transition_event
   auto topic_names_and_types = test_node->get_topic_names_and_types();
-  EXPECT_NE(
+  ASSERT_NE(
     topic_names_and_types.end(),
     topic_names_and_types.find(std::string("/testnode/transition_event")));
   EXPECT_STREQ(
@@ -506,35 +506,35 @@ TEST_F(TestDefaultStateMachine, test_graph) {
 
   auto service_names_and_types = test_node->get_service_names_and_types();
   // These are specific to lifecycle nodes, other services are provided by rclcpp::Node
-  EXPECT_NE(
+  ASSERT_NE(
     service_names_and_types.end(),
     service_names_and_types.find(std::string("/testnode/change_state")));
   EXPECT_STREQ(
     service_names_and_types["/testnode/change_state"][0].c_str(),
     "lifecycle_msgs/srv/ChangeState");
 
-  EXPECT_NE(
+  ASSERT_NE(
     service_names_and_types.end(),
     service_names_and_types.find(std::string("/testnode/get_available_states")));
   EXPECT_STREQ(
     service_names_and_types["/testnode/get_available_states"][0].c_str(),
     "lifecycle_msgs/srv/GetAvailableStates");
 
-  EXPECT_NE(
+  ASSERT_NE(
     service_names_and_types.end(),
     service_names_and_types.find(std::string("/testnode/get_available_transitions")));
   EXPECT_STREQ(
     service_names_and_types["/testnode/get_available_transitions"][0].c_str(),
     "lifecycle_msgs/srv/GetAvailableTransitions");
 
-  EXPECT_NE(
+  ASSERT_NE(
     service_names_and_types.end(),
     service_names_and_types.find(std::string("/testnode/get_state")));
   EXPECT_STREQ(
     service_names_and_types["/testnode/get_state"][0].c_str(),
     "lifecycle_msgs/srv/GetState");
 
-  EXPECT_NE(
+  ASSERT_NE(
     service_names_and_types.end(),
     service_names_and_types.find(std::string("/testnode/get_transition_graph")));
   EXPECT_STREQ(

--- a/rclcpp_lifecycle/test/test_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_node.cpp
@@ -495,7 +495,7 @@ TEST_F(TestDefaultStateMachine, test_graph) {
 
   ASSERT_NE(names.end(), std::find(names.begin(), names.end(), std::string("/testnode")));
 
-  // parameter_events, rosout, /testnode/transition_event
+  // Other topics may exist for an rclcpp::Node, but just checking the lifecycle one exists
   auto topic_names_and_types = test_node->get_topic_names_and_types();
   ASSERT_NE(
     topic_names_and_types.end(),


### PR DESCRIPTION
It looks some rmw-dependent checks made it into this unit test and has started showing up on build.ros2.org.

Example failure:
http://build.ros2.org/job/Fci__nightly-cyclonedds_ubuntu_focal_amd64/181/testReport/(root)/rclcpp_lifecycle/test_lifecycle_node_gtest_missing_result/

Signed-off-by: Stephen Brawner <brawner@gmail.com>