### PR TITLE
Quiet clang memory leak warning on "DoNotOptimize".

### DIFF
--- a/rclcpp/test/benchmark/benchmark_node.cpp
+++ b/rclcpp/test/benchmark/benchmark_node.cpp
@@ -46,7 +46,9 @@ BENCHMARK_F(NodePerformanceTest, create_node)(benchmark::State & state)
   for (auto _ : state) {
     // Using pointer to separate construction and destruction in timing
     auto node = std::make_shared<rclcpp::Node>("node");
+#ifndef __clang_analyzer__
     benchmark::DoNotOptimize(node);
+#endif
     benchmark::ClobberMemory();
 
     // Ensure destruction of node is not counted toward timing
@@ -69,7 +71,9 @@ BENCHMARK_F(NodePerformanceTest, destroy_node)(benchmark::State & state)
     auto node = std::make_shared<rclcpp::Node>("node");
     state.ResumeTiming();
 
+#ifndef __clang_analyzer__
     benchmark::DoNotOptimize(node);
+#endif
     benchmark::ClobberMemory();
 
     node.reset();


### PR DESCRIPTION
When building rclcpp under clang static analysis, it complains
that the "DoNotOptimize" function from Google benchmark can
cause a memory leak.  I can't see how this is possible, so I
can only assume that the inline assembly that is used to implement
"DoNotOptimize" is causing a false positive.  Just quite the
warning here when building under clang static analysis.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>