### PR TITLE
Fix windows build failure

### DIFF
--- a/rclcpp/include/rclcpp/qos_overriding_options.hpp
+++ b/rclcpp/include/rclcpp/qos_overriding_options.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "rclcpp/qos.hpp"
+#include "rclcpp/visibility_control.hpp"
 
 #include "rcl_interfaces/msg/set_parameters_result.hpp"
 #include "rmw/qos_policy_kind.h"
@@ -30,7 +31,7 @@
 namespace rclcpp
 {
 
-enum class QosPolicyKind
+enum class RCLCPP_PUBLIC_TYPE QosPolicyKind
 {
   AvoidRosNamespaceConventions = RMW_QOS_POLICY_AVOID_ROS_NAMESPACE_CONVENTIONS,
   Deadline = RMW_QOS_POLICY_DEADLINE,
@@ -44,9 +45,11 @@ enum class QosPolicyKind
   Invalid = RMW_QOS_POLICY_INVALID,
 };
 
+RCLCPP_PUBLIC
 const char *
 qos_policy_kind_to_cstr(const QosPolicyKind & qpk);
 
+RCLCPP_PUBLIC
 std::ostream &
 operator<<(std::ostream & os, const QosPolicyKind & qpk);
 
@@ -83,7 +86,7 @@ class QosParameters;
  *          depth: 10
  * ```
  */
-struct QosOverridingOptions
+struct RCLCPP_PUBLIC_TYPE QosOverridingOptions
 {
   /// Id of the entity requesting to create parameters.
   std::string id;

--- a/rclcpp/src/rclcpp/qos_overriding_options.cpp
+++ b/rclcpp/src/rclcpp/qos_overriding_options.cpp
@@ -26,6 +26,7 @@
 namespace rclcpp
 {
 
+inline
 const char *
 qos_policy_kind_to_cstr(const QosPolicyKind & qpk)
 {
@@ -36,6 +37,7 @@ qos_policy_kind_to_cstr(const QosPolicyKind & qpk)
   return ret;
 }
 
+inline
 std::ostream &
 operator<<(std::ostream & oss, const QosPolicyKind & qpk)
 {

--- a/rclcpp/src/rclcpp/qos_overriding_options.cpp
+++ b/rclcpp/src/rclcpp/qos_overriding_options.cpp
@@ -26,7 +26,6 @@
 namespace rclcpp
 {
 
-inline
 const char *
 qos_policy_kind_to_cstr(const QosPolicyKind & qpk)
 {
@@ -37,7 +36,6 @@ qos_policy_kind_to_cstr(const QosPolicyKind & qpk)
   return ret;
 }
 
-inline
 std::ostream &
 operator<<(std::ostream & oss, const QosPolicyKind & qpk)
 {


### PR DESCRIPTION
It seems that I ran CI in https://github.com/ros2/rclcpp/pull/1408 using master instead of the appropriate branch :man_facepalming: .

I think this fixes the [Windows issues](https://ci.ros2.org/job/ci_windows/13050/), if not I'm going to revert:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13073)](http://ci.ros2.org/job/ci_linux/13073/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8018)](http://ci.ros2.org/job/ci_linux-aarch64/8018/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10795)](http://ci.ros2.org/job/ci_osx/10795/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13053)](http://ci.ros2.org/job/ci_windows/13053/)