### PR TITLE
Fix test crashes on CentOS 7

### DIFF
--- a/rclcpp/include/rclcpp/graph_listener.hpp
+++ b/rclcpp/include/rclcpp/graph_listener.hpp
@@ -160,6 +160,8 @@ protected:
   void
   run_loop();
 
+  void init_wait_set();
+
 private:
   RCLCPP_DISABLE_COPY(GraphListener)
 

--- a/rclcpp/include/rclcpp/graph_listener.hpp
+++ b/rclcpp/include/rclcpp/graph_listener.hpp
@@ -163,6 +163,9 @@ protected:
   RCLCPP_PUBLIC
   void init_wait_set();
 
+  RCLCPP_PUBLIC
+  void cleanup_wait_set();
+
 private:
   RCLCPP_DISABLE_COPY(GraphListener)
 

--- a/rclcpp/include/rclcpp/graph_listener.hpp
+++ b/rclcpp/include/rclcpp/graph_listener.hpp
@@ -160,6 +160,7 @@ protected:
   void
   run_loop();
 
+  RCLCPP_PUBLIC
   void init_wait_set();
 
 private:

--- a/rclcpp/src/rclcpp/graph_listener.cpp
+++ b/rclcpp/src/rclcpp/graph_listener.cpp
@@ -62,6 +62,27 @@ GraphListener::~GraphListener()
   this->shutdown(std::nothrow);
 }
 
+void GraphListener::init_wait_set()
+{
+  auto parent_context = parent_context_.lock();
+  if (!parent_context) {
+    throw std::runtime_error("parent context was destroyed");
+  }
+  rcl_ret_t ret = rcl_wait_set_init(
+    &wait_set_,
+    0,  // number_of_subscriptions
+    2,  // number_of_guard_conditions
+    0,  // number_of_timers
+    0,  // number_of_clients
+    0,  // number_of_services
+    0,  // number_of_events
+    parent_context->get_rcl_context().get(),
+    rcl_get_default_allocator());
+  if (RCL_RET_OK != ret) {
+    throw_from_rcl_error(ret, "failed to initialize wait set");
+  }
+}
+
 void
 GraphListener::start_if_not_started()
 {
@@ -71,24 +92,8 @@ GraphListener::start_if_not_started()
   }
   if (!is_started_) {
     // Initialize the wait set before starting.
-    auto parent_context = parent_context_.lock();
-    if (!parent_context) {
-      throw std::runtime_error("parent context was destroyed");
-    }
-    rcl_ret_t ret = rcl_wait_set_init(
-      &wait_set_,
-      0,  // number_of_subscriptions
-      2,  // number_of_guard_conditions
-      0,  // number_of_timers
-      0,  // number_of_clients
-      0,  // number_of_services
-      0,  // number_of_events
-      parent_context->get_rcl_context().get(),
-      rcl_get_default_allocator());
-    if (RCL_RET_OK != ret) {
-      throw_from_rcl_error(ret, "failed to initialize wait set");
-    }
-    // Register an on_shutdown hook to shtudown the graph listener.
+    init_wait_set();
+    // Register an on_shutdown hook to shutdown the graph listener.
     // This is important to ensure that the wait set is finalized before
     // destruction of static objects occurs.
     std::weak_ptr<GraphListener> weak_this = shared_from_this();

--- a/rclcpp/src/rclcpp/graph_listener.cpp
+++ b/rclcpp/src/rclcpp/graph_listener.cpp
@@ -356,6 +356,15 @@ GraphListener::remove_node(rclcpp::node_interfaces::NodeGraphInterface * node_gr
 }
 
 void
+GraphListener::cleanup_wait_set()
+{
+  rcl_ret_t ret = rcl_wait_set_fini(&wait_set_);
+  if (RCL_RET_OK != ret) {
+    throw_from_rcl_error(ret, "failed to finalize wait set");
+  }
+}
+
+void
 GraphListener::__shutdown(bool should_throw)
 {
   std::lock_guard<std::mutex> shutdown_lock(shutdown_mutex_);
@@ -391,10 +400,7 @@ GraphListener::__shutdown(bool should_throw)
       shutdown_guard_condition_ = nullptr;
     }
     if (is_started_) {
-      ret = rcl_wait_set_fini(&wait_set_);
-      if (RCL_RET_OK != ret) {
-        throw_from_rcl_error(ret, "failed to finalize wait set");
-      }
+      cleanup_wait_set();
     }
   }
 }

