### PR TITLE
Improved test_subscription_options

### DIFF
--- a/rclcpp/test/rclcpp/test_subscription_options.cpp
+++ b/rclcpp/test/rclcpp/test_subscription_options.cpp
@@ -85,4 +85,16 @@ TEST_F(TestSubscriptionOptions, topic_statistics_options_node_default_mode) {
     rclcpp::detail::resolve_enable_topic_statistics(
       subscription_options,
       *(node->get_node_base_interface())));
+
+  subscription_options.topic_stats_options.state = rclcpp::TopicStatisticsState::Disable;
+  EXPECT_FALSE(
+    rclcpp::detail::resolve_enable_topic_statistics(
+      subscription_options,
+      *(node->get_node_base_interface())));
+
+  subscription_options.topic_stats_options.state = static_cast<rclcpp::TopicStatisticsState>(5);
+  EXPECT_THROW(
+    rclcpp::detail::resolve_enable_topic_statistics(
+      subscription_options,
+      *(node->get_node_base_interface())), std::runtime_error);
 }

--- a/rclcpp/test/rclcpp/test_subscription_options.cpp
+++ b/rclcpp/test/rclcpp/test_subscription_options.cpp
@@ -99,5 +99,5 @@ TEST_F(TestSubscriptionOptions, topic_statistics_options_node_default_mode) {
     rclcpp::detail::resolve_enable_topic_statistics(
       subscription_options,
       *(node->get_node_base_interface())),
-      std::runtime_error("Unrecognized EnableTopicStatistics value"));
+    std::runtime_error("Unrecognized EnableTopicStatistics value"));
 }

--- a/rclcpp/test/rclcpp/test_subscription_options.cpp
+++ b/rclcpp/test/rclcpp/test_subscription_options.cpp
@@ -23,6 +23,8 @@
 #include "rclcpp/node_options.hpp"
 #include "rclcpp/subscription_options.hpp"
 
+#include "../utils/rclcpp_gtest_macros.hpp"
+
 using namespace std::chrono_literals;
 
 namespace
@@ -93,8 +95,9 @@ TEST_F(TestSubscriptionOptions, topic_statistics_options_node_default_mode) {
       *(node->get_node_base_interface())));
 
   subscription_options.topic_stats_options.state = static_cast<rclcpp::TopicStatisticsState>(5);
-  EXPECT_THROW(
+  RCLCPP_EXPECT_THROW_EQ(
     rclcpp::detail::resolve_enable_topic_statistics(
       subscription_options,
-      *(node->get_node_base_interface())), std::runtime_error);
+      *(node->get_node_base_interface())),
+      std::runtime_error("Unrecognized EnableTopicStatistics value"));
 }


### PR DESCRIPTION
I runned lcov locally, some lines are missing here:

![Selección_055](https://user-images.githubusercontent.com/1933907/94672064-0780a500-0315-11eb-8f41-77759bba3c1b.png)


Signed-off-by: ahcorde <ahcorde@gmail.com>