### PR TITLE
Use rclcpp::guard_condition

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -41,6 +41,7 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/clock.cpp
   src/rclcpp/context.cpp
   src/rclcpp/contexts/default_context.cpp
+  src/rclcpp/detail/add_guard_condition_to_rcl_wait_set.cpp
   src/rclcpp/detail/resolve_parameter_overrides.cpp
   src/rclcpp/detail/rmw_implementation_specific_payload.cpp
   src/rclcpp/detail/rmw_implementation_specific_publisher_payload.cpp

--- a/rclcpp/include/rclcpp/detail/add_guard_condition_to_rcl_wait_set.hpp
+++ b/rclcpp/include/rclcpp/detail/add_guard_condition_to_rcl_wait_set.hpp
@@ -1,0 +1,40 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__DETAIL__ADD_GUARD_CONDITION_TO_RCL_WAIT_SET_HPP_
+#define RCLCPP__DETAIL__ADD_GUARD_CONDITION_TO_RCL_WAIT_SET_HPP_
+
+#include "rclcpp/guard_condition.hpp"
+
+namespace rclcpp
+{
+namespace detail
+{
+
+/// Adds the guard condition to a waitset
+/**
+ * This function is thread-safe.
+ * \param[in] wait_set reference to a wait set where to add the guard condition
+ * \param[in] guard_condition reference to the guard_condition to be added
+ */
+RCLCPP_PUBLIC
+void
+add_guard_condition_to_rcl_wait_set(
+  rcl_wait_set_t & wait_set,
+  const rclcpp::GuardCondition & guard_condition);
+
+}  // namespace detail
+}  // namespace rclcpp
+
+#endif  // RCLCPP__DETAIL__ADD_GUARD_CONDITION_TO_RCL_WAIT_SET_HPP_

--- a/rclcpp/include/rclcpp/detail/add_guard_condition_to_rcl_wait_set.hpp
+++ b/rclcpp/include/rclcpp/detail/add_guard_condition_to_rcl_wait_set.hpp
@@ -24,7 +24,6 @@ namespace detail
 
 /// Adds the guard condition to a waitset
 /**
- * This function is thread-safe.
  * \param[in] wait_set reference to a wait set where to add the guard condition
  * \param[in] guard_condition reference to the guard_condition to be added
  */

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -525,7 +525,7 @@ protected:
   std::atomic_bool spinning;
 
   /// Guard condition for signaling the rmw layer to wake up for special events.
-  rcl_guard_condition_t interrupt_guard_condition_ = rcl_get_zero_initialized_guard_condition();
+  rclcpp::GuardCondition interrupt_guard_condition_;
 
   std::shared_ptr<rclcpp::GuardCondition> shutdown_guard_condition_;
 
@@ -549,7 +549,7 @@ protected:
   spin_once_impl(std::chrono::nanoseconds timeout);
 
   typedef std::map<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr,
-      const rcl_guard_condition_t *,
+      const rclcpp::GuardCondition *,
       std::owner_less<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr>>
     WeakNodesToGuardConditionsMap;
 

--- a/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
@@ -102,7 +102,7 @@ public:
    * \throws std::runtime_error if it couldn't add guard condition to wait set
    */
   RCLCPP_PUBLIC
-  bool
+  void
   add_to_wait_set(rcl_wait_set_t * wait_set) override;
 
   RCLCPP_PUBLIC
@@ -328,7 +328,7 @@ private:
   WeakCallbackGroupsToNodesMap weak_groups_to_nodes_associated_with_executor_;
 
   typedef std::map<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr,
-      const rcl_guard_condition_t *,
+      const rclcpp::GuardCondition *,
       std::owner_less<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr>>
     WeakNodesToGuardConditionsMap;
   WeakNodesToGuardConditionsMap weak_nodes_to_guard_conditions_;

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -25,6 +25,7 @@
 
 #include "rcl/error_handling.h"
 
+#include "rclcpp/guard_condition.hpp"
 #include "rclcpp/qos.hpp"
 #include "rclcpp/type_support_decl.hpp"
 #include "rclcpp/waitable.hpp"
@@ -41,9 +42,10 @@ public:
 
   RCLCPP_PUBLIC
   SubscriptionIntraProcessBase(
+    rclcpp::Context::SharedPtr context,
     const std::string & topic_name,
     const rclcpp::QoS & qos_profile)
-  : topic_name_(topic_name), qos_profile_(qos_profile)
+  : gc_(context), topic_name_(topic_name), qos_profile_(qos_profile)
   {}
 
   virtual ~SubscriptionIntraProcessBase() = default;
@@ -53,7 +55,7 @@ public:
   get_number_of_ready_guard_conditions() {return 1;}
 
   RCLCPP_PUBLIC
-  bool
+  void
   add_to_wait_set(rcl_wait_set_t * wait_set);
 
   virtual bool
@@ -79,7 +81,7 @@ public:
 
 protected:
   std::recursive_mutex reentrant_mutex_;
-  rcl_guard_condition_t gc_;
+  rclcpp::GuardCondition gc_;
 
 private:
   virtual void

--- a/rclcpp/include/rclcpp/graph_listener.hpp
+++ b/rclcpp/include/rclcpp/graph_listener.hpp
@@ -24,6 +24,7 @@
 #include "rcl/guard_condition.h"
 #include "rcl/wait.h"
 #include "rclcpp/context.hpp"
+#include "rclcpp/guard_condition.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/node_interfaces/node_graph_interface.hpp"
 #include "rclcpp/visibility_control.hpp"
@@ -187,7 +188,7 @@ private:
   mutable std::mutex node_graph_interfaces_mutex_;
   std::vector<rclcpp::node_interfaces::NodeGraphInterface *> node_graph_interfaces_;
 
-  rcl_guard_condition_t interrupt_guard_condition_ = rcl_get_zero_initialized_guard_condition();
+  rclcpp::GuardCondition interrupt_guard_condition_;
   rcl_wait_set_t wait_set_ = rcl_get_zero_initialized_wait_set();
 };
 

--- a/rclcpp/include/rclcpp/guard_condition.hpp
+++ b/rclcpp/include/rclcpp/guard_condition.hpp
@@ -47,7 +47,9 @@ public:
   RCLCPP_PUBLIC
   explicit GuardCondition(
     rclcpp::Context::SharedPtr context =
-    rclcpp::contexts::get_global_default_context());
+    rclcpp::contexts::get_global_default_context(),
+    rcl_guard_condition_options_t guard_condition_options =
+    rcl_guard_condition_get_default_options());
 
   RCLCPP_PUBLIC
   virtual
@@ -57,6 +59,11 @@ public:
   RCLCPP_PUBLIC
   rclcpp::Context::SharedPtr
   get_context() const;
+
+  /// Return the underlying rcl guard condition structure.
+  RCLCPP_PUBLIC
+  rcl_guard_condition_t &
+  get_rcl_guard_condition();
 
   /// Return the underlying rcl guard condition structure.
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -64,9 +64,11 @@ public:
   virtual void clear_handles() = 0;
   virtual void remove_null_handles(rcl_wait_set_t * wait_set) = 0;
 
-  virtual void add_guard_condition(const rcl_guard_condition_t * guard_condition) = 0;
+  virtual void
+  add_guard_condition(const rclcpp::GuardCondition & guard_condition) = 0;
 
