### PR TITLE
Add tests for declaring statically typed parameters when undeclared parameters are allowed

### DIFF
--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -436,6 +436,17 @@ TEST_F(TestNode, declare_parameter_with_allow_undeclared_parameters) {
     EXPECT_EQ(param.get_type(), rclcpp::PARAMETER_STRING);
     EXPECT_EQ(param.get_value<std::string>(), "asd");
   }
+  {
+    // declare after set is invalid
+    auto param_name = "parameter"_unq;
+    EXPECT_TRUE(node->set_parameter({param_name, 5}).successful);
+    auto param = node->get_parameter(param_name);
+    EXPECT_EQ(param.get_type(), rclcpp::PARAMETER_INTEGER);
+    EXPECT_EQ(param.get_value<int64_t>(), 5);
+    EXPECT_THROW(
+      node->declare_parameter(param_name, 5),
+      rclcpp::exceptions::ParameterAlreadyDeclaredException);
+  }
 }
 
 auto get_fixed_on_parameter_set_callback(const std::string & name, bool successful)


### PR DESCRIPTION
Add tests checking that declaring an statically typed parameter when undeclared parameters are allowed works as described in https://github.com/ros2/rclcpp/pull/1568#discussion_r588763935.

Pending: add test case for https://github.com/ros2/rclcpp/pull/1568#discussion_r589713118.