### PR TITLE
Additional parameter client tests

### DIFF
--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -15,7 +15,12 @@
 #include "rclcpp/parameter_client.hpp"
 
 #include <algorithm>
+#include <chrono>
+#include <functional>
+#include <future>
+#include <iterator>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 

--- a/rclcpp/src/rclcpp/parameter_service.cpp
+++ b/rclcpp/src/rclcpp/parameter_service.cpp
@@ -119,7 +119,7 @@ ParameterService::ParameterService(
         RCLCPP_WARN(
           rclcpp::get_logger("rclcpp"), "Failed to set parameters atomically: %s", ex.what());
         response->result.successful = false;
-        response->result.reason = "One or more parameters wer not declared before setting";
+        response->result.reason = "One or more parameters were not declared before setting";
       }
     },
     qos_profile, nullptr);


### PR DESCRIPTION
This small PR adds some additional tests to the parameter client, and brings us up to 96% line coverage on that file.  It also fixes two very small issues in parameter_server.cpp