-  virtual void remove_guard_condition(const rcl_guard_condition_t * guard_condition) = 0;
+  virtual void
+  remove_guard_condition(const rclcpp::GuardCondition & guard_condition) = 0;
 
   virtual void
   get_next_subscription(

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -68,7 +68,7 @@ public:
   add_guard_condition(const rclcpp::GuardCondition & guard_condition) = 0;
 
   virtual void
-  remove_guard_condition(const rclcpp::GuardCondition & guard_condition) = 0;
+  remove_guard_condition(const rclcpp::GuardCondition * guard_condition) = 0;
 
   virtual void
   get_next_subscription(

--- a/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
@@ -114,12 +114,8 @@ public:
   get_associated_with_executor_atomic() override;
 
   RCLCPP_PUBLIC
-  rcl_guard_condition_t *
+  rclcpp::GuardCondition &
   get_notify_guard_condition() override;
-
-  RCLCPP_PUBLIC
-  std::unique_lock<std::recursive_mutex>
-  acquire_notify_guard_condition_lock() const override;
 
   RCLCPP_PUBLIC
   bool
@@ -149,7 +145,7 @@ private:
 
   /// Guard condition for notifying the Executor of changes to this node.
   mutable std::recursive_mutex notify_guard_condition_mutex_;
-  rcl_guard_condition_t notify_guard_condition_ = rcl_get_zero_initialized_guard_condition();
+  rclcpp::GuardCondition notify_guard_condition_;
   bool notify_guard_condition_is_valid_;
 };
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
@@ -24,6 +24,7 @@
 
 #include "rclcpp/callback_group.hpp"
 #include "rclcpp/context.hpp"
+#include "rclcpp/guard_condition.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/visibility_control.hpp"
 
@@ -142,23 +143,16 @@ public:
   std::atomic_bool &
   get_associated_with_executor_atomic() = 0;
 
-  /// Return guard condition that should be notified when the internal node state changes.
+  /// Return a guard condition that should be notified when the internal node state changes.
   /**
    * For example, this should be notified when a publisher is added or removed.
    *
-   * \return the rcl_guard_condition_t if it is valid, else nullptr
+   * \return the GuardCondition if it is valid, else thow runtime error
    */
   RCLCPP_PUBLIC
   virtual
-  rcl_guard_condition_t *
+  rclcpp::GuardCondition &
   get_notify_guard_condition() = 0;
-
-  /// Acquire and return a scoped lock that protects the notify guard condition.
-  /** This should be used when triggering the notify guard condition. */
-  RCLCPP_PUBLIC
-  virtual
-  std::unique_lock<std::recursive_mutex>
-  acquire_notify_guard_condition_lock() const = 0;
 
   /// Return the default preference for using intra process communication.
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -94,7 +94,7 @@ public:
 
   /// Add the Waitable to a wait set.
   RCLCPP_PUBLIC
-  bool
+  void
   add_to_wait_set(rcl_wait_set_t * wait_set) override;
 
   /// Check if the Waitable is ready.

--- a/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
@@ -72,10 +72,10 @@ public:
     guard_conditions_.push_back(&guard_condition);
   }
 