--- a/rclcpp/test/rclcpp/test_graph_listener.cpp
+++ b/rclcpp/test/rclcpp/test_graph_listener.cpp
@@ -125,16 +125,9 @@ public:
     this->run();
   }
 
-  void mock_start_thread()
+  void mock_init_wait_set()
   {
-    // This function prepares the loop thread to be run, but leave
-    // early with the failure thrown. That way the graph_listener wait_set
-    // is init, without being started
-    auto mock_wait_set_init = mocking_utils::inject_on_return(
-      "lib:rclcpp", rcl_wait_set_init, RCL_RET_ERROR);
-    RCLCPP_EXPECT_THROW_EQ(
-      this->start_if_not_started(),
-      std::runtime_error("failed to initialize wait set: error not set"));
+    this->init_wait_set();
   }
 };
 
@@ -152,7 +145,7 @@ TEST_F(TestGraphListener, error_run_graph_listener_mock_wait_set_clear) {
   auto global_context = rclcpp::contexts::get_global_default_context();
   auto graph_listener_test =
     std::make_shared<TestGraphListenerProtectedMethods>(global_context);
-  graph_listener_test->mock_start_thread();
+  graph_listener_test->mock_init_wait_set();
   auto mock_wait_set_clear = mocking_utils::patch_and_return(
     "lib:rclcpp", rcl_wait_set_clear, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
@@ -164,7 +157,7 @@ TEST_F(TestGraphListener, error_run_graph_listener_mock_wait_set_add_guard_condi
   auto global_context = rclcpp::contexts::get_global_default_context();
   auto graph_listener_test =
     std::make_shared<TestGraphListenerProtectedMethods>(global_context);
-  graph_listener_test->mock_start_thread();
+  graph_listener_test->mock_init_wait_set();
   auto mock_wait_set_clear = mocking_utils::patch_and_return(
     "lib:rclcpp", rcl_wait_set_add_guard_condition, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
@@ -176,7 +169,7 @@ TEST_F(TestGraphListener, error_run_graph_listener_mock_wait_set_add_guard_condi
   auto global_context = rclcpp::contexts::get_global_default_context();
   auto graph_listener_test =
     std::make_shared<TestGraphListenerProtectedMethods>(global_context);
-  graph_listener_test->mock_start_thread();
+  graph_listener_test->mock_init_wait_set();
   auto mock = mocking_utils::patch(
     "lib:rclcpp", rcl_wait_set_add_guard_condition, [](auto, ...) {
       static int counter = 1;
@@ -196,7 +189,7 @@ TEST_F(TestGraphListener, error_run_graph_listener_mock_wait_error) {
   auto global_context = rclcpp::contexts::get_global_default_context();
   auto graph_listener_test =
     std::make_shared<TestGraphListenerProtectedMethods>(global_context);
-  graph_listener_test->mock_start_thread();
+  graph_listener_test->mock_init_wait_set();
   auto mock_wait_set_clear = mocking_utils::patch_and_return(
     "lib:rclcpp", rcl_wait, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
@@ -208,7 +201,7 @@ TEST_F(TestGraphListener, error_run_graph_listener_mock_wait_timeout) {
   auto global_context = rclcpp::contexts::get_global_default_context();
   auto graph_listener_test =
     std::make_shared<TestGraphListenerProtectedMethods>(global_context);
-  graph_listener_test->mock_start_thread();
+  graph_listener_test->mock_init_wait_set();
   auto mock_wait_set_clear = mocking_utils::patch_and_return(
     "lib:rclcpp", rcl_wait, RCL_RET_TIMEOUT);
   RCLCPP_EXPECT_THROW_EQ(
@@ -268,7 +261,7 @@ TEST_F(TestGraphListener, test_errors_graph_listener_add_remove_node) {
 /* Shutdown errors */
 TEST_F(TestGraphListener, test_graph_listener_shutdown_wait_fini_error_nothrow) {
   graph_listener()->start_if_not_started();
-  auto mock_wait_set_fini = mocking_utils::inject_on_return(
+  auto mock_wait_set_fini = mocking_utils::patch_and_return(
     "lib:rclcpp", rcl_wait_set_fini, RCL_RET_ERROR);
   // Exception is logged when using nothrow_t
   EXPECT_NO_THROW(graph_listener()->shutdown(std::nothrow_t()));
@@ -276,7 +269,7 @@ TEST_F(TestGraphListener, test_graph_listener_shutdown_wait_fini_error_nothrow) 
 
 TEST_F(TestGraphListener, test_graph_listener_shutdown_wait_fini_error_throw) {
   graph_listener()->start_if_not_started();
-  auto mock_wait_set_fini = mocking_utils::inject_on_return(
+  auto mock_wait_set_fini = mocking_utils::patch_and_return(
     "lib:rclcpp", rcl_wait_set_fini, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     graph_listener()->shutdown(),
@@ -285,7 +278,7 @@ TEST_F(TestGraphListener, test_graph_listener_shutdown_wait_fini_error_throw) {
 
 TEST_F(TestGraphListener, test_graph_listener_shutdown_guard_fini_error_throw) {
   graph_listener()->start_if_not_started();
-  auto mock_wait_set_fini = mocking_utils::inject_on_return(
+  auto mock_wait_set_fini = mocking_utils::patch_and_return(
     "lib:rclcpp", rcl_guard_condition_fini, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     graph_listener()->shutdown(),

--- a/rclcpp_action/test/test_client.cpp
+++ b/rclcpp_action/test/test_client.cpp
@@ -332,7 +332,7 @@ TEST_F(TestClient, construction_and_destruction_callback_group)
 TEST_F(TestClient, construction_and_destruction_rcl_errors)
 {
   {
-    auto mock = mocking_utils::inject_on_return(
+    auto mock = mocking_utils::patch_and_return(
       "lib:rclcpp_action", rcl_action_client_fini, RCL_RET_ERROR);
     // It just logs an error message and continues
     EXPECT_NO_THROW(

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -1156,7 +1156,7 @@ TEST_F(TestGoalRequestServer, publish_status_publish_status_errors)
 
 TEST_F(TestGoalRequestServer, execute_goal_request_received_take_failed)
 {
-  auto mock = mocking_utils::inject_on_return(
+  auto mock = mocking_utils::patch_and_return(
     "lib:rclcpp_action", rcl_action_take_goal_request, RCL_RET_ACTION_SERVER_TAKE_FAILED);
   try {
     SendClientGoalRequest(std::chrono::milliseconds(100));


### PR DESCRIPTION
CentOS7 has been having test failures for a while; see https://ci.ros2.org/view/nightly/job/nightly_linux-centos_debug/589/#showFailuresLink for the latest example.

The problem ends up being that the mocking_utils `inject_on_return` doesn't work on CentOS7 (https://github.com/ros2/rclcpp/blob/06465ba827da0ce018199fb0f80d15ffe6fc26fd/rclcpp/test/mocking_utils/patch.hpp#L550).  This PR addresses that by changing to `patch_and_return` (which does work on CentOS7), and doing a slight class refactoring so we can stop abusing `inject_on_return` to do partial initialization.  In my testing on CentOS7, this fixes all of the current crashes we are seeing (in rclcpp and rclcpp_action, at least).