### PR TITLE
Goal response callback compatibility shim with deprecation of old signature

### DIFF
--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -340,7 +340,7 @@ public:
       throw std::bad_function_call{};
     }
 
-    operator bool() const noexcept {
+    explicit operator bool() const noexcept {
       return new_callback_ || old_callback_;
     }
 

--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -311,11 +311,11 @@ public:
 
     void
     operator()(typename GoalHandle::SharedPtr goal_handle) const {
-      if (RCUTILS_LIKELY(static_cast<bool>(new_callback_))) {
+      if (new_callback_) {
         new_callback_(std::move(goal_handle));
         return;
       }
-      if (static_cast<bool>(old_callback_)) {
+      if (old_callback_) {
         throw std::runtime_error{
           "Cannot call GoalResponseCallback(GoalHandle::SharedPtr) if using the old goal response callback signature."};
       }
@@ -329,11 +329,11 @@ public:
       " is deprecated.")]]
     void
     operator()(std::shared_future<typename GoalHandle::SharedPtr> goal_handle_future) const {
-      if (RCUTILS_LIKELY(static_cast<bool>(old_callback_))) {
+      if (old_callback_) {
         old_callback_(std::move(goal_handle_future));
         return;
       }
-      if (RCUTILS_LIKELY(static_cast<bool>(new_callback_))) {
+      if (new_callback_) {
         new_callback_(std::move(goal_handle_future).get_future().share());
         return;
       }
@@ -351,11 +351,11 @@ public:
       typename GoalHandle::SharedPtr goal_handle,
       std::shared_future<typename GoalHandle::SharedPtr> goal_handle_future) const
     {
-      if (RCUTILS_LIKELY(static_cast<bool>(new_callback_))) {
+      if (new_callback_) {
         new_callback_(std::move(goal_handle));
         return;
       }
-      if (RCUTILS_LIKELY(static_cast<bool>(old_callback_))) {
+      if (old_callback_) {
         old_callback_(std::move(goal_handle_future));
         return;
       }

--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -457,7 +457,7 @@ private:
         if (!goal_response->accepted) {
           promise->set_value(nullptr);
           if (options.goal_response_callback) {
-            options.goal_response_callback(nullptr, promise->get_future().share());
+            options.goal_response_callback(nullptr, future);
           }
           return;
         }
@@ -473,7 +473,7 @@ private:
         }
         promise->set_value(goal_handle);
         if (options.goal_response_callback) {
-          options.goal_response_callback(goal_handle, promise->get_future().share());
+          options.goal_response_callback(goal_handle, future);
         }
 
         if (options.result_callback) {

--- a/rclcpp_action/test/test_client.cpp
+++ b/rclcpp_action/test/test_client.cpp
@@ -536,6 +536,64 @@ TEST_F(TestClientAgainstServer, async_send_goal_with_goal_response_callback_wait
   }
 }
 
+TEST_F(TestClientAgainstServer, async_send_goal_with_deprecated_goal_response_callback)
+{
+  auto action_client = rclcpp_action::create_client<ActionType>(client_node, action_name);
+  ASSERT_TRUE(action_client->wait_for_action_server(WAIT_FOR_SERVER_TIMEOUT));
+
+  bool goal_response_received = false;
+  auto send_goal_ops = rclcpp_action::Client<ActionType>::SendGoalOptions();
+
+#if !defined(_WIN32)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else
+# pragma warning(push)
+# pragma warning(disable: 4996)
+#endif
+  send_goal_ops.goal_response_callback =
+    [&goal_response_received]
+      (std::shared_future<typename ActionGoalHandle::SharedPtr> goal_future)
+    {
+      if (goal_future.get()) {
+        goal_response_received = true;
+      }
+    };
+#if !defined(_WIN32)
+# pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
+#endif
+
+  {
+    ActionGoal bad_goal;
+    bad_goal.order = -1;
+    auto future_goal_handle = action_client->async_send_goal(bad_goal, send_goal_ops);
+    dual_spin_until_future_complete(future_goal_handle);
+    auto goal_handle = future_goal_handle.get();
+    EXPECT_FALSE(goal_response_received);
+    EXPECT_EQ(nullptr, goal_handle);
+  }
+
+  {
+    ActionGoal goal;
+    goal.order = 4;
+    auto future_goal_handle = action_client->async_send_goal(goal, send_goal_ops);
+    dual_spin_until_future_complete(future_goal_handle);
+    auto goal_handle = future_goal_handle.get();
+    EXPECT_TRUE(goal_response_received);
+    EXPECT_EQ(rclcpp_action::GoalStatus::STATUS_ACCEPTED, goal_handle->get_status());
+    EXPECT_FALSE(goal_handle->is_feedback_aware());
+    EXPECT_FALSE(goal_handle->is_result_aware());
+    auto future_result = action_client->async_get_result(goal_handle);
+    EXPECT_TRUE(goal_handle->is_result_aware());
+    dual_spin_until_future_complete(future_result);
+    auto wrapped_result = future_result.get();
+    ASSERT_EQ(5u, wrapped_result.result->sequence.size());
+    EXPECT_EQ(3, wrapped_result.result->sequence.back());
+  }
+}
+
 TEST_F(TestClientAgainstServer, async_send_goal_with_feedback_callback_wait_for_result)
 {
   auto action_client = rclcpp_action::create_client<ActionType>(client_node, action_name);


### PR DESCRIPTION
https://github.com/ros2/rclcpp/pull/1311 broke the goal response callback signature, this adds a compatibility shim so we affect less users in the next galactic release (see [this comment](https://github.com/ros2/rclcpp/pull/1311#issuecomment-728841765)).

I think this is a good idea, but there's a minor caveat: `goal_response_callback` was before a `std::function<>`, with the full `std::function` API available, and now there are a few things that the shim type doesn't implement (e.g.: `assign`, `swap`), though we could try to implement all of them.