### PR TITLE
Test the remaining node public API

### DIFF
--- a/rclcpp/test/CMakeLists.txt
+++ b/rclcpp/test/CMakeLists.txt
@@ -194,7 +194,7 @@ if(TARGET test_node)
     "rosidl_typesupport_cpp"
     "test_msgs"
   )
-  target_link_libraries(test_node ${PROJECT_NAME})
+  target_link_libraries(test_node ${PROJECT_NAME} mimick)
 endif()
 
 ament_add_gtest(test_node_interfaces__get_node_interfaces

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -807,28 +807,24 @@ TEST_F(TestNode, undeclare_parameter) {
 
 TEST_F(TestNode, has_parameter) {
   auto node = std::make_shared<rclcpp::Node>("test_has_parameter_node"_unq);
-  {
-    // normal use
-    auto name = "parameter"_unq;
-    EXPECT_FALSE(node->has_parameter(name));
-    node->declare_parameter(name);
-    EXPECT_TRUE(node->has_parameter(name));
-    node->undeclare_parameter(name);
-    EXPECT_FALSE(node->has_parameter(name));
-  }
+  // normal use
+  auto name = "parameter"_unq;
+  EXPECT_FALSE(node->has_parameter(name));
+  node->declare_parameter(name);
+  EXPECT_TRUE(node->has_parameter(name));
+  node->undeclare_parameter(name);
+  EXPECT_FALSE(node->has_parameter(name));
 }
 
 TEST_F(TestNode, list_parameters) {
   auto node = std::make_shared<rclcpp::Node>("test_list_parameter_node"_unq);
-  {
-    // normal use
-    auto name = "parameter"_unq;
-    const size_t before_size = node->list_parameters({}, 1u).names.size();
-    node->declare_parameter(name);
-    EXPECT_EQ(1u + before_size, node->list_parameters({}, 1u).names.size());
-    node->undeclare_parameter(name);
-    EXPECT_EQ(before_size, node->list_parameters({}, 1u).names.size());
-  }
+  // normal use
+  auto name = "parameter"_unq;
+  const size_t before_size = node->list_parameters({}, 1u).names.size();
+  node->declare_parameter(name);
+  EXPECT_EQ(1u + before_size, node->list_parameters({}, 1u).names.size());
+  node->undeclare_parameter(name);
+  EXPECT_EQ(before_size, node->list_parameters({}, 1u).names.size());
 }
 
 TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -2538,8 +2538,8 @@ TEST_F(TestNode, wait_for_graph_event) {
       thread_completion = std::chrono::steady_clock::now();
     });
 
-  // Start creating nodes until event triggers in graph_event_wait_thread or until 100 nodes have
-  // been created
+  // Start creating nodes until at least one event triggers in graph_event_wait_thread or until 100
+  // nodes have been created (at which point this is a failure)
   std::vector<std::shared_ptr<rclcpp::Node>> nodes;
   while (thread_completion == thread_start && nodes.size() < 100) {
     nodes.emplace_back(std::make_shared<rclcpp::Node>("node"_unq, "ns"));


### PR DESCRIPTION
This adds tests for the remaining public API in node.hpp/node.cpp.

Signed-off-by: Stephen Brawner <brawner@gmail.com>