### PR TITLE
Fix error when using IPC with StaticSingleThreadExecutor

### DIFF
--- a/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
@@ -323,8 +323,7 @@ StaticExecutorEntitiesCollector::add_callback_group(
     throw std::runtime_error("Callback group was already added to executor.");
   }
   if (is_new_node) {
-    rclcpp::node_interfaces::NodeBaseInterface::WeakPtr node_weak_ptr(node_ptr);
-    weak_nodes_to_guard_conditions_[node_weak_ptr] = node_ptr->get_notify_guard_condition();
+    weak_nodes_to_guard_conditions_[node_ptr] = node_ptr->get_notify_guard_condition();
     return true;
   }
   return false;

--- a/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
@@ -175,9 +175,10 @@ StaticSingleThreadedExecutor::execute_ready_executables()
   }
   // Execute all the ready waitables
   for (size_t i = 0; i < entities_collector_->get_number_of_waitables(); ++i) {
-    if (entities_collector_->get_waitable(i)->is_ready(&wait_set_)) {
-      std::shared_ptr<void> shared_ptr;
-      entities_collector_->get_waitable(i)->execute(shared_ptr);
+    auto waitable = entities_collector_->get_waitable(i);
+    if (waitable->is_ready(&wait_set_)) {
+      auto data = waitable->take_data();
+      waitable->execute(data);
     }
   }
 }


### PR DESCRIPTION
Currently trying to use IPC with the **StaticSingleThreadExecutor** yields:
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  'data' is empty
Aborted (core dumped)
```
This is because the new API `execute(data)` for waitables requires `data` to be non `nullptr`. This PR makes the waitable to take the data (the message itself, on a intra-process subscription) before using it as the `execute` parameter on the static executor.

Taking the oportunity also fixing here a `cppcheck` which was failing:
```
[static_executor_entities_collector.cpp:327]: (error: deallocuse) Dereferencing 'node_ptr' after it is deallocated / released
```
