### PR TITLE
Add instrumentation for linking a timer to a node

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_timers.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_timers.cpp
@@ -16,6 +16,8 @@
 
 #include <string>
 
+#include "tracetools/tracetools.h"
+
 using rclcpp::node_interfaces::NodeTimers;
 
 NodeTimers::NodeTimers(rclcpp::node_interfaces::NodeBaseInterface * node_base)
@@ -44,4 +46,8 @@ NodeTimers::add_timer(
             std::string("Failed to notify wait set on timer creation: ") +
             rmw_get_error_string().str);
   }
+  TRACEPOINT(
+    rclcpp_timer_link_node,
+    static_cast<const void *>(timer->get_timer_handle().get()),
+    static_cast<const void *>(node_base_->get_rcl_node_handle()));
 }


### PR DESCRIPTION
Relates to https://gitlab.com/ros-tracing/tracetools_analysis/-/issues/41

Relates to https://gitlab.com/ros-tracing/ros2_tracing/-/issues/111

Requires https://gitlab.com/ros-tracing/ros2_tracing/-/merge_requests/219

This adds instrumentation for linking a timer to a node.

As mentioned in the linked `tracetools_analysis` issue, from my understanding, timers don't belong to a node in the same way that a publisher/subscriber belongs to a node, at least at the `rcl` level. We can only get the "link" between a node and a timer in `rclcpp`.