### PR TITLE
Add Topic Statistics Options to be configured via Parameters

### DIFF
--- a/rclcpp/include/rclcpp/create_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_subscription.hpp
@@ -122,8 +122,14 @@ create_subscription(
       rclcpp::topic_statistics::SubscriptionTopicStatistics<CallbackMessageT>
       >(node_topics->get_node_base_interface()->get_name(), publisher);
 
-    auto sub_call_back = [subscription_topic_stats]() {
-        subscription_topic_stats->publish_message();
+    std::weak_ptr<
+      rclcpp::topic_statistics::SubscriptionTopicStatistics<CallbackMessageT>
+    > weak_subscription_topic_stats(subscription_topic_stats);
+    auto sub_call_back = [weak_subscription_topic_stats]() {
+        auto subscription_topic_stats = weak_subscription_topic_stats.lock();
+        if (subscription_topic_stats) {
+          subscription_topic_stats->publish_message();
+        }
       };
 
     auto node_timer_interface = node_topics->get_node_timers_interface();

--- a/rclcpp/include/rclcpp/create_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_subscription.hpp
@@ -100,50 +100,66 @@ create_subscription(
   
   using rclcpp::node_interfaces::get_node_parameters_interface; //added
   auto node_parameters = get_node_parameters_interface(std::forward<NodeT>(node)); //added
-  node_parameters->declare_parameter("enable_statistics", rclcpp::ParameterValue(false)); //added  
   
-  if (rclcpp::detail::resolve_enable_topic_statistics(options,*node_topics->get_node_base_interface())||
-  node_parameters->get_parameter("enable_statistics").as_bool()) //added
-  {
-    if (options.topic_stats_options.publish_period <= std::chrono::milliseconds(0)) {
-      throw std::invalid_argument(
-              "topic_stats_options.publish_period must be greater than 0, specified value of " +
-              std::to_string(options.topic_stats_options.publish_period.count()) +
-              " ms");
-    }
+  node_parameters->declare_parameter("stats_enabled", rclcpp::ParameterValue()); //added  
+  rclcpp::Parameter stats_enabled; //added
+  node_parameters->get_parameter("stats_enabled", stats_enabled); //added
+  
+  if (((stats_enabled.get_type()!= rclcpp::PARAMETER_NOT_SET)&&(stats_enabled.as_bool()==true))||
+  ((stats_enabled.get_type()== rclcpp::PARAMETER_NOT_SET)&&(rclcpp::detail::resolve_enable_topic_statistics(options,*node_topics->get_node_base_interface())))) //modified
+  {	
+  	node_parameters->declare_parameter("stats_period", rclcpp::ParameterValue()); //added
+  	rclcpp::Parameter stats_period; //added
+		node_parameters->get_parameter("stats_period", stats_period); //added
+		
+	  if ((stats_period.get_type()!= rclcpp::PARAMETER_NOT_SET)&&(stats_period.as_double()<=0)) {
+			throw std::invalid_argument(
+			          "stats_period must be greater than 0, specified value of " +
+			          std::to_string(stats_period.as_double()) +
+			          " ms");
+	  } else if ((stats_period.get_type()== rclcpp::PARAMETER_NOT_SET)&&(options.topic_stats_options.publish_period <= std::chrono::milliseconds(0))) {
+	    throw std::invalid_argument(
+	            "topic_stats_options.publish_period must be greater than 0, specified value of " +
+	            std::to_string(options.topic_stats_options.publish_period.count()) +
+	            " ms");
+	  }
+	  
+		node_parameters->declare_parameter("stats_topic", rclcpp::ParameterValue()); //added
+		rclcpp::Parameter stats_topic; //added
+		node_parameters->get_parameter("stats_topic", stats_topic); //added
+          
+	  std::shared_ptr<Publisher<statistics_msgs::msg::MetricsMessage>> publisher =
+	    create_publisher<statistics_msgs::msg::MetricsMessage>(
+	    node,
+	    (stats_topic.get_type()!= rclcpp::PARAMETER_NOT_SET) ? stats_topic.as_string() : options.topic_stats_options.publish_topic, 
+	    qos); //modified
 
-    std::shared_ptr<Publisher<statistics_msgs::msg::MetricsMessage>> publisher =
-      create_publisher<statistics_msgs::msg::MetricsMessage>(
-      node,
-      options.topic_stats_options.publish_topic,
-      qos);
+	  subscription_topic_stats = std::make_shared<
+	    rclcpp::topic_statistics::SubscriptionTopicStatistics<CallbackMessageT>
+	    >(node_topics->get_node_base_interface()->get_name(), publisher);
 
-    subscription_topic_stats = std::make_shared<
-      rclcpp::topic_statistics::SubscriptionTopicStatistics<CallbackMessageT>
-      >(node_topics->get_node_base_interface()->get_name(), publisher);
+	  std::weak_ptr<
+	    rclcpp::topic_statistics::SubscriptionTopicStatistics<CallbackMessageT>
+	  > weak_subscription_topic_stats(subscription_topic_stats);
+	  auto sub_call_back = [weak_subscription_topic_stats]() {
+	      auto subscription_topic_stats = weak_subscription_topic_stats.lock();
+	      if (subscription_topic_stats) {
+	        subscription_topic_stats->publish_message();
+	      }
+	    };
 
-    std::weak_ptr<
-      rclcpp::topic_statistics::SubscriptionTopicStatistics<CallbackMessageT>
-    > weak_subscription_topic_stats(subscription_topic_stats);
-    auto sub_call_back = [weak_subscription_topic_stats]() {
-        auto subscription_topic_stats = weak_subscription_topic_stats.lock();
-        if (subscription_topic_stats) {
-          subscription_topic_stats->publish_message();
-        }
-      };
+	  auto node_timer_interface = node_topics->get_node_timers_interface();
 
-    auto node_timer_interface = node_topics->get_node_timers_interface();
+	  auto timer = create_wall_timer(
+	    std::chrono::duration_cast<std::chrono::nanoseconds>(
+	      (stats_period.get_type()!= rclcpp::PARAMETER_NOT_SET) ? std::chrono::seconds(std::chrono::duration_cast<std::chrono::seconds>(std::chrono::milliseconds((int)stats_period.as_double()*1000))) : options.topic_stats_options.publish_period),
+	    sub_call_back,
+	    options.callback_group,
+	    node_topics->get_node_base_interface(),
+	    node_timer_interface
+	  ); //modified
 
-    auto timer = create_wall_timer(
-      std::chrono::duration_cast<std::chrono::nanoseconds>(
-        options.topic_stats_options.publish_period),
-      sub_call_back,
-      options.callback_group,
-      node_topics->get_node_base_interface(),
-      node_timer_interface
-    );
-
-    subscription_topic_stats->set_publisher_timer(timer);
+	  subscription_topic_stats->set_publisher_timer(timer);
   }
 
   auto factory = rclcpp::create_subscription_factory<MessageT>(

--- a/rclcpp/include/rclcpp/create_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_subscription.hpp
@@ -26,10 +26,10 @@
 
 #include "rclcpp/node_interfaces/get_node_timers_interface.hpp"
 #include "rclcpp/node_interfaces/get_node_topics_interface.hpp"
-#include "rclcpp/node_interfaces/get_node_parameters_interface.hpp" //added
+#include "rclcpp/node_interfaces/get_node_parameters_interface.hpp"
 #include "rclcpp/node_interfaces/node_timers_interface.hpp"
 #include "rclcpp/node_interfaces/node_topics_interface.hpp"
-#include "rclcpp/node_interfaces/node_parameters_interface.hpp" //added
+#include "rclcpp/node_interfaces/node_parameters_interface.hpp"
 
 #include "rclcpp/create_publisher.hpp"
 #include "rclcpp/create_timer.hpp"
@@ -98,19 +98,19 @@ create_subscription(
   std::shared_ptr<rclcpp::topic_statistics::SubscriptionTopicStatistics<CallbackMessageT>>
   subscription_topic_stats = nullptr;
   
-  using rclcpp::node_interfaces::get_node_parameters_interface; //added
-  auto node_parameters = get_node_parameters_interface(std::forward<NodeT>(node)); //added
+  using rclcpp::node_interfaces::get_node_parameters_interface;
+  auto node_parameters = get_node_parameters_interface(std::forward<NodeT>(node));
   
-  node_parameters->declare_parameter("stats_enabled", rclcpp::ParameterValue()); //added  
-  rclcpp::Parameter stats_enabled; //added
-  node_parameters->get_parameter("stats_enabled", stats_enabled); //added
+  node_parameters->declare_parameter("stats_enabled", rclcpp::ParameterValue());  
+  rclcpp::Parameter stats_enabled;
+  node_parameters->get_parameter("stats_enabled", stats_enabled);
   
   if (((stats_enabled.get_type()!= rclcpp::PARAMETER_NOT_SET)&&(stats_enabled.as_bool()==true))||
-  ((stats_enabled.get_type()== rclcpp::PARAMETER_NOT_SET)&&(rclcpp::detail::resolve_enable_topic_statistics(options,*node_topics->get_node_base_interface())))) //modified
+  ((stats_enabled.get_type()== rclcpp::PARAMETER_NOT_SET)&&(rclcpp::detail::resolve_enable_topic_statistics(options,*node_topics->get_node_base_interface()))))
   {	
-  	node_parameters->declare_parameter("stats_period", rclcpp::ParameterValue()); //added
-  	rclcpp::Parameter stats_period; //added
-		node_parameters->get_parameter("stats_period", stats_period); //added
+  	node_parameters->declare_parameter("stats_period", rclcpp::ParameterValue());
+  	rclcpp::Parameter stats_period;
+		node_parameters->get_parameter("stats_period", stats_period);
 		
 	  if ((stats_period.get_type()!= rclcpp::PARAMETER_NOT_SET)&&(stats_period.as_double()<=0)) {
 			throw std::invalid_argument(
@@ -124,15 +124,15 @@ create_subscription(
 	            " ms");
 	  }
 	  
-		node_parameters->declare_parameter("stats_topic", rclcpp::ParameterValue()); //added
-		rclcpp::Parameter stats_topic; //added
-		node_parameters->get_parameter("stats_topic", stats_topic); //added
+		node_parameters->declare_parameter("stats_topic", rclcpp::ParameterValue());
+		rclcpp::Parameter stats_topic;
+		node_parameters->get_parameter("stats_topic", stats_topic);
           
 	  std::shared_ptr<Publisher<statistics_msgs::msg::MetricsMessage>> publisher =
 	    create_publisher<statistics_msgs::msg::MetricsMessage>(
 	    node,
 	    (stats_topic.get_type()!= rclcpp::PARAMETER_NOT_SET) ? stats_topic.as_string() : options.topic_stats_options.publish_topic, 
-	    qos); //modified
+	    qos);
 
 	  subscription_topic_stats = std::make_shared<
 	    rclcpp::topic_statistics::SubscriptionTopicStatistics<CallbackMessageT>
@@ -157,7 +157,7 @@ create_subscription(
 	    options.callback_group,
 	    node_topics->get_node_base_interface(),
 	    node_timer_interface
-	  ); //modified
+	  );
 
 	  subscription_topic_stats->set_publisher_timer(timer);
   }

--- a/rclcpp/include/rclcpp/create_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_subscription.hpp
@@ -26,10 +26,10 @@
 
 #include "rclcpp/node_interfaces/get_node_timers_interface.hpp"
 #include "rclcpp/node_interfaces/get_node_topics_interface.hpp"
-#include "rclcpp/node_interfaces/get_node_parameters_interface.hpp"
+#include "rclcpp/node_interfaces/get_node_parameters_interface.hpp"	//added package
 #include "rclcpp/node_interfaces/node_timers_interface.hpp"
 #include "rclcpp/node_interfaces/node_topics_interface.hpp"
-#include "rclcpp/node_interfaces/node_parameters_interface.hpp"
+#include "rclcpp/node_interfaces/node_parameters_interface.hpp"	//added package
 
 #include "rclcpp/create_publisher.hpp"
 #include "rclcpp/create_timer.hpp"
@@ -101,63 +101,63 @@ create_subscription(
   using rclcpp::node_interfaces::get_node_parameters_interface;
   auto node_parameters = get_node_parameters_interface(std::forward<NodeT>(node));
   
-  node_parameters->declare_parameter("stats_enabled", rclcpp::ParameterValue());  
+  node_parameters->declare_parameter("stats_enabled", rclcpp::ParameterValue());  //declared stats_enabled with type PARAMETER_NOT_SET
   rclcpp::Parameter stats_enabled;
   node_parameters->get_parameter("stats_enabled", stats_enabled);
   
   if (((stats_enabled.get_type()!= rclcpp::PARAMETER_NOT_SET)&&(stats_enabled.as_bool()==true))||
-  ((stats_enabled.get_type()== rclcpp::PARAMETER_NOT_SET)&&(rclcpp::detail::resolve_enable_topic_statistics(options,*node_topics->get_node_base_interface()))))
+  ((stats_enabled.get_type()== rclcpp::PARAMETER_NOT_SET)&&(rclcpp::detail::resolve_enable_topic_statistics(options,*node_topics->get_node_base_interface())))) //run-time configuration has prioirty over code-configuration
   {	
-  	node_parameters->declare_parameter("stats_period", rclcpp::ParameterValue());
+  	node_parameters->declare_parameter("stats_period", rclcpp::ParameterValue());	//declared stats_period with type PARAMETER_NOT_SET
   	rclcpp::Parameter stats_period;
 		node_parameters->get_parameter("stats_period", stats_period);
 		
-	  if ((stats_period.get_type()!= rclcpp::PARAMETER_NOT_SET)&&(stats_period.as_double()<=0)) {
-			throw std::invalid_argument(
+		if ((stats_period.get_type()!= rclcpp::PARAMETER_NOT_SET)&&(stats_period.as_double()<=0)) {
+		throw std::invalid_argument(
 			          "stats_period must be greater than 0, specified value of " +
-			          std::to_string(stats_period.as_double()) +
-			          " ms");
+			          std::to_string(stats_period.as_double()) +" ms");
 	  } else if ((stats_period.get_type()== rclcpp::PARAMETER_NOT_SET)&&(options.topic_stats_options.publish_period <= std::chrono::milliseconds(0))) {
-	    throw std::invalid_argument(
+	    	throw std::invalid_argument(
 	            "topic_stats_options.publish_period must be greater than 0, specified value of " +
 	            std::to_string(options.topic_stats_options.publish_period.count()) +
 	            " ms");
 	  }
 	  
-		node_parameters->declare_parameter("stats_topic", rclcpp::ParameterValue());
+		node_parameters->declare_parameter("stats_topic", rclcpp::ParameterValue());	//declared stats_topic with type PARAMETER_NOT_SET
 		rclcpp::Parameter stats_topic;
 		node_parameters->get_parameter("stats_topic", stats_topic);
-          
-	  std::shared_ptr<Publisher<statistics_msgs::msg::MetricsMessage>> publisher =
-	    create_publisher<statistics_msgs::msg::MetricsMessage>(
-	    node,
-	    (stats_topic.get_type()!= rclcpp::PARAMETER_NOT_SET) ? stats_topic.as_string() : options.topic_stats_options.publish_topic, 
-	    qos);
+		        
+		std::shared_ptr<Publisher<statistics_msgs::msg::MetricsMessage>> publisher =
+			  create_publisher<statistics_msgs::msg::MetricsMessage>(
+			  node,
+			  (stats_topic.get_type()!= rclcpp::PARAMETER_NOT_SET) ? stats_topic.as_string() : options.topic_stats_options.publish_topic,
+			  qos);	//run-time configuration has prioirty over code-configuration
 
-	  subscription_topic_stats = std::make_shared<
-	    rclcpp::topic_statistics::SubscriptionTopicStatistics<CallbackMessageT>
-	    >(node_topics->get_node_base_interface()->get_name(), publisher);
+		subscription_topic_stats = std::make_shared<
+			  rclcpp::topic_statistics::SubscriptionTopicStatistics<CallbackMessageT>
+			  >(node_topics->get_node_base_interface()->get_name(), publisher);
 
-	  std::weak_ptr<
-	    rclcpp::topic_statistics::SubscriptionTopicStatistics<CallbackMessageT>
-	  > weak_subscription_topic_stats(subscription_topic_stats);
-	  auto sub_call_back = [weak_subscription_topic_stats]() {
-	      auto subscription_topic_stats = weak_subscription_topic_stats.lock();
-	      if (subscription_topic_stats) {
-	        subscription_topic_stats->publish_message();
-	      }
-	    };
+		std::weak_ptr<
+		  rclcpp::topic_statistics::SubscriptionTopicStatistics<CallbackMessageT>
+		> weak_subscription_topic_stats(subscription_topic_stats);
+		auto sub_call_back = [weak_subscription_topic_stats]() {
+		  auto subscription_topic_stats = weak_subscription_topic_stats.lock();
+		  if (subscription_topic_stats) {
+		    subscription_topic_stats->publish_message();
+		  }
+		};
 
-	  auto node_timer_interface = node_topics->get_node_timers_interface();
+		auto node_timer_interface = node_topics->get_node_timers_interface();
 
-	  auto timer = create_wall_timer(
-	    std::chrono::duration_cast<std::chrono::nanoseconds>(
-	      (stats_period.get_type()!= rclcpp::PARAMETER_NOT_SET) ? std::chrono::seconds(std::chrono::duration_cast<std::chrono::seconds>(std::chrono::milliseconds((int)stats_period.as_double()*1000))) : options.topic_stats_options.publish_period),
-	    sub_call_back,
-	    options.callback_group,
-	    node_topics->get_node_base_interface(),
-	    node_timer_interface
-	  );
+		auto timer = create_wall_timer(
+			  std::chrono::duration_cast<std::chrono::nanoseconds>(
+			    (stats_period.get_type()!= rclcpp::PARAMETER_NOT_SET) ? 						
+			    std::chrono::seconds(std::chrono::duration_cast<std::chrono::seconds>(std::chrono::milliseconds((int)stats_period.as_double()*1000))) : options.topic_stats_options.publish_period),
+			  sub_call_back,
+			  options.callback_group,
+			  node_topics->get_node_base_interface(),
+			  node_timer_interface
+			); //run-time configuration has prioirty over code-configuration
 
 	  subscription_topic_stats->set_publisher_timer(timer);
   }

--- a/rclcpp/include/rclcpp/create_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_subscription.hpp
@@ -26,10 +26,10 @@
 
 #include "rclcpp/node_interfaces/get_node_timers_interface.hpp"
 #include "rclcpp/node_interfaces/get_node_topics_interface.hpp"
-#include "rclcpp/node_interfaces/get_node_parameters_interface.hpp"	//added package
+#include "rclcpp/node_interfaces/get_node_parameters_interface.hpp" //added
+#include "rclcpp/node_interfaces/node_parameters_interface.hpp" //added
 #include "rclcpp/node_interfaces/node_timers_interface.hpp"
 #include "rclcpp/node_interfaces/node_topics_interface.hpp"
-#include "rclcpp/node_interfaces/node_parameters_interface.hpp"	//added package
 
 #include "rclcpp/create_publisher.hpp"
 #include "rclcpp/create_timer.hpp"
@@ -101,31 +101,42 @@ create_subscription(
   using rclcpp::node_interfaces::get_node_parameters_interface;
   auto node_parameters = get_node_parameters_interface(std::forward<NodeT>(node));
   
-  node_parameters->declare_parameter("stats_enabled", rclcpp::ParameterValue());  //declared stats_enabled with type PARAMETER_NOT_SET
   rclcpp::Parameter stats_enabled;
-  node_parameters->get_parameter("stats_enabled", stats_enabled);
+  if(!node_parameters->has_parameter("stats_enabled")) //if not declared
+  {
+  	node_parameters->declare_parameter("stats_enabled", rclcpp::ParameterValue()); //declared  	
+  }
+  node_parameters->get_parameter("stats_enabled", stats_enabled); //assigned
   
   if (((stats_enabled.get_type()!= rclcpp::PARAMETER_NOT_SET)&&(stats_enabled.as_bool()==true))||
   ((stats_enabled.get_type()== rclcpp::PARAMETER_NOT_SET)&&(rclcpp::detail::resolve_enable_topic_statistics(options,*node_topics->get_node_base_interface())))) //run-time configuration has prioirty over code-configuration
   {	
-  	node_parameters->declare_parameter("stats_period", rclcpp::ParameterValue());	//declared stats_period with type PARAMETER_NOT_SET
   	rclcpp::Parameter stats_period;
-	node_parameters->get_parameter("stats_period", stats_period);
+  	if(!node_parameters->has_parameter("stats_period")) //if not declared
+  	{
+  		node_parameters->declare_parameter("stats_period", rclcpp::ParameterValue());	//declared stats_period with type PARAMETER_NOT_SET  	
+  	}  	  	
+		node_parameters->get_parameter("stats_period", stats_period);
 	
-	if ((stats_period.get_type()!= rclcpp::PARAMETER_NOT_SET)&&(stats_period.as_double()<=0)) {
-	throw std::invalid_argument(
+		if ((stats_period.get_type()!= rclcpp::PARAMETER_NOT_SET)&&(stats_period.as_double()<=0)) {
+		throw std::invalid_argument(
 		          "stats_period must be greater than 0, specified value of " +
 		          std::to_string(stats_period.as_double()) +" ms");
-  	} else if ((stats_period.get_type()== rclcpp::PARAMETER_NOT_SET)&&(options.topic_stats_options.publish_period <= std::chrono::milliseconds(0))) {
+  	}
+  	else if ((stats_period.get_type()== rclcpp::PARAMETER_NOT_SET)&&(options.topic_stats_options.publish_period <= std::chrono::milliseconds(0))) 
+  	{
     	throw std::invalid_argument(
             "topic_stats_options.publish_period must be greater than 0, specified value of " +
             std::to_string(options.topic_stats_options.publish_period.count()) +
             " ms");
   	}
-  
-	node_parameters->declare_parameter("stats_topic", rclcpp::ParameterValue());	//declared stats_topic with type PARAMETER_NOT_SET
-	rclcpp::Parameter stats_topic;
-	node_parameters->get_parameter("stats_topic", stats_topic);
+  	
+  	rclcpp::Parameter stats_topic;
+  	if(!node_parameters->has_parameter("stats_topic")) //if not declared
+  	{
+  		node_parameters->declare_parameter("stats_topic", rclcpp::ParameterValue());	//declared stats_period with type PARAMETER_NOT_SET  	
+  	}	
+		node_parameters->get_parameter("stats_topic", stats_topic);
 	        
 	std::shared_ptr<Publisher<statistics_msgs::msg::MetricsMessage>> publisher =
 		  create_publisher<statistics_msgs::msg::MetricsMessage>(


### PR DESCRIPTION
**What:** Implemented the feature in https://github.com/ros-tooling/roadmap/issues/1 of Meta-Ticket https://github.com/ros2/ros2/issues/917

**Why:** Instead requiring a user to manually enable and configure Topic Statistics via NodeOptions, allow them to enable and configure Topic Statistics through Parameters. It would greatly simplify the ability to use the Topic Statistics feature so that users don't have to modify their subscription options in code.

The following should be configurable at runtime:
- enable / disable
- publish period
- published statistics topic

**How:** For any subscriber, run 
```
ros2 run package_name executable_name [--ros-args -p stats_enabled:="a_bool_value"] [-p stats_period:="a_double_value"] [-p stats_topic:="a_string_value"]
```

**Examples with Nodes in [Topic Statistics Tutorial](https://index.ros.org/doc/ros2/Tutorials/Topics/Topic-Statistics-Tutorial/):** 
```
ros2 run cpp_pubsub listener --ros-args -p stats_enabled:=true -p stats_period:=0.5 -p stats_topic:=new_statistics_topic
ros2 run cpp_pubsub listener_with_topic_statistics --ros-args -p stats_enabled:=false
```

**Note:** 

1. The run-time configuration through Parameters has prioirty over code-configuration via NodeOptions. If the Parameters is not given, the default NodeOptions in code will be used if there is.
2. The type double is used for publish-period since I want to make the period smaller als 1 also possible.

 
**Feedback wanted:** It's my first time to try to contribute an open-source project. Any Feedback is appreciated! @dabonnie


