### PR TITLE
Guard against integer overflow in duration conversion

### DIFF
--- a/rclcpp/src/rclcpp/duration.cpp
+++ b/rclcpp/src/rclcpp/duration.cpp
@@ -67,8 +67,8 @@ Duration::operator builtin_interfaces::msg::Duration() const
 {
   builtin_interfaces::msg::Duration msg_duration;
   constexpr rcl_duration_value_t kDivisor = RCL_S_TO_NS(1);
-  constexpr std::int32_t limit_s = std::numeric_limits<std::int32_t>::max();
-  constexpr std::uint32_t limit_ns = std::numeric_limits<std::uint32_t>::max();
+  constexpr int32_t limit_s = std::numeric_limits<int32_t>::max();
+  constexpr uint32_t limit_ns = std::numeric_limits<uint32_t>::max();
   const auto result = std::div(rcl_duration_.nanoseconds, kDivisor);
   if (result.rem >= 0) {
     // saturate if we will overflow
@@ -76,12 +76,12 @@ Duration::operator builtin_interfaces::msg::Duration() const
       msg_duration.sec = limit_s;
       msg_duration.nanosec = limit_ns;
     } else {
-      msg_duration.sec = static_cast<std::int32_t>(result.quot);
-      msg_duration.nanosec = static_cast<std::uint32_t>(result.rem);
+      msg_duration.sec = static_cast<int32_t>(result.quot);
+      msg_duration.nanosec = static_cast<uint32_t>(result.rem);
     }
   } else {
-    msg_duration.sec = static_cast<std::int32_t>(result.quot - 1);
-    msg_duration.nanosec = static_cast<std::uint32_t>(kDivisor + result.rem);
+    msg_duration.sec = static_cast<int32_t>(result.quot - 1);
+    msg_duration.nanosec = static_cast<uint32_t>(kDivisor + result.rem);
   }
   return msg_duration;
 }

--- a/rclcpp/src/rclcpp/duration.cpp
+++ b/rclcpp/src/rclcpp/duration.cpp
@@ -246,8 +246,8 @@ Duration::to_rmw_time() const
     throw std::runtime_error("rmw_time_t cannot be negative");
   }
 
-  // Purposefully avoid using the same message creation logic to avoid possible overflow
-  // converting from uint64_t to int32_t, then back to uint64_t
+  // Purposefully avoid creating from builtin_interfaces::msg::Duration
+  // to avoid possible overflow converting from int64_t to int32_t, then back to uint64_t
   rmw_time_t result;
   constexpr rcl_duration_value_t kDivisor = RCL_S_TO_NS(1);
   const auto div_result = std::div(rcl_duration_.nanoseconds, kDivisor);

