### PR TITLE
basic async service

### DIFF
--- a/rclcpp/include/rclcpp/create_service.hpp
+++ b/rclcpp/include/rclcpp/create_service.hpp
@@ -48,6 +48,7 @@ create_service(
   auto serv = Service<ServiceT>::make_shared(
     node_base->get_shared_rcl_node_handle(),
     service_name, any_service_callback, service_options);
+  any_service_callback.set_service(serv);
   auto serv_base_ptr = std::dynamic_pointer_cast<ServiceBase>(serv);
   node_services->add_service(serv_base_ptr, group);
   return serv;

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -264,22 +264,6 @@ public:
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_services_default,
     rclcpp::CallbackGroup::SharedPtr group = nullptr);
 
-  /// Create and return an AsyncService.
-  /**
-   * \param[in] service_name The topic to service on.
-   * \param[in] callback User-defined callback function.
-   * \param[in] qos_profile rmw_qos_profile_t Quality of service profile for client.
-   * \param[in] group Callback group to call the service.
-   * \return Shared pointer to the created service.
-   */
-  template<typename ServiceT, typename CallbackT>
-  typename rclcpp::Service<ServiceT>::SharedPtr
-  create_service_async(
-    const std::string & service_name,
-    CallbackT && callback,
-    const rmw_qos_profile_t & qos_profile = rmw_qos_profile_services_default,
-    rclcpp::CallbackGroup::SharedPtr group = nullptr);
-
   /// Create and return a GenericPublisher.
   /**
    * The returned pointer will never be empty, but this function can throw various exceptions, for

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -264,6 +264,22 @@ public:
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_services_default,
     rclcpp::CallbackGroup::SharedPtr group = nullptr);
 
+  /// Create and return an AsyncService.
+  /**
+   * \param[in] service_name The topic to service on.
+   * \param[in] callback User-defined callback function.
+   * \param[in] qos_profile rmw_qos_profile_t Quality of service profile for client.
+   * \param[in] group Callback group to call the service.
+   * \return Shared pointer to the created service.
+   */
+  template<typename ServiceT, typename CallbackT>
+  typename rclcpp::Service<ServiceT>::SharedPtr
+  create_service_async(
+    const std::string & service_name,
+    CallbackT && callback,
+    const rmw_qos_profile_t & qos_profile = rmw_qos_profile_services_default,
+    rclcpp::CallbackGroup::SharedPtr group = nullptr);
+
   /// Create and return a GenericPublisher.
   /**
    * The returned pointer will never be empty, but this function can throw various exceptions, for

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -153,22 +153,6 @@ Node::create_service(
     group);
 }
 
-template<typename ServiceT, typename CallbackT>
-typename rclcpp::Service<ServiceT>::SharedPtr
-Node::create_service_async(
-  const std::string & service_name,
-  CallbackT && callback,
-  const rmw_qos_profile_t & qos_profile,
-  rclcpp::CallbackGroup::SharedPtr group)
-{
-  auto service = create_service<ServiceT, CallbackT>(
-    service_name,
-    std::forward<CallbackT>(callback),
-    qos_profile, group);
-  service->set_async(true);
-  return service;
-}
-
 template<typename AllocatorT>
 std::shared_ptr<rclcpp::GenericPublisher>
 Node::create_generic_publisher(

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -153,6 +153,22 @@ Node::create_service(
     group);
 }
 
+template<typename ServiceT, typename CallbackT>
+typename rclcpp::Service<ServiceT>::SharedPtr
+Node::create_service_async(
+  const std::string & service_name,
+  CallbackT && callback,
+  const rmw_qos_profile_t & qos_profile,
+  rclcpp::CallbackGroup::SharedPtr group)
+{
+  auto service = create_service<ServiceT, CallbackT>(
+    service_name,
+    std::forward<CallbackT>(callback),
+    qos_profile, group);
+  service->set_async(true);
+  return service;
+}
+
 template<typename AllocatorT>
 std::shared_ptr<rclcpp::GenericPublisher>
 Node::create_generic_publisher(
@@ -188,6 +204,7 @@ Node::create_generic_subscription(
     options
   );
 }
+
 
 
 template<typename ParameterT>

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -143,6 +143,7 @@ protected:
 template<typename ServiceT>
 class Service : public ServiceBase
 {
+  bool is_async_ = false;
 public:
   using CallbackType = std::function<
     void (
@@ -346,7 +347,9 @@ public:
     auto typed_request = std::static_pointer_cast<typename ServiceT::Request>(request);
     auto response = std::make_shared<typename ServiceT::Response>();
     any_callback_.dispatch(request_header, typed_request, response);
-    send_response(*request_header, *response);
+    if (!is_async_) {
+        send_response(*request_header, *response);
+    }
   }
 
   void
@@ -357,6 +360,12 @@ public:
     if (ret != RCL_RET_OK) {
       rclcpp::exceptions::throw_from_rcl_error(ret, "failed to send response");
     }
+  }
+
+  void
+  set_async(bool async)
+  {
+    is_async_ = async;
   }
 
 private:

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -345,7 +345,7 @@ public:
   {
     auto typed_request = std::static_pointer_cast<typename ServiceT::Request>(request);
     auto response = std::make_shared<typename ServiceT::Response>();
-    if (any_callback_.dispatch(request_header, typed_request, response, this)) {
+    if (any_callback_.dispatch(request_header, typed_request, response)) {
         send_response(*request_header, *response);
     }
   }

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -143,7 +143,6 @@ protected:
 template<typename ServiceT>
 class Service : public ServiceBase
 {
-  bool is_async_ = false;
 public:
   using CallbackType = std::function<
     void (
@@ -346,8 +345,7 @@ public:
   {
     auto typed_request = std::static_pointer_cast<typename ServiceT::Request>(request);
     auto response = std::make_shared<typename ServiceT::Response>();
-    any_callback_.dispatch(request_header, typed_request, response);
-    if (!is_async_) {
+    if (any_callback_.dispatch(request_header, typed_request, response, this)) {
         send_response(*request_header, *response);
     }
   }
@@ -360,12 +358,6 @@ public:
     if (ret != RCL_RET_OK) {
       rclcpp::exceptions::throw_from_rcl_error(ret, "failed to send response");
     }
-  }
-
-  void
-  set_async(bool async)
-  {
-    is_async_ = async;
   }
 
 private:

--- a/rclcpp/test/rclcpp/test_any_service_callback.cpp
+++ b/rclcpp/test/rclcpp/test_any_service_callback.cpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <utility>
 
+#include "rclcpp/service.hpp"
 #include "rclcpp/any_service_callback.hpp"
 #include "test_msgs/srv/empty.hpp"
 #include "test_msgs/srv/empty.h"
@@ -33,6 +34,8 @@ public:
     request_header_ = std::make_shared<rmw_request_id_t>();
     request_ = std::make_shared<test_msgs::srv::Empty::Request>();
     response_ = std::make_shared<test_msgs::srv::Empty::Response>();
+    rclcpp::AnyServiceCallback<test_msgs::srv::Empty> callback;
+    service_ = std::make_shared<rclcpp::Service<test_msgs::srv::Empty>>(nullptr, nullptr, callback);
   }
 
 protected:
@@ -40,11 +43,12 @@ protected:
   std::shared_ptr<rmw_request_id_t> request_header_;
   std::shared_ptr<test_msgs::srv::Empty::Request> request_;
   std::shared_ptr<test_msgs::srv::Empty::Response> response_;
+  std::shared_ptr<rclcpp::Service<test_msgs::srv::Empty>> service_;
 };
 
 TEST_F(TestAnyServiceCallback, no_set_and_dispatch_throw) {
   EXPECT_THROW(
-    any_service_callback_.dispatch(request_header_, request_, response_),
+    any_service_callback_.dispatch(request_header_, request_, response_, service_.get()),
     std::runtime_error);
 }
 
@@ -57,7 +61,7 @@ TEST_F(TestAnyServiceCallback, set_and_dispatch_no_header) {
 
   any_service_callback_.set(callback);
   EXPECT_NO_THROW(
-    any_service_callback_.dispatch(request_header_, request_, response_));
+    any_service_callback_.dispatch(request_header_, request_, response_, service_.get()));
   EXPECT_EQ(callback_calls, 1);
 }
 
@@ -73,6 +77,6 @@ TEST_F(TestAnyServiceCallback, set_and_dispatch_header) {
 
   any_service_callback_.set(callback_with_header);
   EXPECT_NO_THROW(
-    any_service_callback_.dispatch(request_header_, request_, response_));
+    any_service_callback_.dispatch(request_header_, request_, response_, service_.get()));
   EXPECT_EQ(callback_with_header_calls, 1);
 }

--- a/rclcpp/test/rclcpp/test_any_service_callback.cpp
+++ b/rclcpp/test/rclcpp/test_any_service_callback.cpp
@@ -21,7 +21,6 @@
 #include <memory>
 #include <utility>
 
-#include "rclcpp/service.hpp"
 #include "rclcpp/any_service_callback.hpp"
 #include "test_msgs/srv/empty.hpp"
 #include "test_msgs/srv/empty.h"
@@ -34,8 +33,6 @@ public:
     request_header_ = std::make_shared<rmw_request_id_t>();
     request_ = std::make_shared<test_msgs::srv::Empty::Request>();
     response_ = std::make_shared<test_msgs::srv::Empty::Response>();
-    rclcpp::AnyServiceCallback<test_msgs::srv::Empty> callback;
-    service_ = std::make_shared<rclcpp::Service<test_msgs::srv::Empty>>(nullptr, nullptr, callback);
   }
 
 protected:
@@ -48,7 +45,7 @@ protected:
 
 TEST_F(TestAnyServiceCallback, no_set_and_dispatch_throw) {
   EXPECT_THROW(
-    any_service_callback_.dispatch(request_header_, request_, response_, service_.get()),
+    any_service_callback_.dispatch(request_header_, request_, response_),
     std::runtime_error);
 }
 
@@ -61,7 +58,7 @@ TEST_F(TestAnyServiceCallback, set_and_dispatch_no_header) {
 
   any_service_callback_.set(callback);
   EXPECT_NO_THROW(
-    any_service_callback_.dispatch(request_header_, request_, response_, service_.get()));
+    any_service_callback_.dispatch(request_header_, request_, response_));
   EXPECT_EQ(callback_calls, 1);
 }
 
@@ -77,6 +74,6 @@ TEST_F(TestAnyServiceCallback, set_and_dispatch_header) {
 
   any_service_callback_.set(callback_with_header);
   EXPECT_NO_THROW(
-    any_service_callback_.dispatch(request_header_, request_, response_, service_.get()));
+    any_service_callback_.dispatch(request_header_, request_, response_));
   EXPECT_EQ(callback_with_header_calls, 1);
 }


### PR DESCRIPTION
#491 

naive prevention of `handle_request` from calling `send_response`.  Instead let the client do it, when the result is available.