### PR TITLE
Fix UBSAN warnings in any_subscription_callback.

### DIFF
--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -65,6 +65,9 @@ public:
     const_shared_ptr_callback_(nullptr), const_shared_ptr_with_info_callback_(nullptr),
     unique_ptr_callback_(nullptr), unique_ptr_with_info_callback_(nullptr)
   {
+    if (allocator == nullptr) {
+      throw std::runtime_error("invalid allocator");
+    }
     message_allocator_ = std::make_shared<MessageAlloc>(*allocator.get());
     allocator::set_allocator_for_deleter(&message_deleter_, message_allocator_.get());
   }

--- a/rclcpp/test/rclcpp/test_any_subscription_callback.cpp
+++ b/rclcpp/test/rclcpp/test_any_subscription_callback.cpp
@@ -26,7 +26,8 @@ class TestAnySubscriptionCallback : public ::testing::Test
 {
 public:
   TestAnySubscriptionCallback()
-  : any_subscription_callback_(allocator_) {}
+  : allocator_(std::make_shared<std::allocator<void>>()),
+    any_subscription_callback_(allocator_) {}
   void SetUp()
   {
     msg_shared_ptr_ = std::make_shared<test_msgs::msg::Empty>();
@@ -44,6 +45,20 @@ protected:
   std::unique_ptr<test_msgs::msg::Empty> msg_unique_ptr_;
   rclcpp::MessageInfo message_info_;
 };
+
+void construct_with_null_allocator()
+{
+  // We need to wrap this in a function because `EXPECT_THROW` is a macro, and thinks
+  // that the comma in here splits macro arguments, not the template arguments.
+  rclcpp::AnySubscriptionCallback<
+    test_msgs::msg::Empty, std::allocator<void>> any_subscription_callback_(nullptr);
+}
+
+TEST(AnySubscription, null_allocator) {
+  EXPECT_THROW(
+    construct_with_null_allocator(),
+    std::runtime_error);
+}
 
 TEST_F(TestAnySubscriptionCallback, construct_destruct) {
 }


### PR DESCRIPTION
When running the rclcpp tests under UBSAN, it complained that
the AnySubscriptionCallback tests were using an uninitialized
allocator.

Reviewing the code there, it also looks like the AnySubscriptionCallback
constructor wasn't checking for a null allocator.

Fix this by doing 3 things:

1.  Add a check for a null allocator in the AnySubscriptionCallback
constructor.
2.  Add a new test to test_any_subscription_callback that tests the new
nullptr handling.
3.  Fix the test fixture to initialize the allocator before trying to
call the AnySubscriptionCallback constructor.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>