### PR TITLE
Clock subscription callback group spins in its own thread

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/node_time_source.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_time_source.hpp
@@ -48,7 +48,8 @@ public:
     rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
     rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock,
     rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
-    const rclcpp::QoS & qos = rclcpp::RosoutQoS()
+    const rclcpp::QoS & qos = rclcpp::RosoutQoS(),
+    bool use_clock_thread = true
   );
 
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/node_options.hpp
+++ b/rclcpp/include/rclcpp/node_options.hpp
@@ -258,6 +258,21 @@ public:
   NodeOptions &
   clock_qos(const rclcpp::QoS & clock_qos);
 
+
+  /// Return the use_clock_thread flag.
+  RCLCPP_PUBLIC
+  bool
+  use_clock_thread() const;
+
+  /// Set the use_clock_thread flag, return this for parameter idiom.
+  /**
+   * If true, a dedicated thread will be used to subscribe to "/clock"
+   * topic, using a callback group
+   */
+  RCLCPP_PUBLIC
+  NodeOptions &
+  use_clock_thread(bool use_clock_thread);
+
   /// Return a reference to the parameter_event_qos QoS.
   RCLCPP_PUBLIC
   const rclcpp::QoS &
@@ -383,6 +398,8 @@ private:
   bool start_parameter_event_publisher_ {true};
 
   rclcpp::QoS clock_qos_ = rclcpp::ClockQoS();
+
+  bool use_clock_thread_ {true};
 
   rclcpp::QoS parameter_event_qos_ = rclcpp::ParameterEventsQoS(
     rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_parameter_events)

--- a/rclcpp/include/rclcpp/node_options.hpp
+++ b/rclcpp/include/rclcpp/node_options.hpp
@@ -47,6 +47,7 @@ public:
    *   - start_parameter_services = true
    *   - start_parameter_event_publisher = true
    *   - clock_qos = rclcpp::ClockQoS()
+   *   - use_clock_thread = true
    *   - rosout_qos = rclcpp::RosoutQoS()
    *   - parameter_event_qos = rclcpp::ParameterEventQoS
    *     - with history setting and depth from rmw_qos_profile_parameter_events
@@ -266,8 +267,7 @@ public:
 
   /// Set the use_clock_thread flag, return this for parameter idiom.
   /**
-   * If true, a dedicated thread will be used to subscribe to "/clock"
-   * topic, using a callback group
+   * If true, a dedicated thread will be used to subscribe to "/clock" topic.
    */
   RCLCPP_PUBLIC
   NodeOptions &

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -124,6 +124,11 @@ public:
   RCLCPP_PUBLIC
   ~TimeSource();
 
+protected:
+  // Dedicated thread for clock subscription.
+  bool use_clock_thread_;
+  std::thread clock_executor_thread_;
+
 private:
   // Preserve the node reference
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
@@ -140,9 +145,6 @@ private:
   // QoS of the clock subscription.
   rclcpp::QoS qos_;
 
-  // Options to use dedicated thread for clock subscription.
-  bool use_clock_thread_;
-
   // The subscription for the clock callback
   using MessageT = rosgraph_msgs::msg::Clock;
   using Alloc = std::allocator<void>;
@@ -151,7 +153,6 @@ private:
   std::mutex clock_sub_lock_;
   rclcpp::CallbackGroup::SharedPtr clock_callback_group_;
   rclcpp::executors::SingleThreadedExecutor clock_executor_;
-  std::thread clock_executor_thread_;
 
   // The clock callback itself
   void clock_cb(const rosgraph_msgs::msg::Clock::SharedPtr msg);

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -153,6 +153,7 @@ private:
   std::mutex clock_sub_lock_;
   rclcpp::CallbackGroup::SharedPtr clock_callback_group_;
   rclcpp::executors::SingleThreadedExecutor clock_executor_;
+  bool is_clock_executor_cancelled_;
 
   // The clock callback itself
   void clock_cb(const rosgraph_msgs::msg::Clock::SharedPtr msg);

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -58,7 +58,9 @@ public:
    * \param qos QoS that will be used when creating a `/clock` subscription.
    */
   RCLCPP_PUBLIC
