### PR TITLE
Namespace tracetools C++ util functions

### DIFF
--- a/rclcpp/include/rclcpp/any_service_callback.hpp
+++ b/rclcpp/include/rclcpp/any_service_callback.hpp
@@ -107,12 +107,12 @@ public:
       TRACEPOINT(
         rclcpp_callback_register,
         static_cast<const void *>(this),
-        get_symbol(shared_ptr_callback_));
+        tracetools::get_symbol(shared_ptr_callback_));
     } else if (shared_ptr_with_request_header_callback_) {
       TRACEPOINT(
         rclcpp_callback_register,
         static_cast<const void *>(this),
-        get_symbol(shared_ptr_with_request_header_callback_));
+        tracetools::get_symbol(shared_ptr_with_request_header_callback_));
     }
 #endif  // TRACETOOLS_DISABLED
   }

--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -243,22 +243,22 @@ public:
       TRACEPOINT(
         rclcpp_callback_register,
         static_cast<const void *>(this),
-        get_symbol(shared_ptr_callback_));
+        tracetools::get_symbol(shared_ptr_callback_));
     } else if (shared_ptr_with_info_callback_) {
       TRACEPOINT(
         rclcpp_callback_register,
         static_cast<const void *>(this),
-        get_symbol(shared_ptr_with_info_callback_));
+        tracetools::get_symbol(shared_ptr_with_info_callback_));
     } else if (unique_ptr_callback_) {
       TRACEPOINT(
         rclcpp_callback_register,
         static_cast<const void *>(this),
-        get_symbol(unique_ptr_callback_));
+        tracetools::get_symbol(unique_ptr_callback_));
     } else if (unique_ptr_with_info_callback_) {
       TRACEPOINT(
         rclcpp_callback_register,
         static_cast<const void *>(this),
-        get_symbol(unique_ptr_with_info_callback_));
+        tracetools::get_symbol(unique_ptr_with_info_callback_));
     }
 #endif  // TRACETOOLS_DISABLED
   }

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -181,7 +181,7 @@ public:
     TRACEPOINT(
       rclcpp_callback_register,
       static_cast<const void *>(&callback_),
-      get_symbol(callback_));
+      tracetools::get_symbol(callback_));
   }
 
   /// Default destructor.


### PR DESCRIPTION
2nd try for #1603 / #1607

The upstream ros2_tracing MR has been merged: https://gitlab.com/ros-tracing/ros2_tracing/-/merge_requests/229

This makes the hundreds of deprecation warnings go away.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>