### PR TITLE
Change to using unique_ptrs for DummyExecutor.

### DIFF
--- a/rclcpp/test/rclcpp/test_executor.cpp
+++ b/rclcpp/test/rclcpp/test_executor.cpp
@@ -122,14 +122,14 @@ TEST_F(TestExecutor, constructor_bad_guard_condition_init) {
   auto mock = mocking_utils::patch_and_return(
     "lib:rclcpp", rcl_guard_condition_init, RCL_RET_ERROR);
   EXPECT_THROW(
-    std::unique_ptr<DummyExecutor>(new DummyExecutor()),
+    static_cast<void>(std::make_unique<DummyExecutor>()),
     rclcpp::exceptions::RCLError);
 }
 
 TEST_F(TestExecutor, constructor_bad_wait_set_init) {
   auto mock = mocking_utils::patch_and_return("lib:rclcpp", rcl_wait_set_init, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
-    std::unique_ptr<DummyExecutor>(new DummyExecutor()),
+    static_cast<void>(std::make_unique<DummyExecutor>()),
     std::runtime_error("Failed to create wait set in Executor constructor: error not set"));
 }
 

--- a/rclcpp/test/rclcpp/test_executor.cpp
+++ b/rclcpp/test/rclcpp/test_executor.cpp
@@ -122,14 +122,14 @@ TEST_F(TestExecutor, constructor_bad_guard_condition_init) {
   auto mock = mocking_utils::patch_and_return(
     "lib:rclcpp", rcl_guard_condition_init, RCL_RET_ERROR);
   EXPECT_THROW(
-    new DummyExecutor(),
+    std::make_unique<DummyExecutor>(),
     rclcpp::exceptions::RCLError);
 }
 
 TEST_F(TestExecutor, constructor_bad_wait_set_init) {
   auto mock = mocking_utils::patch_and_return("lib:rclcpp", rcl_wait_set_init, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
-    new DummyExecutor(),
+    std::make_unique<DummyExecutor>(),
     std::runtime_error("Failed to create wait set in Executor constructor: error not set"));
 }
 

--- a/rclcpp/test/rclcpp/test_executor.cpp
+++ b/rclcpp/test/rclcpp/test_executor.cpp
@@ -122,14 +122,14 @@ TEST_F(TestExecutor, constructor_bad_guard_condition_init) {
   auto mock = mocking_utils::patch_and_return(
     "lib:rclcpp", rcl_guard_condition_init, RCL_RET_ERROR);
   EXPECT_THROW(
-    std::make_unique<DummyExecutor>(),
+    std::unique_ptr<DummyExecutor>(new DummyExecutor()),
     rclcpp::exceptions::RCLError);
 }
 
 TEST_F(TestExecutor, constructor_bad_wait_set_init) {
   auto mock = mocking_utils::patch_and_return("lib:rclcpp", rcl_wait_set_init, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
-    std::make_unique<DummyExecutor>(),
+    std::unique_ptr<DummyExecutor>(new DummyExecutor()),
     std::runtime_error("Failed to create wait set in Executor constructor: error not set"));
 }
 


### PR DESCRIPTION
clang static analysis suggested that there was a possible memory
leak here, and it is right.  The test is expecting to throw during
the constructor, in which case the memory would be automatically
freed.  However, if the test did *not* throw for some reason,
we would leak the memory.  Switch to using a unique_ptr here
which will free the memory in all cases at the end of the scope.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>