### PR TITLE
Remove allocation from executor::remove_node()

### DIFF
--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -345,7 +345,7 @@ Executor::remove_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node
   }
 
   for (auto it = weak_groups_to_nodes_associated_with_executor_.begin();
-       it != weak_groups_to_nodes_associated_with_executor_.end();)
+    it != weak_groups_to_nodes_associated_with_executor_.end(); )
   {
     auto weak_node_ptr = it->second;
     auto shared_node_ptr = weak_node_ptr.lock();


### PR DESCRIPTION
I noticed this allocation while running benchmark tests with updated pause/resume heap allocations. Creating a std::vector and appending to it allocates on the heap. There is a way of removing these items while iterating through the map to erase from. 

Signed-off-by: Stephen Brawner <brawner@gmail.com>