### PR TITLE
fix segmentation fault when adding multiple executors simultaneously

### DIFF
--- a/rclcpp/src/rclcpp/context.cpp
+++ b/rclcpp/src/rclcpp/context.cpp
@@ -344,6 +344,7 @@ Context::shutdown(const std::string & reason)
 rclcpp::Context::OnShutdownCallback
 Context::on_shutdown(OnShutdownCallback callback)
 {
+  std::lock_guard<std::mutex> lock(on_shutdown_callbacks_mutex_);
   on_shutdown_callbacks_.push_back(callback);
   return callback;
 }

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -2556,6 +2556,7 @@ TEST_F(TestNode, get_publishers_subscriptions_info_by_topic) {
   };
   rclcpp::QoS qos = rclcpp::QoS(qos_initialization, rmw_qos_profile_default);
   auto publisher = node->create_publisher<test_msgs::msg::BasicTypes>(topic_name, qos);
+  std::this_thread::sleep_for(std::chrono::milliseconds(30));
   // List should have one item
   auto publisher_list = node->get_publishers_info_by_topic(fq_topic_name);
   ASSERT_EQ(publisher_list.size(), (size_t)1);


### PR DESCRIPTION
While creating multiple SingleThreadedExecturors in different thread I ran in crashes.
By adding a lock for "on_shutdown_callbacks_" in "on_shutdown" which is called in the constructor of SingleThreadedExecturors I solved the issue.