### PR TITLE
use context from `node_base_` for clock executor.

### DIFF
--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -152,7 +152,7 @@ private:
   std::shared_ptr<SubscriptionT> clock_subscription_{nullptr};
   std::mutex clock_sub_lock_;
   rclcpp::CallbackGroup::SharedPtr clock_callback_group_;
-  rclcpp::executors::SingleThreadedExecutor clock_executor_;
+  rclcpp::executors::SingleThreadedExecutor::SharedPtr clock_executor_;
   std::promise<void> cancel_clock_executor_promise_;
 
   // The clock callback itself

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -256,13 +256,17 @@ void TimeSource::create_clock_sub()
       false
     );
     options.callback_group = clock_callback_group_;
+    rclcpp::ExecutorOptions exec_options;
+    exec_options.context = node_base_->get_context();
+    clock_executor_ =
+      std::make_shared<rclcpp::executors::SingleThreadedExecutor>(exec_options);
     if (!clock_executor_thread_.joinable()) {
       clock_executor_thread_ = std::thread(
         [this]() {
           cancel_clock_executor_promise_ = std::promise<void>{};
           auto future = cancel_clock_executor_promise_.get_future();
-          clock_executor_.add_callback_group(clock_callback_group_, node_base_);
-          clock_executor_.spin_until_future_complete(future);
+          clock_executor_->add_callback_group(clock_callback_group_, node_base_);
+          clock_executor_->spin_until_future_complete(future);
         }
       );
     }
@@ -283,9 +287,9 @@ void TimeSource::destroy_clock_sub()
   std::lock_guard<std::mutex> guard(clock_sub_lock_);
   if (clock_executor_thread_.joinable()) {
     cancel_clock_executor_promise_.set_value();
-    clock_executor_.cancel();
+    clock_executor_->cancel();
     clock_executor_thread_.join();
-    clock_executor_.remove_callback_group(clock_callback_group_);
+    clock_executor_->remove_callback_group(clock_callback_group_);
   }
   clock_subscription_.reset();
 }


### PR DESCRIPTION
address https://github.com/ros2/rclcpp/pull/1556#issuecomment-812256630

this is bugfix introduced originally from https://github.com/ros2/rclcpp/pull/1556

Signed-off-by: Tomoya Fujita <Tomoya.Fujita@sony.com>