-  void remove_guard_condition(const rclcpp::GuardCondition & guard_condition) override
+  void remove_guard_condition(const rclcpp::GuardCondition * guard_condition) override
   {
     for (auto it = guard_conditions_.begin(); it != guard_conditions_.end(); ++it) {
-      if (*it == &guard_condition) {
+      if (*it == guard_condition) {
         guard_conditions_.erase(it);
         break;
       }

--- a/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
@@ -21,6 +21,7 @@
 #include "rcl/allocator.h"
 
 #include "rclcpp/allocator/allocator_common.hpp"
+#include "rclcpp/detail/add_guard_condition_to_rcl_wait_set.hpp"
 #include "rclcpp/memory_strategy.hpp"
 #include "rclcpp/node.hpp"
 #include "rclcpp/visibility_control.hpp"
@@ -61,20 +62,20 @@ public:
     allocator_ = std::make_shared<VoidAlloc>();
   }
 
-  void add_guard_condition(const rcl_guard_condition_t * guard_condition) override
+  void add_guard_condition(const rclcpp::GuardCondition & guard_condition) override
   {
     for (const auto & existing_guard_condition : guard_conditions_) {
-      if (existing_guard_condition == guard_condition) {
+      if (existing_guard_condition == &guard_condition) {
         return;
       }
     }
-    guard_conditions_.push_back(guard_condition);
+    guard_conditions_.push_back(&guard_condition);
   }
 
-  void remove_guard_condition(const rcl_guard_condition_t * guard_condition) override
+  void remove_guard_condition(const rclcpp::GuardCondition & guard_condition) override
   {
     for (auto it = guard_conditions_.begin(); it != guard_conditions_.end(); ++it) {
-      if (*it == guard_condition) {
+      if (*it == &guard_condition) {
         guard_conditions_.erase(it);
         break;
       }
@@ -240,22 +241,11 @@ public:
     }
 
     for (auto guard_condition : guard_conditions_) {
-      if (rcl_wait_set_add_guard_condition(wait_set, guard_condition, NULL) != RCL_RET_OK) {
-        RCUTILS_LOG_ERROR_NAMED(
-          "rclcpp",
-          "Couldn't add guard_condition to wait set: %s",
-          rcl_get_error_string().str);
-        return false;
-      }
+      detail::add_guard_condition_to_rcl_wait_set(*wait_set, *guard_condition);
     }
 
     for (auto waitable : waitable_handles_) {
-      if (!waitable->add_to_wait_set(wait_set)) {
-        RCUTILS_LOG_ERROR_NAMED(
-          "rclcpp",
-          "Couldn't add waitable to wait set: %s", rcl_get_error_string().str);
-        return false;
-      }
+      waitable->add_to_wait_set(wait_set);
     }
     return true;
   }
@@ -509,7 +499,7 @@ private:
   using VectorRebind =
     std::vector<T, typename std::allocator_traits<Alloc>::template rebind_alloc<T>>;
 
-  VectorRebind<const rcl_guard_condition_t *> guard_conditions_;
+  VectorRebind<const rclcpp::GuardCondition *> guard_conditions_;
 
   VectorRebind<std::shared_ptr<const rcl_subscription_t>> subscription_handles_;
   VectorRebind<std::shared_ptr<const rcl_service_t>> service_handles_;

--- a/rclcpp/include/rclcpp/wait_set_policies/detail/storage_policy_common.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/detail/storage_policy_common.hpp
@@ -383,10 +383,7 @@ protected:
         continue;
       }
       rclcpp::Waitable & waitable = *waitable_ptr_pair.second;
-      bool successful = waitable.add_to_wait_set(&rcl_wait_set_);
-      if (!successful) {
-        throw std::runtime_error("waitable unexpectedly failed to be added to wait set");
-      }
+      waitable.add_to_wait_set(&rcl_wait_set_);
     }
   }
 

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -103,12 +103,11 @@ public:
   /// Add the Waitable to a wait set.
   /**
    * \param[in] wait_set A handle to the wait set to add the Waitable to.
-   * \return `true` if the Waitable is added successfully, `false` otherwise.
    * \throws rclcpp::execptions::RCLError from rcl_wait_set_add_*()
    */
   RCLCPP_PUBLIC
   virtual
-  bool
+  void
   add_to_wait_set(rcl_wait_set_t * wait_set) = 0;
 
   /// Check if the Waitable is ready.
@@ -145,8 +144,7 @@ public:
    * ```cpp
    * // ... create a wait set and a Waitable
    * // Add the Waitable to the wait set
-   * bool add_ret = waitable.add_to_wait_set(wait_set);
-   * // ... error handling
+   * waitable.add_to_wait_set(wait_set);
    * // Wait
    * rcl_ret_t wait_ret = rcl_wait(wait_set);
    * // ... error handling
@@ -172,8 +170,7 @@ public:
    * ```cpp
    * // ... create a wait set and a Waitable
    * // Add the Waitable to the wait set
-   * bool add_ret = waitable.add_to_wait_set(wait_set);
-   * // ... error handling
+   * waitable.add_to_wait_set(wait_set);
    * // Wait
    * rcl_ret_t wait_ret = rcl_wait(wait_set);
    * // ... error handling

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -45,18 +45,12 @@ using rclcpp::FutureReturnCode;
 
 Executor::Executor(const rclcpp::ExecutorOptions & options)
 : spinning(false),
+  interrupt_guard_condition_(options.context),
   shutdown_guard_condition_(std::make_shared<rclcpp::GuardCondition>(options.context)),
   memory_strategy_(options.memory_strategy)
 {
   // Store the context for later use.
   context_ = options.context;
-
-  rcl_guard_condition_options_t guard_condition_options = rcl_guard_condition_get_default_options();
-  rcl_ret_t ret = rcl_guard_condition_init(
-    &interrupt_guard_condition_, context_->get_rcl_context().get(), guard_condition_options);
-  if (RCL_RET_OK != ret) {
-    throw_from_rcl_error(ret, "Failed to create interrupt guard condition in Executor constructor");
-  }
 
   shutdown_callback_handle_ = context_->add_on_shutdown_callback(
     [weak_gc = std::weak_ptr<rclcpp::GuardCondition>{shutdown_guard_condition_}]() {
@@ -68,13 +62,13 @@ Executor::Executor(const rclcpp::ExecutorOptions & options)
 
   // The number of guard conditions is always at least 2: 1 for the ctrl-c guard cond,
   // and one for the executor's guard cond (interrupt_guard_condition_)
-  memory_strategy_->add_guard_condition(&shutdown_guard_condition_->get_rcl_guard_condition());
+  memory_strategy_->add_guard_condition(*shutdown_guard_condition_.get());
 
   // Put the executor's guard condition in
-  memory_strategy_->add_guard_condition(&interrupt_guard_condition_);
+  memory_strategy_->add_guard_condition(interrupt_guard_condition_);
   rcl_allocator_t allocator = memory_strategy_->get_allocator();
 
-  ret = rcl_wait_set_init(
+  rcl_ret_t ret = rcl_wait_set_init(
     &wait_set_,
     0, 2, 0, 0, 0, 0,
     context_->get_rcl_context().get(),
@@ -84,12 +78,6 @@ Executor::Executor(const rclcpp::ExecutorOptions & options)
       "rclcpp",
       "failed to create wait set: %s", rcl_get_error_string().str);
     rcl_reset_error();
-    if (rcl_guard_condition_fini(&interrupt_guard_condition_) != RCL_RET_OK) {
-      RCUTILS_LOG_ERROR_NAMED(
-        "rclcpp",
-        "failed to destroy guard condition: %s", rcl_get_error_string().str);
-      rcl_reset_error();
-    }
     throw_from_rcl_error(ret, "Failed to create wait set in Executor constructor");
   }
 }
@@ -120,7 +108,7 @@ Executor::~Executor()
   weak_groups_to_nodes_.clear();
   for (const auto & pair : weak_nodes_to_guard_conditions_) {
     auto & guard_condition = pair.second;
-    memory_strategy_->remove_guard_condition(guard_condition);
+    memory_strategy_->remove_guard_condition(*guard_condition);
   }
   weak_nodes_to_guard_conditions_.clear();
 
@@ -131,15 +119,9 @@ Executor::~Executor()
       "failed to destroy wait set: %s", rcl_get_error_string().str);
     rcl_reset_error();
   }
-  // Finalize the interrupt guard condition.
-  if (rcl_guard_condition_fini(&interrupt_guard_condition_) != RCL_RET_OK) {
-    RCUTILS_LOG_ERROR_NAMED(
-      "rclcpp",
-      "failed to destroy guard condition: %s", rcl_get_error_string().str);
-    rcl_reset_error();
-  }
   // Remove and release the sigint guard condition
-  memory_strategy_->remove_guard_condition(&shutdown_guard_condition_->get_rcl_guard_condition());
+  memory_strategy_->remove_guard_condition(*shutdown_guard_condition_.get());
+  memory_strategy_->remove_guard_condition(interrupt_guard_condition_);
 
   // Remove shutdown callback handle registered to Context
   if (!context_->remove_on_shutdown_callback(shutdown_callback_handle_)) {
@@ -234,17 +216,20 @@ Executor::add_callback_group_to_map(
   // Also add to the map that contains all callback groups
   weak_groups_to_nodes_.insert(std::make_pair(weak_group_ptr, node_ptr));
   if (is_new_node) {
-    rclcpp::node_interfaces::NodeBaseInterface::WeakPtr node_weak_ptr(node_ptr);
-    weak_nodes_to_guard_conditions_[node_weak_ptr] = node_ptr->get_notify_guard_condition();
+    const auto & gc = node_ptr->get_notify_guard_condition();
+    weak_nodes_to_guard_conditions_[node_ptr] = &gc;
     if (notify) {
       // Interrupt waiting to handle new node
-      rcl_ret_t ret = rcl_trigger_guard_condition(&interrupt_guard_condition_);
-      if (ret != RCL_RET_OK) {
-        throw_from_rcl_error(ret, "Failed to trigger guard condition on callback group add");
+      try {
+        interrupt_guard_condition_.trigger();
+      } catch (const rclcpp::exceptions::RCLError & ex) {
+        throw std::runtime_error(
+                std::string(
+                  "Failed to trigger guard condition on callback group add: ") + ex.what());
       }
     }
     // Add the node's notify condition to the guard condition handles
-    memory_strategy_->add_guard_condition(node_ptr->get_notify_guard_condition());
+    memory_strategy_->add_guard_condition(gc);
   }
 }
 
@@ -315,12 +300,14 @@ Executor::remove_callback_group_from_map(
   if (!has_node(node_ptr, weak_groups_to_nodes_associated_with_executor_) &&
     !has_node(node_ptr, weak_groups_associated_with_executor_to_nodes_))
   {
-    rclcpp::node_interfaces::NodeBaseInterface::WeakPtr node_weak_ptr(node_ptr);
-    weak_nodes_to_guard_conditions_.erase(node_weak_ptr);
+    weak_nodes_to_guard_conditions_.erase(node_ptr);
     if (notify) {
-      rcl_ret_t ret = rcl_trigger_guard_condition(&interrupt_guard_condition_);
-      if (ret != RCL_RET_OK) {
-        throw_from_rcl_error(ret, "Failed to trigger guard condition on callback group remove");
+      try {
+        interrupt_guard_condition_.trigger();
+      } catch (const rclcpp::exceptions::RCLError & ex) {
+        throw std::runtime_error(
+                std::string(
+                  "Failed to trigger guard condition on callback group remove: ") + ex.what());
       }
     }
     memory_strategy_->remove_guard_condition(node_ptr->get_notify_guard_condition());
@@ -494,9 +481,11 @@ void
 Executor::cancel()
 {
   spinning.store(false);
-  rcl_ret_t ret = rcl_trigger_guard_condition(&interrupt_guard_condition_);
-  if (ret != RCL_RET_OK) {
-    throw_from_rcl_error(ret, "Failed to trigger guard condition in cancel");
+  try {
+    interrupt_guard_condition_.trigger();
+  } catch (const rclcpp::exceptions::RCLError & ex) {
+    throw std::runtime_error(
+            std::string("Failed to trigger guard condition in cancel: ") + ex.what());
   }
 }
 
@@ -541,9 +530,12 @@ Executor::execute_any_executable(AnyExecutable & any_exec)
   any_exec.callback_group->can_be_taken_from().store(true);
   // Wake the wait, because it may need to be recalculated or work that
   // was previously blocked is now available.
-  rcl_ret_t ret = rcl_trigger_guard_condition(&interrupt_guard_condition_);
-  if (ret != RCL_RET_OK) {
-    throw_from_rcl_error(ret, "Failed to trigger guard condition from execute_any_executable");
+  try {
+    interrupt_guard_condition_.trigger();
+  } catch (const rclcpp::exceptions::RCLError & ex) {
+    throw std::runtime_error(
+            std::string(
+              "Failed to trigger guard condition from execute_any_executable: ") + ex.what());
   }
 }
 
@@ -710,9 +702,9 @@ Executor::wait_for_work(std::chrono::nanoseconds timeout)
           invalid_group_ptrs.push_back(weak_group_ptr);
           auto node_guard_pair = weak_nodes_to_guard_conditions_.find(weak_node_ptr);
           if (node_guard_pair != weak_nodes_to_guard_conditions_.end()) {
-            auto guard_condition = node_guard_pair->second;
+            const auto & guard_condition = node_guard_pair->second;
             weak_nodes_to_guard_conditions_.erase(weak_node_ptr);
-            memory_strategy_->remove_guard_condition(guard_condition);
+            memory_strategy_->remove_guard_condition(*guard_condition);
           }
         }
       }

--- a/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
@@ -139,9 +139,7 @@ StaticSingleThreadedExecutor::add_callback_group(
   bool is_new_node = entities_collector_->add_callback_group(group_ptr, node_ptr);
   if (is_new_node && notify) {
     // Interrupt waiting to handle new node
-    if (rcl_trigger_guard_condition(&interrupt_guard_condition_) != RCL_RET_OK) {
-      throw std::runtime_error(rcl_get_error_string().str);
-    }
+    interrupt_guard_condition_.trigger();
   }
 }
 
@@ -152,9 +150,7 @@ StaticSingleThreadedExecutor::add_node(
   bool is_new_node = entities_collector_->add_node(node_ptr);
   if (is_new_node && notify) {
     // Interrupt waiting to handle new node
-    if (rcl_trigger_guard_condition(&interrupt_guard_condition_) != RCL_RET_OK) {
-      throw std::runtime_error(rcl_get_error_string().str);
-    }
+    interrupt_guard_condition_.trigger();
   }
 }
 
@@ -171,9 +167,7 @@ StaticSingleThreadedExecutor::remove_callback_group(
   bool node_removed = entities_collector_->remove_callback_group(group_ptr);
   // If the node was matched and removed, interrupt waiting
   if (node_removed && notify) {
-    if (rcl_trigger_guard_condition(&interrupt_guard_condition_) != RCL_RET_OK) {
-      throw std::runtime_error(rcl_get_error_string().str);
-    }
+    interrupt_guard_condition_.trigger();
   }
 }
 
@@ -187,9 +181,7 @@ StaticSingleThreadedExecutor::remove_node(
   }
   // If the node was matched and removed, interrupt waiting
   if (notify) {
-    if (rcl_trigger_guard_condition(&interrupt_guard_condition_) != RCL_RET_OK) {
-      throw std::runtime_error(rcl_get_error_string().str);
-    }
+    interrupt_guard_condition_.trigger();
   }
 }
 

--- a/rclcpp/src/rclcpp/guard_condition.cpp
+++ b/rclcpp/src/rclcpp/guard_condition.cpp
@@ -20,19 +20,20 @@
 namespace rclcpp
 {
 
-GuardCondition::GuardCondition(rclcpp::Context::SharedPtr context)
+GuardCondition::GuardCondition(
+  rclcpp::Context::SharedPtr context,
+  rcl_guard_condition_options_t guard_condition_options)
 : context_(context), rcl_guard_condition_{rcl_get_zero_initialized_guard_condition()}
 {
   if (!context_) {
     throw std::invalid_argument("context argument unexpectedly nullptr");
   }
-  rcl_guard_condition_options_t guard_condition_options = rcl_guard_condition_get_default_options();
   rcl_ret_t ret = rcl_guard_condition_init(
     &this->rcl_guard_condition_,
     context_->get_rcl_context().get(),
     guard_condition_options);
   if (RCL_RET_OK != ret) {
-    rclcpp::exceptions::throw_from_rcl_error(ret);
+    rclcpp::exceptions::throw_from_rcl_error(ret, "failed to create guard condition");
   }
 }
 
@@ -45,7 +46,7 @@ GuardCondition::~GuardCondition()
     } catch (const std::exception & exception) {
       RCLCPP_ERROR(
         rclcpp::get_logger("rclcpp"),
-        "Error in destruction of rcl guard condition: %s", exception.what());
+        "failed to finalize guard condition: %s", exception.what());
     }
   }
 }
@@ -54,6 +55,12 @@ rclcpp::Context::SharedPtr
 GuardCondition::get_context() const
 {
   return context_;
+}
+
+rcl_guard_condition_t &
+GuardCondition::get_rcl_guard_condition()
+{
+  return rcl_guard_condition_;
 }
 
 const rcl_guard_condition_t &

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -322,7 +322,7 @@ NodeBase::get_notify_guard_condition()
 {
   std::lock_guard<std::recursive_mutex> notify_condition_lock(notify_guard_condition_mutex_);
   if (!notify_guard_condition_is_valid_) {
-    throw std::runtime_error("Trying to get invalid notify guard condition");
+    throw std::runtime_error("failed to get notify guard condition because it is invalid");
   }
   return notify_guard_condition_;
 }

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -132,30 +132,15 @@ NodeBase::NodeBase(
   node_handle_(nullptr),
   default_callback_group_(nullptr),
   associated_with_executor_(false),
+  notify_guard_condition_(context),
   notify_guard_condition_is_valid_(false)
 {
-  // Setup the guard condition that is notified when changes occur in the graph.
-  rcl_guard_condition_options_t guard_condition_options = rcl_guard_condition_get_default_options();
-  rcl_ret_t ret = rcl_guard_condition_init(
-    &notify_guard_condition_, context_->get_rcl_context().get(), guard_condition_options);
-  if (ret != RCL_RET_OK) {
-    throw_from_rcl_error(ret, "failed to create interrupt guard condition");
-  }
-
-  // Setup a safe exit lamda to clean up the guard condition in case of an error here.
-  auto finalize_notify_guard_condition = [this]() {
-      // Finalize the interrupt guard condition.
-      if (rcl_guard_condition_fini(&notify_guard_condition_) != RCL_RET_OK) {
-        RCUTILS_LOG_ERROR_NAMED(
-          "rclcpp",
-          "failed to destroy guard condition: %s", rcl_get_error_string().str);
-      }
-    };
-
   // Create the rcl node and store it in a shared_ptr with a custom destructor.
   std::unique_ptr<rcl_node_t> rcl_node(new rcl_node_t(rcl_get_zero_initialized_node()));
 
   std::shared_ptr<std::recursive_mutex> logging_mutex = get_global_logging_mutex();
+
+  rcl_ret_t ret;
   {
     std::lock_guard<std::recursive_mutex> guard(*logging_mutex);
     // TODO(ivanpauno): /rosout Qos should be reconfigurable.
@@ -168,9 +153,6 @@ NodeBase::NodeBase(
       context_->get_rcl_context().get(), &rcl_node_options);
   }
   if (ret != RCL_RET_OK) {
-    // Finalize the interrupt guard condition.
-    finalize_notify_guard_condition();
-
     if (ret == RCL_RET_NODE_INVALID_NAME) {
       rcl_reset_error();  // discard rcl_node_init error
       int validation_result;
@@ -235,11 +217,6 @@ NodeBase::~NodeBase()
   {
     std::lock_guard<std::recursive_mutex> notify_condition_lock(notify_guard_condition_mutex_);
     notify_guard_condition_is_valid_ = false;
-    if (rcl_guard_condition_fini(&notify_guard_condition_) != RCL_RET_OK) {
-      RCUTILS_LOG_ERROR_NAMED(
-        "rclcpp",
-        "failed to destroy guard condition: %s", rcl_get_error_string().str);
-    }
   }
 }
 
@@ -340,20 +317,14 @@ NodeBase::get_associated_with_executor_atomic()
   return associated_with_executor_;
 }
 
-rcl_guard_condition_t *
+rclcpp::GuardCondition &
 NodeBase::get_notify_guard_condition()
 {
   std::lock_guard<std::recursive_mutex> notify_condition_lock(notify_guard_condition_mutex_);
   if (!notify_guard_condition_is_valid_) {
-    return nullptr;
+    throw std::runtime_error("Trying to get invalid notify guard condition");
   }
-  return &notify_guard_condition_;
-}
-
-std::unique_lock<std::recursive_mutex>
-NodeBase::acquire_notify_guard_condition_lock() const
-{
-  return std::unique_lock<std::recursive_mutex>(notify_guard_condition_mutex_);
+  return notify_guard_condition_;
 }
 
 bool

--- a/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
@@ -533,12 +533,12 @@ NodeGraph::notify_graph_change()
     }
   }
   graph_cv_.notify_all();
-  {
-    auto notify_condition_lock = node_base_->acquire_notify_guard_condition_lock();
-    rcl_ret_t ret = rcl_trigger_guard_condition(node_base_->get_notify_guard_condition());
-    if (RCL_RET_OK != ret) {
-      throw_from_rcl_error(ret, "failed to trigger notify guard condition");
-    }
+  auto & node_gc = node_base_->get_notify_guard_condition();
+  try {
+    node_gc.trigger();
+  } catch (const rclcpp::exceptions::RCLError & ex) {
+    throw std::runtime_error(
+            std::string("Failed to notify wait set on graph change: ") + ex.what());
   }
 }
 

--- a/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
@@ -538,7 +538,7 @@ NodeGraph::notify_graph_change()
     node_gc.trigger();
   } catch (const rclcpp::exceptions::RCLError & ex) {
     throw std::runtime_error(
-            std::string("Failed to notify wait set on graph change: ") + ex.what());
+            std::string("failed to notify wait set on graph change: ") + ex.what());
   }
 }
 

