### PR TITLE
Static parameter type fixes

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -389,6 +389,10 @@ __declare_parameter_common(
     callback_container,
     callback);
 
+  if (!result.successful) {
+    return result;
+  }
+
   // Add declared parameters to storage.
   parameters_out[name] = parameter_infos.at(name);
 

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -620,6 +620,22 @@ TEST_F(TestNode, declare_parameter_with_overrides) {
       {node->declare_parameter("parameter_type_mismatch", 42);},
       rclcpp::exceptions::InvalidParameterTypeException);
   }
+  {
+    // default type and expected type do not match
+    EXPECT_THROW(
+      {node->declare_parameter(
+          "parameter_type_mismatch", rclcpp::ParameterType::PARAMETER_INTEGER);},
+      rclcpp::exceptions::InvalidParameterTypeException);
+  }
+  {
+    // cannot pass an expected type and a descriptor with dynamic_typing=True
+    rcl_interfaces::msg::ParameterDescriptor descriptor{};
+    descriptor.dynamic_typing = true;
+    EXPECT_THROW(
+      {node->declare_parameter(
+          "invalid_argument", rclcpp::ParameterType::PARAMETER_INTEGER, descriptor);},
+      std::invalid_argument);
+  }
 }
 
 TEST_F(TestNode, declare_parameters_with_no_initial_values) {


### PR DESCRIPTION
When working on https://github.com/ros2/rclpy/pull/683 I realized of a few problems in https://github.com/ros2/rclcpp/pull/1522:

- The `NoParameterOverrideProvided` exception was being thrown in some cases where it shouldn't. See [this](https://github.com/ros2/rclcpp/blob/2036857e92a1c0a96c4626272724be3e0f267964/rclcpp/test/rclcpp/test_node.cpp#L625-L628) new test case.
- `node->declare_parameter("my_param", rclcpp::ParameterType::PARAMETER_INTEGER, descriptor_dynamic_typing_on` shouldn't be valid. Discussion in [rclpy PR](https://github.com/ros2/rclpy/pull/683#discussion_r585039574). See [this other](https://github.com/ros2/rclcpp/blob/2036857e92a1c0a96c4626272724be3e0f267964/rclcpp/test/rclcpp/test_node.cpp#L632-L637) new test case.

And when working on this, I find a super old bug which [this commit] fixes ....
I will rebase-merge so that fix can be backported alone. 