### PR TITLE
Fix action server deadlock (#1285)

### DIFF
--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -344,10 +344,7 @@ ServerBase::execute_goal_request_received(std::shared_ptr<void> & data)
 
     if (GoalResponse::ACCEPT_AND_EXECUTE == status) {
       // Change status to executing
-      {
-        std::lock_guard<std::recursive_mutex> lock(pimpl_->action_server_reentrant_mutex_);
-        ret = rcl_action_update_goal_state(handle.get(), GOAL_EVENT_EXECUTE);
-      }
+      ret = rcl_action_update_goal_state(handle.get(), GOAL_EVENT_EXECUTE);
       if (RCL_RET_OK != ret) {
         rclcpp::exceptions::throw_from_rcl_error(ret);
       }

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -47,8 +47,6 @@ public:
 
   // Lock everything except user callbacks
   std::recursive_mutex action_server_reentrant_mutex_;
-  // Lock to gurantee the call order of user callbacks in execute_goal_request_received
-  std::recursive_mutex goal_request_mutex_;
 
   std::shared_ptr<rcl_action_server_t> action_server_;
 
@@ -288,20 +286,16 @@ ServerBase::execute_goal_request_received(std::shared_ptr<void> & data)
   rmw_request_id_t request_header = std::get<2>(*shared_ptr);
   std::shared_ptr<void> message = std::get<3>(*shared_ptr);
 
-  std::lock_guard<std::recursive_mutex> goal_lock(pimpl_->goal_request_mutex_);
-  std::unique_lock<std::recursive_mutex> lock(pimpl_->action_server_reentrant_mutex_);
+
+  std::lock_guard<std::recursive_mutex> lock(pimpl_->action_server_reentrant_mutex_);
 
   pimpl_->goal_request_ready_ = false;
 
   GoalUUID uuid = get_goal_id_from_goal_request(message.get());
   convert(uuid, &goal_info);
 
-  lock.unlock();
-
   // Call user's callback, getting the user's response and a ros message to send back
   auto response_pair = call_handle_goal_callback(uuid, message);
-
-  lock.lock();
 
   ret = rcl_action_send_goal_response(
     pimpl_->action_server_.get(),
@@ -352,8 +346,6 @@ ServerBase::execute_goal_request_received(std::shared_ptr<void> & data)
     // publish status since a goal's state has changed (was accepted or has begun execution)
     publish_status();
 
-    lock.unlock();
-
     // Tell user to start executing action
     call_goal_accepted_callback(handle, uuid, message);
   }
@@ -367,7 +359,7 @@ ServerBase::execute_cancel_request_received(std::shared_ptr<void> & data)
     <std::tuple<rcl_ret_t, std::shared_ptr<action_msgs::srv::CancelGoal::Request>,
       rmw_request_id_t>>(data);
   auto ret = std::get<0>(*shared_ptr);
-  std::unique_lock<std::recursive_mutex> lock(pimpl_->action_server_reentrant_mutex_);
+  std::lock_guard<std::recursive_mutex> lock(pimpl_->action_server_reentrant_mutex_);
   if (RCL_RET_ACTION_SERVER_TAKE_FAILED == ret) {
     // Ignore take failure because connext fails if it receives a sample without valid data.
     // This happens when a client shuts down and connext receives a sample saying the client is
@@ -404,8 +396,6 @@ ServerBase::execute_cancel_request_received(std::shared_ptr<void> & data)
     }
   });
 
-  lock.unlock();
-
   auto response = std::make_shared<action_msgs::srv::CancelGoal::Response>();
 
   response->return_code = cancel_response.msg.return_code;
@@ -424,8 +414,6 @@ ServerBase::execute_cancel_request_received(std::shared_ptr<void> & data)
       response->goals_canceling.push_back(cpp_info);
     }
   }
-
-  lock.lock();
 
   // If the user rejects all individual requests to cancel goals,
   // then we consider the top-level cancel request as rejected.

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -1221,3 +1221,92 @@ TEST_F(TestCancelRequestServer, publish_status_send_cancel_response_errors)
 
   EXPECT_THROW(SendClientCancelRequest(), std::runtime_error);
 }