--- a/rclcpp/src/rclcpp/node_interfaces/node_services.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_services.cpp
@@ -41,14 +41,12 @@ NodeServices::add_service(
   }
 
   // Notify the executor that a new service was created using the parent Node.
-  {
-    auto notify_guard_condition_lock = node_base_->acquire_notify_guard_condition_lock();
-    if (rcl_trigger_guard_condition(node_base_->get_notify_guard_condition()) != RCL_RET_OK) {
-      throw std::runtime_error(
-              std::string("Failed to notify wait set on service creation: ") +
-              rmw_get_error_string().str
-      );
-    }
+  auto & node_gc = node_base_->get_notify_guard_condition();
+  try {
+    node_gc.trigger();
+  } catch (const rclcpp::exceptions::RCLError & ex) {
+    throw std::runtime_error(
+            std::string("Failed to notify wait set on service creation: ") + ex.what());
   }
 }
 
@@ -68,14 +66,12 @@ NodeServices::add_client(
   }
 
   // Notify the executor that a new client was created using the parent Node.
-  {
-    auto notify_guard_condition_lock = node_base_->acquire_notify_guard_condition_lock();
-    if (rcl_trigger_guard_condition(node_base_->get_notify_guard_condition()) != RCL_RET_OK) {
-      throw std::runtime_error(
-              std::string("Failed to notify wait set on client creation: ") +
-              rmw_get_error_string().str
-      );
-    }
+  auto & node_gc = node_base_->get_notify_guard_condition();
+  try {
+    node_gc.trigger();
+  } catch (const rclcpp::exceptions::RCLError & ex) {
+    throw std::runtime_error(
+            std::string("Failed to notify wait set on client creation: ") + ex.what());
   }
 }
 

