### PR TITLE
Reference test resources directly from source tree

### DIFF
--- a/rclcpp/test/CMakeLists.txt
+++ b/rclcpp/test/CMakeLists.txt
@@ -4,6 +4,8 @@ find_package(test_msgs REQUIRED)
 
 include(cmake/rclcpp_add_build_failure_test.cmake)
 
+set(TEST_RESOURCES_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/resources")
+
 add_subdirectory(benchmark)
 add_subdirectory(rclcpp)
 
@@ -11,8 +13,3 @@ ament_add_gtest(test_rclcpp_gtest_macros utils/test_rclcpp_gtest_macros.cpp)
 if(TARGET test_rclcpp_gtest_macros)
   target_link_libraries(test_rclcpp_gtest_macros ${PROJECT_NAME})
 endif()
-
-# Install test resources
-install(
-  DIRECTORY resources
-  DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -2,7 +2,7 @@ find_package(ament_cmake_gtest REQUIRED)
 
 find_package(rmw_implementation_cmake REQUIRED)
 
-add_definitions(-DTEST_RESOURCES_DIRECTORY="${CMAKE_CURRENT_BINARY_DIR}/../resources")
+add_definitions(-DTEST_RESOURCES_DIRECTORY="${TEST_RESOURCES_DIRECTORY}")
 
 rosidl_generate_interfaces(${PROJECT_NAME}_test_msgs
   ../msg/Header.msg


### PR DESCRIPTION
The CMake `install` command should never be used to copy content from the source tree to the build directory like this. The destination directory is affected by the `DESTDIR` variable on UNIX platforms, which will get prefixed onto the destination directory and we'll end up installing the test resources into the target install space.

This change will eliminate the excess test collateral present in the rclcpp deb packages being installed to `/tmp/binarydeb`:
```
$ dpkg-query -L ros-rolling-rclcpp
/.
/opt
/opt/ros
/opt/ros/rolling

...

/tmp
/tmp/binarydeb
/tmp/binarydeb/ros-rolling-rclcpp-6.3.0
/tmp/binarydeb/ros-rolling-rclcpp-6.3.0/obj-x86_64-linux-gnu
/tmp/binarydeb/ros-rolling-rclcpp-6.3.0/obj-x86_64-linux-gnu/test
/tmp/binarydeb/ros-rolling-rclcpp-6.3.0/obj-x86_64-linux-gnu/test/resources
/tmp/binarydeb/ros-rolling-rclcpp-6.3.0/obj-x86_64-linux-gnu/test/resources/test_node
/tmp/binarydeb/ros-rolling-rclcpp-6.3.0/obj-x86_64-linux-gnu/test/resources/test_node/test_parameters.yaml
```

On RPM builds, it is a fatal build error for a ROS package to install files outside of `/opt/ros/foo`.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13619)](http://ci.ros2.org/job/ci_linux/13619/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8501)](http://ci.ros2.org/job/ci_linux-aarch64/8501/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11334)](http://ci.ros2.org/job/ci_osx/11334/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13679)](http://ci.ros2.org/job/ci_windows/13679/)