### PR TITLE
Use a different implementation of mutex two priorities

### DIFF
--- a/rclcpp/include/rclcpp/detail/mutex_two_priorities.hpp
+++ b/rclcpp/include/rclcpp/detail/mutex_two_priorities.hpp
@@ -15,6 +15,7 @@
 #ifndef RCLCPP__DETAIL__MUTEX_TWO_PRIORITIES_HPP_
 #define RCLCPP__DETAIL__MUTEX_TWO_PRIORITIES_HPP_
 
+#include <condition_variable>
 #include <mutex>
 
 namespace rclcpp
@@ -62,11 +63,10 @@ private:
   get_low_priority_lockable();
 
 private:
-  // Implementation detail: the idea here is that only one low priority thread can be
-  // trying to take the data_ mutex while the others are excluded by the barrier_ mutex.
-  // All high priority threads are already waiting for the data_ mutex.
-  std::mutex barrier_;
-  std::mutex data_;
+  std::condition_variable cv_;
+  std::mutex cv_mutex_;
+  size_t hp_waiting_count_{0u};
+  bool data_taken_{false};
 };
 
 }  // namespace detail

--- a/rclcpp/include/rclcpp/detail/mutex_two_priorities.hpp
+++ b/rclcpp/include/rclcpp/detail/mutex_two_priorities.hpp
@@ -63,7 +63,8 @@ private:
   get_low_priority_lockable();
 
 private:
-  std::condition_variable cv_;
+  std::condition_variable hp_cv_;
+  std::condition_variable lp_cv_;
   std::mutex cv_mutex_;
   size_t hp_waiting_count_{0u};
   bool data_taken_{false};

--- a/rclcpp/src/rclcpp/detail/mutex_two_priorities.cpp
+++ b/rclcpp/src/rclcpp/detail/mutex_two_priorities.cpp
@@ -31,16 +31,12 @@ HighPriorityLockable::HighPriorityLockable(MutexTwoPriorities & parent)
 void
 HighPriorityLockable::lock()
 {
-  bool did_aument_count{false};
   std::unique_lock<std::mutex> guard{parent_.cv_mutex_};
   if (parent_.data_taken_) {
     ++parent_.hp_waiting_count_;
-    did_aument_count = true;
-  }
-  while (parent_.data_taken_) {
-    parent_.cv_.wait(guard);
-  }
-  if (did_aument_count) {
+    while (parent_.data_taken_) {
+      parent_.cv_.wait(guard);
+    }
     --parent_.hp_waiting_count_;
   }
   parent_.data_taken_ = true;


### PR DESCRIPTION
Fixes #1008 

The naive implementation added in https://github.com/ros2/rclcpp/pull/1516 doesn't work as well as I expected.
Even though only one "low priority thread" can be waiting in the "data mutex", it's still pretty likely to find the following behavior:

- low priority thread releases data mutex and then the "barrier" mutex
- another low priority thread releases takes the barrier mutex and then also takes the "data" mutex, even when there was a "high priority" thread waiting.

i.e.: the "high priority" take isn't always as "high priority" as we wanted.

Investigating https://github.com/ros2/rclcpp/issues/1008, I realized that the problem was that the executor was taking too long to schedule a timer callback (see investigation in https://github.com/ros2/rclcpp/pull/1624).
After some further investigation, I realized that the problem is that one of the "worker threads" is taking too long to remove the timer from the scheduled timers map, so a new timer callback can't be scheduled:

https://github.com/ros2/rclcpp/blob/a62287bf8d1eab0f146394ff0efdd4da44d4ef34/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp#L109-L113

Esentially, that's the same problem we observed in https://github.com/ros2/rclcpp/pull/1516, but the "MutexTwoPriorities" implementation wasn't good enough.

With this patch, I cannot reproduce the issue locally anymore.

---

Steps to reproduce the issue (on linux):

```basj
stress --cpu 8 &  # use number of cores instead of 8
for i in {1..100}; do ./test_multi_threaded_executor; if [ $? -ne 0 ]; then break;fi;clear; done
```

That should sometimes fails with the old implementation, and shouldn't fail at all with the new one.

---

The new implementation of "MutexTwoPriorities" is way trickier than the previous one, it should be reviewed with care.

https://www.modernescpp.com/index.php/c-core-guidelines-be-aware-of-the-traps-of-condition-variables