-  explicit TimeSource(rclcpp::Node::SharedPtr node, const rclcpp::QoS & qos = rclcpp::ClockQoS());
+  explicit TimeSource(rclcpp::Node::SharedPtr node,
+                      const rclcpp::QoS & qos = rclcpp::ClockQoS(),
+                      bool use_clock_thread = true);
 
   /// Empty constructor
   /**
@@ -67,7 +69,8 @@ public:
    * \param qos QoS that will be used when creating a `/clock` subscription.
    */
   RCLCPP_PUBLIC
-  explicit TimeSource(const rclcpp::QoS & qos = rclcpp::ClockQoS());
+  explicit TimeSource(const rclcpp::QoS & qos = rclcpp::ClockQoS(),
+                     bool use_clock_thread = true);
 
   /// Attack node to the time source.
   /**
@@ -134,6 +137,9 @@ private:
 
   // QoS of the clock subscription.
   rclcpp::QoS qos_;
+
+  // Options to use dedicated thread for clock subscription.
+  bool use_clock_thread_;
 
   // The subscription for the clock callback
   using MessageT = rosgraph_msgs::msg::Clock;

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -153,7 +153,7 @@ private:
   std::mutex clock_sub_lock_;
   rclcpp::CallbackGroup::SharedPtr clock_callback_group_;
   rclcpp::executors::SingleThreadedExecutor clock_executor_;
-  bool is_clock_executor_cancelled_;
+  std::promise<void> cancel_clock_executor_promise_;
 
   // The clock callback itself
   void clock_cb(const rosgraph_msgs::msg::Clock::SharedPtr msg);

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -25,6 +25,7 @@
 #include "rcl_interfaces/msg/parameter_event.hpp"
 
 #include "rclcpp/node.hpp"
+#include "rclcpp/executors.hpp"
 #include "rclcpp/node_interfaces/node_parameters_interface.hpp"
 
 
@@ -140,6 +141,9 @@ private:
   using SubscriptionT = rclcpp::Subscription<MessageT, Alloc>;
   std::shared_ptr<SubscriptionT> clock_subscription_{nullptr};
   std::mutex clock_sub_lock_;
+  rclcpp::CallbackGroup::SharedPtr clock_callback_group_;
+  rclcpp::executors::SingleThreadedExecutor clock_executor_;
+  std::thread clock_executor_thread_;
 
   // The clock callback itself
   void clock_cb(const rosgraph_msgs::msg::Clock::SharedPtr msg);

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -59,9 +59,9 @@ public:
    */
   RCLCPP_PUBLIC
   explicit TimeSource(
-      rclcpp::Node::SharedPtr node,
-      const rclcpp::QoS & qos = rclcpp::ClockQoS(),
-      bool use_clock_thread = true);
+    rclcpp::Node::SharedPtr node,
+    const rclcpp::QoS & qos = rclcpp::ClockQoS(),
+    bool use_clock_thread = true);
 
   /// Empty constructor
   /**
@@ -71,8 +71,8 @@ public:
    */
   RCLCPP_PUBLIC
   explicit TimeSource(
-      const rclcpp::QoS & qos = rclcpp::ClockQoS(),
-      bool use_clock_thread = true);
+    const rclcpp::QoS & qos = rclcpp::ClockQoS(),
+    bool use_clock_thread = true);
 
   /// Attack node to the time source.
   /**

--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -58,9 +58,10 @@ public:
    * \param qos QoS that will be used when creating a `/clock` subscription.
    */
   RCLCPP_PUBLIC
-  explicit TimeSource(rclcpp::Node::SharedPtr node,
-                      const rclcpp::QoS & qos = rclcpp::ClockQoS(),
-                      bool use_clock_thread = true);
+  explicit TimeSource(
+      rclcpp::Node::SharedPtr node,
+      const rclcpp::QoS & qos = rclcpp::ClockQoS(),
+      bool use_clock_thread = true);
 
   /// Empty constructor
   /**
@@ -69,8 +70,9 @@ public:
    * \param qos QoS that will be used when creating a `/clock` subscription.
    */
   RCLCPP_PUBLIC
