### PR TITLE
Fix parameter event handler test

### DIFF
--- a/rclcpp/test/rclcpp/test_parameter_event_handler.cpp
+++ b/rclcpp/test/rclcpp/test_parameter_event_handler.cpp
@@ -149,8 +149,8 @@ TEST_F(TestNode, RegisterParameterCallback)
 
 TEST_F(TestNode, SameParameterDifferentNode)
 {
-  int64_t int_param_node1;
-  int64_t int_param_node2;
+  int64_t int_param_node1 = 0;
+  int64_t int_param_node2 = 0;
 
   auto cb1 = [&int_param_node1](const rclcpp::Parameter & p) {
       int_param_node1 = p.get_value<int64_t>();


### PR DESCRIPTION
Zero-initialize variables, otherwise the test may fail.
This can happen in release builds.

I think this should fix: https://ci.ros2.org/job/nightly_linux_release/1870/testReport/junit/rclcpp/TestNode/SameParameterDifferentNode/