### PR TITLE
Document design decisions that were made for statically typed parameters

### DIFF
--- a/rclcpp/doc/notes_on_statically_typed_parameters.md
+++ b/rclcpp/doc/notes_on_statically_typed_parameters.md
@@ -106,3 +106,35 @@ node->declare_parameter("my_param", rclcpp::ParameterValue{});  // not valid, wi
 ```py
 node.declare_parameter("my_param", None);  # not valid, will raise error
 ```
+
+## Possible improvements
+
+### Easier way to declare dynamically typed parameters
+
+Declaring a dynamically typed parameter in `rclcpp` could be considered to be a bit verbose:
+
+```cpp
+rcl_interfaces::msg::ParameterDescriptor descriptor;
+descriptor.dynamic_typing = true;
+
+node->declare_parameter(name, rclcpp::ParameterValue{}, descriptor);
+```
+
+the following ways could be supported to make it simpler:
+
+```cpp
+node->declare_parameter(name, rclcpp::PARAMETER_DYNAMIC);
+node->declare_parameter(name, default_value, rclcpp::PARAMETER_DYNAMIC);
+```
+
+or alternatively:
+
+```cpp
+node->declare_parameter(name, default_value, rclcpp::ParameterDescriptor{}.dynamic_typing());
+```
+
+For `rclpy`, there's already a short way to do it:
+
+```py
+node.declare_parameter(name, default_value, rclpy.ParameterDescriptor(dynamic_typing=true));
+```

--- a/rclcpp/doc/notes_on_statically_typed_parameters.md
+++ b/rclcpp/doc/notes_on_statically_typed_parameters.md
@@ -14,7 +14,7 @@ $ ros2 param get /listener use_sim_time
 String value is: not_a_boolean
 ```
 
-For most use cases, having a static parameter types is enough.
+For most use cases, having static parameter types is enough.
 This notes document some of the decisions that were made when implementing static parameter types enforcement in:
 
 * https://github.com/ros2/rclcpp/pull/1522

--- a/rclcpp/doc/notes_on_statically_typed_parameters.md
+++ b/rclcpp/doc/notes_on_statically_typed_parameters.md
@@ -56,7 +56,7 @@ In the current implementation that isn't enforce, but it might make sense to do 
 ## Declaring a parameter without a default value
 
 There might be cases were a default value does not make sense and the user must always provide an override.
-In those cases, the parameter type can be specified explicetly:
+In those cases, the parameter type can be specified explicitly:
 
 ```cpp
 // method signature

