### PR TITLE
Call two iterator overload of vector::erase with end iterator in dynamic_storage.hpp

### DIFF
--- a/rclcpp/include/rclcpp/wait_set_policies/dynamic_storage.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/dynamic_storage.hpp
@@ -382,11 +382,13 @@ public:
         return weak_ptr.expired();
       };
     // remove guard conditions which have been deleted
-    guard_conditions_.erase(std::remove_if(guard_conditions_.begin(), guard_conditions_.end(), p));
-    timers_.erase(std::remove_if(timers_.begin(), timers_.end(), p));
-    clients_.erase(std::remove_if(clients_.begin(), clients_.end(), p));
-    services_.erase(std::remove_if(services_.begin(), services_.end(), p));
-    waitables_.erase(std::remove_if(waitables_.begin(), waitables_.end(), p));
+    guard_conditions_.erase(
+      std::remove_if(guard_conditions_.begin(), guard_conditions_.end(), p),
+      guard_conditions_.end());
+    timers_.erase(std::remove_if(timers_.begin(), timers_.end(), p), timers_.end());
+    clients_.erase(std::remove_if(clients_.begin(), clients_.end(), p), clients_.end());
+    services_.erase(std::remove_if(services_.begin(), services_.end(), p), services_.end());
+    waitables_.erase(std::remove_if(waitables_.begin(), waitables_.end(), p), waitables_.end());
   }
 
   void


### PR DESCRIPTION
In the case where the predicate `p` is false for all elements or these vectors are empty, these calls to std::remove_if will return the `std::vector::end()`, which is not a valid iterator position to `std::vector::erase(std::iterator)` and in turn an exception will be thrown. However, passing two `end()` iterators to `std::vector::erase` is ok.

Testing this PR, which doesn't include the failing unit test. Those will be added separately (`--packages-select rclcpp`)
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12330)](http://ci.ros2.org/job/ci_linux/12330/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7299)](http://ci.ros2.org/job/ci_linux-aarch64/7299/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10043)](http://ci.ros2.org/job/ci_osx/10043/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12233)](http://ci.ros2.org/job/ci_windows/12233/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>