### PR TITLE
Allow timers to keep up the intended rate in MultiThreadedExecutor

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -39,6 +39,7 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/clock.cpp
   src/rclcpp/context.cpp
   src/rclcpp/contexts/default_context.cpp
+  src/rclcpp/detail/mutex_two_priorities.cpp
   src/rclcpp/detail/rmw_implementation_specific_payload.cpp
   src/rclcpp/detail/rmw_implementation_specific_publisher_payload.cpp
   src/rclcpp/detail/rmw_implementation_specific_subscription_payload.cpp

--- a/rclcpp/include/rclcpp/detail/mutex_two_priorities.hpp
+++ b/rclcpp/include/rclcpp/detail/mutex_two_priorities.hpp
@@ -1,0 +1,90 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__DETAIL__MUTEX_TWO_PRIORITIES_HPP_
+#define RCLCPP__DETAIL__MUTEX_TWO_PRIORITIES_HPP_
+
+#include <mutex>
+
+namespace rclcpp
+{
+namespace detail
+{
+/// \internal A mutex that has two locking mechanism, one with higher priority than the other.
+/**
+ * After the current mutex owner release the lock, a thread that used the high
+ * priority mechanism will have priority over threads that used the low priority mechanism.
+ */
+class MutexTwoPriorities
+{
+public:
+  class HighPriorityMutex
+  {
+public:
+    explicit HighPriorityMutex(MutexTwoPriorities & parent)
+    : parent_(parent) {}
+
+    void lock()
+    {
+      parent_.data_.lock();
+    }
+
+    void unlock()
+    {
+      parent_.data_.unlock();
+    }
+
+private:
+    MutexTwoPriorities & parent_;
+  };
+
+  class LowPriorityMutex
+  {
+public:
+    explicit LowPriorityMutex(MutexTwoPriorities & parent)
+    : parent_(parent) {}
+
+    void lock()
+    {
+      std::unique_lock<std::mutex> barrier_guard{parent_.barrier_};
+      parent_.data_.lock();
+      barrier_guard.release();
+    }
+
+    void unlock()
+    {
+      // data_.unlock(); low_prio_.unlock()
+      std::lock_guard<std::mutex> barrier_guard{parent_.barrier_, std::adopt_lock};
+      parent_.data_.unlock();
+    }
+
+private:
+    MutexTwoPriorities & parent_;
+  };
+
+  HighPriorityMutex get_high_priority_mutex() {return HighPriorityMutex{*this};}
+  LowPriorityMutex get_low_priority_mutex() {return LowPriorityMutex{*this};}
+
+private:
+  // Implementation detail: the idea here is that only one low priority thread can be
+  // trying to take the data_ mutex while the others are excluded by the barrier_ mutex.
+  // All high priority threads are already waiting for the data_ mutex.
+  std::mutex barrier_;
+  std::mutex data_;
+  };
+
+}  // namespace detail
+}  // namespace rclcpp
+
+#endif  // RCLCPP__DETAIL__MUTEX_TWO_PRIORITIES_HPP_

