### PR TITLE
Log error instead of throwing exception in Transition and State reset(), mark no except

### DIFF
--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/state.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/state.hpp
@@ -87,7 +87,7 @@ public:
 protected:
   RCLCPP_LIFECYCLE_PUBLIC
   void
-  reset();
+  reset() noexcept;
 
   rcutils_allocator_t allocator_;
 

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/transition.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/transition.hpp
@@ -119,7 +119,7 @@ public:
 protected:
   RCLCPP_LIFECYCLE_PUBLIC
   void
-  reset();
+  reset() noexcept;
 
   rcutils_allocator_t allocator_;
 

--- a/rclcpp_lifecycle/src/state.cpp
+++ b/rclcpp_lifecycle/src/state.cpp
@@ -83,13 +83,7 @@ State::State(const State & rhs)
 
 State::~State()
 {
-  try {
-    reset();
-  } catch (...) {
-    RCLCPP_ERROR(
-      rclcpp::get_logger("rclcpp_lifecycle"),
-      "Resetting rclcpp_lifecycle::State threw during destruction, leaking memory");
-  }
+  reset();
 }
 
 State &
@@ -150,7 +144,7 @@ State::label() const
 }
 
 void
-State::reset()
+State::reset() noexcept
 {
   if (!owns_rcl_state_handle_) {
     state_handle_ = nullptr;
@@ -164,7 +158,9 @@ State::reset()
   allocator_.deallocate(state_handle_, allocator_.state);
   state_handle_ = nullptr;
   if (ret != RCL_RET_OK) {
-    rclcpp::exceptions::throw_from_rcl_error(ret);
+    RCLCPP_ERROR(
+      rclcpp::get_logger("rclcpp_lifecycle"),
+      "rcl_lifecycle_transition_fini did not complete successfully, leaking memory");
   }
 }
 

--- a/rclcpp_lifecycle/src/state.cpp
+++ b/rclcpp_lifecycle/src/state.cpp
@@ -21,6 +21,7 @@
 #include "rcl_lifecycle/rcl_lifecycle.h"
 
 #include "rclcpp/exceptions.hpp"
+#include "rclcpp/logging.hpp"
 
 #include "rcutils/allocator.h"
 
@@ -82,7 +83,13 @@ State::State(const State & rhs)
 
 State::~State()
 {
-  reset();
+  try {
+    reset();
+  } catch (...) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("rclcpp_lifecycle"),
+      "Resetting rclcpp_lifecycle::State threw during destruction, leaking memory");
+  }
 }
 
 State &

--- a/rclcpp_lifecycle/src/transition.cpp
+++ b/rclcpp_lifecycle/src/transition.cpp
@@ -21,6 +21,7 @@
 #include "rcl_lifecycle/rcl_lifecycle.h"
 
 #include "rclcpp/exceptions.hpp"
+#include "rclcpp/logging.hpp"
 
 #include "rcutils/allocator.h"
 
@@ -118,7 +119,13 @@ Transition::Transition(const Transition & rhs)
 
 Transition::~Transition()
 {
-  reset();
+  try {
+    reset();
+  } catch (...) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("rclcpp_lifecycle"),
+      "Resetting rclcpp_lifecycle::Transition threw during destructor, leaking memory");
+  }
 }
 
 Transition &

--- a/rclcpp_lifecycle/src/transition.cpp
+++ b/rclcpp_lifecycle/src/transition.cpp
@@ -119,13 +119,7 @@ Transition::Transition(const Transition & rhs)
 
 Transition::~Transition()
 {
-  try {
-    reset();
-  } catch (...) {
-    RCLCPP_ERROR(
-      rclcpp::get_logger("rclcpp_lifecycle"),
-      "Resetting rclcpp_lifecycle::Transition threw during destructor, leaking memory");
-  }
+  reset();
 }
 
 Transition &
@@ -253,7 +247,7 @@ Transition::goal_state() const
 }
 
 void
-Transition::reset()
+Transition::reset() noexcept
 {
   // can't free anything which is not owned
   if (!owns_rcl_transition_handle_) {
@@ -268,7 +262,9 @@ Transition::reset()
   allocator_.deallocate(transition_handle_, allocator_.state);
   transition_handle_ = nullptr;
   if (ret != RCL_RET_OK) {
-    rclcpp::exceptions::throw_from_rcl_error(ret);
+    RCLCPP_ERROR(
+      rclcpp::get_logger("rclcpp_lifecycle"),
+      "rcl_lifecycle_transition_fini did not complete successfully, leaking memory");
   }
 }
 }  // namespace rclcpp_lifecycle


### PR DESCRIPTION
This was discovered during fault injection testing, but if for some reason `rcl_lifecycle_state_fini` fails during `rclcpp::Transition::reset()` or `rclcpp::State::reset()`, these destructors will throw an uncatchable exception because destructors are `noexcept` by default.

There are other potential resolutions to this issue, like marking these destructors `noexcept(false)`, but that has performance side effects by poisoning the chain of destructors that eventually call these.

Signed-off-by: Stephen Brawner <brawner@gmail.com>