### PR TITLE
Avoid `Resource deadlock avoided` if use intra_process_comms

### DIFF
--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -361,8 +361,8 @@ private:
       if (subscription_it == subscriptions_.end()) {
         throw std::runtime_error("subscription has unexpectedly gone out of scope");
       }
-      auto subscription_base_weak = subscription_it->second.subscription;
-      if (auto subscription_base = subscription_base_weak.lock()) {
+      auto subscription_base = subscription_it->second.subscription.lock();
+      if (subscription_base) {
         auto subscription = std::static_pointer_cast<
           rclcpp::experimental::SubscriptionIntraProcess<MessageT>
           >(subscription_base);
@@ -392,8 +392,8 @@ private:
       if (subscription_it == subscriptions_.end()) {
         throw std::runtime_error("subscription has unexpectedly gone out of scope");
       }
-      auto subscription_base_weak = subscription_it->second.subscription;
-      if (auto subscription_base = subscription_base_weak.lock()) {
+      auto subscription_base = subscription_it->second.subscription.lock();
+      if (subscription_base) {
         auto subscription = std::static_pointer_cast<
           rclcpp::experimental::SubscriptionIntraProcess<MessageT>
           >(subscription_base);

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -307,7 +307,7 @@ private:
   {
     SubscriptionInfo() = default;
 
-    rclcpp::experimental::SubscriptionIntraProcessBase::SharedPtr subscription;
+    rclcpp::experimental::SubscriptionIntraProcessBase::WeakPtr subscription;
     rmw_qos_profile_t qos;
     const char * topic_name;
     bool use_take_shared_method;
@@ -361,13 +361,16 @@ private:
       if (subscription_it == subscriptions_.end()) {
         throw std::runtime_error("subscription has unexpectedly gone out of scope");
       }
-      auto subscription_base = subscription_it->second.subscription;
+      auto subscription_base_weak = subscription_it->second.subscription;
+      if (auto subscription_base = subscription_base_weak.lock()) {
+        auto subscription = std::static_pointer_cast<
+          rclcpp::experimental::SubscriptionIntraProcess<MessageT>
+          >(subscription_base);
 
-      auto subscription = std::static_pointer_cast<
-        rclcpp::experimental::SubscriptionIntraProcess<MessageT>
-        >(subscription_base);
-
-      subscription->provide_intra_process_message(message);
+        subscription->provide_intra_process_message(message);
+      } else {
+        subscriptions_.erase(id);
+      }
     }
   }
 
@@ -389,24 +392,27 @@ private:
       if (subscription_it == subscriptions_.end()) {
         throw std::runtime_error("subscription has unexpectedly gone out of scope");
       }
-      auto subscription_base = subscription_it->second.subscription;
+      auto subscription_base_weak = subscription_it->second.subscription;
+      if (auto subscription_base = subscription_base_weak.lock()) {
+        auto subscription = std::static_pointer_cast<
+          rclcpp::experimental::SubscriptionIntraProcess<MessageT>
+          >(subscription_base);
 
-      auto subscription = std::static_pointer_cast<
-        rclcpp::experimental::SubscriptionIntraProcess<MessageT>
-        >(subscription_base);
+        if (std::next(it) == subscription_ids.end()) {
+          // If this is the last subscription, give up ownership
+          subscription->provide_intra_process_message(std::move(message));
+        } else {
+          // Copy the message since we have additional subscriptions to serve
+          MessageUniquePtr copy_message;
+          Deleter deleter = message.get_deleter();
+          auto ptr = MessageAllocTraits::allocate(*allocator.get(), 1);
+          MessageAllocTraits::construct(*allocator.get(), ptr, *message);
+          copy_message = MessageUniquePtr(ptr, deleter);
 
-      if (std::next(it) == subscription_ids.end()) {
-        // If this is the last subscription, give up ownership
-        subscription->provide_intra_process_message(std::move(message));
+          subscription->provide_intra_process_message(std::move(copy_message));
+        }
       } else {
-        // Copy the message since we have additional subscriptions to serve
-        MessageUniquePtr copy_message;
-        Deleter deleter = message.get_deleter();
-        auto ptr = MessageAllocTraits::allocate(*allocator.get(), 1);
-        MessageAllocTraits::construct(*allocator.get(), ptr, *message);
-        copy_message = MessageUniquePtr(ptr, deleter);
-
-        subscription->provide_intra_process_message(std::move(copy_message));
+        subscriptions_.erase(subscription_it);
       }
     }
   }

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -348,7 +348,6 @@ private:
     AllocatorT,
     typename MessageUniquePtr::deleter_type>;
   std::shared_ptr<SubscriptionIntraProcessT> subscription_intra_process_;
-
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -171,11 +171,7 @@ public:
 
       // First create a SubscriptionIntraProcess which will be given to the intra-process manager.
       auto context = node_base->get_context();
-      using SubscriptionIntraProcessT = rclcpp::experimental::SubscriptionIntraProcess<
-        CallbackMessageT,
-        AllocatorT,
-        typename MessageUniquePtr::deleter_type>;
-      auto subscription_intra_process = std::make_shared<SubscriptionIntraProcessT>(
+      subscription_intra_process_ = std::make_shared<SubscriptionIntraProcessT>(
         callback,
         options.get_allocator(),
         context,
@@ -185,12 +181,12 @@ public:
       TRACEPOINT(
         rclcpp_subscription_init,
         static_cast<const void *>(get_subscription_handle().get()),
-        static_cast<const void *>(subscription_intra_process.get()));
+        static_cast<const void *>(subscription_intra_process_.get()));
 
       // Add it to the intra process manager.
       using rclcpp::experimental::IntraProcessManager;
       auto ipm = context->get_sub_context<IntraProcessManager>();
-      uint64_t intra_process_subscription_id = ipm->add_subscription(subscription_intra_process);
+      uint64_t intra_process_subscription_id = ipm->add_subscription(subscription_intra_process_);
       this->setup_intra_process(intra_process_subscription_id, ipm);
     }
 
@@ -347,6 +343,12 @@ private:
     message_memory_strategy_;
   /// Component which computes and publishes topic statistics for this subscriber
   SubscriptionTopicStatisticsSharedPtr subscription_topic_statistics_{nullptr};
+  using SubscriptionIntraProcessT = rclcpp::experimental::SubscriptionIntraProcess<
+    CallbackMessageT,
+    AllocatorT,
+    typename MessageUniquePtr::deleter_type>;
+  std::shared_ptr<SubscriptionIntraProcessT> subscription_intra_process_;
+
 };
 
 }  // namespace rclcpp

