### PR TITLE
modify excluding callback duration from topic statistics

### DIFF
--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -277,7 +277,6 @@ public:
       return;
     }
     auto typed_message = std::static_pointer_cast<CallbackMessageT>(message);
-    any_callback_.dispatch(typed_message, message_info);
 
     if (subscription_topic_statistics_) {
       const auto nanos = std::chrono::time_point_cast<std::chrono::nanoseconds>(
@@ -285,6 +284,8 @@ public:
       const auto time = rclcpp::Time(nanos.time_since_epoch().count());
       subscription_topic_statistics_->handle_message(*typed_message, time);
     }
+
+    any_callback_.dispatch(typed_message, message_info);
   }
 
   void

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -280,7 +280,8 @@ public:
 
     std::chrono::time_point<std::chrono::system_clock> now;
     if (subscription_topic_statistics_) {
-      // get current time before executing callback to exclude callback duration from topic statistics result.
+      // get current time before executing callback to
+      // exclude callback duration from topic statistics result.
       now = std::chrono::system_clock::now();
     }
 


### PR DESCRIPTION
Closes #1491
Change the execution order of callback dispatch and topic statistic calculating
Signed-off-by: hsgwa <hasegawa@isp.co.jp>

Current topic statistics include callback duration.
To measure communication latency, this patch moves topic statics calculation before callback execution.
It excludes callback duration from statistics results and enables finding whether a specific callback duration is a bottleneck or not.