### PR TITLE
Restore test exception for Connext

### DIFF
--- a/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
@@ -511,8 +511,10 @@ TEST_F(TestAllocatorMemoryStrategy, number_of_entities_with_subscription) {
   RclWaitSetSizes expected_sizes = {};
   expected_sizes.size_of_subscriptions = 1;
   const std::string implementation_identifier = rmw_get_implementation_identifier();
-  if (implementation_identifier == "rmw_cyclonedds_cpp") {
-    // For cyclonedds, a subscription will also add an event and waitable
+  if (implementation_identifier == "rmw_cyclonedds_cpp" ||
+    implementation_identifier == "rmw_connextdds")
+  {
+    // For cyclonedds and connext, a subscription will also add an event and waitable
     expected_sizes.size_of_events += 1;
     expected_sizes.size_of_waitables += 1;
   }


### PR DESCRIPTION
This PR restores an exception for Connext in test `TestAllocatorMemoryStrategy::number_of_entities_with_subscription` which was [deleted](https://github.com/ros2/rclcpp/pull/1595/files#diff-4e1d578c35ec70e95e1a61099f536a316415483223a17061108a1a4e3f379a5bL514) in the process of replacing `rmw_connext_cpp` with `rmw_connextdds`.

The fix will enable `rmw_connextdds` to pass the test, as discovered while working on [rmw_connextdds#22](https://github.com/ros2/rmw_connextdds/pull/22).