### PR TITLE
Change nullptr checks to use ASSERT_TRUE.

### DIFF
--- a/rclcpp/test/rclcpp/allocator/test_allocator_common.cpp
+++ b/rclcpp/test/rclcpp/allocator/test_allocator_common.cpp
@@ -23,6 +23,8 @@ TEST(TestAllocatorCommon, retyped_allocate) {
   void * untyped_allocator = &allocator;
   void * allocated_mem =
     rclcpp::allocator::retyped_allocate<std::allocator<char>>(1u, untyped_allocator);
+  // The more natural check here is ASSERT_NE(nullptr, ptr), but clang static
+  // analysis throws a false-positive memory leak warning.  Use ASSERT_TRUE instead.
   ASSERT_TRUE(nullptr != allocated_mem);
 
   auto code = [&untyped_allocator, allocated_mem]() {
@@ -32,10 +34,14 @@ TEST(TestAllocatorCommon, retyped_allocate) {
   EXPECT_NO_THROW(code());
 
   allocated_mem = allocator.allocate(1);
+  // The more natural check here is ASSERT_NE(nullptr, ptr), but clang static
+  // analysis throws a false-positive memory leak warning.  Use ASSERT_TRUE instead.
   ASSERT_TRUE(nullptr != allocated_mem);
   void * reallocated_mem =
     rclcpp::allocator::retyped_reallocate<int, std::allocator<int>>(
     allocated_mem, 2u, untyped_allocator);
+  // The more natural check here is ASSERT_NE(nullptr, ptr), but clang static
+  // analysis throws a false-positive memory leak warning.  Use ASSERT_TRUE instead.
   ASSERT_TRUE(nullptr != reallocated_mem);
 
   auto code2 = [&untyped_allocator, reallocated_mem]() {

--- a/rclcpp/test/rclcpp/allocator/test_allocator_common.cpp
+++ b/rclcpp/test/rclcpp/allocator/test_allocator_common.cpp
@@ -23,7 +23,7 @@ TEST(TestAllocatorCommon, retyped_allocate) {
   void * untyped_allocator = &allocator;
   void * allocated_mem =
     rclcpp::allocator::retyped_allocate<std::allocator<char>>(1u, untyped_allocator);
-  ASSERT_NE(nullptr, allocated_mem);
+  ASSERT_TRUE(nullptr != allocated_mem);
 
   auto code = [&untyped_allocator, allocated_mem]() {
       rclcpp::allocator::retyped_deallocate<int, std::allocator<int>>(
@@ -32,11 +32,11 @@ TEST(TestAllocatorCommon, retyped_allocate) {
   EXPECT_NO_THROW(code());
 
   allocated_mem = allocator.allocate(1);
-  ASSERT_NE(nullptr, allocated_mem);
+  ASSERT_TRUE(nullptr != allocated_mem);
   void * reallocated_mem =
     rclcpp::allocator::retyped_reallocate<int, std::allocator<int>>(
     allocated_mem, 2u, untyped_allocator);
-  ASSERT_NE(nullptr, reallocated_mem);
+  ASSERT_TRUE(nullptr != reallocated_mem);
 
   auto code2 = [&untyped_allocator, reallocated_mem]() {
       rclcpp::allocator::retyped_deallocate<int, std::allocator<int>>(

--- a/rclcpp/test/rclcpp/allocator/test_allocator_deleter.cpp
+++ b/rclcpp/test/rclcpp/allocator/test_allocator_deleter.cpp
@@ -38,7 +38,7 @@ TEST(TestAllocatorDeleter, construct_destruct) {
 TEST(TestAllocatorDeleter, delete) {
   std::allocator<int> allocator;
   int * some_mem = allocator.allocate(1u);
-  ASSERT_NE(nullptr, some_mem);
+  ASSERT_TRUE(nullptr != some_mem);
 
   rclcpp::allocator::AllocatorDeleter<std::allocator<int>> deleter(&allocator);
   EXPECT_NO_THROW(deleter(some_mem));

--- a/rclcpp/test/rclcpp/allocator/test_allocator_deleter.cpp
+++ b/rclcpp/test/rclcpp/allocator/test_allocator_deleter.cpp
@@ -38,6 +38,8 @@ TEST(TestAllocatorDeleter, construct_destruct) {
 TEST(TestAllocatorDeleter, delete) {
   std::allocator<int> allocator;
   int * some_mem = allocator.allocate(1u);
+  // The more natural check here is ASSERT_NE(nullptr, ptr), but clang static
+  // analysis throws a false-positive memory leak warning.  Use ASSERT_TRUE instead.
   ASSERT_TRUE(nullptr != some_mem);
 
   rclcpp::allocator::AllocatorDeleter<std::allocator<int>> deleter(&allocator);


### PR DESCRIPTION
clang static analysis gets a bit confused going through the
gtest macros, so switch from ASSERT_NE to ASSERT_TRUE as
we've done elsewhere.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>