+
+class TestDeadlockServer : public TestServer
+{
+public:
+  void SetUp()
+  {
+    node_ = std::make_shared<rclcpp::Node>("goal_request", "/rclcpp_action/goal_request");
+    uuid1_ = {{1, 2, 3, 4, 5, 6, 70, 80, 9, 1, 11, 120, 13, 140, 15, 160}};
+    uuid2_ = {{2, 2, 3, 4, 5, 6, 70, 80, 9, 1, 11, 120, 13, 140, 15, 160}};
+    action_server_ = rclcpp_action::create_server<Fibonacci>(
+      node_, "fibonacci",
+      [this](const GoalUUID &, std::shared_ptr<const Fibonacci::Goal>) {
+        // instead of making a deadlock, check if it can acquire the lock in a second
+        std::unique_lock<std::recursive_timed_mutex> lock(server_mutex_, std::defer_lock);
+        this->TryLockFor(lock, std::chrono::milliseconds(1000));
+        return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+      },
+      [this](std::shared_ptr<GoalHandle>) {
+        // instead of making a deadlock, check if it can acquire the lock in a second
+        std::unique_lock<std::recursive_timed_mutex> lock(server_mutex_, std::defer_lock);
+        this->TryLockFor(lock, std::chrono::milliseconds(1000));
+        return rclcpp_action::CancelResponse::ACCEPT;
+      },
+      [this](std::shared_ptr<GoalHandle> handle) {
+        // instead of making a deadlock, check if it can acquire the lock in a second
+        std::unique_lock<std::recursive_timed_mutex> lock(server_mutex_, std::defer_lock);
+        this->TryLockFor(lock, std::chrono::milliseconds(1000));
+        goal_handle_ = handle;
+      });
+  }
+
+  void GoalSucceeded()
+  {
+    std::lock_guard<std::recursive_timed_mutex> lock(server_mutex_);
+    rclcpp::sleep_for(std::chrono::milliseconds(100));
+    auto result = std::make_shared<Fibonacci::Result>();
+    result->sequence = {5, 8, 13, 21};
+    goal_handle_->succeed(result);
+  }
+
+  void GoalCanceled()
+  {
+    std::lock_guard<std::recursive_timed_mutex> lock(server_mutex_);
+    rclcpp::sleep_for(std::chrono::milliseconds(100));
+    auto result = std::make_shared<Fibonacci::Result>();
+    goal_handle_->canceled(result);
+  }
+
+  void TryLockFor(
+    std::unique_lock<std::recursive_timed_mutex> & lock,
+    std::chrono::milliseconds timeout
+  )
+  {
+    ASSERT_TRUE(lock.try_lock_for(timeout));
+  }
+
+protected:
+  std::recursive_timed_mutex server_mutex_;
+  GoalUUID uuid1_, uuid2_;
+  std::shared_ptr<rclcpp::Node> node_;
+  std::shared_ptr<rclcpp_action::Server<Fibonacci>> action_server_;
+
+  using GoalHandle = rclcpp_action::ServerGoalHandle<Fibonacci>;
+  std::shared_ptr<GoalHandle> goal_handle_;
+};
+
+TEST_F(TestDeadlockServer, deadlock_while_succeed)
+{
+  send_goal_request(node_, uuid1_);
+  // this will lock wrapper's mutex and intentionally wait 100ms for calling succeed
+  // to try to acquire the lock of rclcpp_action mutex
+  std::thread t(&TestDeadlockServer::GoalSucceeded, this);
+  // after the wrapper's mutex is locked and before succeed is called
+  rclcpp::sleep_for(std::chrono::milliseconds(50));
+  // call next goal request to intentionally reproduce deadlock
+  // this first locks rclcpp_action mutex and then call callback to lock wrapper's mutex
+  send_goal_request(node_, uuid2_);
+  t.join();
+}
+
+TEST_F(TestDeadlockServer, deadlock_while_canceled)
+{
+  send_goal_request(node_, uuid1_);
+  send_cancel_request(node_, uuid1_);
+  std::thread t(&TestDeadlockServer::GoalCanceled, this);
+  rclcpp::sleep_for(std::chrono::milliseconds(50));
+  send_goal_request(node_, uuid2_);  // deadlock here
+  t.join();
+}


### PR DESCRIPTION
To fix the issue https://github.com/ros2/rclcpp/issues/1285

I think the problem is that the server can let the next goal accept during processing `on_terminal_state` callback.
It can be solved by putting them in a single `reentrant_mutex_` context.

This does not make any deadlock with [my test code](https://gist.github.com/daisukes/46298b083a48e5db7016f3c0efba7e2d) so far.