### PR TITLE
Fix flaky lifecycle node tests

### DIFF
--- a/rclcpp_lifecycle/test/test_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_node.cpp
@@ -34,6 +34,9 @@
 using lifecycle_msgs::msg::State;
 using lifecycle_msgs::msg::Transition;
 
+static const std::chrono::nanoseconds DEFAULT_EVENT_TIMEOUT = std::chrono::seconds(3);
+static const std::chrono::nanoseconds DEFAULT_EVENT_SLEEP_PERIOD = std::chrono::milliseconds(100);
+
 static
 bool wait_for_event(
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
@@ -60,8 +63,8 @@ static
 bool wait_for_topic(
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
   const std::string & topic,
-  std::chrono::nanoseconds timeout = std::chrono::seconds(3),
-  std::chrono::nanoseconds sleep_period = std::chrono::milliseconds(100))
+  std::chrono::nanoseconds timeout = DEFAULT_EVENT_TIMEOUT,
+  std::chrono::nanoseconds sleep_period = DEFAULT_EVENT_SLEEP_PERIOD)
 {
   return wait_for_event(
     node,
@@ -78,8 +81,8 @@ static
 bool wait_for_service(
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
   const std::string & service,
-  std::chrono::nanoseconds timeout = std::chrono::seconds(3),
-  std::chrono::nanoseconds sleep_period = std::chrono::milliseconds(100))
+  std::chrono::nanoseconds timeout = DEFAULT_EVENT_TIMEOUT,
+  std::chrono::nanoseconds sleep_period = DEFAULT_EVENT_SLEEP_PERIOD)
 {
   return wait_for_event(
     node,

--- a/rclcpp_lifecycle/test/test_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_node.cpp
@@ -100,8 +100,8 @@ bool wait_for_service_by_node(
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
   const std::string & node_name,
   const std::string & service,
-  std::chrono::nanoseconds timeout = std::chrono::seconds(3),
-  std::chrono::nanoseconds sleep_period = std::chrono::milliseconds(100))
+  std::chrono::nanoseconds timeout = DEFAULT_EVENT_TIMEOUT,
+  std::chrono::nanoseconds sleep_period = DEFAULT_EVENT_SLEEP_PERIOD)
 {
   return wait_for_event(
     node,

--- a/rclcpp_lifecycle/test/test_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_node.cpp
@@ -64,14 +64,14 @@ bool wait_for_topic(
   std::chrono::nanoseconds sleep_period = std::chrono::milliseconds(100))
 {
   return wait_for_event(
-      node,
-      [node, topic]()
-      {
-        auto topic_names_and_types = node->get_topic_names_and_types();
-        return topic_names_and_types.end() != topic_names_and_types.find(topic);
-      },
-      timeout,
-      sleep_period);
+    node,
+    [node, topic]()
+    {
+      auto topic_names_and_types = node->get_topic_names_and_types();
+      return topic_names_and_types.end() != topic_names_and_types.find(topic);
+    },
+    timeout,
+    sleep_period);
 }
 
 static
@@ -82,14 +82,14 @@ bool wait_for_service(
   std::chrono::nanoseconds sleep_period = std::chrono::milliseconds(100))
 {
   return wait_for_event(
-      node,
-      [node, service]()
-      {
-        auto service_names_and_types = node->get_service_names_and_types();
-        return service_names_and_types.end() != service_names_and_types.find(service);
-      },
-      timeout,
-      sleep_period);
+    node,
+    [node, service]()
+    {
+      auto service_names_and_types = node->get_service_names_and_types();
+      return service_names_and_types.end() != service_names_and_types.find(service);
+    },
+    timeout,
+    sleep_period);
 }
 
 static
@@ -101,16 +101,16 @@ bool wait_for_service_by_node(
   std::chrono::nanoseconds sleep_period = std::chrono::milliseconds(100))
 {
   return wait_for_event(
-      node,
-      [node, node_name, service]()
-      {
-        auto service_names_and_types_by_node =
-          node->get_service_names_and_types_by_node(node_name, "");
-        return service_names_and_types_by_node.end() !=
-            service_names_and_types_by_node.find(service);
-      },
-      timeout,
-      sleep_period);
+    node,
+    [node, node_name, service]()
+    {
+      auto service_names_and_types_by_node = node->get_service_names_and_types_by_node(
+        node_name, "");
+      return service_names_and_types_by_node.end() != service_names_and_types_by_node.find(
+        service);
+    },
+    timeout,
+    sleep_period);
 }
 
 class TestDefaultStateMachine : public ::testing::Test

--- a/rclcpp_lifecycle/test/test_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_node.cpp
@@ -44,7 +44,8 @@ bool wait_for_event(
   auto start = std::chrono::steady_clock::now();
   std::chrono::microseconds time_slept(0);
 
-  while (!predicate() &&
+  bool predicate_result;
+  while (!(predicate_result = predicate()) &&
     time_slept < std::chrono::duration_cast<std::chrono::microseconds>(timeout))
   {
     rclcpp::Event::SharedPtr graph_event = node->get_graph_event();
@@ -52,7 +53,7 @@ bool wait_for_event(
     time_slept = std::chrono::duration_cast<std::chrono::microseconds>(
       std::chrono::steady_clock::now() - start);
   }
-  return predicate();
+  return predicate_result;
 }
 
 static


### PR DESCRIPTION
Apparently, the topics and services that LifecycleNode provides are not
available immediately after creating a node.

Fix flaky tests by accounting for some delay between the LifecycleNode
constructor and queries about its topics and services.

Fixes #1605 