### PR TITLE
Initialize integers in test_parameter_event_handler.cpp to avoid undefined behavior

### DIFF
--- a/rclcpp/test/rclcpp/test_parameter_event_handler.cpp
+++ b/rclcpp/test/rclcpp/test_parameter_event_handler.cpp
@@ -149,8 +149,8 @@ TEST_F(TestNode, RegisterParameterCallback)
 
 TEST_F(TestNode, SameParameterDifferentNode)
 {
-  int64_t int_param_node1;
-  int64_t int_param_node2;
+  int64_t int_param_node1{0};
+  int64_t int_param_node2{0};
 
   auto cb1 = [&int_param_node1](const rclcpp::Parameter & p) {
       int_param_node1 = p.get_value<int64_t>();


### PR DESCRIPTION
Likely fixes https://ci.ros2.org/view/nightly/job/nightly_linux_release/1870/testReport/junit/projectroot.test/rclcpp/test_parameter_event_handler/

I have only see that once, it's probably flaky due to the variables not being initialized.