### PR TITLE
Returns CancelResponse::REJECT while goal handle failed to transit to CANCELING state

### DIFF
--- a/rclcpp_action/include/rclcpp_action/server.hpp
+++ b/rclcpp_action/include/rclcpp_action/server.hpp
@@ -372,6 +372,9 @@ protected:
         try {
           goal_handle->_cancel_goal();
         } catch (const rclcpp::exceptions::RCLError & ex) {
+          RCLCPP_DEBUG(
+            rclcpp::get_logger("rclcpp_action"),
+            "Failed to cancel goal in call_handle_cancel_callback: %s", ex.what());
           return CancelResponse::REJECT;
         }
       }

--- a/rclcpp_action/include/rclcpp_action/server.hpp
+++ b/rclcpp_action/include/rclcpp_action/server.hpp
@@ -369,7 +369,11 @@ protected:
     if (goal_handle) {
       resp = handle_cancel_(goal_handle);
       if (CancelResponse::ACCEPT == resp) {
-        goal_handle->_cancel_goal();
+        try {
+          goal_handle->_cancel_goal();
+        } catch (const rclcpp::exceptions::RCLError & ex) {
+          return CancelResponse::REJECT;
+        }
       }
     }
     return resp;


### PR DESCRIPTION
For fixing #1599. Some conversations in https://github.com/ros2/rclcpp/pull/1635 are helpful to this PR.