### PR TITLE
Reserve vector capacities and use emplace_back for constructing vectors

### DIFF
--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -265,6 +265,7 @@ public:
       throw std::runtime_error(
               "Can't get available states. State machine is not initialized.");
     }
+    resp->available_states.reserve(state_machine_.transition_map.states_size);
     for (unsigned int i = 0; i < state_machine_.transition_map.states_size; ++i) {
       lifecycle_msgs::msg::State state;
       state.id = static_cast<uint8_t>(state_machine_.transition_map.states[i].id);
@@ -286,6 +287,7 @@ public:
               "Can't get available transitions. State machine is not initialized.");
     }
 
+    resp->available_transitions.reserve(state_machine_.current_state->valid_transition_size);
     for (unsigned int i = 0; i < state_machine_.current_state->valid_transition_size; ++i) {
       auto rcl_transition = state_machine_.current_state->valid_transitions[i];
       lifecycle_msgs::msg::TransitionDescription trans_desc;
@@ -312,6 +314,7 @@ public:
               "Can't get available transitions. State machine is not initialized.");
     }
 
+    resp->available_transitions.reserve(state_machine_.transition_map.transitions_size);
     for (unsigned int i = 0; i < state_machine_.transition_map.transitions_size; ++i) {
       auto rcl_transition = state_machine_.transition_map.transitions[i];
       lifecycle_msgs::msg::TransitionDescription trans_desc;
@@ -336,9 +339,10 @@ public:
   get_available_states()
   {
     std::vector<State> states;
+    states.reserve(state_machine_.transition_map.states_size);
+
     for (unsigned int i = 0; i < state_machine_.transition_map.states_size; ++i) {
-      State state(&state_machine_.transition_map.states[i]);
-      states.push_back(state);
+      states.emplace_back(&state_machine_.transition_map.states[i]);
     }
     return states;
   }
@@ -347,11 +351,10 @@ public:
   get_available_transitions()
   {
     std::vector<Transition> transitions;
+    transitions.reserve(state_machine_.transition_map.transitions_size);
 
     for (unsigned int i = 0; i < state_machine_.transition_map.transitions_size; ++i) {
-      Transition transition(
-        &state_machine_.transition_map.transitions[i]);
-      transitions.push_back(transition);
+      transitions.emplace_back(&state_machine_.transition_map.transitions[i]);
     }
     return transitions;
   }

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -265,12 +265,13 @@ public:
       throw std::runtime_error(
               "Can't get available states. State machine is not initialized.");
     }
-    resp->available_states.reserve(state_machine_.transition_map.states_size);
+
+    resp->available_states.resize(state_machine_.transition_map.states_size);
     for (unsigned int i = 0; i < state_machine_.transition_map.states_size; ++i) {
-      lifecycle_msgs::msg::State state;
-      state.id = static_cast<uint8_t>(state_machine_.transition_map.states[i].id);
-      state.label = static_cast<std::string>(state_machine_.transition_map.states[i].label);
-      resp->available_states.push_back(state);
+      resp->available_states[i].id =
+        static_cast<uint8_t>(state_machine_.transition_map.states[i].id);
+      resp->available_states[i].label =
+        static_cast<std::string>(state_machine_.transition_map.states[i].label);
     }
   }
 
@@ -287,17 +288,17 @@ public:
               "Can't get available transitions. State machine is not initialized.");
     }
 
-    resp->available_transitions.reserve(state_machine_.current_state->valid_transition_size);
+    resp->available_transitions.resize(state_machine_.current_state->valid_transition_size);
     for (unsigned int i = 0; i < state_machine_.current_state->valid_transition_size; ++i) {
+      lifecycle_msgs::msg::TransitionDescription & trans_desc = resp->available_transitions[i];
+
       auto rcl_transition = state_machine_.current_state->valid_transitions[i];
-      lifecycle_msgs::msg::TransitionDescription trans_desc;
       trans_desc.transition.id = static_cast<uint8_t>(rcl_transition.id);
       trans_desc.transition.label = rcl_transition.label;
       trans_desc.start_state.id = static_cast<uint8_t>(rcl_transition.start->id);
       trans_desc.start_state.label = rcl_transition.start->label;
       trans_desc.goal_state.id = static_cast<uint8_t>(rcl_transition.goal->id);
       trans_desc.goal_state.label = rcl_transition.goal->label;
-      resp->available_transitions.push_back(trans_desc);
     }
   }
 
@@ -314,10 +315,11 @@ public:
               "Can't get available transitions. State machine is not initialized.");
     }
 
-    resp->available_transitions.reserve(state_machine_.transition_map.transitions_size);
+    resp->available_transitions.resize(state_machine_.transition_map.transitions_size);
     for (unsigned int i = 0; i < state_machine_.transition_map.transitions_size; ++i) {
+      lifecycle_msgs::msg::TransitionDescription & trans_desc = resp->available_transitions[i];
+
       auto rcl_transition = state_machine_.transition_map.transitions[i];
-      lifecycle_msgs::msg::TransitionDescription trans_desc;
       trans_desc.transition.id = static_cast<uint8_t>(rcl_transition.id);
       trans_desc.transition.label = rcl_transition.label;
       trans_desc.start_state.id = static_cast<uint8_t>(rcl_transition.start->id);

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -326,7 +326,6 @@ public:
       trans_desc.start_state.label = rcl_transition.start->label;
       trans_desc.goal_state.id = static_cast<uint8_t>(rcl_transition.goal->id);
       trans_desc.goal_state.label = rcl_transition.goal->label;
-      resp->available_transitions.push_back(trans_desc);
     }
   }
 


### PR DESCRIPTION
While benchmarking, I noticed some good performance improvements with `get_available_states` and `get_available_transitions`. By reserving, allocations can be reduced and using emplace_back where possible can save a duplicate construction. The biggest benefits are in the `get_available_states()` and `get_available_transitions()` method, where there is a 3-5x performance increase.

Target branch benchmarks:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13075)](http://ci.ros2.org/job/ci_linux/13075/)

This branch:
* Linux [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13077)](https://ci.ros2.org/job/ci_linux/13077/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8021)](http://ci.ros2.org/job/ci_linux-aarch64/8021/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10798)](http://ci.ros2.org/job/ci_osx/10798/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13056)](http://ci.ros2.org/job/ci_windows/13056/)


Signed-off-by: Stephen Brawner <brawner@gmail.com>