### PR TITLE
Enable qos parameter overrides for the /parameter_events topic 

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -40,6 +40,7 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/context.cpp
   src/rclcpp/contexts/default_context.cpp
   src/rclcpp/detail/mutex_two_priorities.cpp
+  src/rclcpp/detail/resolve_parameter_overrides.cpp
   src/rclcpp/detail/rmw_implementation_specific_payload.cpp
   src/rclcpp/detail/rmw_implementation_specific_publisher_payload.cpp
   src/rclcpp/detail/rmw_implementation_specific_subscription_payload.cpp

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -30,7 +30,6 @@
 
 namespace rclcpp
 {
-
 namespace node_interfaces
 {
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -30,6 +30,7 @@
 
 namespace rclcpp
 {
+
 namespace node_interfaces
 {
 

--- a/rclcpp/src/rclcpp/detail/resolve_parameter_overrides.cpp
+++ b/rclcpp/src/rclcpp/detail/resolve_parameter_overrides.cpp
@@ -1,0 +1,77 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "./resolve_parameter_overrides.hpp"
+
+#include <string>
+#include <map>
+#include <vector>
+
+#include "rcl_yaml_param_parser/parser.h"
+
+#include "rclcpp/scope_exit.hpp"
+#include "rclcpp/parameter_map.hpp"
+
+std::map<std::string, rclcpp::ParameterValue>
+rclcpp::detail::resolve_parameter_overrides(
+  const std::string & node_fqn,
+  const std::vector<rclcpp::Parameter> & parameter_overrides,
+  const rcl_arguments_t * local_args,
+  const rcl_arguments_t * global_args)
+{
+  std::map<std::string, rclcpp::ParameterValue> result;
+
+  // global before local so that local overwrites global
+  std::array<const rcl_arguments_t *, 2> argument_sources = {global_args, local_args};
+
+  // Get fully qualified node name post-remapping to use to find node's params in yaml files
+
+  for (const rcl_arguments_t * source : argument_sources) {
+    if (!source) {
+      continue;
+    }
+    rcl_params_t * params = NULL;
+    rcl_ret_t ret = rcl_arguments_get_param_overrides(source, &params);
+    if (RCL_RET_OK != ret) {
+      rclcpp::exceptions::throw_from_rcl_error(ret);
+    }
+    if (params) {
+      auto cleanup_params = make_scope_exit(
+        [params]() {
+          rcl_yaml_node_struct_fini(params);
+        });
+      rclcpp::ParameterMap initial_map = rclcpp::parameter_map_from(params);
+
+      // Enforce wildcard matching precedence
+      // TODO(cottsay) implement further wildcard matching
+      const std::array<std::string, 2> node_matching_names{"/**", node_fqn};
+      for (const auto & node_name : node_matching_names) {
+        if (initial_map.count(node_name) > 0) {
+          // Combine parameter yaml files, overwriting values in older ones
+          for (const rclcpp::Parameter & param : initial_map.at(node_name)) {
+            result[param.get_name()] =
+              rclcpp::ParameterValue(param.get_value_message());
+          }
+        }
+      }
+    }
+  }
+
+  // parameter overrides passed to constructor will overwrite overrides from yaml file sources
+  for (auto & param : parameter_overrides) {
+    result[param.get_name()] =
+      rclcpp::ParameterValue(param.get_value_message());
+  }
+  return result;
+}

--- a/rclcpp/src/rclcpp/detail/resolve_parameter_overrides.hpp
+++ b/rclcpp/src/rclcpp/detail/resolve_parameter_overrides.hpp
@@ -1,0 +1,44 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__DETAIL__RESOLVE_PARAMETER_OVERRIDES_HPP_
+#define RCLCPP__DETAIL__RESOLVE_PARAMETER_OVERRIDES_HPP_
+
+#include <string>
+#include <map>
+#include <vector>
+
+#include "rcl/arguments.h"
+
+#include "rclcpp/parameter.hpp"
+#include "rclcpp/parameter_value.hpp"
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+namespace detail
+{
+/// \internal Get the parameter overrides from the arguments.
+RCLCPP_LOCAL
+std::map<std::string, rclcpp::ParameterValue>
+resolve_parameter_overrides(
+  const std::string & node_name,
+  const std::vector<rclcpp::Parameter> & parameter_overrides,
+  const rcl_arguments_t * local_args,
+  const rcl_arguments_t * global_args);
+
+}  // namespace detail
+}  // namespace rclcpp
+
+#endif  // RCLCPP__DETAIL__RESOLVE_PARAMETER_OVERRIDES_HPP_

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -16,6 +16,7 @@
 
 #include <rcl_yaml_param_parser/parser.h>
 
+#include <array>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -34,6 +35,8 @@
 #include "rclcpp/scope_exit.hpp"
 #include "rcutils/logging_macros.h"
 #include "rmw/qos_profiles.h"
+
+#include "../detail/resolve_parameter_overrides.hpp"
 
 using rclcpp::node_interfaces::NodeParameters;
 
@@ -86,50 +89,15 @@ NodeParameters::NodeParameters(
     throw std::runtime_error("Need valid node options in NodeParameters");
   }
 
-  std::vector<const rcl_arguments_t *> argument_sources;
-  // global before local so that local overwrites global
+  const rcl_arguments_t * global_args = nullptr;
   if (options->use_global_arguments) {
     auto context_ptr = node_base->get_context()->get_rcl_context();
-    argument_sources.push_back(&(context_ptr->global_arguments));
+    global_args = &(context_ptr->global_arguments);
   }
-  argument_sources.push_back(&options->arguments);
-
-  // Get fully qualified node name post-remapping to use to find node's params in yaml files
   combined_name_ = node_base->get_fully_qualified_name();
 
-  for (const rcl_arguments_t * source : argument_sources) {
-    rcl_params_t * params = NULL;
-    rcl_ret_t ret = rcl_arguments_get_param_overrides(source, &params);
-    if (RCL_RET_OK != ret) {
-      rclcpp::exceptions::throw_from_rcl_error(ret);
-    }
-    if (params) {
-      auto cleanup_params = make_scope_exit(
-        [params]() {
-          rcl_yaml_node_struct_fini(params);
-        });
-      rclcpp::ParameterMap initial_map = rclcpp::parameter_map_from(params);
-
-      // Enforce wildcard matching precedence
-      // TODO(cottsay) implement further wildcard matching
-      const std::vector<std::string> node_matching_names{"/**", combined_name_};
-      for (const auto & node_name : node_matching_names) {
-        if (initial_map.count(node_name) > 0) {
-          // Combine parameter yaml files, overwriting values in older ones
-          for (const rclcpp::Parameter & param : initial_map.at(node_name)) {
-            parameter_overrides_[param.get_name()] =
-              rclcpp::ParameterValue(param.get_value_message());
-          }
-        }
-      }
-    }
-  }
-
-  // parameter overrides passed to constructor will overwrite overrides from yaml file sources
-  for (auto & param : parameter_overrides) {
-    parameter_overrides_[param.get_name()] =
-      rclcpp::ParameterValue(param.get_value_message());
-  }
+  parameter_overrides_ = rclcpp::detail::resolve_parameter_overrides(
+    combined_name_, parameter_overrides, &options->arguments, global_args);
 
   // If asked, initialize any parameters that ended up in the initial parameter values,
   // but did not get declared explcitily by this point.

--- a/rclcpp/test/rclcpp/test_qos_parameters.cpp
+++ b/rclcpp/test/rclcpp/test_qos_parameters.cpp
@@ -234,7 +234,8 @@ TEST(TestQosParameters, declare_no_parameters_interface) {
 
   std::map<std::string, rclcpp::Parameter> qos_params;
   EXPECT_FALSE(
-    node->get_node_parameters_interface()->get_parameters_by_prefix("qos_overrides", qos_params));
+    node->get_node_parameters_interface()->get_parameters_by_prefix(
+      "qos_overrides./my/fully/qualified/topic_name", qos_params));
 
   rclcpp::shutdown();
 }


### PR DESCRIPTION
This is a bit complex because the final qos profile is needed before a parameters node interface is created.

For `/rosout` it will even be more complex, because the final profile is needed even before a `rcl_node_t` is written!! (it's possible, but it requires some surgery probably involving `rcl`).
I'm not sure what's the best way to handle that one, opinions welcomed!