### PR TITLE
Fix wrong test expectations

### DIFF
--- a/rclcpp/test/rclcpp/test_publisher.cpp
+++ b/rclcpp/test/rclcpp/test_publisher.cpp
@@ -506,6 +506,6 @@ TEST_F(TestPublisher, run_event_handlers) {
 
   for (const auto & handler : publisher->get_event_handlers()) {
     std::shared_ptr<void> data = handler->take_data();
-    EXPECT_THROW(handler->execute(data), std::runtime_error);
+    handler->execute(data);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/ros2/rclcpp/issues/1475.

The test was passing with fastrtps, because it does nothing in that case :smile: (fastrtps doesn't implement the incompatible qos event).