### PR TITLE
Remove deprecated client goal handle method for getting result

### DIFF
--- a/rclcpp_action/include/rclcpp_action/client_goal_handle.hpp
+++ b/rclcpp_action/include/rclcpp_action/client_goal_handle.hpp
@@ -89,22 +89,6 @@ public:
   rclcpp::Time
   get_goal_stamp() const;
 
-  /// Get a future to the goal result.
-  /**
-   * \deprecated Use rclcpp_action::Client::async_get_result() instead.
-   *
-   * This method should not be called if the `ignore_result` flag was set when
-   * sending the original goal request (see Client::async_send_goal).
-   *
-   * `is_result_aware()` can be used to check if it is safe to call this method.
-   *
-   * \throws exceptions::UnawareGoalHandleError If the the goal handle is unaware of the result.
-   * \return A future to the result.
-   */
-  [[deprecated("use rclcpp_action::Client::async_get_result() instead")]]
-  std::shared_future<WrappedResult>
-  async_result();
-
   /// Get the goal status code.
   int8_t
   get_status();

--- a/rclcpp_action/include/rclcpp_action/client_goal_handle_impl.hpp
+++ b/rclcpp_action/include/rclcpp_action/client_goal_handle_impl.hpp
@@ -57,13 +57,6 @@ ClientGoalHandle<ActionT>::get_goal_stamp() const
 
 template<typename ActionT>
 std::shared_future<typename ClientGoalHandle<ActionT>::WrappedResult>
-ClientGoalHandle<ActionT>::async_result()
-{
-  return this->async_get_result();
-}
-
-template<typename ActionT>
-std::shared_future<typename ClientGoalHandle<ActionT>::WrappedResult>
 ClientGoalHandle<ActionT>::async_get_result()
 {
   std::lock_guard<std::mutex> guard(handle_mutex_);


### PR DESCRIPTION
The method was deprecated in Foxy.