### PR TITLE
Remove 'struct' from the rcl_time_jump_t.

### DIFF
--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -136,7 +136,7 @@ private:
   RCLCPP_PUBLIC
   static void
   on_time_jump(
-    const struct rcl_time_jump_t * time_jump,
+    const rcl_time_jump_t * time_jump,
     bool before_jump,
     void * user_data);
 

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -113,7 +113,7 @@ Clock::get_clock_mutex() noexcept
 
 void
 Clock::on_time_jump(
-  const struct rcl_time_jump_t * time_jump,
+  const rcl_time_jump_t * time_jump,
   bool before_jump,
   void * user_data)
 {


### PR DESCRIPTION
It is redundant.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>