### PR TITLE
Add publishing instrumentation

### DIFF
--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -40,6 +40,8 @@
 #include "rclcpp/type_support_decl.hpp"
 #include "rclcpp/visibility_control.hpp"
 
+#include "tracetools/tracetools.h"
+
 namespace rclcpp
 {
 
@@ -279,6 +281,10 @@ protected:
   void
   do_inter_process_publish(const MessageT & msg)
   {
+    TRACEPOINT(
+      rclcpp_publish,
+      static_cast<const void *>(publisher_handle_.get()),
+      static_cast<const void *>(&msg));
     auto status = rcl_publish(publisher_handle_.get(), &msg, nullptr);
 
     if (RCL_RET_PUBLISHER_INVALID == status) {


### PR DESCRIPTION
This adds publishing instrumentation, with the goal being to be able to track a message across all the layers.

Note that we're only supporting "normal," inter-process publishing for now.

Requires https://gitlab.com/ros-tracing/ros2_tracing/-/merge_requests/227

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>