### PR TITLE
Clear members for StaticExecutorEntitiesCollector to avoid shared_ptr dependency

### DIFF
--- a/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
@@ -64,8 +64,13 @@ public:
   void
   init(
     rcl_wait_set_t * p_wait_set,
-    rclcpp::memory_strategy::MemoryStrategy::SharedPtr & memory_strategy,
+    rclcpp::memory_strategy::MemoryStrategy::SharedPtr memory_strategy,
     rcl_guard_condition_t * executor_guard_condition);
+
+  /// Finalize StaticExecutorEntitiesCollector to clear resources
+  RCLCPP_PUBLIC
+  void
+  fini();
 
   RCLCPP_PUBLIC
   void

--- a/rclcpp/include/rclcpp/executors/static_single_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/static_single_threaded_executor.hpp
@@ -194,6 +194,7 @@ public:
 
     entities_collector_->init(&wait_set_, memory_strategy_, &interrupt_guard_condition_);
 
+    rclcpp::FutureReturnCode ret = rclcpp::FutureReturnCode::INTERRUPTED;
     while (rclcpp::ok(this->context_)) {
       // Do one set of work.
       entities_collector_->refresh_wait_set(timeout_left);
@@ -201,7 +202,8 @@ public:
       // Check if the future is set, return SUCCESS if it is.
       status = future.wait_for(std::chrono::seconds(0));
       if (status == std::future_status::ready) {
-        return rclcpp::FutureReturnCode::SUCCESS;
+        ret = rclcpp::FutureReturnCode::SUCCESS;
+        break;
       }
       // If the original timeout is < 0, then this is blocking, never TIMEOUT.
       if (timeout_ns < std::chrono::nanoseconds::zero()) {
@@ -210,14 +212,17 @@ public:
       // Otherwise check if we still have time to wait, return TIMEOUT if not.
       auto now = std::chrono::steady_clock::now();
       if (now >= end_time) {
-        return rclcpp::FutureReturnCode::TIMEOUT;
+        ret = rclcpp::FutureReturnCode::TIMEOUT;
+        break;
       }
       // Subtract the elapsed time from the original timeout.
       timeout_left = std::chrono::duration_cast<std::chrono::nanoseconds>(end_time - now);
     }
 
+    entities_collector_->fini();
+
     // The future did not complete before ok() returned false, return INTERRUPTED.
-    return rclcpp::FutureReturnCode::INTERRUPTED;
+    return ret;
   }
 
   /// Not yet implemented, see https://github.com/ros2/rclcpp/issues/1219 for tracking

--- a/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
@@ -61,7 +61,7 @@ StaticExecutorEntitiesCollector::~StaticExecutorEntitiesCollector()
 void
 StaticExecutorEntitiesCollector::init(
   rcl_wait_set_t * p_wait_set,
-  rclcpp::memory_strategy::MemoryStrategy::SharedPtr & memory_strategy,
+  rclcpp::memory_strategy::MemoryStrategy::SharedPtr memory_strategy,
   rcl_guard_condition_t * executor_guard_condition)
 {
   // Empty initialize executable list
@@ -78,6 +78,13 @@ StaticExecutorEntitiesCollector::init(
   memory_strategy_->add_guard_condition(executor_guard_condition);
   // Get memory strategy and executable list. Prepare wait_set_
   execute();
+}
+
+void
+StaticExecutorEntitiesCollector::fini()
+{
+  memory_strategy_->clear_handles();
+  exec_list_.clear();
 }
 
 void

--- a/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
@@ -48,6 +48,8 @@ StaticSingleThreadedExecutor::spin()
     entities_collector_->refresh_wait_set();
     execute_ready_executables();
   }
+
+  entities_collector_->fini();
 }
 
 void

--- a/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
@@ -42,14 +42,13 @@ StaticSingleThreadedExecutor::spin()
   // Set memory_strategy_ and exec_list_ based on weak_nodes_
   // Prepare wait_set_ based on memory_strategy_
   entities_collector_->init(&wait_set_, memory_strategy_, &interrupt_guard_condition_);
