### PR TITLE
Only exchange subscription intra_process waitable if nonnull

### DIFF
--- a/rclcpp/include/rclcpp/wait_set_template.hpp
+++ b/rclcpp/include/rclcpp/wait_set_template.hpp
@@ -233,9 +233,9 @@ public:
         }
         if (mask.include_intra_process_waitable) {
           auto local_waitable = inner_subscription->get_intra_process_waitable();
-          inner_subscription->exchange_in_use_by_wait_set_state(local_waitable.get(), false);
           if (nullptr != local_waitable) {
-            // This is the case when intra process is disabled for the subscription.
+            // This is the case when intra process is enabled for the subscription.
+            inner_subscription->exchange_in_use_by_wait_set_state(local_waitable.get(), false);
             this->storage_remove_waitable(std::move(local_waitable));
           }
         }


### PR DESCRIPTION
`SubscriptionBase::exchange_in_use_by_wait_set_state` does not allow nullptr's, but `SubscriptionWaitSetMask` defaults to true so an exception will be thrown in WaitSet::remove_subscription in a simple use case:

```
rclcpp::WaitSet wait_set;

auto subscription = node->create_subscription<test_msgs::msg::Empty>(
    "topic", 10, [](test_msgs::msg::Empty::SharedPtr) {});

wait_set.add_subscription(subscription);
wait_set.remove_subscription(subscription);  // throws here
```

Signed-off-by: Stephen Brawner <brawner@gmail.com>