### PR TITLE
Make the test of graph users more robust.

### DIFF
--- a/rclcpp/test/rclcpp/node_interfaces/test_node_graph.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_graph.cpp
@@ -84,10 +84,6 @@ protected:
       EXPECT_NO_THROW(node()->wait_for_graph_change(event, timeout));
     }
 
-    // Run notify_graph_change() here to remove the graph_event users we created
-    // in the loop above.
-    node_graph_->notify_graph_change();
-
     return num_things;
   }
 
@@ -132,7 +128,7 @@ TEST_F(TestNodeGraph, construct_from_node)
 
   // get_graph_event is non-const
   EXPECT_NE(nullptr, node()->get_node_graph_interface()->get_graph_event());
-  EXPECT_EQ(1u, node_graph()->count_graph_users());
+  EXPECT_LE(1u, node_graph()->count_graph_users());
 }
 
 TEST_F(TestNodeGraph, get_topic_names_and_types)


### PR DESCRIPTION
In particular, we don't know for sure that the graph will only
have 1 user; we just know that it should have *at least* one
user.  So change that check to be more robust.  This also
lets us get rid of the slightly strange call to 'notify_graph_change'
that was being used to cleanup graph users.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This is a followup to #1503 