--- a/rclcpp/src/rclcpp/node_interfaces/node_services.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_services.cpp
@@ -46,7 +46,7 @@ NodeServices::add_service(
     node_gc.trigger();
   } catch (const rclcpp::exceptions::RCLError & ex) {
     throw std::runtime_error(
-            std::string("Failed to notify wait set on service creation: ") + ex.what());
+            std::string("failed to notify wait set on service creation: ") + ex.what());
   }
 }
 
@@ -71,7 +71,7 @@ NodeServices::add_client(
     node_gc.trigger();
   } catch (const rclcpp::exceptions::RCLError & ex) {
     throw std::runtime_error(
-            std::string("Failed to notify wait set on client creation: ") + ex.what());
+            std::string("failed to notify wait set on client creation: ") + ex.what());
   }
 }
 

--- a/rclcpp/src/rclcpp/node_interfaces/node_timers.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_timers.cpp
@@ -41,11 +41,15 @@ NodeTimers::add_timer(
   } else {
     node_base_->get_default_callback_group()->add_timer(timer);
   }
-  if (rcl_trigger_guard_condition(node_base_->get_notify_guard_condition()) != RCL_RET_OK) {
+
+  auto & node_gc = node_base_->get_notify_guard_condition();
+  try {
+    node_gc.trigger();
+  } catch (const rclcpp::exceptions::RCLError & ex) {
     throw std::runtime_error(
-            std::string("Failed to notify wait set on timer creation: ") +
-            rmw_get_error_string().str);
+            std::string("Failed to notify wait set on timer creation: ") + ex.what());
   }
+
   TRACEPOINT(
     rclcpp_timer_link_node,
     static_cast<const void *>(timer->get_timer_handle().get()),

--- a/rclcpp/src/rclcpp/node_interfaces/node_timers.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_timers.cpp
@@ -47,7 +47,7 @@ NodeTimers::add_timer(
     node_gc.trigger();
   } catch (const rclcpp::exceptions::RCLError & ex) {
     throw std::runtime_error(
-            std::string("Failed to notify wait set on timer creation: ") + ex.what());
+            std::string("failed to notify wait set on timer creation: ") + ex.what());
   }
 
   TRACEPOINT(

--- a/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
@@ -65,7 +65,7 @@ NodeTopics::add_publisher(
     node_gc.trigger();
   } catch (const rclcpp::exceptions::RCLError & ex) {
     throw std::runtime_error(
-            std::string("Failed to notify wait set on publisher creation: ") + ex.what());
+            std::string("failed to notify wait set on publisher creation: ") + ex.what());
   }
 }
 
@@ -112,7 +112,7 @@ NodeTopics::add_subscription(
     node_gc.trigger();
   } catch (const rclcpp::exceptions::RCLError & ex) {
     throw std::runtime_error(
-            std::string("Failed to notify wait set on subscription creation: ") + ex.what());
+            std::string("failed to notify wait set on subscription creation: ") + ex.what());
   }
 }
 

--- a/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
@@ -60,13 +60,12 @@ NodeTopics::add_publisher(
   }
 
   // Notify the executor that a new publisher was created using the parent Node.
-  {
-    auto notify_guard_condition_lock = node_base_->acquire_notify_guard_condition_lock();
-    if (rcl_trigger_guard_condition(node_base_->get_notify_guard_condition()) != RCL_RET_OK) {
-      throw std::runtime_error(
-              std::string("Failed to notify wait set on publisher creation: ") +
-              rmw_get_error_string().str);
-    }
+  auto & node_gc = node_base_->get_notify_guard_condition();
+  try {
+    node_gc.trigger();
+  } catch (const rclcpp::exceptions::RCLError & ex) {
+    throw std::runtime_error(
+            std::string("Failed to notify wait set on publisher creation: ") + ex.what());
   }
 }
 
@@ -108,13 +107,12 @@ NodeTopics::add_subscription(
   }
 
   // Notify the executor that a new subscription was created using the parent Node.
-  {
-    auto notify_guard_condition_lock = node_base_->acquire_notify_guard_condition_lock();
-    auto ret = rcl_trigger_guard_condition(node_base_->get_notify_guard_condition());
-    if (ret != RCL_RET_OK) {
-      using rclcpp::exceptions::throw_from_rcl_error;
-      throw_from_rcl_error(ret, "failed to notify wait set on subscription creation");
-    }
+  auto & node_gc = node_base_->get_notify_guard_condition();
+  try {
+    node_gc.trigger();
+  } catch (const rclcpp::exceptions::RCLError & ex) {
+    throw std::runtime_error(
+            std::string("Failed to notify wait set on subscription creation: ") + ex.what());
   }
 }
 

--- a/rclcpp/src/rclcpp/node_interfaces/node_waitables.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_waitables.cpp
@@ -41,14 +41,12 @@ NodeWaitables::add_waitable(
   }
 
   // Notify the executor that a new waitable was created using the parent Node.
