### PR TITLE
Check first parameter type and range before calling the user validation callbacks

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -300,12 +300,13 @@ __set_parameters_atomically_common(
   bool allow_undeclared = false)
 {
   // Check if the value being set complies with the descriptor.
-  result = __check_parameters(parameter_infos, parameters, allow_undeclared);
+  rcl_interfaces::msg::SetParametersResult result = __check_parameters(
+    parameter_infos, parameters, allow_undeclared);
   if (!result.successful) {
     return result;
   }
   // Call the user callback to see if the new value(s) are allowed.
-  rcl_interfaces::msg::SetParametersResult result =
+  result =
     __call_on_parameters_set_callbacks(parameters, callback_container, callback);
   if (!result.successful) {
     return result;

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -299,14 +299,14 @@ __set_parameters_atomically_common(
   const OnParametersSetCallbackType & callback,
   bool allow_undeclared = false)
 {
-  // Call the user callback to see if the new value(s) are allowed.
-  rcl_interfaces::msg::SetParametersResult result =
-    __call_on_parameters_set_callbacks(parameters, callback_container, callback);
+  // Check if the value being set complies with the descriptor.
+  result = __check_parameters(parameter_infos, parameters, allow_undeclared);
   if (!result.successful) {
     return result;
   }
-  // Check if the value being set complies with the descriptor.
-  result = __check_parameters(parameter_infos, parameters, allow_undeclared);
+  // Call the user callback to see if the new value(s) are allowed.
+  rcl_interfaces::msg::SetParametersResult result =
+    __call_on_parameters_set_callbacks(parameters, callback_container, callback);
   if (!result.successful) {
     return result;
   }


### PR DESCRIPTION
Based on @jacobperron comment:

```cpp
node->declare_parameter("my_int", 42);
node->add_on_set_parameters_callback([](const std::vector<rclcpp::Parameter> & params) {
  for (const auto & param : params) {
    if (param.get_name() == "my_int") {
      param.as_int();
    }
  }
});
```

This could throw as the parameter type was checked after calling the user provided "on set" parameters callback.
Inver the order so parameter type is checked first (integer/floating point range will also be checked before user callbacks now).

This is also consistent with the current `rclpy` behavior: https://github.com/ros2/rclpy/blob/e938f92933a6919b8f277b17e5cd7deb18d75da1/rclpy/rclpy/node.py#L795-L811.