### PR TITLE
Add support for rmw_connextdds

### DIFF
--- a/rclcpp/test/rclcpp/executors/test_multi_threaded_executor.cpp
+++ b/rclcpp/test/rclcpp/executors/test_multi_threaded_executor.cpp
@@ -86,10 +86,13 @@ TEST_F(TestMultiThreadedExecutor, timer_over_take) {
         double diff = static_cast<double>(std::abs((now - last).nanoseconds())) / 1.0e9;
         last = now;
 
-        if (diff < PERIOD - TOLERANCE) {
+        double diff_exp =
+            static_cast<double>(PERIOD) - static_cast<double>(TOLERANCE);
+        if (diff < diff_exp) {
           executor.cancel();
-          ASSERT_GT(diff, PERIOD - TOLERANCE);
+          ASSERT_GT(diff, diff_exp);
         }
+
       }
     };
 

--- a/rclcpp/test/rclcpp/executors/test_multi_threaded_executor.cpp
+++ b/rclcpp/test/rclcpp/executors/test_multi_threaded_executor.cpp
@@ -87,7 +87,7 @@ TEST_F(TestMultiThreadedExecutor, timer_over_take) {
         last = now;
 
         double diff_exp =
-            static_cast<double>(PERIOD) - static_cast<double>(TOLERANCE);
+          static_cast<double>(PERIOD) - static_cast<double>(TOLERANCE);
         if (diff < diff_exp) {
           executor.cancel();
           ASSERT_GT(diff, diff_exp);

--- a/rclcpp/test/rclcpp/executors/test_multi_threaded_executor.cpp
+++ b/rclcpp/test/rclcpp/executors/test_multi_threaded_executor.cpp
@@ -86,11 +86,9 @@ TEST_F(TestMultiThreadedExecutor, timer_over_take) {
         double diff = static_cast<double>(std::abs((now - last).nanoseconds())) / 1.0e9;
         last = now;
 
-        double diff_exp =
-          static_cast<double>(PERIOD) - static_cast<double>(TOLERANCE);
-        if (diff < diff_exp) {
+        if (diff < PERIOD - TOLERANCE) {
           executor.cancel();
-          ASSERT_GT(diff, diff_exp);
+          ASSERT_GT(diff, PERIOD - TOLERANCE);
         }
       }
     };

--- a/rclcpp/test/rclcpp/executors/test_multi_threaded_executor.cpp
+++ b/rclcpp/test/rclcpp/executors/test_multi_threaded_executor.cpp
@@ -92,7 +92,6 @@ TEST_F(TestMultiThreadedExecutor, timer_over_take) {
           executor.cancel();
           ASSERT_GT(diff, diff_exp);
         }
-
       }
     };
 