--- a/rclcpp/include/rclcpp/detail/mutex_two_priorities.hpp
+++ b/rclcpp/include/rclcpp/detail/mutex_two_priorities.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Open Source Robotics Foundation, Inc.
+// Copyright 2021 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,18 +32,11 @@ public:
   class HighPriorityMutex
   {
 public:
-    explicit HighPriorityMutex(MutexTwoPriorities & parent)
-    : parent_(parent) {}
+    explicit HighPriorityMutex(MutexTwoPriorities & parent);
 
-    void lock()
-    {
-      parent_.data_.lock();
-    }
+    void lock();
 
-    void unlock()
-    {
-      parent_.data_.unlock();
-    }
+    void unlock();
 
 private:
     MutexTwoPriorities & parent_;
@@ -52,29 +45,21 @@ private:
   class LowPriorityMutex
   {
 public:
-    explicit LowPriorityMutex(MutexTwoPriorities & parent)
-    : parent_(parent) {}
+    explicit LowPriorityMutex(MutexTwoPriorities & parent);
 
-    void lock()
-    {
-      std::unique_lock<std::mutex> barrier_guard{parent_.barrier_};
-      parent_.data_.lock();
-      barrier_guard.release();
-    }
+    void lock();
 
-    void unlock()
-    {
-      // data_.unlock(); low_prio_.unlock()
-      std::lock_guard<std::mutex> barrier_guard{parent_.barrier_, std::adopt_lock};
-      parent_.data_.unlock();
-    }
+    void unlock();
 
 private:
     MutexTwoPriorities & parent_;
   };
 
-  HighPriorityMutex get_high_priority_mutex() {return HighPriorityMutex{*this};}
-  LowPriorityMutex get_low_priority_mutex() {return LowPriorityMutex{*this};}
+  HighPriorityMutex
+  get_high_priority_mutex();
+
+  LowPriorityMutex
+  get_low_priority_mutex();
 
 private:
   // Implementation detail: the idea here is that only one low priority thread can be
@@ -82,7 +67,7 @@ private:
   // All high priority threads are already waiting for the data_ mutex.
   std::mutex barrier_;
   std::mutex data_;
-  };
+};
 
 }  // namespace detail
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/detail/mutex_two_priorities.hpp
+++ b/rclcpp/include/rclcpp/detail/mutex_two_priorities.hpp
@@ -29,10 +29,10 @@ namespace detail
 class MutexTwoPriorities
 {
 public:
-  class HighPriorityMutex
+  class HighPriorityLockable
   {
 public:
-    explicit HighPriorityMutex(MutexTwoPriorities & parent);
+    explicit HighPriorityLockable(MutexTwoPriorities & parent);
 
     void lock();
 
@@ -42,10 +42,10 @@ private:
     MutexTwoPriorities & parent_;
   };
 
-  class LowPriorityMutex
+  class LowPriorityLockable
   {
 public:
-    explicit LowPriorityMutex(MutexTwoPriorities & parent);
+    explicit LowPriorityLockable(MutexTwoPriorities & parent);
 
     void lock();
 
@@ -55,11 +55,11 @@ private:
     MutexTwoPriorities & parent_;
   };
 
-  HighPriorityMutex
-  get_high_priority_mutex();
+  HighPriorityLockable
+  get_high_priority_lockable();
 
-  LowPriorityMutex
-  get_low_priority_mutex();
+  LowPriorityLockable
+  get_low_priority_lockable();
 
 private:
   // Implementation detail: the idea here is that only one low priority thread can be

--- a/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
@@ -22,6 +22,7 @@
 #include <thread>
 #include <unordered_map>
 
+#include "rclcpp/detail/mutex_two_priorities.hpp"
 #include "rclcpp/executor.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/memory_strategies.hpp"
@@ -81,70 +82,7 @@ protected:
 private:
   RCLCPP_DISABLE_COPY(MultiThreadedExecutor)
 
-  /// \internal A mutex that has two locking mechanism, one with higher priority than the other.
-  /**
-   * After the current mutex owner release the lock, a thread that used the high
-   * priority mechanism will have priority over threads that used the low priority mechanism.
-   */
-  class MutexTwoPriorities
-  {
-public:
-    class HpMutex
-    {
-public:
-      explicit HpMutex(MutexTwoPriorities & parent)
-      : parent_(parent) {}
-
-      void lock()
-      {
-        parent_.data_.lock();
-      }
-
-      void unlock()
-      {
-        parent_.data_.unlock();
-      }
-
-private:
-      MutexTwoPriorities & parent_;
-    };
-
-    class LpMutex
-    {
-public:
-      explicit LpMutex(MutexTwoPriorities & parent)
-      : parent_(parent) {}
-
-      void lock()
-      {
-        // low_prio_.lock(); data_.lock();
-        std::unique_lock<std::mutex> lpg{parent_.low_prio_};
-        parent_.data_.lock();
-        lpg.release();
-      }
-
-      void unlock()
-      {
-        // data_.unlock(); low_prio_.unlock()
-        std::lock_guard<std::mutex> lpg{parent_.low_prio_, std::adopt_lock};
-        parent_.data_.unlock();
-      }
-
-private:
-      MutexTwoPriorities & parent_;
-    };
-
-    HpMutex hp() {return HpMutex{*this};}
-    LpMutex lp() {return LpMutex{*this};}
-
-private:
-    // Implementation detail: the whole idea here is that only one low priority thread can be
-    // trying to take the data_ mutex, while all high priority threads are already waiting there.
-    std::mutex low_prio_;
-    std::mutex data_;
-  };
-
-  MutexTwoPriorities wait_mutex_;
+  detail::MutexTwoPriorities wait_mutex_;
   size_t number_of_threads_;
   bool yield_before_execute_;
   std::chrono::nanoseconds next_exec_timeout_;

--- a/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
@@ -81,66 +81,13 @@ protected:
 private:
   RCLCPP_DISABLE_COPY(MultiThreadedExecutor)
 
-  /// \internal A mutex that has two locking mechanism, one with higher priority than the other.
-  /**
-   * After the current mutex owner release the lock, a thread that used the high
-   * priority mechanism will have priority over threads that used the low priority mechanism.
-   */
-  class MutexTwoPriorities {
-public:
-    class HpMutex
-    {
-public:
-      HpMutex(MutexTwoPriorities & parent) : parent_(parent) {}
-
-      void lock() {
-        parent_.data_.lock();
-      }
-
-      void unlock() {
-        parent_.data_.unlock();
-      }
-private:
-      MutexTwoPriorities & parent_;
-    };
-
-    class LpMutex
-    {
-public:
-      LpMutex(MutexTwoPriorities & parent) : parent_(parent) {}
-
-      void lock() {
-        // low_prio_.lock(); data_.lock();
-        std::unique_lock<std::mutex> lpg{parent_.low_prio_};
-        parent_.data_.lock();
-        lpg.release();
-      }
-
-      void unlock() {
-        // data_.unlock(); low_prio_.unlock()
-        std::lock_guard<std::mutex> lpg{parent_.low_prio_, std::adopt_lock};
-        parent_.data_.unlock();
-      }
-private:
-      MutexTwoPriorities & parent_;
-    };
-
-    HpMutex hp() {return HpMutex{*this};}
-    LpMutex lp() {return LpMutex{*this};}
-  
-private:
-    // Implementation detail: the whole idea here is that only one low priority thread can be
-    // trying to take the data_ mutex, while all high priority threads are already waiting there.
-    std::mutex low_prio_;
-    std::mutex data_;
-  };
-
-  MutexTwoPriorities wait_mutex_;
+  std::mutex wait_mutex_;
   size_t number_of_threads_;
   bool yield_before_execute_;
   std::chrono::nanoseconds next_exec_timeout_;
 
   std::set<TimerBase::SharedPtr> scheduled_timers_;
+  std::mutex scheduled_timers_mutex_;
 };
 
 }  // namespace executors

