### PR TITLE
Adjust logic around finding and erasing guard_condition

### DIFF
--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -683,8 +683,11 @@ Executor::wait_for_work(std::chrono::nanoseconds timeout)
         if (weak_group_ptr.expired() || weak_node_ptr.expired()) {
           invalid_group_ptrs.push_back(weak_group_ptr);
           auto node_guard_pair = weak_nodes_to_guard_conditions_.find(weak_node_ptr);
-          weak_nodes_to_guard_conditions_.erase(weak_node_ptr);
-          memory_strategy_->remove_guard_condition(node_guard_pair->second);
+          if (node_guard_pair != weak_nodes_to_guard_conditions_.end()) {
+            auto guard_condition = node_guard_pair->second;
+            weak_nodes_to_guard_conditions_.erase(weak_node_ptr);
+            memory_strategy_->remove_guard_condition(guard_condition);
+          }
         }
       }
       std::for_each(


### PR DESCRIPTION
Windows debug has been complaining about dereferencing a value initialized map/set iterator, which just meant it was dereferencing `std::map::end()` after the find. This PR adds logic to check the result of find, dereference, then erase. This issue existed on other platforms as well, windows just had the particular assert statement enabled during debug. 

Example failure:
https://ci.ros2.org/view/nightly/job/ci_windows/13158/testReport/junit/projectroot.test/rclcpp/test_executors/

Fixes #1456 

Build with debug, testing `--packages-select rclcpp`
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13160)](http://ci.ros2.org/job/ci_linux/13160/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8091)](http://ci.ros2.org/job/ci_linux-aarch64/8091/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10875)](http://ci.ros2.org/job/ci_osx/10875/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13166)](http://ci.ros2.org/job/ci_windows/13166/)
Signed-off-by: Stephen Brawner <brawner@gmail.com>