--- a/rclcpp/src/rclcpp/intra_process_manager.cpp
+++ b/rclcpp/src/rclcpp/intra_process_manager.cpp
@@ -157,7 +157,13 @@ IntraProcessManager::get_subscription_intra_process(uint64_t intra_process_subsc
   if (subscription_it == subscriptions_.end()) {
     return nullptr;
   } else {
-    return subscription_it->second.subscription;
+    auto subscription_weak = subscription_it->second.subscription;
+    if (auto subscription = subscription_weak.lock()) {
+      return subscription;
+    } else {
+      subscriptions_.erase(subscription_it);
+      return nullptr;
+    }
   }
 }
 

--- a/rclcpp/src/rclcpp/intra_process_manager.cpp
+++ b/rclcpp/src/rclcpp/intra_process_manager.cpp
@@ -157,8 +157,8 @@ IntraProcessManager::get_subscription_intra_process(uint64_t intra_process_subsc
   if (subscription_it == subscriptions_.end()) {
     return nullptr;
   } else {
-    auto subscription_weak = subscription_it->second.subscription;
-    if (auto subscription = subscription_weak.lock()) {
+    auto subscription = subscription_it->second.subscription.lock();
+    if (subscription) {
       return subscription;
     } else {
       subscriptions_.erase(subscription_it);


### PR DESCRIPTION
Fixes #1519 

NOTE: To reproduce the issue, please refer to https://github.com/ros2/rclcpp/issues/1519#issuecomment-768817649.

Signed-off-by: Chen Lihui <Lihui.Chen@sony.com>