### PR TITLE
[Dashing] Fix typo

### DIFF
--- a/rclcpp_action/src/client.cpp
+++ b/rclcpp_action/src/client.cpp
@@ -41,7 +41,7 @@ public:
     const rcl_action_client_options_t & client_options)
   : node_graph_(node_graph),
     node_handle(node_base->get_shared_rcl_node_handle()),
-    logger(node_logging->get_logger().get_child("rclcpp_acton")),
+    logger(node_logging->get_logger().get_child("rclcpp_action")),
     random_bytes_generator(std::random_device{} ())
   {
     std::weak_ptr<rcl_node_t> weak_node_handle(node_handle);


### PR DESCRIPTION
Add missing backport of commit 6ef2384: Fix typo in action client logger name (#937) to branch `dashing`.