### PR TITLE
Use std compliant non-method std::filesystem::exists function

### DIFF
--- a/rclcpp_components/test/test_component_manager.cpp
+++ b/rclcpp_components/test/test_component_manager.cpp
@@ -51,9 +51,10 @@ TEST_F(TestComponentManager, get_component_resources_valid)
   EXPECT_EQ("test_rclcpp_components::TestComponentBar", resources[1].first);
   EXPECT_EQ("test_rclcpp_components::TestComponentNoNode", resources[2].first);
 
-  EXPECT_TRUE(rcpputils::fs::path(resources[0].second).exists());
-  EXPECT_TRUE(rcpputils::fs::path(resources[1].second).exists());
-  EXPECT_TRUE(rcpputils::fs::path(resources[2].second).exists());
+  namespace fs = rcpputils::fs;
+  EXPECT_TRUE(fs::exists(fs::path(resources[0].second)));
+  EXPECT_TRUE(fs::exists(fs::path(resources[1].second)));
+  EXPECT_TRUE(fs::exists(fs::path(resources[2].second)));
 }
 
 TEST_F(TestComponentManager, create_component_factory_valid)


### PR DESCRIPTION
I was looking into updating `rcpputils::fs` to be more compliant with `std::filesystem` for an eventual C++17 migration and found the current functionality includes a `path::exists()` method which [doesn't exist](https://en.cppreference.com/w/cpp/filesystem/path) in `std::filesystem`. This simply changes usage to the non-member function and can be merged regardless of any future changes to `rcpputils`.