--- a/rclcpp/doc/notes_on_statically_typed_parameters.md
+++ b/rclcpp/doc/notes_on_statically_typed_parameters.md
@@ -1,0 +1,111 @@
+# Notes on statically typed parameters
+
+## Introduction
+
+Up to ROS 2 Foxy, all parameters could be changed of type anytime, except the user installed a parameter callback to reject that change.
+This could generate confusing errors, for example:
+
+```
+$ ros2 run demo_nodes_py listener &
+$ ros2 param set /listener use_sim_time not_a_boolean
+[ERROR] [1614712713.233733147] [listener]: use_sim_time parameter set to something besides a bool
+Set parameter successful
+$ ros2 param get /listener use_sim_time
+String value is: not_a_boolean
+```
+
+For most use cases, having a static parameter types is enough.
+This notes document some of the decisions that were made when implementing static parameter types enforcement in:
+
+* https://github.com/ros2/rclcpp/pull/1522
+* https://github.com/ros2/rclpy/pull/683
+
+## Allowing dynamically typed parameters
+
+There might be some scenarios were dynamic typing is desired, so a `dynamic_typing` field was added to the [parameter descriptor](https://github.com/ros2/rcl_interfaces/blob/09b5ed93a733adb9deddc47f9a4a8c6e9f584667/rcl_interfaces/msg/ParameterDescriptor.msg#L25).
+It defaults to `false`.
+
+For example:
+
+```cpp
+rcl_interfaces::msg::ParameterDescriptor descriptor;
+descriptor.dynamic_typing = true;
+
+node->declare_parameter("dynamically_typed_parameter", rclcpp::ParameterValue{}, descriptor);
+```
+
+```py
+rcl_interfaces.msg.ParameterDescriptor descriptor;
+descriptor.dynamic_typing = True;
+
+node.declare_parameter("dynamically_typed_parameter", None, descriptor);
+```
+
+## How is the parameter type specified?
+
+The parameter type will be inferred from the default value provided when declaring it.
+
+## Statically typed parameters when allowing undeclared parameters
+
+When undeclared parameters are allowed, the descriptor of undeclared parameters will have the dynamic typing field set.
+That's because in that case there is no declaration, and it doesn't make much sense to enforce the type of the first value set.
+
+TBD: Should parameters that were declared with the dynamic typing option off enforce that the parameter doesn't change the type even if allow undeclared parameters is set?
+In the current implementation that isn't enforce, but it might make sense to do it for parameters that were declared.
+
+## Declaring a parameter without a default value
+
+There might be cases were a default value does not make sense and the user must always provide an override.
+In those cases, the parameter type can be specified explicetly:
+
+```cpp
+// method signature
+template<typename T>
+Node::declare_parameter<T>(std::string name, rcl_interfaces::msg::ParameterDescriptor = rcl_interfaces::msg::ParameterDescriptor{});
+// or alternatively
+Node::declare_parameter(std::string name, rclcpp::ParameterType type, rcl_interfaces::msg::ParameterDescriptor = rcl_interfaces::msg::ParameterDescriptor{});
+
+// examples
+node->declare_paramter<int64_t>("my_integer_parameter");  // declare an integer parameter
+node->declare_paramter("another_integer_parameter", rclcpp::ParameterType::PARAMETER_INTEGER);  // another way to do the same
+```
+
+```py
+# method signature
+Node.declare_parameter(name: str, param_type: rclpy.Parameter.Type, descriptor: rcl_interfaces.msg.ParameterDescriptor = rcl_interfaces.msg.ParameterDescriptor())
+
+# example
+node.declare_paramter('my_integer_parameter', rclpy.Parameter.Type.INTEGER);  # declare an integer parameter
+```
+
+If the parameter is optional, e.g.: only needed depending on the value of another parameter, the recommended approach is to conditionally declare the parameter:
+
+```cpp
+auto mode = node->declare_parameter("mode", "modeA");  // "mode" parameter is an string
+if (mode == "modeB") {
+    node->declare_parameter<int64_t>("param_needed_when_mode_b");  // when "modeB", the user must provide "param_needed_when_mode_b"
+}
+```
+
+## Other migration notes
+
+Declaring a parameter with only a name is deprecated:
+
+```cpp
+node->declare_parameter("my_param");  // this generates a build warning
+```
+
+```py
+node.declare_parameter("my_param");  # this generates a python user warning
+```
+
+Before, you could initialize a parameter with the "NOT SET" value (in cpp `rclcpp::ParameterValue{}`, in python `None`).
+Now this will throw an exception in both cases:
+
+```cpp
+node->declare_parameter("my_param", rclcpp::ParameterValue{});  // not valid, will throw exception
+```
+
+```py
+node.declare_parameter("my_param", None);  # not valid, will raise error
+```

--- a/rclcpp/doc/notes_on_statically_typed_parameters.md
+++ b/rclcpp/doc/notes_on_statically_typed_parameters.md
@@ -47,7 +47,8 @@ The parameter type will be inferred from the default value provided when declari
 
 ## Statically typed parameters when allowing undeclared parameters
 
-When undeclared parameters are allowed and a parameter is set without a previous declaration, the parameter will be dynamically typed. This is consistent with other allowed behaviors when undeclared parameters are allowed, e.g. trying to get an undeclared parameter returns "NOT_SET".
+When undeclared parameters are allowed and a parameter is set without a previous declaration, the parameter will be dynamically typed.
+This is consistent with other allowed behaviors when undeclared parameters are allowed, e.g. trying to get an undeclared parameter returns "NOT_SET".
 Parameter declarations will remain special and dynamic or static typing will be used based on the parameter descriptor (default to static).
 
 ## Declaring a parameter without a default value

--- a/rclcpp/doc/notes_on_statically_typed_parameters.md
+++ b/rclcpp/doc/notes_on_statically_typed_parameters.md
@@ -47,11 +47,8 @@ The parameter type will be inferred from the default value provided when declari
 
 ## Statically typed parameters when allowing undeclared parameters
 
-When undeclared parameters are allowed, the descriptor of undeclared parameters will have the dynamic typing field set.
-That's because in that case there is no declaration, and it doesn't make much sense to enforce the type of the first value set.
-
-TBD: Should parameters that were declared with the dynamic typing option off enforce that the parameter doesn't change the type even if allow undeclared parameters is set?
-In the current implementation that isn't enforce, but it might make sense to do it for parameters that were declared.
+When undeclared parameters are allowed and a parameter is set without a previous declaration, the parameter will be dynamically typed. This is consistent with other allowed behaviors when undeclared parameters are allowed, e.g. trying to get an undeclared parameter returns "NOT_SET".
+Parameter declarations will remain special and dynamic or static typing will be used based on the parameter descriptor (default to static).
 
 ## Declaring a parameter without a default value
 
@@ -78,7 +75,7 @@ Node.declare_parameter(name: str, param_type: rclpy.Parameter.Type, descriptor: 
 node.declare_paramter('my_integer_parameter', rclpy.Parameter.Type.INTEGER);  # declare an integer parameter
 ```
 
-If the parameter is optional, e.g.: only needed depending on the value of another parameter, the recommended approach is to conditionally declare the parameter:
+If the parameter may be unused, but when used requires a parameter override, then you could conditionally declare it:
 
 ```cpp
 auto mode = node->declare_parameter("mode", "modeA");  // "mode" parameter is an string

--- a/rclcpp/doc/notes_on_statically_typed_parameters.md
+++ b/rclcpp/doc/notes_on_statically_typed_parameters.md
@@ -15,7 +15,7 @@ String value is: not_a_boolean
 ```
 
 For most use cases, having static parameter types is enough.
-This notes document some of the decisions that were made when implementing static parameter types enforcement in:
+This article documents some of the decisions that were made when implementing static parameter types enforcement in:
 
 * https://github.com/ros2/rclcpp/pull/1522
 * https://github.com/ros2/rclpy/pull/683

--- a/rclcpp/doc/notes_on_statically_typed_parameters.md
+++ b/rclcpp/doc/notes_on_statically_typed_parameters.md
@@ -22,7 +22,7 @@ This article documents some of the decisions that were made when implementing st
 
 ## Allowing dynamically typed parameters
 
-There might be some scenarios were dynamic typing is desired, so a `dynamic_typing` field was added to the [parameter descriptor](https://github.com/ros2/rcl_interfaces/blob/09b5ed93a733adb9deddc47f9a4a8c6e9f584667/rcl_interfaces/msg/ParameterDescriptor.msg#L25).
+There might be some scenarios where dynamic typing is desired, so a `dynamic_typing` field was added to the [parameter descriptor](https://github.com/ros2/rcl_interfaces/blob/09b5ed93a733adb9deddc47f9a4a8c6e9f584667/rcl_interfaces/msg/ParameterDescriptor.msg#L25).
 It defaults to `false`.
 
 For example:

--- a/rclcpp/doc/notes_on_statically_typed_parameters.md
+++ b/rclcpp/doc/notes_on_statically_typed_parameters.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Up to ROS 2 Foxy, all parameters could be changed of type anytime, except the user installed a parameter callback to reject that change.
+Until ROS 2 Foxy, all parameters could change type anytime, except if the user installed a parameter callback to reject a change.
 This could generate confusing errors, for example:
 
 ```

--- a/rclcpp/doc/notes_on_statically_typed_parameters.md
+++ b/rclcpp/doc/notes_on_statically_typed_parameters.md
@@ -63,8 +63,8 @@ Node::declare_parameter<T>(std::string name, rcl_interfaces::msg::ParameterDescr
 Node::declare_parameter(std::string name, rclcpp::ParameterType type, rcl_interfaces::msg::ParameterDescriptor = rcl_interfaces::msg::ParameterDescriptor{});
 
 // examples
-node->declare_paramter<int64_t>("my_integer_parameter");  // declare an integer parameter
-node->declare_paramter("another_integer_parameter", rclcpp::ParameterType::PARAMETER_INTEGER);  // another way to do the same
+node->declare_parameter<int64_t>("my_integer_parameter");  // declare an integer parameter
+node->declare_parameter("another_integer_parameter", rclcpp::ParameterType::PARAMETER_INTEGER);  // another way to do the same
 ```
 
 ```py
@@ -72,7 +72,7 @@ node->declare_paramter("another_integer_parameter", rclcpp::ParameterType::PARAM
 Node.declare_parameter(name: str, param_type: rclpy.Parameter.Type, descriptor: rcl_interfaces.msg.ParameterDescriptor = rcl_interfaces.msg.ParameterDescriptor())
 
 # example
-node.declare_paramter('my_integer_parameter', rclpy.Parameter.Type.INTEGER);  # declare an integer parameter
+node.declare_parameter('my_integer_parameter', rclpy.Parameter.Type.INTEGER);  # declare an integer parameter
 ```
 
 If the parameter may be unused, but when used requires a parameter override, then you could conditionally declare it:


### PR DESCRIPTION
Document some of the decisions that were made in https://github.com/ros2/rclcpp/pull/1522, https://github.com/ros2/rclpy/pull/683.

There's also a question in the document.