### PR TITLE
Document alternative for declaring an optional parameter

### DIFF
--- a/rclcpp/doc/notes_on_statically_typed_parameters.md
+++ b/rclcpp/doc/notes_on_statically_typed_parameters.md
@@ -85,6 +85,16 @@ if (mode == "modeB") {
 }
 ```
 
+Or, wrap the declaration in a try-catch:
+
+```cpp
+try {
+  node->declare_parameter<int64_t>("param_that_is_optional");
+} catch (const rclcpp::exceptions::NoParameterOverrideProvided &) {
+  // a parameter value was not provided
+}
+```
+
 ## Other migration notes
 
 Declaring a parameter with only a name is deprecated:


### PR DESCRIPTION
While we could conditionally declare a parameter by using a second
parameter, we can also just catch the expected exception in the
case that no parameter override is provided.

I think this makes for a better user experience.