--- a/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
@@ -511,7 +511,10 @@ TEST_F(TestAllocatorMemoryStrategy, number_of_entities_with_subscription) {
   RclWaitSetSizes expected_sizes = {};
   expected_sizes.size_of_subscriptions = 1;
   const std::string implementation_identifier = rmw_get_implementation_identifier();
-  if (implementation_identifier == "rmw_cyclonedds_cpp") {
+  // TODO(asorbini): Remove Connext exception once ros2/rmw_connext is deprecated.
+  if (implementation_identifier == "rmw_connext_cpp" ||
+    implementation_identifier == "rmw_cyclonedds_cpp")
+  {
     // For cyclonedds, a subscription will also add an event and waitable
     expected_sizes.size_of_events += 1;
     expected_sizes.size_of_waitables += 1;

--- a/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
@@ -511,9 +511,7 @@ TEST_F(TestAllocatorMemoryStrategy, number_of_entities_with_subscription) {
   RclWaitSetSizes expected_sizes = {};
   expected_sizes.size_of_subscriptions = 1;
   const std::string implementation_identifier = rmw_get_implementation_identifier();
-  if (implementation_identifier == "rmw_connext_cpp" ||
-    implementation_identifier == "rmw_cyclonedds_cpp")
-  {
+  if (implementation_identifier == "rmw_cyclonedds_cpp") {
     // For connext, a subscription will also add an event and waitable
     expected_sizes.size_of_events += 1;
     expected_sizes.size_of_waitables += 1;

--- a/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
@@ -512,7 +512,7 @@ TEST_F(TestAllocatorMemoryStrategy, number_of_entities_with_subscription) {
   expected_sizes.size_of_subscriptions = 1;
   const std::string implementation_identifier = rmw_get_implementation_identifier();
   if (implementation_identifier == "rmw_cyclonedds_cpp") {
-    // For connext, a subscription will also add an event and waitable
+    // For cyclonedds, a subscription will also add an event and waitable
     expected_sizes.size_of_events += 1;
     expected_sizes.size_of_waitables += 1;
   }

--- a/rclcpp/test/rclcpp/test_add_callback_groups_to_executor.cpp
+++ b/rclcpp/test/rclcpp/test_add_callback_groups_to_executor.cpp
@@ -30,10 +30,6 @@
 #include "rclcpp/executor.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-// Note: This is a long running test with rmw_connext_cpp, if you change this file, please check
-// that this test can complete fully, or adjust the timeout as necessary.
-// See https://github.com/ros2/rmw_connext/issues/325 for resolution]
-
 using namespace std::chrono_literals;
 
 template<typename T>

--- a/rclcpp/test/rclcpp/test_publisher.cpp
+++ b/rclcpp/test/rclcpp/test_publisher.cpp
@@ -29,10 +29,6 @@
 
 #include "test_msgs/msg/empty.hpp"
 
-// Note: This is a long running test with rmw_connext_cpp, if you change this file, please check
-// that this test can complete fully, or adjust the timeout as necessary.
-// See https://github.com/ros2/rmw_connext/issues/325 for resolution
-
 class TestPublisher : public ::testing::Test
 {
 public:

--- a/rclcpp/test/rclcpp/test_subscription.cpp
+++ b/rclcpp/test/rclcpp/test_subscription.cpp
@@ -29,10 +29,6 @@
 
 #include "test_msgs/msg/empty.hpp"
 
-// Note: This is a long running test with rmw_connext_cpp, if you change this file, please check
-// that this test can complete fully, or adjust the timeout as necessary.
-// See https://github.com/ros2/rmw_connext/issues/325 for resolution
-
 using namespace std::chrono_literals;
 
 class TestSubscription : public ::testing::Test

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -29,10 +29,6 @@
 #include "rclcpp_action/server.hpp"
 #include "./mocking_utils/patch.hpp"
 
-// Note: This is a long running test with rmw_connext_cpp, if you change this file, please check
-// that this test can complete fully, or adjust the timeout as necessary.
-// See https://github.com/ros2/rmw_connext/issues/325 for resolution
-
 using Fibonacci = test_msgs::action::Fibonacci;
 using CancelResponse = typename Fibonacci::Impl::CancelGoalService::Response;
 using GoalUUID = rclcpp_action::GoalUUID;

--- a/rclcpp_lifecycle/test/test_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_node.cpp
@@ -31,10 +31,6 @@
 
 #include "./mocking_utils/patch.hpp"
 
-// Note: This is a long running test with rmw_connext_cpp, if you change this file, please check
-// that this test can complete fully, or adjust the timeout as necessary.
-// See https://github.com/ros2/rmw_connext/issues/325 for resolution
-
 using lifecycle_msgs::msg::State;
 using lifecycle_msgs::msg::Transition;
 

--- a/rclcpp_lifecycle/test/test_lifecycle_service_client.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_service_client.cpp
@@ -52,10 +52,6 @@ constexpr char const * node_get_transition_graph_topic =
   "/lc_talker/get_transition_graph";
 const lifecycle_msgs::msg::State unknown_state = lifecycle_msgs::msg::State();
 
-// Note: This is a long running test with rmw_connext_cpp, if you change this file, please check
-// that this test can complete fully, or adjust the timeout as necessary.
-// See https://github.com/ros2/rmw_connext/issues/325 for resolution
-
 class EmptyLifecycleNode : public rclcpp_lifecycle::LifecycleNode
 {
 public:


### PR DESCRIPTION
This PR removes all references to `rmw_connext_cpp`, so that it may be replaced by `rmw_connextdds`.

Changes mostly involved getting rid of several comments about "long running tests", and re-enabling a test in `test_allocator_memory_strategy.cpp`.

The PR also includes a fix for `test_multi_threaded_executor.cpp`, to avoid an implicit conversion from integer to double which was causing the test to fail.

See [rticommunity/rmw_connextdds #9](https://github.com/rticommunity/rmw_connextdds/issues/9) for a list of related PRs, and an overview of all the changes required to replace [ros2/rmw_connext](https://github.com/ros2/rmw_connext) (`rmw_connext_cpp`) with [rticommunity/rmw_connextdds](https://github.com/rticommunity/rmw_connextdds) in the ROS2 source tree.