--- a/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
@@ -86,20 +86,25 @@ private:
    * After the current mutex owner release the lock, a thread that used the high
    * priority mechanism will have priority over threads that used the low priority mechanism.
    */
-  class MutexTwoPriorities {
+  class MutexTwoPriorities
+  {
 public:
     class HpMutex
     {
 public:
-      HpMutex(MutexTwoPriorities & parent) : parent_(parent) {}
+      explicit HpMutex(MutexTwoPriorities & parent)
+      : parent_(parent) {}
 
-      void lock() {
+      void lock()
+      {
         parent_.data_.lock();
       }
 
-      void unlock() {
+      void unlock()
+      {
         parent_.data_.unlock();
       }
+
 private:
       MutexTwoPriorities & parent_;
     };
@@ -107,27 +112,31 @@ private:
     class LpMutex
     {
 public:
-      LpMutex(MutexTwoPriorities & parent) : parent_(parent) {}
+      explicit LpMutex(MutexTwoPriorities & parent)
+      : parent_(parent) {}
 
-      void lock() {
+      void lock()
+      {
         // low_prio_.lock(); data_.lock();
         std::unique_lock<std::mutex> lpg{parent_.low_prio_};
         parent_.data_.lock();
         lpg.release();
       }
 
-      void unlock() {
+      void unlock()
+      {
         // data_.unlock(); low_prio_.unlock()
         std::lock_guard<std::mutex> lpg{parent_.low_prio_, std::adopt_lock};
         parent_.data_.unlock();
       }
+
 private:
       MutexTwoPriorities & parent_;
     };
 
     HpMutex hp() {return HpMutex{*this};}
     LpMutex lp() {return LpMutex{*this};}
-  
+
 private:
     // Implementation detail: the whole idea here is that only one low priority thread can be
     // trying to take the data_ mutex, while all high priority threads are already waiting there.

--- a/rclcpp/src/rclcpp/detail/mutex_two_priorities.cpp
+++ b/rclcpp/src/rclcpp/detail/mutex_two_priorities.cpp
@@ -1,0 +1,71 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/detail/mutex_two_priorities.hpp"
+
+#include <mutex>
+
+namespace rclcpp
+{
+namespace detail
+{
+
+using LowPriorityMutex = MutexTwoPriorities::LowPriorityMutex;
+using HighPriorityMutex = MutexTwoPriorities::HighPriorityMutex;
+
+HighPriorityMutex::HighPriorityMutex(MutexTwoPriorities & parent) : parent_(parent) {}
+
+void
+HighPriorityMutex::lock()
+{
+  parent_.data_.lock();
+}
+
+void
+HighPriorityMutex::unlock()
+{
+  parent_.data_.unlock();
+}
+
+LowPriorityMutex::LowPriorityMutex(MutexTwoPriorities & parent) : parent_(parent) {}
+
+void
+LowPriorityMutex::lock()
+{
+  std::unique_lock<std::mutex> barrier_guard{parent_.barrier_};
+  parent_.data_.lock();
+  barrier_guard.release();
+}
+
+void
+LowPriorityMutex::unlock()
+{
+  std::lock_guard<std::mutex> barrier_guard{parent_.barrier_, std::adopt_lock};
+  parent_.data_.unlock();
+}
+
+HighPriorityMutex
+MutexTwoPriorities::get_high_priority_mutex()
+{
+  return HighPriorityMutex{*this};
+}
+
+LowPriorityMutex
+MutexTwoPriorities::get_low_priority_mutex()
+{
+  return LowPriorityMutex{*this};
+}
+
+}  // namespace detail
+}  // namespace rclcpp

--- a/rclcpp/src/rclcpp/detail/mutex_two_priorities.cpp
+++ b/rclcpp/src/rclcpp/detail/mutex_two_priorities.cpp
@@ -21,27 +21,31 @@ namespace rclcpp
 namespace detail
 {
 
-using LowPriorityMutex = MutexTwoPriorities::LowPriorityMutex;
-using HighPriorityMutex = MutexTwoPriorities::HighPriorityMutex;
+using LowPriorityLockable = MutexTwoPriorities::LowPriorityLockable;
+using HighPriorityLockable = MutexTwoPriorities::HighPriorityLockable;
 
-HighPriorityMutex::HighPriorityMutex(MutexTwoPriorities & parent) : parent_(parent) {}
+HighPriorityLockable::HighPriorityLockable(MutexTwoPriorities & parent)
+: parent_(parent)
+{}
 
 void
-HighPriorityMutex::lock()
+HighPriorityLockable::lock()
 {
   parent_.data_.lock();
 }
 
 void
-HighPriorityMutex::unlock()
+HighPriorityLockable::unlock()
 {
   parent_.data_.unlock();
 }
 
-LowPriorityMutex::LowPriorityMutex(MutexTwoPriorities & parent) : parent_(parent) {}
+LowPriorityLockable::LowPriorityLockable(MutexTwoPriorities & parent)
+: parent_(parent)
+{}
 
 void
-LowPriorityMutex::lock()
+LowPriorityLockable::lock()
 {
   std::unique_lock<std::mutex> barrier_guard{parent_.barrier_};
   parent_.data_.lock();
@@ -49,22 +53,22 @@ LowPriorityMutex::lock()
 }
 
 void
-LowPriorityMutex::unlock()
+LowPriorityLockable::unlock()
 {
   std::lock_guard<std::mutex> barrier_guard{parent_.barrier_, std::adopt_lock};
   parent_.data_.unlock();
 }
 
-HighPriorityMutex
-MutexTwoPriorities::get_high_priority_mutex()
+HighPriorityLockable
+MutexTwoPriorities::get_high_priority_lockable()
 {
-  return HighPriorityMutex{*this};
+  return HighPriorityLockable{*this};
 }
 
-LowPriorityMutex
-MutexTwoPriorities::get_low_priority_mutex()
+LowPriorityLockable
+MutexTwoPriorities::get_low_priority_lockable()
 {
-  return LowPriorityMutex{*this};
+  return LowPriorityLockable{*this};
 }
 
 }  // namespace detail

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -22,6 +22,7 @@
 #include "rclcpp/utilities.hpp"
 #include "rclcpp/scope_exit.hpp"
 
+using rclcpp::detail::MutexTwoPriorities;
 using rclcpp::executors::MultiThreadedExecutor;
 
 MultiThreadedExecutor::MultiThreadedExecutor(
@@ -44,7 +45,6 @@ MultiThreadedExecutor::~MultiThreadedExecutor() {}
 void
 MultiThreadedExecutor::spin()
 {
-  using MutexTwoPriorities = rclcpp::executors::MultiThreadedExecutor::MutexTwoPriorities;
   if (spinning.exchange(true)) {
     throw std::runtime_error("spin() called while already spinning");
   }
@@ -52,8 +52,8 @@ MultiThreadedExecutor::spin()
   std::vector<std::thread> threads;
   size_t thread_id = 0;
   {
-    auto lp_wait_mutex = wait_mutex_.lp();
-    std::lock_guard<MutexTwoPriorities::LpMutex> wait_lock(lp_wait_mutex);
+    auto low_priority_wait_mutex = wait_mutex_.get_low_priority_mutex();
+    std::lock_guard<MutexTwoPriorities::LowPriorityMutex> wait_lock(low_priority_wait_mutex);
     for (; thread_id < number_of_threads_ - 1; ++thread_id) {
       auto func = std::bind(&MultiThreadedExecutor::run, this, thread_id);
       threads.emplace_back(func);
@@ -75,12 +75,11 @@ MultiThreadedExecutor::get_number_of_threads()
 void
 MultiThreadedExecutor::run(size_t)
 {
-  using MutexTwoPriorities = rclcpp::executors::MultiThreadedExecutor::MutexTwoPriorities;
   while (rclcpp::ok(this->context_) && spinning.load()) {
     rclcpp::AnyExecutable any_exec;
     {
-      auto lp_wait_mutex = wait_mutex_.lp();
-      std::lock_guard<MutexTwoPriorities::LpMutex> wait_lock(lp_wait_mutex);
+      auto low_priority_wait_mutex = wait_mutex_.get_low_priority_mutex();
+      std::lock_guard<MutexTwoPriorities::LowPriorityMutex> wait_lock(low_priority_wait_mutex);
       if (!rclcpp::ok(this->context_) || !spinning.load()) {
         return;
       }
@@ -107,8 +106,8 @@ MultiThreadedExecutor::run(size_t)
     execute_any_executable(any_exec);
 
     if (any_exec.timer) {
-      auto hp_wait_mutex = wait_mutex_.hp();
-      std::lock_guard<MutexTwoPriorities::HpMutex> wait_lock(hp_wait_mutex);
+      auto high_priority_wait_mutex = wait_mutex_.get_high_priority_mutex();
+      std::lock_guard<MutexTwoPriorities::HighPriorityMutex> wait_lock(high_priority_wait_mutex);
       auto it = scheduled_timers_.find(any_exec.timer);
       if (it != scheduled_timers_.end()) {
         scheduled_timers_.erase(it);

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -113,7 +113,7 @@ MultiThreadedExecutor::run(size_t)
       // DON'T DELETE THE scheduled_timers_mutex_ AND REPLACE IT WITH THE wait_mutex_ here.
       // Now, this mutex will only compete with ONE worker thread that's is trying to insert
       // a timer.
-      // (and also, N other worker threads also trying to delete a timer).
+      // (and also, N other worker threads trying to delete a timer).
       // If the wait_mutex_ is used here, this will compete with all the other worker threads!!!
       // If we're waiting too long too remove the scheduled timer, maybe we are discarding a timer
       // execution that we shouldn't!

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -52,8 +52,8 @@ MultiThreadedExecutor::spin()
   std::vector<std::thread> threads;
   size_t thread_id = 0;
   {
-    auto low_priority_wait_mutex = wait_mutex_.get_low_priority_mutex();
-    std::lock_guard<MutexTwoPriorities::LowPriorityMutex> wait_lock(low_priority_wait_mutex);
+    auto low_priority_wait_mutex = wait_mutex_.get_low_priority_lockable();
+    std::lock_guard<MutexTwoPriorities::LowPriorityLockable> wait_lock(low_priority_wait_mutex);
     for (; thread_id < number_of_threads_ - 1; ++thread_id) {
       auto func = std::bind(&MultiThreadedExecutor::run, this, thread_id);
       threads.emplace_back(func);
@@ -78,8 +78,8 @@ MultiThreadedExecutor::run(size_t)
   while (rclcpp::ok(this->context_) && spinning.load()) {
     rclcpp::AnyExecutable any_exec;
     {
-      auto low_priority_wait_mutex = wait_mutex_.get_low_priority_mutex();
-      std::lock_guard<MutexTwoPriorities::LowPriorityMutex> wait_lock(low_priority_wait_mutex);
+      auto low_priority_wait_mutex = wait_mutex_.get_low_priority_lockable();
+      std::lock_guard<MutexTwoPriorities::LowPriorityLockable> wait_lock(low_priority_wait_mutex);
       if (!rclcpp::ok(this->context_) || !spinning.load()) {
         return;
       }
@@ -106,8 +106,8 @@ MultiThreadedExecutor::run(size_t)
     execute_any_executable(any_exec);
 
     if (any_exec.timer) {
-      auto high_priority_wait_mutex = wait_mutex_.get_high_priority_mutex();
-      std::lock_guard<MutexTwoPriorities::HighPriorityMutex> wait_lock(high_priority_wait_mutex);
+      auto high_priority_wait_mutex = wait_mutex_.get_high_priority_lockable();
+      std::lock_guard<MutexTwoPriorities::HighPriorityLockable> wait_lock(high_priority_wait_mutex);
       auto it = scheduled_timers_.find(any_exec.timer);
       if (it != scheduled_timers_.end()) {
         scheduled_timers_.erase(it);

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -44,7 +44,6 @@ MultiThreadedExecutor::~MultiThreadedExecutor() {}
 void
 MultiThreadedExecutor::spin()
 {
-  using MutexTwoPriorities = rclcpp::executors::MultiThreadedExecutor::MutexTwoPriorities;
   if (spinning.exchange(true)) {
     throw std::runtime_error("spin() called while already spinning");
   }
@@ -52,8 +51,7 @@ MultiThreadedExecutor::spin()
   std::vector<std::thread> threads;
   size_t thread_id = 0;
   {
-    auto lp_wait_mutex = wait_mutex_.lp();
-    std::lock_guard<MutexTwoPriorities::LpMutex> wait_lock(lp_wait_mutex);
+    std::lock_guard<std::mutex> wait_lock(wait_mutex_);
     for (; thread_id < number_of_threads_ - 1; ++thread_id) {
       auto func = std::bind(&MultiThreadedExecutor::run, this, thread_id);
       threads.emplace_back(func);
@@ -75,12 +73,10 @@ MultiThreadedExecutor::get_number_of_threads()
 void
 MultiThreadedExecutor::run(size_t)
 {
-  using MutexTwoPriorities = rclcpp::executors::MultiThreadedExecutor::MutexTwoPriorities;
   while (rclcpp::ok(this->context_) && spinning.load()) {
     rclcpp::AnyExecutable any_exec;
     {
-      auto lp_wait_mutex = wait_mutex_.lp();
-      std::lock_guard<MutexTwoPriorities::LpMutex> wait_lock(lp_wait_mutex);
+      std::lock_guard<std::mutex> wait_guard{wait_mutex_};
       if (!rclcpp::ok(this->context_) || !spinning.load()) {
         return;
       }
@@ -89,6 +85,13 @@ MultiThreadedExecutor::run(size_t)
       }
       if (any_exec.timer) {
         // Guard against multiple threads getting the same timer.
+
+        // THIS MUST BE DONE WITH BOTH THE WAIT_MUTEX AND SCHEDULED TIMERS MUTEX TAKEN!!
+        // It might seem unnecessary, but you avoid the following race:
+        // Thread A: get timer, context switch.
+        // Thread B: get timer, insert scheduled timer, execute timer, remove scheduled timer.
+        // Thread A: execute timer.
+        std::lock_guard<std::mutex> scheduled_timers_guard{scheduled_timers_mutex_};
         if (scheduled_timers_.count(any_exec.timer) != 0) {
           // Make sure that any_exec's callback group is reset before
           // the lock is released.
@@ -107,8 +110,15 @@ MultiThreadedExecutor::run(size_t)
     execute_any_executable(any_exec);
 
     if (any_exec.timer) {
-      auto hp_wait_mutex = wait_mutex_.hp();
-      std::lock_guard<MutexTwoPriorities::HpMutex> wait_lock(hp_wait_mutex);
+      // DON'T DELETE THE scheduled_timers_mutex_ AND REPLACE IT WITH THE wait_mutex_ here.
+      // Now, this mutex will only compete with ONE worker thread that's is trying to insert
+      // a timer.
+      // (and also, N other worker threads also trying to delete a timer).
+      // If the wait_mutex_ is used here, this will compete with all the other worker threads!!!
+      // If we're waiting too long too remove the scheduled timer, maybe we are discarding a timer
+      // execution that we shouldn't!
+      // Of course, this can still happen if the callback is too long ...
+      std::lock_guard<std::mutex> scheduled_timers_guard{scheduled_timers_mutex_};
       auto it = scheduled_timers_.find(any_exec.timer);
       if (it != scheduled_timers_.end()) {
         scheduled_timers_.erase(it);

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -113,7 +113,7 @@ MultiThreadedExecutor::run(size_t)
       // DON'T DELETE THE scheduled_timers_mutex_ AND REPLACE IT WITH THE wait_mutex_ here.
       // Now, this mutex will only compete with ONE worker thread that's is trying to insert
       // a timer.
-      // (and also, N other worker threads trying to delete a timer).
+      // (and also, N other worker threads also trying to delete a timer).
       // If the wait_mutex_ is used here, this will compete with all the other worker threads!!!
       // If we're waiting too long too remove the scheduled timer, maybe we are discarding a timer
       // execution that we shouldn't!


### PR DESCRIPTION
Fixes https://github.com/ros2/rclcpp/issues/1487.

Something in between https://github.com/ros2/rclcpp/pull/621 and https://github.com/ros2/rclcpp/pull/1168.
The whole idea of the `scheduled_timers_` container seems wrong, but this works around the issue.