### PR TITLE
Fix #1526.

### DIFF
--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -50,6 +50,7 @@ public:
 
   rclcpp::Clock::SharedPtr clock_;
 
+  // Do not declare this before clock_ as this depends on clock_(see #1526)
   std::shared_ptr<rcl_action_server_t> action_server_;
 
   size_t num_subscriptions_ = 0;

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -48,9 +48,9 @@ public:
   // Lock everything except user callbacks
   std::recursive_mutex action_server_reentrant_mutex_;
 
-  std::shared_ptr<rcl_action_server_t> action_server_;
-
   rclcpp::Clock::SharedPtr clock_;
+
+  std::shared_ptr<rcl_action_server_t> action_server_;
 
   size_t num_subscriptions_ = 0;
   size_t num_timers_ = 0;


### PR DESCRIPTION
Fixes #1526.

As action_server_ depends on clock_, we declare clock_ first.
Then the order of deletion becomes action_server_, clock_.

There are still errors in the following test, but we have solved errors for test_server.
- test_client
- test_server_goal_handle

