### PR TITLE
Address #1423 by moving rosidl_generate_interfaces call

### DIFF
--- a/rclcpp/test/CMakeLists.txt
+++ b/rclcpp/test/CMakeLists.txt
@@ -4,14 +4,6 @@ find_package(test_msgs REQUIRED)
 
 include(cmake/rclcpp_add_build_failure_test.cmake)
 
-rosidl_generate_interfaces(${PROJECT_NAME}_test_msgs
-  msg/Header.msg
-  msg/MessageWithHeader.msg
-  DEPENDENCIES builtin_interfaces
-  LIBRARY_NAME ${PROJECT_NAME}
-  SKIP_INSTALL
-)
-
 add_subdirectory(benchmark)
 add_subdirectory(rclcpp)
 

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -4,6 +4,14 @@ find_package(rmw_implementation_cmake REQUIRED)
 
 add_definitions(-DTEST_RESOURCES_DIRECTORY="${CMAKE_CURRENT_BINARY_DIR}/../resources")
 
+rosidl_generate_interfaces(${PROJECT_NAME}_test_msgs
+  ../msg/Header.msg
+  ../msg/MessageWithHeader.msg
+  DEPENDENCIES builtin_interfaces
+  LIBRARY_NAME ${PROJECT_NAME}
+  SKIP_INSTALL
+)
+
 ament_add_gtest(
   test_allocator_common
   allocator/test_allocator_common.cpp)


### PR DESCRIPTION
These interfaces are needed by the test_subscription_topic_statistics test, but somehow generating them at a different scope than where the `rosidl_target_interfaces` call occurs doesn't correctly target the libraries.

Fixes #1423 

Testing `--packages-select rclcpp`
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12861)](http://ci.ros2.org/job/ci_linux/12861/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7816)](http://ci.ros2.org/job/ci_linux-aarch64/7816/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10572)](http://ci.ros2.org/job/ci_osx/10572/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12804)](http://ci.ros2.org/job/ci_windows/12804/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>