### PR TITLE
Make use of new pause/resume_performance_metric methods

### DIFF
--- a/rclcpp/test/benchmark/benchmark_client.cpp
+++ b/rclcpp/test/benchmark/benchmark_client.cpp
@@ -66,9 +66,9 @@ BENCHMARK_F(ClientPerformanceTest, construct_client_no_service)(benchmark::State
     benchmark::DoNotOptimize(client);
     benchmark::ClobberMemory();
 
-    state.PauseTiming();
+    pause_performance_measurements(state);
     client.reset();
-    state.ResumeTiming();
+    resume_performance_measurements(state);
   }
 }
 
@@ -83,9 +83,9 @@ BENCHMARK_F(ClientPerformanceTest, construct_client_empty_srv)(benchmark::State 
     benchmark::DoNotOptimize(client);
     benchmark::ClobberMemory();
 
-    state.PauseTiming();
+    pause_performance_measurements(state);
     client.reset();
-    state.ResumeTiming();
+    resume_performance_measurements(state);
   }
 }
 
@@ -96,9 +96,9 @@ BENCHMARK_F(ClientPerformanceTest, destroy_client_empty_srv)(benchmark::State & 
 
   reset_heap_counters();
   for (auto _ : state) {
-    state.PauseTiming();
+    pause_performance_measurements(state);
     auto client = node->create_client<test_msgs::srv::Empty>(empty_service_name);
-    state.ResumeTiming();
+    resume_performance_measurements(state);
     benchmark::DoNotOptimize(client);
     benchmark::ClobberMemory();
 
@@ -109,7 +109,7 @@ BENCHMARK_F(ClientPerformanceTest, destroy_client_empty_srv)(benchmark::State & 
 BENCHMARK_F(ClientPerformanceTest, wait_for_service)(benchmark::State & state) {
   int count = 0;
   for (auto _ : state) {
-    state.PauseTiming();
+    pause_performance_measurements(state);
     const std::string service_name = std::string("service_") + std::to_string(count++);
     // Create client before service so it has to 'discover' the service after construction
     auto client = node->create_client<test_msgs::srv::Empty>(service_name);
@@ -119,7 +119,7 @@ BENCHMARK_F(ClientPerformanceTest, wait_for_service)(benchmark::State & state) {
       test_msgs::srv::Empty::Response::SharedPtr) {};
     auto service =
       node->create_service<test_msgs::srv::Empty>(service_name, callback);
-    state.ResumeTiming();
+    resume_performance_measurements(state);
 
     client->wait_for_service(std::chrono::seconds(1));
     benchmark::ClobberMemory();

--- a/rclcpp/test/benchmark/benchmark_executor.cpp
+++ b/rclcpp/test/benchmark/benchmark_executor.cpp
@@ -78,11 +78,11 @@ BENCHMARK_F(PerformanceTestExecutor, single_thread_executor_spin_some)(benchmark
   reset_heap_counters();
 
   for (auto _ : st) {
-    st.PauseTiming();
+    pause_performance_measurements(st);
     for (unsigned int i = 0u; i < kNumberOfNodes; i++) {
       publishers[i]->publish(empty_msgs);
     }
-    st.ResumeTiming();
+    resume_performance_measurements(st);
 
     executor.spin_some(100ms);
   }
@@ -104,11 +104,11 @@ BENCHMARK_F(PerformanceTestExecutor, multi_thread_executor_spin_some)(benchmark:
   reset_heap_counters();
 
   for (auto _ : st) {
-    st.PauseTiming();
+    pause_performance_measurements(st);
     for (unsigned int i = 0u; i < kNumberOfNodes; i++) {
       publishers[i]->publish(empty_msgs);
     }
-    st.ResumeTiming();
+    resume_performance_measurements(st);
 
     executor.spin_some(100ms);
   }
@@ -143,9 +143,9 @@ BENCHMARK_F(PerformanceTestExecutorSimple, single_thread_executor_add_node)(benc
   rclcpp::executors::SingleThreadedExecutor executor;
   for (auto _ : st) {
     executor.add_node(node);
-    st.PauseTiming();
+    pause_performance_measurements(st);
     executor.remove_node(node);
-    st.ResumeTiming();
+    resume_performance_measurements(st);
   }
 }
 
@@ -154,9 +154,9 @@ BENCHMARK_F(
 {
   rclcpp::executors::SingleThreadedExecutor executor;
   for (auto _ : st) {
-    st.PauseTiming();
+    pause_performance_measurements(st);
     executor.add_node(node);
-    st.ResumeTiming();
+    resume_performance_measurements(st);
     executor.remove_node(node);
   }
 }
@@ -166,9 +166,9 @@ BENCHMARK_F(PerformanceTestExecutorSimple, multi_thread_executor_add_node)(bench
   rclcpp::executors::MultiThreadedExecutor executor;
   for (auto _ : st) {
     executor.add_node(node);
-    st.PauseTiming();
+    pause_performance_measurements(st);
     executor.remove_node(node);
-    st.ResumeTiming();
+    resume_performance_measurements(st);
   }
 }
 
@@ -176,9 +176,9 @@ BENCHMARK_F(PerformanceTestExecutorSimple, multi_thread_executor_remove_node)(be
 {
   rclcpp::executors::MultiThreadedExecutor executor;
   for (auto _ : st) {
-    st.PauseTiming();
+    pause_performance_measurements(st);
     executor.add_node(node);
-    st.ResumeTiming();
+    resume_performance_measurements(st);
     executor.remove_node(node);
   }
 }
@@ -190,9 +190,9 @@ BENCHMARK_F(
   rclcpp::executors::StaticSingleThreadedExecutor executor;
   for (auto _ : st) {
     executor.add_node(node);
-    st.PauseTiming();
+    pause_performance_measurements(st);
     executor.remove_node(node);
-    st.ResumeTiming();
+    resume_performance_measurements(st);
   }
 }
 
@@ -202,9 +202,9 @@ BENCHMARK_F(
 {
   rclcpp::executors::StaticSingleThreadedExecutor executor;
   for (auto _ : st) {
-    st.PauseTiming();
+    pause_performance_measurements(st);
     executor.add_node(node);
-    st.ResumeTiming();
+    resume_performance_measurements(st);
     executor.remove_node(node);
   }
 }
@@ -230,18 +230,18 @@ BENCHMARK_F(
   for (auto _ : st) {
     // static_single_thread_executor has a special design. We need to add/remove the node each
     // time you call spin
-    st.PauseTiming();
+    pause_performance_measurements(st);
     executor.add_node(node);
-    st.ResumeTiming();
+    resume_performance_measurements(st);
 
     ret = executor.spin_until_future_complete(shared_future, 100ms);
     if (ret != rclcpp::FutureReturnCode::SUCCESS) {
       st.SkipWithError(rcutils_get_error_string().str);
       break;
     }
-    st.PauseTiming();
+    pause_performance_measurements(st);
     executor.remove_node(node);
-    st.ResumeTiming();
+    resume_performance_measurements(st);
   }
 }
 

--- a/rclcpp/test/benchmark/benchmark_executor.cpp
+++ b/rclcpp/test/benchmark/benchmark_executor.cpp
@@ -78,11 +78,13 @@ BENCHMARK_F(PerformanceTestExecutor, single_thread_executor_spin_some)(benchmark
   reset_heap_counters();
 
   for (auto _ : st) {
-    pause_performance_measurements(st);
-    for (unsigned int i = 0u; i < kNumberOfNodes; i++) {
-      publishers[i]->publish(empty_msgs);
-    }
-    resume_performance_measurements(st);
+    PERFORMANCE_TEST_FIXTURE_PAUSE_MEASUREMENTS(
+      st,
+    {
+      for (unsigned int i = 0u; i < kNumberOfNodes; i++) {
+        publishers[i]->publish(empty_msgs);
+      }
+    });
 
     executor.spin_some(100ms);
   }
@@ -104,11 +106,13 @@ BENCHMARK_F(PerformanceTestExecutor, multi_thread_executor_spin_some)(benchmark:
   reset_heap_counters();
 
   for (auto _ : st) {
-    pause_performance_measurements(st);
-    for (unsigned int i = 0u; i < kNumberOfNodes; i++) {
-      publishers[i]->publish(empty_msgs);
-    }
-    resume_performance_measurements(st);
+    PERFORMANCE_TEST_FIXTURE_PAUSE_MEASUREMENTS(
+      st,
+    {
+      for (unsigned int i = 0u; i < kNumberOfNodes; i++) {
+        publishers[i]->publish(empty_msgs);
+      }
+    });
 
     executor.spin_some(100ms);
   }
@@ -143,9 +147,11 @@ BENCHMARK_F(PerformanceTestExecutorSimple, single_thread_executor_add_node)(benc
   rclcpp::executors::SingleThreadedExecutor executor;
   for (auto _ : st) {
     executor.add_node(node);
-    pause_performance_measurements(st);
-    executor.remove_node(node);
-    resume_performance_measurements(st);
+    PERFORMANCE_TEST_FIXTURE_PAUSE_MEASUREMENTS(
+      st,
+    {
+      executor.remove_node(node);
+    });
   }
 }
 
@@ -154,9 +160,11 @@ BENCHMARK_F(
 {
   rclcpp::executors::SingleThreadedExecutor executor;
   for (auto _ : st) {
-    pause_performance_measurements(st);
-    executor.add_node(node);
-    resume_performance_measurements(st);
+    PERFORMANCE_TEST_FIXTURE_PAUSE_MEASUREMENTS(
+      st,
+    {
+      executor.add_node(node);
+    });
     executor.remove_node(node);
   }
 }
@@ -166,9 +174,11 @@ BENCHMARK_F(PerformanceTestExecutorSimple, multi_thread_executor_add_node)(bench
   rclcpp::executors::MultiThreadedExecutor executor;
   for (auto _ : st) {
     executor.add_node(node);
-    pause_performance_measurements(st);
-    executor.remove_node(node);
-    resume_performance_measurements(st);
+    PERFORMANCE_TEST_FIXTURE_PAUSE_MEASUREMENTS(
+      st,
+    {
+      executor.remove_node(node);
+    });
   }
 }
 
@@ -176,9 +186,11 @@ BENCHMARK_F(PerformanceTestExecutorSimple, multi_thread_executor_remove_node)(be
 {
   rclcpp::executors::MultiThreadedExecutor executor;
   for (auto _ : st) {
-    pause_performance_measurements(st);
-    executor.add_node(node);
-    resume_performance_measurements(st);
+    PERFORMANCE_TEST_FIXTURE_PAUSE_MEASUREMENTS(
+      st,
+    {
+      executor.add_node(node);
+    });
     executor.remove_node(node);
   }
 }
@@ -190,9 +202,11 @@ BENCHMARK_F(
   rclcpp::executors::StaticSingleThreadedExecutor executor;
   for (auto _ : st) {
     executor.add_node(node);
-    pause_performance_measurements(st);
-    executor.remove_node(node);
-    resume_performance_measurements(st);
+    PERFORMANCE_TEST_FIXTURE_PAUSE_MEASUREMENTS(
+      st,
+    {
+      executor.remove_node(node);
+    });
   }
 }
 
@@ -202,9 +216,11 @@ BENCHMARK_F(
 {
   rclcpp::executors::StaticSingleThreadedExecutor executor;
   for (auto _ : st) {
-    pause_performance_measurements(st);
-    executor.add_node(node);
-    resume_performance_measurements(st);
+    PERFORMANCE_TEST_FIXTURE_PAUSE_MEASUREMENTS(
+      st,
+    {
+      executor.add_node(node);
+    });
     executor.remove_node(node);
   }
 }
@@ -230,18 +246,22 @@ BENCHMARK_F(
   for (auto _ : st) {
     // static_single_thread_executor has a special design. We need to add/remove the node each
     // time you call spin
-    pause_performance_measurements(st);
-    executor.add_node(node);
-    resume_performance_measurements(st);
+    PERFORMANCE_TEST_FIXTURE_PAUSE_MEASUREMENTS(
+      st,
+    {
+      executor.add_node(node);
+    });
 
     ret = executor.spin_until_future_complete(shared_future, 100ms);
     if (ret != rclcpp::FutureReturnCode::SUCCESS) {
       st.SkipWithError(rcutils_get_error_string().str);
       break;
     }
-    pause_performance_measurements(st);
-    executor.remove_node(node);
-    resume_performance_measurements(st);
+    PERFORMANCE_TEST_FIXTURE_PAUSE_MEASUREMENTS(
+      st,
+    {
+      executor.remove_node(node);
+    });
   }
 }
 

--- a/rclcpp/test/benchmark/benchmark_init_shutdown.cpp
+++ b/rclcpp/test/benchmark/benchmark_init_shutdown.cpp
@@ -28,9 +28,9 @@ BENCHMARK_F(PerformanceTest, rclcpp_init)(benchmark::State & state)
   for (auto _ : state) {
     rclcpp::init(0, nullptr);
 
-    state.PauseTiming();
+    pause_performance_measurements(state);
     rclcpp::shutdown();
-    state.ResumeTiming();
+    resume_performance_measurements(state);
     benchmark::ClobberMemory();
   }
 }
@@ -43,9 +43,9 @@ BENCHMARK_F(PerformanceTest, rclcpp_shutdown)(benchmark::State & state)
 
   reset_heap_counters();
   for (auto _ : state) {
-    state.PauseTiming();
+    pause_performance_measurements(state);
     rclcpp::init(0, nullptr);
-    state.ResumeTiming();
+    resume_performance_measurements(state);
 
     rclcpp::shutdown();
     benchmark::ClobberMemory();

--- a/rclcpp/test/benchmark/benchmark_init_shutdown.cpp
+++ b/rclcpp/test/benchmark/benchmark_init_shutdown.cpp
@@ -28,9 +28,11 @@ BENCHMARK_F(PerformanceTest, rclcpp_init)(benchmark::State & state)
   for (auto _ : state) {
     rclcpp::init(0, nullptr);
 
-    pause_performance_measurements(state);
-    rclcpp::shutdown();
-    resume_performance_measurements(state);
+    PERFORMANCE_TEST_FIXTURE_PAUSE_MEASUREMENTS(
+      state,
+    {
+      rclcpp::shutdown();
+    });
     benchmark::ClobberMemory();
   }
 }
@@ -43,9 +45,11 @@ BENCHMARK_F(PerformanceTest, rclcpp_shutdown)(benchmark::State & state)
 
   reset_heap_counters();
   for (auto _ : state) {
-    pause_performance_measurements(state);
-    rclcpp::init(0, nullptr);
-    resume_performance_measurements(state);
+    PERFORMANCE_TEST_FIXTURE_PAUSE_MEASUREMENTS(
+      state,
+    {
+      rclcpp::init(0, nullptr);
+    });
 
     rclcpp::shutdown();
     benchmark::ClobberMemory();

--- a/rclcpp/test/benchmark/benchmark_node.cpp
+++ b/rclcpp/test/benchmark/benchmark_node.cpp
@@ -50,25 +50,28 @@ BENCHMARK_F(NodePerformanceTest, create_node)(benchmark::State & state)
     benchmark::ClobberMemory();
 
     // Ensure destruction of node is not counted toward timing
-    pause_performance_measurements(state);
-    node.reset();
-    resume_performance_measurements(state);
+    PERFORMANCE_TEST_FIXTURE_PAUSE_MEASUREMENTS(
+      state,
+    {
+      node.reset();
+    });
   }
 }
 
 BENCHMARK_F(NodePerformanceTest, destroy_node)(benchmark::State & state)
 {
   // Warmup and prime caches
-  auto outer_node = std::make_shared<rclcpp::Node>("node");
-  outer_node.reset();
+  auto node = std::make_shared<rclcpp::Node>("node");
+  node.reset();
 
   reset_heap_counters();
   for (auto _ : state) {
     // Using pointer to separate construction and destruction in timing
-    pause_performance_measurements(state);
-    auto node = std::make_shared<rclcpp::Node>("node");
-    resume_performance_measurements(state);
-
+    PERFORMANCE_TEST_FIXTURE_PAUSE_MEASUREMENTS(
+      state,
+    {
+      node = std::make_shared<rclcpp::Node>("node");
+    });
     benchmark::DoNotOptimize(node);
     benchmark::ClobberMemory();
 

--- a/rclcpp/test/benchmark/benchmark_node.cpp
+++ b/rclcpp/test/benchmark/benchmark_node.cpp
@@ -50,9 +50,9 @@ BENCHMARK_F(NodePerformanceTest, create_node)(benchmark::State & state)
     benchmark::ClobberMemory();
 
     // Ensure destruction of node is not counted toward timing
-    state.PauseTiming();
+    pause_performance_measurements(state);
     node.reset();
-    state.ResumeTiming();
+    resume_performance_measurements(state);
   }
 }
 
@@ -65,9 +65,9 @@ BENCHMARK_F(NodePerformanceTest, destroy_node)(benchmark::State & state)
   reset_heap_counters();
   for (auto _ : state) {
     // Using pointer to separate construction and destruction in timing
-    state.PauseTiming();
+    pause_performance_measurements(state);
     auto node = std::make_shared<rclcpp::Node>("node");
-    state.ResumeTiming();
+    resume_performance_measurements(state);
 
     benchmark::DoNotOptimize(node);
     benchmark::ClobberMemory();

--- a/rclcpp/test/benchmark/benchmark_service.cpp
+++ b/rclcpp/test/benchmark/benchmark_service.cpp
@@ -73,9 +73,9 @@ BENCHMARK_F(ServicePerformanceTest, construct_service_no_client)(benchmark::Stat
     benchmark::DoNotOptimize(service);
     benchmark::ClobberMemory();
 
-    state.PauseTiming();
+    pause_performance_measurements(state);
     service.reset();
-    state.ResumeTiming();
+    resume_performance_measurements(state);
   }
 }
 
@@ -91,9 +91,9 @@ BENCHMARK_F(ServicePerformanceTest, construct_service_empty_srv)(benchmark::Stat
     benchmark::DoNotOptimize(service);
     benchmark::ClobberMemory();
 
-    state.PauseTiming();
+    pause_performance_measurements(state);
     service.reset();
-    state.ResumeTiming();
+    resume_performance_measurements(state);
   }
 }
 
@@ -105,9 +105,9 @@ BENCHMARK_F(ServicePerformanceTest, destroy_service_empty_srv)(benchmark::State 
 
   reset_heap_counters();
   for (auto _ : state) {
-    state.PauseTiming();
+    pause_performance_measurements(state);
     auto service = node->create_service<test_msgs::srv::Empty>(empty_service_name, callback);
-    state.ResumeTiming();
+    resume_performance_measurements(state);
     benchmark::DoNotOptimize(service);
     benchmark::ClobberMemory();
 
@@ -123,13 +123,13 @@ BENCHMARK_F(ServicePerformanceTest, async_send_response)(benchmark::State & stat
 
   reset_heap_counters();
   for (auto _ : state) {
-    state.PauseTiming();
+    pause_performance_measurements(state);
     // Clear executor queue
     rclcpp::spin_some(node->get_node_base_interface());
 
     auto request = std::make_shared<test_msgs::srv::Empty::Request>();
     auto future = empty_client->async_send_request(request);
-    state.ResumeTiming();
+    resume_performance_measurements(state);
     benchmark::DoNotOptimize(service);
     benchmark::ClobberMemory();
 


### PR DESCRIPTION
This switches calls of `benchmark::State::PauseTiming` and `ResumeTiming` to proposed `pause_performance_measurements` and `resume_performance_measurements`. This should help keep allocations more accurate for the code under test.

Testing with benchmarks and `--packages-select rclcpp`
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12992)](http://ci.ros2.org/job/ci_linux/12992/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7944)](http://ci.ros2.org/job/ci_linux-aarch64/7944/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10719)](http://ci.ros2.org/job/ci_osx/10719/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12972)](http://ci.ros2.org/job/ci_windows/12972/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>