-  {
-    auto notify_guard_condition_lock = node_base_->acquire_notify_guard_condition_lock();
-    if (rcl_trigger_guard_condition(node_base_->get_notify_guard_condition()) != RCL_RET_OK) {
-      throw std::runtime_error(
-              std::string("Failed to notify wait set on waitable creation: ") +
-              rmw_get_error_string().str
-      );
-    }
+  auto & node_gc = node_base_->get_notify_guard_condition();
+  try {
+    node_gc.trigger();
+  } catch (const rclcpp::exceptions::RCLError & ex) {
+    throw std::runtime_error(
+            std::string("Failed to notify wait set on waitable creation: ") + ex.what());
   }
 }
 

--- a/rclcpp/src/rclcpp/node_interfaces/node_waitables.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_waitables.cpp
@@ -46,7 +46,7 @@ NodeWaitables::add_waitable(
     node_gc.trigger();
   } catch (const rclcpp::exceptions::RCLError & ex) {
     throw std::runtime_error(
-            std::string("Failed to notify wait set on waitable creation: ") + ex.what());
+            std::string("failed to notify wait set on waitable creation: ") + ex.what());
   }
 }
 

--- a/rclcpp/src/rclcpp/qos_event.cpp
+++ b/rclcpp/src/rclcpp/qos_event.cpp
@@ -51,14 +51,13 @@ QOSEventHandlerBase::get_number_of_ready_events()
 }
 
 /// Add the Waitable to a wait set.
-bool
+void
 QOSEventHandlerBase::add_to_wait_set(rcl_wait_set_t * wait_set)
 {
   rcl_ret_t ret = rcl_wait_set_add_event(wait_set, &event_handle_, &wait_set_event_index_);
   if (RCL_RET_OK != ret) {
     exceptions::throw_from_rcl_error(ret, "Couldn't add event to wait set");
   }
-  return true;
 }
 
 /// Check if the Waitable is ready.

--- a/rclcpp/test/rclcpp/executors/test_static_executor_entities_collector.cpp
+++ b/rclcpp/test/rclcpp/executors/test_static_executor_entities_collector.cpp
@@ -230,7 +230,7 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_remove_node_out_of_scope) {
 class TestWaitable : public rclcpp::Waitable
 {
 public:
-  bool add_to_wait_set(rcl_wait_set_t *) override {return true;}
+  void add_to_wait_set(rcl_wait_set_t *) override {}
 
   bool is_ready(rcl_wait_set_t *) override {return true;}
 
@@ -513,9 +513,9 @@ TEST_F(TestStaticExecutorEntitiesCollector, add_to_wait_set_nullptr) {
   entities_collector_->init(&wait_set, memory_strategy);
   RCPPUTILS_SCOPE_EXIT(entities_collector_->fini());
 
-  RCLCPP_EXPECT_THROW_EQ(
+  EXPECT_THROW(
     entities_collector_->add_to_wait_set(nullptr),
-    std::runtime_error("Executor waitable: couldn't add guard condition to wait set"));
+    std::invalid_argument);
   rcl_reset_error();
 
   EXPECT_TRUE(entities_collector_->remove_node(node->get_node_base_interface()));

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_graph.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_graph.cpp
@@ -558,7 +558,7 @@ TEST_F(TestNodeGraph, notify_graph_change_rcl_error)
     "lib:rclcpp", rcl_trigger_guard_condition, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     node()->get_node_graph_interface()->notify_graph_change(),
-    std::runtime_error("Failed to notify wait set on graph change: error not set"));
+    std::runtime_error("failed to notify wait set on graph change: error not set"));
 }
 
 TEST_F(TestNodeGraph, get_info_by_topic)

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_graph.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_graph.cpp
@@ -556,9 +556,9 @@ TEST_F(TestNodeGraph, notify_graph_change_rcl_error)
 {
   auto mock = mocking_utils::patch_and_return(
     "lib:rclcpp", rcl_trigger_guard_condition, RCL_RET_ERROR);
-  EXPECT_THROW(
+  RCLCPP_EXPECT_THROW_EQ(
     node()->get_node_graph_interface()->notify_graph_change(),
-    rclcpp::exceptions::RCLError);
+    std::runtime_error("Failed to notify wait set on graph change: error not set"));
 }
 
 TEST_F(TestNodeGraph, get_info_by_topic)

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_services.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_services.cpp
@@ -103,7 +103,7 @@ TEST_F(TestNodeService, add_service_rcl_trigger_guard_condition_error)
     "lib:rclcpp", rcl_trigger_guard_condition, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     node_services->add_service(service, callback_group),
-    std::runtime_error("Failed to notify wait set on service creation: error not set"));
+    std::runtime_error("failed to notify wait set on service creation: error not set"));
 }
 
 TEST_F(TestNodeService, add_client)
@@ -130,7 +130,7 @@ TEST_F(TestNodeService, add_client_rcl_trigger_guard_condition_error)
     "lib:rclcpp", rcl_trigger_guard_condition, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     node_services->add_client(client, callback_group),
-    std::runtime_error("Failed to notify wait set on client creation: error not set"));
+    std::runtime_error("failed to notify wait set on client creation: error not set"));
 }
 
 TEST_F(TestNodeService, resolve_service_name)

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_timers.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_timers.cpp
@@ -87,5 +87,5 @@ TEST_F(TestNodeTimers, add_timer_rcl_trigger_guard_condition_error)
     "lib:rclcpp", rcl_trigger_guard_condition, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     node_timers->add_timer(timer, callback_group),
-    std::runtime_error("Failed to notify wait set on timer creation: error not set"));
+    std::runtime_error("failed to notify wait set on timer creation: error not set"));
 }

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_topics.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_topics.cpp
@@ -157,7 +157,7 @@ TEST_F(TestNodeTopics, add_subscription_rcl_trigger_guard_condition_error)
     "lib:rclcpp", rcl_trigger_guard_condition, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     node_topics->add_subscription(subscription, callback_group),
-    std::runtime_error("failed to notify wait set on subscription creation: error not set"));
+    std::runtime_error("Failed to notify wait set on subscription creation: error not set"));
 }
 
 TEST_F(TestNodeTopics, resolve_topic_name)

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_topics.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_topics.cpp
@@ -129,7 +129,7 @@ TEST_F(TestNodeTopics, add_publisher_rcl_trigger_guard_condition_error)
     "lib:rclcpp", rcl_trigger_guard_condition, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     node_topics->add_publisher(publisher, callback_group),
-    std::runtime_error("Failed to notify wait set on publisher creation: error not set"));
+    std::runtime_error("failed to notify wait set on publisher creation: error not set"));
 }
 
 TEST_F(TestNodeTopics, add_subscription)
@@ -157,7 +157,7 @@ TEST_F(TestNodeTopics, add_subscription_rcl_trigger_guard_condition_error)
     "lib:rclcpp", rcl_trigger_guard_condition, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     node_topics->add_subscription(subscription, callback_group),
-    std::runtime_error("Failed to notify wait set on subscription creation: error not set"));
+    std::runtime_error("failed to notify wait set on subscription creation: error not set"));
 }
 
 TEST_F(TestNodeTopics, resolve_topic_name)

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_waitables.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_waitables.cpp
@@ -96,5 +96,5 @@ TEST_F(TestNodeWaitables, add_waitable_rcl_trigger_guard_condition_error)
     "lib:rclcpp", rcl_trigger_guard_condition, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     node_waitables->add_waitable(waitable, callback_group),