+  RCLCPP_SCOPE_EXIT(entities_collector_->fini());
 
   while (rclcpp::ok(this->context_) && spinning.load()) {
     // Refresh wait set and wait for work
     entities_collector_->refresh_wait_set();
     execute_ready_executables();
   }
-
-  entities_collector_->fini();
 }
 
 void

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -410,6 +410,14 @@ public:
     }
   }
 
+  ~TestWaitable()
+  {
+    rcl_ret_t ret = rcl_guard_condition_fini(&gc_);
+    if (RCL_RET_OK != ret) {
+      rclcpp::exceptions::throw_from_rcl_error(ret);
+    }
+  }
+
   bool
   add_to_wait_set(rcl_wait_set_t * wait_set) override
   {

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -414,7 +414,7 @@ public:
   {
     rcl_ret_t ret = rcl_guard_condition_fini(&gc_);
     if (RCL_RET_OK != ret) {
-      rclcpp::exceptions::throw_from_rcl_error(ret);
+      fprintf(stderr, "failed to call rcl_guard_condition_fini\n");
     }
   }
 

--- a/rclcpp/test/rclcpp/executors/test_static_executor_entities_collector.cpp
+++ b/rclcpp/test/rclcpp/executors/test_static_executor_entities_collector.cpp
@@ -369,6 +369,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, prepare_wait_set_rcl_wait_set_clear_
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
   entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->fini();
 }
 
 TEST_F(TestStaticExecutorEntitiesCollector, prepare_wait_set_rcl_wait_set_resize_error) {
@@ -399,6 +400,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, prepare_wait_set_rcl_wait_set_resize
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
   entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->fini();
 }
 
 TEST_F(TestStaticExecutorEntitiesCollector, refresh_wait_set_not_initialized) {
@@ -436,6 +438,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, refresh_wait_set_rcl_wait_failed) {
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
   entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->fini();
 }
 
 TEST_F(TestStaticExecutorEntitiesCollector, refresh_wait_set_add_handles_to_wait_set_failed) {
@@ -487,6 +490,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, refresh_wait_set_add_handles_to_wait
 
   entities_collector_->remove_node(node->get_node_base_interface());
   entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->fini();
 }
 
 TEST_F(TestStaticExecutorEntitiesCollector, add_to_wait_set_nullptr) {
@@ -515,6 +519,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_to_wait_set_nullptr) {
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
   entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->fini();
 }
 
 TEST_F(TestStaticExecutorEntitiesCollector, fill_memory_strategy_invalid_group) {
@@ -547,6 +552,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, fill_memory_strategy_invalid_group) 
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
   entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->fini();
 }
 
 TEST_F(TestStaticExecutorEntitiesCollector, remove_callback_group_after_node) {
@@ -619,4 +625,5 @@ TEST_F(
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
   entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  entities_collector_->fini();
 }

--- a/rclcpp/test/rclcpp/executors/test_static_executor_entities_collector.cpp
+++ b/rclcpp/test/rclcpp/executors/test_static_executor_entities_collector.cpp
@@ -190,6 +190,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_remove_basic_node) {
 
   // Still one for the executor
   EXPECT_EQ(1u, entities_collector_->get_number_of_waitables());
+  entities_collector_->fini();
 }
 
 TEST_F(TestStaticExecutorEntitiesCollector, add_remove_node_out_of_scope) {
@@ -224,6 +225,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_remove_node_out_of_scope) {
 
   // Still one for the executor
   EXPECT_EQ(1u, entities_collector_->get_number_of_waitables());
+  entities_collector_->fini();
 }
 
 class TestWaitable : public rclcpp::Waitable
