### PR TITLE
Avoid returning loan when none was obtained

### DIFF
--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -610,16 +610,18 @@ Executor::execute_subscription(rclcpp::SubscriptionBase::SharedPtr subscription)
         return true;
       },
       [&]() {subscription->handle_loaned_message(loaned_msg, message_info);});
-    rcl_ret_t ret = rcl_return_loaned_message_from_subscription(
-      subscription->get_subscription_handle().get(),
-      loaned_msg);
-    if (RCL_RET_OK != ret) {
-      RCLCPP_ERROR(
-        rclcpp::get_logger("rclcpp"),
-        "rcl_return_loaned_message_from_subscription() failed for subscription on topic '%s': %s",
-        subscription->get_topic_name(), rcl_get_error_string().str);
+    if (nullptr != loaned_msg) {
+      rcl_ret_t ret = rcl_return_loaned_message_from_subscription(
+        subscription->get_subscription_handle().get(),
+        loaned_msg);
+      if (RCL_RET_OK != ret) {
+        RCLCPP_ERROR(
+          rclcpp::get_logger("rclcpp"),
+          "rcl_return_loaned_message_from_subscription() failed for subscription on topic '%s': %s",
+          subscription->get_topic_name(), rcl_get_error_string().str);
+      }
+      loaned_msg = nullptr;
     }
-    loaned_msg = nullptr;
   } else {
     // This case is taking a copy of the message data from the middleware via
     // inter-process communication.


### PR DESCRIPTION
While testing ros2/rmw_fastrtps#523 I saw the following error message several times during the execution of `test_communication`

```
[ERROR] [rclcpp]: rcl_return_loaned_message_from_subscription() failed for subscription on topic '/test_message_BasicTypes': loaned_message argument is null
```

I discovered that `Executor::execute_subscription` was trying to return a loaned message, even when none was obtained (i.e. there was no data available)