### PR TITLE
Fix race condition in TimeSource clock thread setup

### DIFF
--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -261,9 +261,9 @@ void TimeSource::create_clock_sub()
     clock_executor_ =
       std::make_shared<rclcpp::executors::SingleThreadedExecutor>(exec_options);
     if (!clock_executor_thread_.joinable()) {
+      cancel_clock_executor_promise_ = std::promise<void>{};
       clock_executor_thread_ = std::thread(
         [this]() {
-          cancel_clock_executor_promise_ = std::promise<void>{};
           auto future = cancel_clock_executor_promise_.get_future();
           clock_executor_->add_callback_group(clock_callback_group_, node_base_);
           clock_executor_->spin_until_future_complete(future);


### PR DESCRIPTION
This patch hopefully (as I cannot even locally reproduce CI failures) fixes what appears to be a race condition introduced by #1556, which is causing [test timeouts in CI](https://ci.ros2.org/view/nightly/job/nightly_linux_repeated/lastCompletedBuild/testReport/projectroot.test/rclcpp/test_time_source/). See https://github.com/ros2/rclcpp/pull/1556#issuecomment-814255120 for further reference.

Repeated CI up to `rclcpp`:

* Linux [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14267)](https://ci.ros2.org/job/ci_linux/14267/)