@@ -303,6 +305,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_remove_node_with_entities) {
   EXPECT_EQ(0u, entities_collector_->get_number_of_clients());
   // Still one for the executor
   EXPECT_EQ(1u, entities_collector_->get_number_of_waitables());
+  entities_collector_->fini();
 }
 
 TEST_F(TestStaticExecutorEntitiesCollector, add_callback_group) {

--- a/rclcpp/test/rclcpp/executors/test_static_executor_entities_collector.cpp
+++ b/rclcpp/test/rclcpp/executors/test_static_executor_entities_collector.cpp
@@ -170,6 +170,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_remove_basic_node) {
   rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
 
   entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  RCLCPP_SCOPE_EXIT(entities_collector_->fini());
   EXPECT_EQ(
     expected_number_of_entities->subscriptions,
     entities_collector_->get_number_of_subscriptions());
@@ -190,7 +191,6 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_remove_basic_node) {
 
   // Still one for the executor
   EXPECT_EQ(1u, entities_collector_->get_number_of_waitables());
-  entities_collector_->fini();
 }
 
 TEST_F(TestStaticExecutorEntitiesCollector, add_remove_node_out_of_scope) {
@@ -218,6 +218,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_remove_node_out_of_scope) {
 
   // Expect weak_node pointers to be cleaned up and used
   entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  RCLCPP_SCOPE_EXIT(entities_collector_->fini());
   EXPECT_EQ(0u, entities_collector_->get_number_of_subscriptions());
   EXPECT_EQ(0u, entities_collector_->get_number_of_timers());
   EXPECT_EQ(0u, entities_collector_->get_number_of_services());
@@ -225,7 +226,6 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_remove_node_out_of_scope) {
 
   // Still one for the executor
   EXPECT_EQ(1u, entities_collector_->get_number_of_waitables());
-  entities_collector_->fini();
 }
 
 class TestWaitable : public rclcpp::Waitable