--- a/rclcpp/src/rclcpp/duration.cpp
+++ b/rclcpp/src/rclcpp/duration.cpp
@@ -81,9 +81,9 @@ Duration::operator builtin_interfaces::msg::Duration() const
       msg_duration.nanosec = static_cast<uint32_t>(result.rem);
     }
   } else {
-    if (result.quot < min_s) {
+    if (result.quot <= min_s) {
       msg_duration.sec = min_s;
-      msg_duration.nanosec = max_ns;
+      msg_duration.nanosec = 0u;
     } else {
       msg_duration.sec = static_cast<int32_t>(result.quot - 1);
       msg_duration.nanosec = static_cast<uint32_t>(kDivisor + result.rem);

--- a/rclcpp/test/rclcpp/test_duration.cpp
+++ b/rclcpp/test/rclcpp/test_duration.cpp
@@ -283,6 +283,19 @@ TEST_F(TestDuration, conversions) {
     auto chrono_duration = duration.to_chrono<std::chrono::nanoseconds>();
     EXPECT_EQ(chrono_duration.count(), MAX_NANOSECONDS);
   }
+
+  {
+    auto duration = rclcpp::Duration::from_nanoseconds(-MAX_NANOSECONDS);
+
+    const auto duration_msg = static_cast<builtin_interfaces::msg::Duration>(duration);
+    EXPECT_EQ(duration_msg.sec, std::numeric_limits<int32_t>::min());
+    EXPECT_EQ(duration_msg.nanosec, std::numeric_limits<uint32_t>::max());
+
+    EXPECT_THROW(duration.to_rmw_time(), std::runtime_error);
+
+    auto chrono_duration = duration.to_chrono<std::chrono::nanoseconds>();
+    EXPECT_EQ(chrono_duration.count(), -MAX_NANOSECONDS);
+  }
 }
 
 TEST_F(TestDuration, test_some_constructors) {

--- a/rclcpp/test/rclcpp/test_duration.cpp
+++ b/rclcpp/test/rclcpp/test_duration.cpp
@@ -272,7 +272,7 @@ TEST_F(TestDuration, conversions) {
   {
     auto duration = rclcpp::Duration::from_nanoseconds(MAX_NANOSECONDS);
 
-    const builtin_interfaces::msg::Duration duration_msg = static_cast<builtin_interfaces::msg::Duration>(duration);
+    const auto duration_msg = static_cast<builtin_interfaces::msg::Duration>(duration);
     EXPECT_EQ(duration_msg.sec, std::numeric_limits<std::int32_t>::max());
     EXPECT_EQ(duration_msg.nanosec, std::numeric_limits<std::uint32_t>::max());
 

--- a/rclcpp/test/rclcpp/test_duration.cpp
+++ b/rclcpp/test/rclcpp/test_duration.cpp
@@ -138,6 +138,7 @@ TEST_F(TestDuration, maximum_duration) {
 static const int64_t HALF_SEC_IN_NS = 500 * 1000 * 1000;
 static const int64_t ONE_SEC_IN_NS = 1000 * 1000 * 1000;
 static const int64_t ONE_AND_HALF_SEC_IN_NS = 3 * HALF_SEC_IN_NS;
+static const int64_t MAX_NANOSECONDS = std::numeric_limits<int64_t>::max();
 
 TEST_F(TestDuration, from_seconds) {
   EXPECT_EQ(rclcpp::Duration(0ns), rclcpp::Duration::from_seconds(0.0));
@@ -266,6 +267,21 @@ TEST_F(TestDuration, conversions) {
 
     auto chrono_duration = duration.to_chrono<std::chrono::nanoseconds>();
     EXPECT_EQ(chrono_duration.count(), -ONE_AND_HALF_SEC_IN_NS);
+  }
+
+  {
+    auto duration = rclcpp::Duration::from_nanoseconds(MAX_NANOSECONDS);
+
+    const builtin_interfaces::msg::Duration duration_msg = static_cast<builtin_interfaces::msg::Duration>(duration);
+    EXPECT_EQ(duration_msg.sec, std::numeric_limits<std::int32_t>::max());
+    EXPECT_EQ(duration_msg.nanosec, std::numeric_limits<std::uint32_t>::max());
+
+    auto rmw_time = duration.to_rmw_time();
+    EXPECT_EQ(rmw_time.sec, 9223372036u);
+    EXPECT_EQ(rmw_time.nsec, 854775807u);
+
+    auto chrono_duration = duration.to_chrono<std::chrono::nanoseconds>();
+    EXPECT_EQ(chrono_duration.count(), MAX_NANOSECONDS);
   }
 }
 

--- a/rclcpp/test/rclcpp/test_duration.cpp
+++ b/rclcpp/test/rclcpp/test_duration.cpp
@@ -289,7 +289,7 @@ TEST_F(TestDuration, conversions) {
 
     const auto duration_msg = static_cast<builtin_interfaces::msg::Duration>(duration);
     EXPECT_EQ(duration_msg.sec, std::numeric_limits<int32_t>::min());
-    EXPECT_EQ(duration_msg.nanosec, std::numeric_limits<uint32_t>::max());
+    EXPECT_EQ(duration_msg.nanosec, 0u);
 
     EXPECT_THROW(duration.to_rmw_time(), std::runtime_error);
 

--- a/rclcpp/test/rclcpp/test_duration.cpp
+++ b/rclcpp/test/rclcpp/test_duration.cpp
@@ -273,8 +273,8 @@ TEST_F(TestDuration, conversions) {
     auto duration = rclcpp::Duration::from_nanoseconds(MAX_NANOSECONDS);
 
     const auto duration_msg = static_cast<builtin_interfaces::msg::Duration>(duration);
-    EXPECT_EQ(duration_msg.sec, std::numeric_limits<std::int32_t>::max());
-    EXPECT_EQ(duration_msg.nanosec, std::numeric_limits<std::uint32_t>::max());
+    EXPECT_EQ(duration_msg.sec, std::numeric_limits<int32_t>::max());
+    EXPECT_EQ(duration_msg.nanosec, std::numeric_limits<uint32_t>::max());
 
     auto rmw_time = duration.to_rmw_time();
     EXPECT_EQ(rmw_time.sec, 9223372036u);


### PR DESCRIPTION
Guard against overflow when converting from rclcpp::Duration to builtin_interfaces::msg::Duration,
which is a unsigned to signed conversion.

---

I discovered this bug when making a copy of a `rclcpp::QoS` object with default duration values. Since default durations are max int64 values, they end up overflowing during the copy which uses `rclcpp::Duration::from_rmw_time()` internally.

We can easily see the issue with this reproduction, where we would expect `foo` and `baz` to be equivalent, but they are not:

```c++
  auto foo = rclcpp::Duration::from_nanoseconds(9223372036854775807u);
  auto bar = foo.to_rmw_time();
  rclcpp::Duration baz = rclcpp::Duration::from_rmw_time(bar);

  std::cerr << "foo: " << foo.nanoseconds() << std::endl;
  std::cerr << "baz: " << baz.nanoseconds() << std::endl;
```