### PR TITLE
Mark test_multi_threaded_executor as xfail

### DIFF
--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -593,6 +593,7 @@ ament_add_gtest(test_multi_threaded_executor executors/test_multi_threaded_execu
 if(TARGET test_multi_threaded_executor)
   ament_target_dependencies(test_multi_threaded_executor
     "rcl")
+  ament_add_test_label(test_multi_threaded_executor xfail)
   target_link_libraries(test_multi_threaded_executor ${PROJECT_NAME})
 endif()
 


### PR DESCRIPTION
Related to https://github.com/ros2/rclcpp/issues/1008.

This test has been failing since a while ago, and doesn't seem to be easy to solve.
Marking it as xfail until a solution is found to avoid confusions.

---

What I think is happening is that the executor is being slow to execute the timer callback sometimes, and then the measured period is sometimes smaller than expected.

e.g.: period = 1000ms
timer ready at t1
callback executed at t1 + 500ms (executor delayed to schedule the callback)
timer ready again at t1 + 1000ms
callback executed at t1 + 1100ms
measured period of 1100ms - 500ms = 600ms

I remember experiencing something like that a lot ago, though I should try again to confirm.