### PR TITLE
Add graph method to wait for publishers

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/node_graph.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph.hpp
@@ -124,6 +124,13 @@ public:
     const std::string & topic_name,
     bool no_mangle = false) const override;
 
+  RCLCPP_PUBLIC
+  bool
+  wait_for_publishers(
+    const std::string & topic_name,
+    size_t count,
+    const std::chrono::nanoseconds & timeout) const override;
+
 private:
   RCLCPP_DISABLE_COPY(NodeGraph)
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
@@ -299,6 +299,27 @@ public:
   virtual
   std::vector<rclcpp::TopicEndpointInfo>
   get_subscriptions_info_by_topic(const std::string & topic_name, bool no_mangle = false) const = 0;
+
+  /// Wait for a number of publishers to be available on a topic.
+  /**
+   * This function will block until the provided number of publishers are available or a timeout occurs.
+   *
+   * This function should not be called concurrently with an executor spinning on the node.
+   * If this happens an exception is thrown.
+   *
+   * \param[in] topic_name the topic to check for publishers. It will not be automatically remapped.
+   * \param[in] count the number of publishers to wait for.
+   * \param[in] timeout elapsed time to wait for publishers.
+   * \return `true` if the number of publishers is greater than or equal to the provided count, or
+   *   `false` if a timeout occurs.
+   */
+  RCLCPP_PUBLIC
+  virtual
+  bool
+  wait_for_publishers(
+    const std::string & topic_name,
+    size_t count,
+    const std::chrono::nanoseconds & timeout) const = 0;
 };
 
 }  // namespace node_interfaces

--- a/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
@@ -533,6 +533,31 @@ NodeGraph::get_subscriptions_info_by_topic(
     rcl_get_subscriptions_info_by_topic);
 }
 
+bool
+NodeGraph::wait_for_publishers(
+  const std::string & topic_name,
+  size_t count,
+  const std::chrono::nanoseconds & timeout) const
+{
+  // TODO(jacobperron): Guard against concurrent use of graph guard condition
+  // (e.g. with GraphListener)
+  // rcl_wait_for_publishers() also uses the graph guard condition
+  auto rcl_node_handle = node_base_->get_rcl_node_handle();
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  bool success = false;
+  rcl_ret_t ret = rcl_wait_for_publishers(
+    rcl_node_handle,
+    &allocator,
+    topic_name.c_str(),
+    count,
+    timeout.count(),
+    &success);
+  if (ret != RCL_RET_OK && ret != RCL_RET_TIMEOUT) {
+    throw_from_rcl_error(ret, "error while waiting for publishers");
+  }
+  return success;
+}
+
 std::string &
 rclcpp::TopicEndpointInfo::node_name()
 {


### PR DESCRIPTION
Wrapping the rcl API introduced in https://github.com/ros2/rcl/pull/907

---

There are some issues with this change. Opening as a draft for visibility.

The issue boils down to using the node's graph guard condition in multiple wait sets concurrently.

The `rcl_wait_for_*` API uses the graph guard condition in a wait set as part of it's implementation.
The `rclcpp::GraphListener` also uses the graph guard condition, running in a separate thread:

https://github.com/ros2/rclcpp/blob/091a8bcf86ca2697df8b94f485d62fc5687cc19c/rclcpp/src/rclcpp/graph_listener.cpp#L175-L180

This means that if a users try to use the `GraphListener`, which is [lazily started](https://github.com/ros2/rclcpp/blob/091a8bcf86ca2697df8b94f485d62fc5687cc19c/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp#L377-L380), and then try to call one of the `rcl_wait_for_*` functions we get [undefined behavior](https://github.com/ros2/rcl/blob/b5a6c1831114e6fdaeaeb0995679f5715c8db168/rcl/include/rcl/wait.h#L458-L459).

Out of curiosity, I've tried to replicate this undefined behavior scenario and I didn't notice anything unexpected:

```c++
#include <rclcpp/rclcpp.hpp>

int main(void)
{
  rclcpp::init(0, nullptr);
  auto node = std::make_shared<rclcpp::Node>("my_node");
  auto graph = node->get_node_graph_interface();

  // This starts the GraphListener
  auto event = graph->get_graph_event();

  // Concurrently access the node's graph guard condition
  bool wait_result = graph->wait_for_publishers("/foo", 2, std::chrono::seconds(10));

  return 0;
}
```

---

I think rather than wrapping the rcl functions, we could add similar implementations based on the `rclcpp::GraphListener`. This way we avoid undefined behavior.

We could additionally expose the `rcl` functions, but we should "guard" against using the same guard condition as the GraphListener (e.g. detect that they are both being used concurrently and throw an informative exception).

Alternatively, we could add support to `rcl` (and `rmw`?) for multiple graph guard conditions. Then, the `rcl` functions could use a different guard condition than the `rclcpp::GraphListener`. I think this approach is more involved and is probably not worth the added complexity.