-    std::runtime_error("Failed to notify wait set on waitable creation: error not set"));
+    std::runtime_error("failed to notify wait set on waitable creation: error not set"));
 }

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_waitables.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_waitables.cpp
@@ -28,7 +28,7 @@
 class TestWaitable : public rclcpp::Waitable
 {
 public:
-  bool add_to_wait_set(rcl_wait_set_t *) override {return false;}
+  void add_to_wait_set(rcl_wait_set_t *) override {}
   bool is_ready(rcl_wait_set_t *) override {return false;}
 
   std::shared_ptr<void>

--- a/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
@@ -39,9 +39,11 @@ static bool test_waitable_result = false;
 class TestWaitable : public rclcpp::Waitable
 {
 public:
-  bool add_to_wait_set(rcl_wait_set_t *) override
+  void add_to_wait_set(rcl_wait_set_t *) override
   {
-    return test_waitable_result;
+    if (!test_waitable_result) {
+      throw std::runtime_error("TestWaitable add_to_wait_set failed");
+    }
   }
 
   bool is_ready(rcl_wait_set_t *) override
@@ -453,30 +455,30 @@ TEST_F(TestAllocatorMemoryStrategy, construct_destruct) {
 }
 
 TEST_F(TestAllocatorMemoryStrategy, add_remove_guard_conditions) {
-  rcl_guard_condition_t guard_condition1 = rcl_get_zero_initialized_guard_condition();
-  rcl_guard_condition_t guard_condition2 = rcl_get_zero_initialized_guard_condition();
-  rcl_guard_condition_t guard_condition3 = rcl_get_zero_initialized_guard_condition();
+  rclcpp::GuardCondition guard_condition1;
+  rclcpp::GuardCondition guard_condition2;
+  rclcpp::GuardCondition guard_condition3;
 
-  EXPECT_NO_THROW(allocator_memory_strategy()->add_guard_condition(&guard_condition1));
-  EXPECT_NO_THROW(allocator_memory_strategy()->add_guard_condition(&guard_condition2));
-  EXPECT_NO_THROW(allocator_memory_strategy()->add_guard_condition(&guard_condition3));
+  EXPECT_NO_THROW(allocator_memory_strategy()->add_guard_condition(guard_condition1));
+  EXPECT_NO_THROW(allocator_memory_strategy()->add_guard_condition(guard_condition2));
+  EXPECT_NO_THROW(allocator_memory_strategy()->add_guard_condition(guard_condition3));
   EXPECT_EQ(3u, allocator_memory_strategy()->number_of_guard_conditions());
 
   // Adding a second time should not add to vector
-  EXPECT_NO_THROW(allocator_memory_strategy()->add_guard_condition(&guard_condition1));
-  EXPECT_NO_THROW(allocator_memory_strategy()->add_guard_condition(&guard_condition2));
-  EXPECT_NO_THROW(allocator_memory_strategy()->add_guard_condition(&guard_condition3));
+  EXPECT_NO_THROW(allocator_memory_strategy()->add_guard_condition(guard_condition1));
+  EXPECT_NO_THROW(allocator_memory_strategy()->add_guard_condition(guard_condition2));
+  EXPECT_NO_THROW(allocator_memory_strategy()->add_guard_condition(guard_condition3));
   EXPECT_EQ(3u, allocator_memory_strategy()->number_of_guard_conditions());
 
-  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(&guard_condition1));
-  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(&guard_condition2));
-  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(&guard_condition3));
+  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(guard_condition1));
+  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(guard_condition2));
+  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(guard_condition3));
   EXPECT_EQ(0u, allocator_memory_strategy()->number_of_guard_conditions());
 
   // Removing second time should have no effect
-  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(&guard_condition1));
-  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(&guard_condition2));
-  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(&guard_condition3));
+  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(guard_condition1));
+  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(guard_condition2));
+  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(guard_condition3));
   EXPECT_EQ(0u, allocator_memory_strategy()->number_of_guard_conditions());
 }
 
@@ -569,24 +571,17 @@ TEST_F(TestAllocatorMemoryStrategy, add_handles_to_wait_set_client) {
 
 TEST_F(TestAllocatorMemoryStrategy, add_handles_to_wait_set_guard_condition) {
   auto node = create_node_with_disabled_callback_groups("node");
-  rcl_guard_condition_t guard_condition = rcl_get_zero_initialized_guard_condition();
   auto context = node->get_node_base_interface()->get_context();
-  rcl_context_t * rcl_context = context->get_rcl_context().get();
-  rcl_guard_condition_options_t guard_condition_options = {
-    rcl_get_default_allocator()};
 
-  EXPECT_EQ(
-    RCL_RET_OK,
-    rcl_guard_condition_init(&guard_condition, rcl_context, guard_condition_options));
-  RCPPUTILS_SCOPE_EXIT(
-  {
-    EXPECT_EQ(RCL_RET_OK, rcl_guard_condition_fini(&guard_condition));
-  });
+  rclcpp::GuardCondition guard_condition(context);
 
-  allocator_memory_strategy()->add_guard_condition(&guard_condition);
+  EXPECT_NO_THROW(rclcpp::GuardCondition guard_condition(context););
+
+  allocator_memory_strategy()->add_guard_condition(guard_condition);
+
   RclWaitSetSizes insufficient_capacities = SufficientWaitSetCapacities();
   insufficient_capacities.size_of_guard_conditions = 0;
-  EXPECT_TRUE(TestAddHandlesToWaitSet(node, insufficient_capacities));
+  EXPECT_THROW(TestAddHandlesToWaitSet(node, insufficient_capacities), std::runtime_error);
 }
 
 TEST_F(TestAllocatorMemoryStrategy, add_handles_to_wait_set_timer) {
@@ -607,7 +602,9 @@ TEST_F(TestAllocatorMemoryStrategy, add_handles_to_wait_set_waitable) {
   EXPECT_TRUE(allocator_memory_strategy()->add_handles_to_wait_set(nullptr));
 
   test_waitable_result = false;
-  EXPECT_FALSE(allocator_memory_strategy()->add_handles_to_wait_set(nullptr));
+  EXPECT_THROW(
+    allocator_memory_strategy()->add_handles_to_wait_set(nullptr),
+    std::runtime_error);
 
   // This calls TestWaitable's functions, so rcl errors are not set
   EXPECT_FALSE(rcl_error_is_set());

--- a/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
@@ -470,15 +470,15 @@ TEST_F(TestAllocatorMemoryStrategy, add_remove_guard_conditions) {
   EXPECT_NO_THROW(allocator_memory_strategy()->add_guard_condition(guard_condition3));
   EXPECT_EQ(3u, allocator_memory_strategy()->number_of_guard_conditions());
 
-  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(guard_condition1));
-  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(guard_condition2));
-  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(guard_condition3));
+  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(&guard_condition1));
+  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(&guard_condition2));
+  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(&guard_condition3));
   EXPECT_EQ(0u, allocator_memory_strategy()->number_of_guard_conditions());
 
   // Removing second time should have no effect
-  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(guard_condition1));
-  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(guard_condition2));
-  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(guard_condition3));
+  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(&guard_condition1));
+  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(&guard_condition2));
+  EXPECT_NO_THROW(allocator_memory_strategy()->remove_guard_condition(&guard_condition3));
   EXPECT_EQ(0u, allocator_memory_strategy()->number_of_guard_conditions());
 }
 

--- a/rclcpp/test/rclcpp/test_graph_listener.cpp
+++ b/rclcpp/test/rclcpp/test_graph_listener.cpp
@@ -87,7 +87,7 @@ TEST_F(TestGraphListener, error_construct_graph_listener) {
     auto graph_listener_error =
     std::make_shared<rclcpp::graph_listener::GraphListener>(get_global_default_context());
     graph_listener_error.reset();
-  }, std::runtime_error("failed to create interrupt guard condition: error not set"));
+  }, std::runtime_error("failed to create guard condition: error not set"));
 }
 
 // Required for mocking_utils below