-  explicit TimeSource(const rclcpp::QoS & qos = rclcpp::ClockQoS(),
-                     bool use_clock_thread = true);
+  explicit TimeSource(
+      const rclcpp::QoS & qos = rclcpp::ClockQoS(),
+      bool use_clock_thread = true);
 
   /// Attack node to the time source.
   /**

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -187,7 +187,8 @@ Node::Node(
       node_logging_,
       node_clock_,
       node_parameters_,
-      options.clock_qos()
+      options.clock_qos(),
+      options.use_clock_thread()
     )),
   node_waitables_(new rclcpp::node_interfaces::NodeWaitables(node_base_.get())),
   node_options_(options),

--- a/rclcpp/src/rclcpp/node_interfaces/node_time_source.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_time_source.cpp
@@ -27,7 +27,8 @@ NodeTimeSource::NodeTimeSource(
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
   rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock,
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
-  const rclcpp::QoS & qos)
+  const rclcpp::QoS & qos,
+  bool use_clock_thread)
 : node_base_(node_base),
   node_topics_(node_topics),
   node_graph_(node_graph),
@@ -35,7 +36,7 @@ NodeTimeSource::NodeTimeSource(
   node_logging_(node_logging),
   node_clock_(node_clock),
   node_parameters_(node_parameters),
-  time_source_(qos)
+  time_source_(qos, use_clock_thread)
 {
   time_source_.attachNode(
     node_base_,

--- a/rclcpp/src/rclcpp/node_options.cpp
+++ b/rclcpp/src/rclcpp/node_options.cpp
@@ -78,6 +78,7 @@ NodeOptions::operator=(const NodeOptions & other)
     this->start_parameter_services_ = other.start_parameter_services_;
     this->start_parameter_event_publisher_ = other.start_parameter_event_publisher_;
     this->clock_qos_ = other.clock_qos_;
+    this->use_clock_thread_ = other.use_clock_thread_;
     this->parameter_event_qos_ = other.parameter_event_qos_;
     this->rosout_qos_ = other.rosout_qos_;
     this->parameter_event_publisher_options_ = other.parameter_event_publisher_options_;
@@ -269,6 +270,19 @@ NodeOptions &
 NodeOptions::clock_qos(const rclcpp::QoS & clock_qos)
 {
   this->clock_qos_ = clock_qos;
+  return *this;
+}
+
+bool
+NodeOptions::use_clock_thread() const
+{
+  return this->use_clock_thread_;
+}
+
+NodeOptions &
+NodeOptions::use_clock_thread(bool use_clock_thread)
+{
+  this->use_clock_thread_ = use_clock_thread;
   return *this;
 }
 

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -261,9 +261,11 @@ void TimeSource::create_clock_sub()
     options
   );
 
-  clock_executor_thread_ = std::thread([this]() {
-    clock_executor_.add_callback_group(clock_callback_group_, node_base_);
-    clock_executor_.spin();}
+  clock_executor_thread_ = std::thread(
+    [this]() {
+        clock_executor_.add_callback_group(clock_callback_group_, node_base_);
+        clock_executor_.spin();
+    }
   );
 }
 

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -179,7 +179,7 @@ TimeSource::~TimeSource()
     this->detachNode();
   }
 
-  if (clock_subscription_) {
+  if (clock_executor_thread_.joinable()) {
     clock_executor_.cancel();
     clock_executor_thread_.join();
   }

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -254,6 +254,14 @@ void TimeSource::create_clock_sub()
     );
   }
   options.callback_group = clock_callback_group_;
+  if (!clock_executor_thread_.joinable()) {
+    clock_executor_thread_ = std::thread(
+      [this]() {
+        clock_executor_.add_callback_group(clock_callback_group_, node_base_);
+        clock_executor_.spin();
+      }
+    );
+  }
 
   clock_subscription_ = rclcpp::create_subscription<rosgraph_msgs::msg::Clock>(
     node_parameters_,

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -252,12 +252,10 @@ void TimeSource::create_clock_sub()
     });
 
   if (use_clock_thread_) {
-    if (clock_callback_group_ == nullptr) {
-      clock_callback_group_ = node_base_->create_callback_group(
-        rclcpp::CallbackGroupType::MutuallyExclusive,
-        false
-      );
-    }
+    clock_callback_group_ = node_base_->create_callback_group(
+      rclcpp::CallbackGroupType::MutuallyExclusive,
+      false
+    );
     options.callback_group = clock_callback_group_;
     if (!clock_executor_thread_.joinable()) {
       clock_executor_thread_ = std::thread(

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -246,7 +246,10 @@ void TimeSource::create_clock_sub()
       rclcpp::QosPolicyKind::History,
       rclcpp::QosPolicyKind::Reliability,
     });
-  clock_callback_group_ = node_base_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
+  clock_callback_group_ = node_base_->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive,
+    false
+  );
   options.callback_group = clock_callback_group_;
 
   clock_subscription_ = rclcpp::create_subscription<rosgraph_msgs::msg::Clock>(

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -149,6 +149,10 @@ void TimeSource::detachNode()
   sim_time_cb_handler_.reset();
   node_parameters_.reset();
   disable_ros_time();
+  if (clock_executor_thread_.joinable()) {
+    clock_executor_.cancel();
+    clock_executor_thread_.join();
+  }
 }
 
 void TimeSource::attachClock(std::shared_ptr<rclcpp::Clock> clock)

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -55,6 +55,7 @@ TimeSource::TimeSource(
 
 void TimeSource::attachNode(rclcpp::Node::SharedPtr node)
 {
+  use_clock_thread_ = node->get_node_options().use_clock_thread();
   attachNode(
     node->get_node_base_interface(),
     node->get_node_topics_interface(),

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -34,9 +34,9 @@ namespace rclcpp
 {
 
 TimeSource::TimeSource(
-    std::shared_ptr<rclcpp::Node> node,
-    const rclcpp::QoS & qos,
-    bool use_clock_thread)
+  std::shared_ptr<rclcpp::Node> node,
+  const rclcpp::QoS & qos,
+  bool use_clock_thread)
 : logger_(rclcpp::get_logger("rclcpp")),
   qos_(qos),
   use_clock_thread_(use_clock_thread)
@@ -45,8 +45,8 @@ TimeSource::TimeSource(
 }
 
 TimeSource::TimeSource(
-    const rclcpp::QoS & qos,
-    bool use_clock_thread)
+  const rclcpp::QoS & qos,
+  bool use_clock_thread)
 : logger_(rclcpp::get_logger("rclcpp")),
   qos_(qos),
   use_clock_thread_(use_clock_thread)

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -37,9 +37,9 @@ TimeSource::TimeSource(
   std::shared_ptr<rclcpp::Node> node,
   const rclcpp::QoS & qos,
   bool use_clock_thread)
-: logger_(rclcpp::get_logger("rclcpp")),
-  qos_(qos),
-  use_clock_thread_(use_clock_thread)
+: use_clock_thread_(use_clock_thread),
+  logger_(rclcpp::get_logger("rclcpp")),
+  qos_(qos)
 {
   this->attachNode(node);
 }
@@ -47,9 +47,9 @@ TimeSource::TimeSource(
 TimeSource::TimeSource(
   const rclcpp::QoS & qos,
   bool use_clock_thread)
-: logger_(rclcpp::get_logger("rclcpp")),
-  qos_(qos),
-  use_clock_thread_(use_clock_thread)
+: use_clock_thread_(use_clock_thread),
+  logger_(rclcpp::get_logger("rclcpp")),
+  qos_(qos)
 {
 }
 

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -246,10 +246,13 @@ void TimeSource::create_clock_sub()
       rclcpp::QosPolicyKind::History,
       rclcpp::QosPolicyKind::Reliability,
     });
-  clock_callback_group_ = node_base_->create_callback_group(
-    rclcpp::CallbackGroupType::MutuallyExclusive,
-    false
-  );
+
+  if (clock_callback_group_ == nullptr) {
+    clock_callback_group_ = node_base_->create_callback_group(
+      rclcpp::CallbackGroupType::MutuallyExclusive,
+      false
+    );
+  }
   options.callback_group = clock_callback_group_;
 
   clock_subscription_ = rclcpp::create_subscription<rosgraph_msgs::msg::Clock>(

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -263,8 +263,8 @@ void TimeSource::create_clock_sub()
 
   clock_executor_thread_ = std::thread(
     [this]() {
-        clock_executor_.add_callback_group(clock_callback_group_, node_base_);
-        clock_executor_.spin();
+      clock_executor_.add_callback_group(clock_callback_group_, node_base_);
+      clock_executor_.spin();
     }
   );
 }

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -283,6 +283,7 @@ void TimeSource::destroy_clock_sub()
   std::lock_guard<std::mutex> guard(clock_sub_lock_);
   if (clock_executor_thread_.joinable()) {
     cancel_clock_executor_promise_.set_value();
+    clock_executor_.cancel();
     clock_executor_thread_.join();
     clock_executor_.remove_callback_group(clock_callback_group_);
   }

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -33,9 +33,10 @@
 namespace rclcpp
 {
 
-TimeSource::TimeSource(std::shared_ptr<rclcpp::Node> node,
-                       const rclcpp::QoS & qos,
-                       bool use_clock_thread)
+TimeSource::TimeSource(
+    std::shared_ptr<rclcpp::Node> node,
+    const rclcpp::QoS & qos,
+    bool use_clock_thread)
 : logger_(rclcpp::get_logger("rclcpp")),
   qos_(qos),
   use_clock_thread_(use_clock_thread)
@@ -43,8 +44,9 @@ TimeSource::TimeSource(std::shared_ptr<rclcpp::Node> node,
   this->attachNode(node);
 }
 
-TimeSource::TimeSource(const rclcpp::QoS & qos,
-                       bool use_clock_thread)
+TimeSource::TimeSource(
+    const rclcpp::QoS & qos,
+    bool use_clock_thread)
 : logger_(rclcpp::get_logger("rclcpp")),
   qos_(qos),
   use_clock_thread_(use_clock_thread)

--- a/rclcpp/test/rclcpp/test_time_source.cpp
+++ b/rclcpp/test/rclcpp/test_time_source.cpp
@@ -518,7 +518,7 @@ TEST_F(TestTimeSource, no_pre_jump_callback) {
 }
 
 // A TimeSource-inheriting class
-// that allows to access to TimeSource protected attributes
+// that allows access to TimeSource protected attributes
 // use_clock_thread_ and clock_executor_thread_
 class ClockThreadTestingTimeSource : public rclcpp::TimeSource
 {

--- a/rclcpp/test/rclcpp/test_time_source.cpp
+++ b/rclcpp/test/rclcpp/test_time_source.cpp
@@ -656,7 +656,7 @@ private:
   void timer_callback()
   {
     // Increment clock msg and publish it
-    clock_msg_.clock.nanosec += 1 * 1e6;
+    clock_msg_.clock.nanosec += 1000000;
     clock_pub_->publish(clock_msg_);
   }
 

--- a/rclcpp/test/rclcpp/test_time_source.cpp
+++ b/rclcpp/test/rclcpp/test_time_source.cpp
@@ -631,8 +631,8 @@ public:
     );
 
     // Init clock msg to zero
-    clock_msg_.clock.sec = 0.0;
-    clock_msg_.clock.nanosec = 0.0;
+    clock_msg_.clock.sec = 0;
+    clock_msg_.clock.nanosec = 0;
   }
 
   ~SimClockPublisherNode()

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -102,7 +102,8 @@ LifecycleNode::LifecycleNode(
       node_logging_,
       node_clock_,
       node_parameters_,
-      options.clock_qos()
+      options.clock_qos(),
+      options.use_clock_thread()
     )),
   node_waitables_(new rclcpp::node_interfaces::NodeWaitables(node_base_.get())),
   node_options_(options),


### PR DESCRIPTION
Good morning,

this pull request is motivated by the #1540 issue. In short, we would like the node's clock behavior to be consistent, independently from the `use_sim_time` parameter value. Currently, if using simulation time, the node's clock time won't be updated within callbacks. 

To always keep node's clock time up to date, we added a callback group to the existing clock subscription's options and make this callback group spins in its own thread, in [`TimeSource::create_clock_sub` method](https://github.com/wyca-robotics/rclcpp/blob/10ae308afd4194aab65b0dc9fd30d118425e272e/rclcpp/src/rclcpp/time_source.cpp#L249). The thread is cleanly finished in the [class destructor](https://github.com/wyca-robotics/rclcpp/blob/10ae308afd4194aab65b0dc9fd30d118425e272e/rclcpp/src/rclcpp/time_source.cpp#L182). 