### PR TITLE
Increase coverage of publisher/subscription API

### DIFF
--- a/rclcpp/test/CMakeLists.txt
+++ b/rclcpp/test/CMakeLists.txt
@@ -299,12 +299,13 @@ endif()
 ament_add_gtest(test_publisher rclcpp/test_publisher.cpp)
 if(TARGET test_publisher)
   ament_target_dependencies(test_publisher
+    "rcl"
     "rmw"
     "rosidl_runtime_cpp"
     "rosidl_typesupport_cpp"
     "test_msgs"
   )
-  target_link_libraries(test_publisher ${PROJECT_NAME})
+  target_link_libraries(test_publisher ${PROJECT_NAME} mimick)
 endif()
 ament_add_gtest(test_publisher_subscription_count_api rclcpp/test_publisher_subscription_count_api.cpp)
 if(TARGET test_publisher_subscription_count_api)
@@ -386,7 +387,7 @@ if(TARGET test_subscription)
     "rosidl_typesupport_cpp"
     "test_msgs"
   )
-  target_link_libraries(test_subscription ${PROJECT_NAME})
+  target_link_libraries(test_subscription ${PROJECT_NAME} mimick)
 endif()
 ament_add_gtest(test_subscription_publisher_count_api rclcpp/test_subscription_publisher_count_api.cpp)
 if(TARGET test_subscription_publisher_count_api)

--- a/rclcpp/test/rclcpp/test_subscription.cpp
+++ b/rclcpp/test/rclcpp/test_subscription.cpp
@@ -23,6 +23,9 @@
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/rclcpp.hpp"
 
+#include "../mocking_utils/patch.hpp"
+#include "../utils/rclcpp_gtest_macros.hpp"
+
 #include "test_msgs/msg/empty.hpp"
 
 using namespace std::chrono_literals;
@@ -150,7 +153,19 @@ TEST_F(TestSubscription, construction_and_destruction) {
       (void)msg;
     };
   {
-    auto sub = node->create_subscription<Empty>("topic", 10, callback);
+    constexpr size_t depth = 10u;
+    auto sub = node->create_subscription<Empty>("topic", depth, callback);
+
+    EXPECT_NE(nullptr, sub->get_subscription_handle());
+    // Converting to base class was necessary for the compiler to choose the const version of
+    // get_subscription_handle()
+    const rclcpp::SubscriptionBase * const_sub = sub.get();
+    EXPECT_NE(nullptr, const_sub->get_subscription_handle());
+    EXPECT_FALSE(sub->use_take_shared_method());
+
+    EXPECT_NE(nullptr, sub->get_message_type_support_handle().typesupport_identifier);
+    EXPECT_NE(nullptr, sub->get_message_type_support_handle().data);
+    EXPECT_EQ(depth, sub->get_actual_qos().get_rmw_qos_profile().depth);
   }
 
   {
@@ -227,6 +242,21 @@ TEST_F(TestSubscription, various_creation_signatures) {
   {
     auto sub = rclcpp::create_subscription<Empty>(
       node, "topic", 42, cb, rclcpp::SubscriptionOptions());
+    (void)sub;
+  }
+  {
+    rclcpp::SubscriptionOptionsWithAllocator<std::allocator<void>> options;
+    options.allocator = std::make_shared<std::allocator<void>>();
+    EXPECT_NE(nullptr, options.get_allocator());
+    auto sub = rclcpp::create_subscription<Empty>(
+      node, "topic", 42, cb, options);
+    (void)sub;
+  }
+  {
+    rclcpp::SubscriptionOptionsBase options_base;
+    rclcpp::SubscriptionOptionsWithAllocator<std::allocator<void>> options(options_base);
+    auto sub = rclcpp::create_subscription<Empty>(
+      node, "topic", 42, cb, options);
     (void)sub;
   }
 }
@@ -327,6 +357,86 @@ TEST_F(TestSubscription, take_serialized) {
     } while (!message_recieved && std::chrono::steady_clock::now() - start < 10s);
     EXPECT_TRUE(message_recieved);
   }
