### PR TITLE
Avoid timers to be executed twice in the multithreaded executor

### DIFF
--- a/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
@@ -85,8 +85,6 @@ private:
   size_t number_of_threads_;
   bool yield_before_execute_;
   std::chrono::nanoseconds next_exec_timeout_;
-
-  std::set<TimerBase::SharedPtr> scheduled_timers_;
 };
 
 }  // namespace executors


### PR DESCRIPTION
~Fixes https://github.com/ros2/rclcpp/issues/1374 by adding a mutex in `Timer` class, that makes `is_ready` and `execute` methods mutually exclusive.~

Fixes https://github.com/ros2/rclcpp/issues/1487.

It deletes the old "scheduled timers" mechanism, that has a long history of being error prone.