### PR TITLE
Remove unused private function (rclcpp::Node and rclcpp_lifecycle::Node)

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -1182,10 +1182,6 @@ protected:
 private:
   RCLCPP_DISABLE_COPY(Node)
 
-  RCLCPP_PUBLIC
-  bool
-  group_in_node(CallbackGroup::SharedPtr group);
-
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
   rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_;
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_;

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -218,12 +218,6 @@ Node::create_callback_group(
   return node_base_->create_callback_group(group_type, automatically_add_to_executor_with_node);
 }
 
-bool
-Node::group_in_node(rclcpp::CallbackGroup::SharedPtr group)
-{
-  return node_base_->callback_group_in_node(group);
-}
-
 const rclcpp::ParameterValue &
 Node::declare_parameter(
   const std::string & name,

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -896,10 +896,6 @@ protected:
 private:
   RCLCPP_DISABLE_COPY(LifecycleNode)
 
-  RCLCPP_LIFECYCLE_PUBLIC
-  bool
-  group_in_node(rclcpp::CallbackGroup::SharedPtr group);
-
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
   rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_;
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_;

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -180,12 +180,6 @@ LifecycleNode::set_parameter(const rclcpp::Parameter & parameter)
   return this->set_parameters_atomically({parameter});
 }
 
-bool
-LifecycleNode::group_in_node(rclcpp::CallbackGroup::SharedPtr group)
-{
-  return node_base_->callback_group_in_node(group);
-}
-
 std::vector<rcl_interfaces::msg::SetParametersResult>
 LifecycleNode::set_parameters(
   const std::vector<rclcpp::Parameter> & parameters)


### PR DESCRIPTION
This function `group_in_node` is declared private, but is otherwise unused. This is a PR for removing it, but I can also move it to protected or public if it's inclusion might be helpful.

Signed-off-by: Stephen Brawner <brawner@gmail.com>