+}
+
+TEST_F(TestSubscription, rcl_subscription_init_error) {
+  initialize();
+  auto callback = [](std::shared_ptr<const test_msgs::msg::Empty>) {};
+  auto mock = mocking_utils::patch_and_return(
+    "lib:rclcpp", rcl_subscription_init, RCL_RET_TOPIC_NAME_INVALID);
+
+  // reset() is not needed for triggering exception, just to avoid an unused return value warning
+  EXPECT_THROW(
+    node->create_subscription<test_msgs::msg::Empty>("topic", 10, callback).reset(),
+    rclcpp::exceptions::RCLError);
+}
+
+TEST_F(TestSubscription, rcl_subscription_fini_error) {
+  initialize();
+  auto callback = [](std::shared_ptr<const test_msgs::msg::Empty>) {};
+  auto mock = mocking_utils::inject_on_return(
+    "lib:rclcpp", rcl_subscription_fini, RCL_RET_ERROR);
+
+  // Cleanup just fails, no exception expected
+  EXPECT_NO_THROW(
+    node->create_subscription<test_msgs::msg::Empty>("topic", 10, callback).reset());
+}
+
+TEST_F(TestSubscription, rcl_subscription_get_actual_qos_error) {
+  initialize();
+  auto callback = [](std::shared_ptr<const test_msgs::msg::Empty>) {};
+  auto mock = mocking_utils::patch_and_return(
+    "lib:rclcpp", rcl_subscription_get_actual_qos, nullptr);
+
+  auto sub = node->create_subscription<test_msgs::msg::Empty>("topic", 10, callback);
+  RCLCPP_EXPECT_THROW_EQ(
+    sub->get_actual_qos(), std::runtime_error("failed to get qos settings: error not set"));
+}
+
+TEST_F(TestSubscription, rcl_take_type_erased_error) {
+  initialize();
+  auto callback = [](std::shared_ptr<const test_msgs::msg::Empty>) {};
+  auto mock = mocking_utils::patch_and_return(
+    "lib:rclcpp", rcl_take, RCL_RET_ERROR);
+
+  auto sub = node->create_subscription<test_msgs::msg::Empty>("topic", 10, callback);
+  test_msgs::msg::Empty msg;
+  rclcpp::MessageInfo message_info;
+
+  EXPECT_THROW(sub->take_type_erased(&msg, message_info), rclcpp::exceptions::RCLError);
+}
+
+TEST_F(TestSubscription, rcl_take_serialized_message_error) {
+  initialize();
+  auto callback = [](std::shared_ptr<const test_msgs::msg::Empty>) {};
+  auto mock = mocking_utils::patch_and_return(
+    "lib:rclcpp", rcl_take_serialized_message, RCL_RET_ERROR);
+
+  auto sub = node->create_subscription<test_msgs::msg::Empty>("topic", 10, callback);
+  rclcpp::SerializedMessage msg;
+  rclcpp::MessageInfo message_info;
+
+  EXPECT_THROW(sub->take_serialized(msg, message_info), rclcpp::exceptions::RCLError);
+}
+
+TEST_F(TestSubscription, rcl_subscription_get_publisher_count_error) {
+  initialize();
+  auto callback = [](std::shared_ptr<const test_msgs::msg::Empty>) {};
+  auto mock = mocking_utils::patch_and_return(
+    "lib:rclcpp", rcl_subscription_get_publisher_count, RCL_RET_ERROR);
+
+  auto sub = node->create_subscription<test_msgs::msg::Empty>("topic", 10, callback);
+  EXPECT_THROW(sub->get_publisher_count(), rclcpp::exceptions::RCLError);
+}
+
+TEST_F(TestSubscription, handle_loaned_message) {
+  initialize();
+  auto callback = [](std::shared_ptr<const test_msgs::msg::Empty>) {};
+  auto sub = node->create_subscription<test_msgs::msg::Empty>("topic", 10, callback);
+
+  test_msgs::msg::Empty msg;
+  rclcpp::MessageInfo message_info;
+  EXPECT_NO_THROW(sub->handle_loaned_message(&msg, message_info));
 }
 
 /*


### PR DESCRIPTION
This increases the test coverage of the publisher/subscription API. It also adds coverage for missing public API functions.

Signed-off-by: Stephen Brawner <brawner@gmail.com>