### PR TITLE
Call rclcpp::shutdown in test_node for clean shutdown on Windows

### DIFF
--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -43,6 +43,11 @@ protected:
     rclcpp::init(0, nullptr);
   }
 
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
+
   void SetUp() override
   {
     test_resources_path /= "test_node";


### PR DESCRIPTION
The graph_listener thread is started in the background in some of the tests and this thread is killed by Windows prior to executing global destructors if it is still running when leaving main().  This then corrupts state because the RMW layer is blocking in a waitset and causes Cyclone to hang trying to destroy the waitset.

This fixes the issue mentioned in https://github.com/ros2/rmw/pull/293#issuecomment-758322651 (for me locally anyway!)