### PR TITLE
add automatically_add_executor_with_node option

### DIFF
--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -183,7 +183,9 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   rclcpp::CallbackGroup::SharedPtr
-  create_callback_group(rclcpp::CallbackGroupType group_type);
+  create_callback_group(
+    rclcpp::CallbackGroupType group_type,
+    bool automatically_add_executor_with_node = true);
 
   /// Return the list of callback groups in the node.
   /**

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -179,6 +179,9 @@ public:
   /// Create and return a callback group.
   /**
    * \param[in] group_type callback group type to create by this method.
+   * \param[in] automatically_add_to_executor_with_node A boolean that
+   *   determines whether a callback group is automatically added to an executor
+   *   with the node with which it is associated.
    * \return a callback group
    */
   RCLCPP_LIFECYCLE_PUBLIC

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -185,7 +185,7 @@ public:
   rclcpp::CallbackGroup::SharedPtr
   create_callback_group(
     rclcpp::CallbackGroupType group_type,
-    bool automatically_add_executor_with_node = true);
+    bool automatically_add_to_executor_with_node = true);
 
   /// Return the list of callback groups in the node.
   /**

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -165,9 +165,9 @@ LifecycleNode::get_logger() const
 rclcpp::CallbackGroup::SharedPtr
 LifecycleNode::create_callback_group(
   rclcpp::CallbackGroupType group_type,
-  bool automatically_add_executor_with_node)
+  bool automatically_add_to_executor_with_node)
 {
-  return node_base_->create_callback_group(group_type, automatically_add_executor_with_node);
+  return node_base_->create_callback_group(group_type, automatically_add_to_executor_with_node);
 }
 
 const rclcpp::ParameterValue &

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -164,9 +164,10 @@ LifecycleNode::get_logger() const
 
 rclcpp::CallbackGroup::SharedPtr
 LifecycleNode::create_callback_group(
-  rclcpp::CallbackGroupType group_type)
+  rclcpp::CallbackGroupType group_type,
+  bool automatically_add_executor_with_node)
 {
-  return node_base_->create_callback_group(group_type);
+  return node_base_->create_callback_group(group_type, automatically_add_executor_with_node);
 }
 
 const rclcpp::ParameterValue &

--- a/rclcpp_lifecycle/test/test_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_node.cpp
@@ -666,7 +666,7 @@ TEST_F(TestDefaultStateMachine, test_callback_groups) {
   EXPECT_EQ(groups.size(), 1u);
 
   auto group = test_node->create_callback_group(
-    rclcpp::CallbackGroupType::MutuallyExclusive);
+    rclcpp::CallbackGroupType::MutuallyExclusive, true);
   EXPECT_NE(nullptr, group);
 
   groups = test_node->get_callback_groups();


### PR DESCRIPTION
This PR tries to implement #1589

It adds the `automatically_add_executor_with_node` option when creating a callback_group for a LifecycleNode.