### PR TITLE
Reapply "Add get_logging_directory method to rclcpp::Logger (#1509)"

### DIFF
--- a/rclcpp/include/rclcpp/logger.hpp
+++ b/rclcpp/include/rclcpp/logger.hpp
@@ -22,6 +22,12 @@
 
 #include "rcl/node.h"
 #include "rcutils/logging.h"
+#ifdef _WIN32
+# ifndef NOMINMAX
+#   define NOMINMAX
+# endif
+#endif
+#include "rcpputils/filesystem_helper.hpp"
 
 /**
  * \def RCLCPP_LOGGING_ENABLED
@@ -74,6 +80,18 @@ get_logger(const std::string & name);
 RCLCPP_PUBLIC
 Logger
 get_node_logger(const rcl_node_t * node);
+
+/// Get the current logging directory.
+/**
+ * For more details of how the logging directory is determined,
+ * see \ref rcl_logging_get_logging_directory.
+ *
+ * \returns the logging directory being used.
+ * \throws rclcpp::exceptions::RCLError if an unexpected error occurs.
+ */
+RCLCPP_PUBLIC
+rcpputils::fs::path
+get_logging_directory();
 
 class Logger
 {

--- a/rclcpp/include/rclcpp/logger.hpp
+++ b/rclcpp/include/rclcpp/logger.hpp
@@ -22,11 +22,6 @@
 
 #include "rcl/node.h"
 #include "rcutils/logging.h"
-#ifdef _WIN32
-# ifndef NOMINMAX
-#   define NOMINMAX
-# endif
-#endif
 #include "rcpputils/filesystem_helper.hpp"
 
 /**

--- a/rclcpp/src/rclcpp/logger.cpp
+++ b/rclcpp/src/rclcpp/logger.cpp
@@ -14,6 +14,8 @@
 
 #include <string>
 
+#include "rcl_logging_interface/rcl_logging_interface.h"
+
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/logger.hpp"
 #include "rclcpp/logging.hpp"
@@ -44,6 +46,20 @@ get_node_logger(const rcl_node_t * node)
     return logger;
   }
   return rclcpp::get_logger(logger_name);
+}
+
+rcpputils::fs::path
+get_logging_directory()
+{
+  char * log_dir = NULL;
+  auto allocator = rcutils_get_default_allocator();
+  rcl_logging_ret_t ret = rcl_logging_get_logging_directory(allocator, &log_dir);
+  if (RCL_LOGGING_RET_OK != ret) {
+    rclcpp::exceptions::throw_from_rcl_error(ret);
+  }
+  std::string path{log_dir};
+  allocator.deallocate(log_dir, allocator.state);
+  return path;
 }
 
 void

--- a/rclcpp/test/rclcpp/test_logger.cpp
+++ b/rclcpp/test/rclcpp/test_logger.cpp
@@ -17,6 +17,8 @@
 #include <memory>
 #include <string>
 
+#include "rcutils/env.h"
+
 #include "rclcpp/logger.hpp"
 #include "rclcpp/logging.hpp"
 #include "rclcpp/node.hpp"
@@ -156,4 +158,23 @@ TEST(TestLogger, set_level) {
 
   rcutils_logging_set_output_handler(previous_output_handler);
   EXPECT_EQ(RCUTILS_RET_OK, rcutils_logging_shutdown());
+}
+
+TEST(TestLogger, get_logging_directory) {
+  ASSERT_EQ(true, rcutils_set_env("HOME", "/fake_home_dir"));
+  ASSERT_EQ(true, rcutils_set_env("USERPROFILE", nullptr));
+  ASSERT_EQ(true, rcutils_set_env("ROS_LOG_DIR", nullptr));
+  ASSERT_EQ(true, rcutils_set_env("ROS_HOME", nullptr));
+
+  auto path = rclcpp::get_logging_directory();
+  auto expected_path = rcpputils::fs::path{"/fake_home_dir"} / ".ros" / "log";
+
+  // TODO(ivanpauno): Add operator== to rcpputils::fs::path
+  auto it = path.cbegin();
+  auto eit = expected_path.cbegin();
+  for (; it != path.cend() && eit != expected_path.cend(); ++it, ++eit) {
+    EXPECT_EQ(*eit, *it);
+  }
+  EXPECT_EQ(it, path.cend());
+  EXPECT_EQ(eit, expected_path.cend());
 }


### PR DESCRIPTION
This should be safe to reapply now that https://github.com/ros2/rcpputils/pull/118 went in.