@@ -280,6 +280,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_remove_node_with_entities) {
   rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
 
   entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  RCLCPP_SCOPE_EXIT(entities_collector_->fini());
 
   EXPECT_EQ(
     1u + expected_number_of_entities->subscriptions,
@@ -305,7 +306,6 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_remove_node_with_entities) {
   EXPECT_EQ(0u, entities_collector_->get_number_of_clients());
   // Still one for the executor
   EXPECT_EQ(1u, entities_collector_->get_number_of_waitables());
-  entities_collector_->fini();
 }
 
 TEST_F(TestStaticExecutorEntitiesCollector, add_callback_group) {
@@ -359,6 +359,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, prepare_wait_set_rcl_wait_set_clear_
   rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
 
   entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  RCLCPP_SCOPE_EXIT(entities_collector_->fini());
 
   {
     auto mock = mocking_utils::patch_and_return("lib:rclcpp", rcl_wait_set_clear, RCL_RET_ERROR);
@@ -368,7 +369,6 @@ TEST_F(TestStaticExecutorEntitiesCollector, prepare_wait_set_rcl_wait_set_clear_
   }
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
-  entities_collector_->fini();
 }
 
 TEST_F(TestStaticExecutorEntitiesCollector, prepare_wait_set_rcl_wait_set_resize_error) {
@@ -389,6 +389,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, prepare_wait_set_rcl_wait_set_resize
   rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
 
   entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  RCLCPP_SCOPE_EXIT(entities_collector_->fini());
 
   {
     auto mock = mocking_utils::patch_and_return("lib:rclcpp", rcl_wait_set_resize, RCL_RET_ERROR);
@@ -398,7 +399,6 @@ TEST_F(TestStaticExecutorEntitiesCollector, prepare_wait_set_rcl_wait_set_resize
   }
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
-  entities_collector_->fini();
 }
 
 TEST_F(TestStaticExecutorEntitiesCollector, refresh_wait_set_not_initialized) {
@@ -426,6 +426,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, refresh_wait_set_rcl_wait_failed) {
   rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
 
   entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  RCLCPP_SCOPE_EXIT(entities_collector_->fini());
 
   {
     auto mock = mocking_utils::patch_and_return("lib:rclcpp", rcl_wait, RCL_RET_ERROR);
@@ -435,7 +436,6 @@ TEST_F(TestStaticExecutorEntitiesCollector, refresh_wait_set_rcl_wait_failed) {
   }
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
-  entities_collector_->fini();
 }
 
 TEST_F(TestStaticExecutorEntitiesCollector, refresh_wait_set_add_handles_to_wait_set_failed) {
@@ -475,6 +475,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, refresh_wait_set_add_handles_to_wait
   rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
 
   entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  RCLCPP_SCOPE_EXIT(entities_collector_->fini());
 
   {
     auto mock = mocking_utils::patch_and_return(
@@ -486,7 +487,6 @@ TEST_F(TestStaticExecutorEntitiesCollector, refresh_wait_set_add_handles_to_wait
   }
 
   entities_collector_->remove_node(node->get_node_base_interface());
-  entities_collector_->fini();
 }
 
 TEST_F(TestStaticExecutorEntitiesCollector, add_to_wait_set_nullptr) {
@@ -507,6 +507,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_to_wait_set_nullptr) {
   rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
 
   entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  RCLCPP_SCOPE_EXIT(entities_collector_->fini());
 
   RCLCPP_EXPECT_THROW_EQ(
     entities_collector_->add_to_wait_set(nullptr),
@@ -514,7 +515,6 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_to_wait_set_nullptr) {
   rcl_reset_error();
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
-  entities_collector_->fini();
 }
 
 TEST_F(TestStaticExecutorEntitiesCollector, fill_memory_strategy_invalid_group) {
@@ -543,10 +543,10 @@ TEST_F(TestStaticExecutorEntitiesCollector, fill_memory_strategy_invalid_group) 
   cb_group.reset();
 
   entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  RCLCPP_SCOPE_EXIT(entities_collector_->fini());
   ASSERT_EQ(entities_collector_->get_all_callback_groups().size(), 1u);
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
-  entities_collector_->fini();
 }
 
 TEST_F(TestStaticExecutorEntitiesCollector, remove_callback_group_after_node) {
@@ -613,10 +613,10 @@ TEST_F(
   rcl_guard_condition_t rcl_guard_condition = guard_condition.get_rcl_guard_condition();
 
   entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
+  RCLCPP_SCOPE_EXIT(entities_collector_->fini());
 
   cb_group->get_associated_with_executor_atomic().exchange(false);
   entities_collector_->execute();
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
-  entities_collector_->fini();
 }

--- a/rclcpp/test/rclcpp/executors/test_static_executor_entities_collector.cpp
+++ b/rclcpp/test/rclcpp/executors/test_static_executor_entities_collector.cpp
@@ -368,7 +368,6 @@ TEST_F(TestStaticExecutorEntitiesCollector, prepare_wait_set_rcl_wait_set_clear_
   }
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
   entities_collector_->fini();
 }
 
@@ -399,7 +398,6 @@ TEST_F(TestStaticExecutorEntitiesCollector, prepare_wait_set_rcl_wait_set_resize
   }
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
   entities_collector_->fini();
 }
 
@@ -437,7 +435,6 @@ TEST_F(TestStaticExecutorEntitiesCollector, refresh_wait_set_rcl_wait_failed) {
   }
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
   entities_collector_->fini();
 }
 
@@ -489,7 +486,6 @@ TEST_F(TestStaticExecutorEntitiesCollector, refresh_wait_set_add_handles_to_wait
   }
 
   entities_collector_->remove_node(node->get_node_base_interface());
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
   entities_collector_->fini();
 }
 
@@ -518,7 +514,6 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_to_wait_set_nullptr) {
   rcl_reset_error();
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
   entities_collector_->fini();
 }
 
@@ -551,7 +546,6 @@ TEST_F(TestStaticExecutorEntitiesCollector, fill_memory_strategy_invalid_group) 
   ASSERT_EQ(entities_collector_->get_all_callback_groups().size(), 1u);
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
   entities_collector_->fini();
 }
 
@@ -624,6 +618,5 @@ TEST_F(
   entities_collector_->execute();
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));
-  entities_collector_->init(&wait_set, memory_strategy, &rcl_guard_condition);
   entities_collector_->fini();
 }


### PR DESCRIPTION
Fixes #1302

Signed-off-by: Chen Lihui <Lihui.Chen@sony.com>