### PR TITLE
[foxy backport] Add ostream test for FutureReturnCode (#1327)

### DIFF
--- a/rclcpp/include/rclcpp/future_return_code.hpp
+++ b/rclcpp/include/rclcpp/future_return_code.hpp
@@ -42,6 +42,20 @@ RCLCPP_PUBLIC
 std::string
 to_string(const FutureReturnCode & future_return_code);
 
+namespace executor
+{
+
+using FutureReturnCode [[deprecated("use rclcpp::FutureReturnCode instead")]] = FutureReturnCode;
+
+[[deprecated("use rclcpp::to_string(const rclcpp::FutureReturnCode &) instead")]]
+inline
+std::string
+to_string(const rclcpp::FutureReturnCode & future_return_code)
+{
+  return rclcpp::to_string(future_return_code);
+}
+
+}  // namespace executor
 }  // namespace rclcpp
 
 #endif  // RCLCPP__FUTURE_RETURN_CODE_HPP_

--- a/rclcpp/include/rclcpp/future_return_code.hpp
+++ b/rclcpp/include/rclcpp/future_return_code.hpp
@@ -42,20 +42,6 @@ RCLCPP_PUBLIC
 std::string
 to_string(const FutureReturnCode & future_return_code);
 
-namespace executor
-{
-
-using FutureReturnCode [[deprecated("use rclcpp::FutureReturnCode instead")]] = FutureReturnCode;
-
-[[deprecated("use rclcpp::to_string(const rclcpp::FutureReturnCode &) instead")]]
-inline
-std::string
-to_string(const rclcpp::FutureReturnCode & future_return_code)
-{
-  return rclcpp::to_string(future_return_code);
-}
-
-}  // namespace executor
 }  // namespace rclcpp
 
 #endif  // RCLCPP__FUTURE_RETURN_CODE_HPP_

--- a/rclcpp/test/rclcpp/test_future_return_code.cpp
+++ b/rclcpp/test/rclcpp/test_future_return_code.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 Open Source Robotics Foundation, Inc.
+// Copyright 2020 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <sstream>
 #include <string>
 
 #include "rclcpp/future_return_code.hpp"
@@ -31,4 +32,11 @@ TEST(TestFutureReturnCode, to_string) {
     "Unknown enum value (3)", rclcpp::to_string(rclcpp::FutureReturnCode(3)));
   EXPECT_EQ(
     "Unknown enum value (100)", rclcpp::to_string(rclcpp::FutureReturnCode(100)));
+}
+
+TEST(FutureReturnCode, ostream) {
+  std::ostringstream ostream;
+
+  ostream << rclcpp::FutureReturnCode::SUCCESS;
+  ASSERT_EQ("SUCCESS (0)", ostream.str());
 }


### PR DESCRIPTION
This backports the unit test introduced it #1327 without removing the deprecation warning.

This will be squash merged into #1383, which will be ultimate be rebase merged back into foxy 