### PR TITLE
Increase service coverage

### DIFF
--- a/rclcpp/test/CMakeLists.txt
+++ b/rclcpp/test/CMakeLists.txt
@@ -401,7 +401,7 @@ if(TARGET test_service)
     "rosidl_typesupport_cpp"
     "test_msgs"
   )
-  target_link_libraries(test_service ${PROJECT_NAME})
+  target_link_libraries(test_service ${PROJECT_NAME} mimick)
 endif()
 ament_add_gtest(test_subscription rclcpp/test_subscription.cpp)
 if(TARGET test_subscription)


### PR DESCRIPTION
This PR adds coverage for rclcpp::Service API. It should fully cover service.hpp and service.cpp nearly 100%. It's just missing one protected function :(

Signed-off-by: Stephen Brawner <brawner@gmail.com>