### PR TITLE
[foxy] Fix implementation of NodeOptions::use_global_arguments() (#1176)

### DIFF
--- a/rclcpp/src/rclcpp/node_options.cpp
+++ b/rclcpp/src/rclcpp/node_options.cpp
@@ -176,7 +176,7 @@ NodeOptions::parameter_overrides(const std::vector<rclcpp::Parameter> & paramete
 bool
 NodeOptions::use_global_arguments() const
 {
-  return this->node_options_->use_global_arguments;
+  return this->use_global_arguments_;
 }
 
 NodeOptions &

--- a/rclcpp/test/rclcpp/test_node_options.cpp
+++ b/rclcpp/test/rclcpp/test_node_options.cpp
@@ -105,6 +105,38 @@ TEST(TestNodeOptions, bad_ros_args) {
     rclcpp::exceptions::UnknownROSArgsError);
 }
 
+TEST(TestNodeOptions, use_global_arguments) {
+  {
+    auto options = rclcpp::NodeOptions();
+    EXPECT_TRUE(options.use_global_arguments());
+    EXPECT_TRUE(options.get_rcl_node_options()->use_global_arguments);
+  }
+
+  {
+    auto options = rclcpp::NodeOptions().use_global_arguments(false);
+    EXPECT_FALSE(options.use_global_arguments());
+    EXPECT_FALSE(options.get_rcl_node_options()->use_global_arguments);
+  }
+
+  {
+    auto options = rclcpp::NodeOptions().use_global_arguments(true);
+    EXPECT_TRUE(options.use_global_arguments());
+    EXPECT_TRUE(options.get_rcl_node_options()->use_global_arguments);
+  }
+
+  {
+    auto options = rclcpp::NodeOptions();
+    EXPECT_TRUE(options.use_global_arguments());
+    EXPECT_TRUE(options.get_rcl_node_options()->use_global_arguments);
+    options.use_global_arguments(false);
+    EXPECT_FALSE(options.use_global_arguments());
+    EXPECT_FALSE(options.get_rcl_node_options()->use_global_arguments);
+    options.use_global_arguments(true);
+    EXPECT_TRUE(options.use_global_arguments());
+    EXPECT_TRUE(options.get_rcl_node_options()->use_global_arguments);
+  }
+}
+
 TEST(TestNodeOptions, enable_rosout) {
   {
     auto options = rclcpp::NodeOptions();


### PR DESCRIPTION
Backport #1176 to Foxy.