@@ -169,7 +169,7 @@ TEST_F(TestGraphListener, error_run_graph_listener_mock_wait_set_add_guard_condi
     "lib:rclcpp", rcl_wait_set_add_guard_condition, RCL_RET_ERROR);
   RCLCPP_EXPECT_THROW_EQ(
     graph_listener_test->run_protected(),
-    std::runtime_error("failed to add interrupt guard condition to wait set: error not set"));
+    std::runtime_error("failed to add guard condition to wait set: error not set"));
 }
 
 TEST_F(TestGraphListener, error_run_graph_listener_mock_wait_error) {
@@ -292,9 +292,7 @@ TEST_F(TestGraphListener, test_graph_listener_shutdown_guard_fini_error_throw) {
   auto mock_wait_set_fini = mocking_utils::patch_and_return(
     "lib:rclcpp", rcl_guard_condition_fini, RCL_RET_ERROR);
 
-  RCLCPP_EXPECT_THROW_EQ(
-    graph_listener_test->shutdown(),
-    std::runtime_error("failed to finalize interrupt guard condition: error not set"));
+  EXPECT_NO_THROW(graph_listener_test->shutdown());
 
   graph_listener_test->mock_cleanup_wait_set();
 }

--- a/rclcpp/test/rclcpp/test_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/test_memory_strategy.cpp
@@ -35,7 +35,7 @@ typedef std::map<rclcpp::CallbackGroup::WeakPtr,
 class TestWaitable : public rclcpp::Waitable
 {
 public:
-  bool add_to_wait_set(rcl_wait_set_t *) override {return true;}
+  void add_to_wait_set(rcl_wait_set_t *) override {}
   bool is_ready(rcl_wait_set_t *) override {return true;}
   std::shared_ptr<void> take_data() override {return nullptr;}
   void execute(std::shared_ptr<void> & data) override {(void)data;}

--- a/rclcpp/test/rclcpp/test_qos_event.cpp
+++ b/rclcpp/test/rclcpp/test_qos_event.cpp
@@ -315,7 +315,7 @@ TEST_F(TestQosEvent, add_to_wait_set) {
   {
     rcl_wait_set_t wait_set = rcl_get_zero_initialized_wait_set();
     auto mock = mocking_utils::patch_and_return("lib:rclcpp", rcl_wait_set_add_event, RCL_RET_OK);
-    EXPECT_TRUE(handler.add_to_wait_set(&wait_set));
+    EXPECT_NO_THROW(handler.add_to_wait_set(&wait_set));
   }
 
   {

--- a/rclcpp/test/rclcpp/wait_set_policies/test_dynamic_storage.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_dynamic_storage.cpp
@@ -51,7 +51,7 @@ public:
   TestWaitable()
   : is_ready_(false) {}
 
-  bool add_to_wait_set(rcl_wait_set_t *) override {return true;}
+  void add_to_wait_set(rcl_wait_set_t *) override {}
 
   bool is_ready(rcl_wait_set_t *) override {return is_ready_;}
 

--- a/rclcpp/test/rclcpp/wait_set_policies/test_static_storage.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_static_storage.cpp
@@ -50,7 +50,7 @@ class TestWaitable : public rclcpp::Waitable
 public:
   TestWaitable()
   : is_ready_(false) {}
-  bool add_to_wait_set(rcl_wait_set_t *) override {return true;}
+  void add_to_wait_set(rcl_wait_set_t *) override {}
 
   bool is_ready(rcl_wait_set_t *) override {return is_ready_;}
 

--- a/rclcpp/test/rclcpp/wait_set_policies/test_storage_policy_common.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_storage_policy_common.cpp
@@ -50,7 +50,12 @@ class TestWaitable : public rclcpp::Waitable
 public:
   TestWaitable()
   : is_ready_(false), add_to_wait_set_(false) {}
-  bool add_to_wait_set(rcl_wait_set_t *) override {return add_to_wait_set_;}
+  void add_to_wait_set(rcl_wait_set_t *) override
+  {
+    if (!add_to_wait_set_) {
+      throw std::runtime_error("waitable unexpectedly failed to be added to wait set");
+    }
+  }
 
   bool is_ready(rcl_wait_set_t *) override {return is_ready_;}
 

--- a/rclcpp/test/rclcpp/wait_set_policies/test_thread_safe_synchronization.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_thread_safe_synchronization.cpp
@@ -50,7 +50,7 @@ class TestWaitable : public rclcpp::Waitable
 public:
   TestWaitable()
   : is_ready_(false) {}
-  bool add_to_wait_set(rcl_wait_set_t *) override {return true;}
+  void add_to_wait_set(rcl_wait_set_t *) override {}
 
   bool is_ready(rcl_wait_set_t *) override {return is_ready_;}
 

--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -108,7 +108,7 @@ public:
 
   /// \internal
   RCLCPP_ACTION_PUBLIC
-  bool
+  void
   add_to_wait_set(rcl_wait_set_t * wait_set) override;
 
   /// \internal

--- a/rclcpp_action/include/rclcpp_action/server.hpp
+++ b/rclcpp_action/include/rclcpp_action/server.hpp
@@ -109,7 +109,7 @@ public:
   /// Add all entities to a wait set.
   /// \internal
   RCLCPP_ACTION_PUBLIC
-  bool
+  void
   add_to_wait_set(rcl_wait_set_t * wait_set) override;
 
   /// Return true if any entity belonging to the action server is ready to be executed.

--- a/rclcpp_action/src/client.cpp
+++ b/rclcpp_action/src/client.cpp
@@ -252,12 +252,14 @@ ClientBase::get_number_of_ready_services()
   return pimpl_->num_services;
 }
 
-bool
+void
 ClientBase::add_to_wait_set(rcl_wait_set_t * wait_set)
 {
   rcl_ret_t ret = rcl_action_wait_set_add_action_client(
     wait_set, pimpl_->client_handle.get(), nullptr, nullptr);
-  return RCL_RET_OK == ret;
+  if (RCL_RET_OK != ret) {
+    rclcpp::exceptions::throw_from_rcl_error(ret, "ClientBase::add_to_wait_set() failed");
+  }
 }
 
 bool

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -164,13 +164,15 @@ ServerBase::get_number_of_ready_guard_conditions()
   return pimpl_->num_guard_conditions_;
 }
 
-bool
+void
 ServerBase::add_to_wait_set(rcl_wait_set_t * wait_set)
 {
   std::lock_guard<std::recursive_mutex> lock(pimpl_->action_server_reentrant_mutex_);
   rcl_ret_t ret = rcl_action_wait_set_add_action_server(
     wait_set, pimpl_->action_server_.get(), NULL);
-  return RCL_RET_OK == ret;
+  if (RCL_RET_OK != ret) {
+    rclcpp::exceptions::throw_from_rcl_error(ret, "ServerBase::add_to_wait_set() failed");
+  }
 }
 
 bool

--- a/rclcpp_action/test/test_client.cpp
+++ b/rclcpp_action/test/test_client.cpp
@@ -397,7 +397,7 @@ TEST_F(TestClient, is_ready) {
   ASSERT_EQ(
     RCL_RET_OK,
     rcl_wait_set_init(&wait_set, 10, 10, 10, 10, 10, 10, rcl_context, allocator));
-  ASSERT_TRUE(action_client->add_to_wait_set(&wait_set));
+  ASSERT_NO_THROW(action_client->add_to_wait_set(&wait_set));
   EXPECT_TRUE(action_client->is_ready(&wait_set));
 
   {

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -1107,7 +1107,7 @@ TEST_F(TestGoalRequestServer, is_ready_rcl_error) {
   {
     EXPECT_EQ(RCL_RET_OK, rcl_wait_set_fini(&wait_set));
   });
-  ASSERT_TRUE(action_server_->add_to_wait_set(&wait_set));
+  EXPECT_NO_THROW(action_server_->add_to_wait_set(&wait_set));
 
   EXPECT_TRUE(action_server_->is_ready(&wait_set));
   auto mock = mocking_utils::patch_and_return(


### PR DESCRIPTION
This PR makes **rclcpp** to not handle directly `rcl_guard_condition_t`, but to use the `rclcpp::GuardCondition` class which takes care of creation/init/delete of it, which makes the code cleaner and less error prone. 

The work being done in https://github.com/ros2/rmw/pull/286 assigns listener callbacks to RMW entities, and originally also assigned a callback to the RMW guard conditions, since many events are generated from the triggering of a guard condition. The listener callback for guard conditions is now removed, so this PR sets the ground for a possible implementation where the guard condition callback is called directly from `rclcpp::GuardCondition` (instead of the originall call from RMW guard conditions).

Signed-off-by: Mauro Passerino <mpasserino@irobot.com>