### PR TITLE
use dynamic_pointer_cast to detect allocator mismatch in intra process manager

### DIFF
--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -372,9 +372,10 @@ private:
           >(subscription_base);
         if (nullptr == subscription) {
           throw std::runtime_error(
-            "failed to dynamic cast SubscriptionIntraProcessBase to "
-            "SubscriptionIntraProcess<MessageT>, which can happen when the publisher "
-            "and subscription use different allocator types, which is not supported");
+                  "failed to dynamic cast SubscriptionIntraProcessBase to "
+                  "SubscriptionIntraProcess<MessageT, Alloc, Deleter>, which "
+                  "can happen when the publisher and subscription use different "
+                  "allocator types, which is not supported");
         }
 
         subscription->provide_intra_process_message(message);
@@ -409,9 +410,10 @@ private:
           >(subscription_base);
         if (nullptr == subscription) {
           throw std::runtime_error(
-            "failed to dynamic cast SubscriptionIntraProcessBase to "
-            "SubscriptionIntraProcess<MessageT>, which can happen when the publisher "
-            "and subscription use different allocator types, which is not supported");
+                  "failed to dynamic cast SubscriptionIntraProcessBase to "
+                  "SubscriptionIntraProcess<MessageT, Alloc, Deleter>, which "
+                  "can happen when the publisher and subscription use different "
+                  "allocator types, which is not supported");
         }
 
         if (std::next(it) == subscription_ids.end()) {

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -368,7 +368,9 @@ private:
           >(subscription_base);
         if (nullptr == subscription) {
           throw std::runtime_error(
-            "failed to dynamic cast SubscriptionIntraProcessBase to SubscriptionIntraProcess<MessageT>");
+            "failed to dynamic cast SubscriptionIntraProcessBase to "
+            "SubscriptionIntraProcess<MessageT>, which can happen when the publisher "
+            "and subscription use different allocator types, which is not supported");
         }
 
         subscription->provide_intra_process_message(message);
@@ -403,7 +405,9 @@ private:
           >(subscription_base);
         if (nullptr == subscription) {
           throw std::runtime_error(
-            "failed to dynamic cast SubscriptionIntraProcessBase to SubscriptionIntraProcess<MessageT>");
+            "failed to dynamic cast SubscriptionIntraProcessBase to "
+            "SubscriptionIntraProcess<MessageT>, which can happen when the publisher "
+            "and subscription use different allocator types, which is not supported");
         }
 
         if (std::next(it) == subscription_ids.end()) {

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -202,7 +202,8 @@ public:
       // None of the buffers require ownership, so we promote the pointer
       std::shared_ptr<MessageT> msg = std::move(message);
 
-      this->template add_shared_msg_to_buffers<MessageT>(msg, sub_ids.take_shared_subscriptions);
+      this->template add_shared_msg_to_buffers<MessageT, Alloc, Deleter>(
+        msg, sub_ids.take_shared_subscriptions);
     } else if (!sub_ids.take_ownership_subscriptions.empty() && // NOLINT
       sub_ids.take_shared_subscriptions.size() <= 1)
     {
@@ -227,7 +228,7 @@ public:
       // for the buffers that do not require ownership
       auto shared_msg = std::allocate_shared<MessageT, MessageAllocatorT>(*allocator, *message);
 
-      this->template add_shared_msg_to_buffers<MessageT>(
+      this->template add_shared_msg_to_buffers<MessageT, Alloc, Deleter>(
         shared_msg, sub_ids.take_shared_subscriptions);
       this->template add_owned_msg_to_buffers<MessageT, Alloc, Deleter>(
         std::move(message), sub_ids.take_ownership_subscriptions, allocator);
@@ -263,7 +264,7 @@ public:
       // If there are no owning, just convert to shared.
       std::shared_ptr<MessageT> shared_msg = std::move(message);
       if (!sub_ids.take_shared_subscriptions.empty()) {
-        this->template add_shared_msg_to_buffers<MessageT>(
+        this->template add_shared_msg_to_buffers<MessageT, Alloc, Deleter>(
           shared_msg, sub_ids.take_shared_subscriptions);
       }
       return shared_msg;
@@ -273,7 +274,7 @@ public:
       auto shared_msg = std::allocate_shared<MessageT, MessageAllocatorT>(*allocator, *message);
 
       if (!sub_ids.take_shared_subscriptions.empty()) {
-        this->template add_shared_msg_to_buffers<MessageT>(
+        this->template add_shared_msg_to_buffers<MessageT, Alloc, Deleter>(
           shared_msg,
           sub_ids.take_shared_subscriptions);
       }
@@ -350,7 +351,10 @@ private:
   bool
   can_communicate(PublisherInfo pub_info, SubscriptionInfo sub_info) const;
 
-  template<typename MessageT>
+  template<
+    typename MessageT,
+    typename Alloc,
+    typename Deleter>
   void
   add_shared_msg_to_buffers(
     std::shared_ptr<const MessageT> message,
@@ -364,7 +368,7 @@ private:
       auto subscription_base = subscription_it->second.subscription.lock();
       if (subscription_base) {
         auto subscription = std::dynamic_pointer_cast<
-          rclcpp::experimental::SubscriptionIntraProcess<MessageT>
+          rclcpp::experimental::SubscriptionIntraProcess<MessageT, Alloc, Deleter>
           >(subscription_base);
         if (nullptr == subscription) {
           throw std::runtime_error(
@@ -401,7 +405,7 @@ private:
       auto subscription_base = subscription_it->second.subscription.lock();
       if (subscription_base) {
         auto subscription = std::dynamic_pointer_cast<
-          rclcpp::experimental::SubscriptionIntraProcess<MessageT>
+          rclcpp::experimental::SubscriptionIntraProcess<MessageT, Alloc, Deleter>
           >(subscription_base);
         if (nullptr == subscription) {
           throw std::runtime_error(

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -363,9 +363,13 @@ private:
       }
       auto subscription_base = subscription_it->second.subscription.lock();
       if (subscription_base) {
-        auto subscription = std::static_pointer_cast<
+        auto subscription = std::dynamic_pointer_cast<
           rclcpp::experimental::SubscriptionIntraProcess<MessageT>
           >(subscription_base);
+        if (nullptr == subscription) {
+          throw std::runtime_error(
+            "failed to dynamic cast SubscriptionIntraProcessBase to SubscriptionIntraProcess<MessageT>");
+        }
 
         subscription->provide_intra_process_message(message);
       } else {
@@ -394,9 +398,13 @@ private:
       }
       auto subscription_base = subscription_it->second.subscription.lock();
       if (subscription_base) {
-        auto subscription = std::static_pointer_cast<
+        auto subscription = std::dynamic_pointer_cast<
           rclcpp::experimental::SubscriptionIntraProcess<MessageT>
           >(subscription_base);
+        if (nullptr == subscription) {
+          throw std::runtime_error(
+            "failed to dynamic cast SubscriptionIntraProcessBase to SubscriptionIntraProcess<MessageT>");
+        }
 
         if (std::next(it) == subscription_ids.end()) {
           // If this is the last subscription, give up ownership

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -143,6 +143,13 @@ if(TARGET test_intra_process_manager)
   )
   target_link_libraries(test_intra_process_manager ${PROJECT_NAME})
 endif()
+ament_add_gmock(test_intra_process_manager_with_allocators test_intra_process_manager_with_allocators.cpp)
+if(TARGET test_intra_process_manager_with_allocators)
+  ament_target_dependencies(test_intra_process_manager_with_allocators
+    "test_msgs"
+  )
+  target_link_libraries(test_intra_process_manager_with_allocators ${PROJECT_NAME})
+endif()
 ament_add_gtest(test_ring_buffer_implementation test_ring_buffer_implementation.cpp)
 if(TARGET test_ring_buffer_implementation)
   ament_target_dependencies(test_ring_buffer_implementation

--- a/rclcpp/test/rclcpp/test_intra_process_manager.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager.cpp
@@ -216,7 +216,10 @@ public:
   const char * topic_name;
 };
 
-template<typename MessageT>
+template<
+  typename MessageT,
+  typename Alloc = std::allocator<void>,
+  typename Deleter = std::default_delete<MessageT>>
 class SubscriptionIntraProcess : public SubscriptionIntraProcessBase
 {
 public:

--- a/rclcpp/test/rclcpp/test_intra_process_manager_with_allocators.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager_with_allocators.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 Open Source Robotics Foundation, Inc.
+// Copyright 2021 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rclcpp/test/rclcpp/test_intra_process_manager_with_allocators.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager_with_allocators.cpp
@@ -106,7 +106,7 @@ void
 do_custom_allocator_test(
   PublishedMessageAllocatorT published_message_allocator,
   PublisherAllocatorT publisher_allocator,
-  SubscribedMessageAllocatorT /* subscribed_message_allocator */,  // intentinally unused
+  SubscribedMessageAllocatorT /* subscribed_message_allocator */,  // intentionally unused
   SubscriptionAllocatorT subscription_allocator,
   MessageMemoryStrategyAllocatorT message_memory_strategy,
   MemoryStrategyAllocatorT memory_strategy_allocator)

--- a/rclcpp/test/rclcpp/test_intra_process_manager_with_allocators.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager_with_allocators.cpp
@@ -121,7 +121,7 @@ TEST(TestIntraProcessManagerWithAllocators, custom_allocator) {
   subscription_options.allocator = alloc;
   auto msg_mem_strat =
     std::make_shared<
-      rclcpp::message_memory_strategy::MessageMemoryStrategy<test_msgs::msg::Empty, Alloc>
+    rclcpp::message_memory_strategy::MessageMemoryStrategy<test_msgs::msg::Empty, Alloc>
     >(alloc);
   auto subscriber = node->create_subscription<test_msgs::msg::Empty>(
     "custom_allocator_test", 10, callback, subscription_options, msg_mem_strat);
@@ -148,7 +148,8 @@ TEST(TestIntraProcessManagerWithAllocators, custom_allocator) {
   auto ptr = MessageAllocTraits::allocate(message_alloc, 1);
   MessageAllocTraits::construct(message_alloc, ptr);
   std::unique_ptr<test_msgs::msg::Empty, MessageDeleter> msg(ptr, message_deleter);
-  EXPECT_NO_THROW({
+  EXPECT_NO_THROW(
+  {
     publisher->publish(std::move(msg));
     executor.spin_some();
   });
@@ -184,7 +185,8 @@ TEST(TestIntraProcessManagerWithAllocators, custom_allocator_wrong) {
   subscription_options.allocator = std_alloc;
   auto msg_mem_strat =
     std::make_shared<
-      rclcpp::message_memory_strategy::MessageMemoryStrategy<test_msgs::msg::Empty, std::allocator<void>>
+    rclcpp::message_memory_strategy::MessageMemoryStrategy<test_msgs::msg::Empty,
+    std::allocator<void>>
     >(std_alloc);
   auto subscriber = node->create_subscription<test_msgs::msg::Empty>(
     "custom_allocator_test", 10, callback, subscription_options, msg_mem_strat);
@@ -211,7 +213,8 @@ TEST(TestIntraProcessManagerWithAllocators, custom_allocator_wrong) {
   auto ptr = MessageAllocTraits::allocate(message_alloc, 1);
   MessageAllocTraits::construct(message_alloc, ptr);
   std::unique_ptr<test_msgs::msg::Empty, MessageDeleter> msg(ptr, message_deleter);
-  EXPECT_THROW({
+  EXPECT_THROW(
+  {
     publisher->publish(std::move(msg));
     executor.spin_some();
   }, std::runtime_error);

--- a/rclcpp/test/rclcpp/test_intra_process_manager_with_allocators.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager_with_allocators.cpp
@@ -1,0 +1,218 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <chrono>
+#include <list>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "test_msgs/msg/empty.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/allocator/allocator_common.hpp"
+#include "rclcpp/strategies/allocator_memory_strategy.hpp"
+
+// For demonstration purposes only, not necessary for allocator_traits
+static uint32_t num_allocs = 0;
+static uint32_t num_deallocs = 0;
+// A very simple custom allocator. Counts calls to allocate and deallocate.
+template<typename T = void>
+struct MyAllocator
+{
+public:
+  using value_type = T;
+  using size_type = std::size_t;
+  using pointer = T *;
+  using const_pointer = const T *;
+  using difference_type = typename std::pointer_traits<pointer>::difference_type;
+
+  MyAllocator() noexcept
+  {
+  }
+
+  ~MyAllocator() noexcept {}
+
+  template<typename U>
+  MyAllocator(const MyAllocator<U> &) noexcept
+  {
+  }
+
+  T * allocate(size_t size, const void * = 0)
+  {
+    if (size == 0) {
+      return nullptr;
+    }
+    num_allocs++;
+    return static_cast<T *>(std::malloc(size * sizeof(T)));
+  }
+
+  void deallocate(T * ptr, size_t size)
+  {
+    (void)size;
+    if (!ptr) {
+      return;
+    }
+    num_deallocs++;
+    std::free(ptr);
+  }
+
+  template<typename U>
+  struct rebind
+  {
+    typedef MyAllocator<U> other;
+  };
+};
+
+template<typename T, typename U>
+constexpr bool operator==(
+  const MyAllocator<T> &,
+  const MyAllocator<U> &) noexcept
+{
+  return true;
+}
+
+template<typename T, typename U>
+constexpr bool operator!=(
+  const MyAllocator<T> &,
+  const MyAllocator<U> &) noexcept
+{
+  return false;
+}
+
+/*
+   This tests the case where a custom allocator is used correctly, i.e. the same
+   custom allocator on both sides.
+ */
+TEST(TestIntraProcessManagerWithAllocators, custom_allocator) {
+  auto context = std::make_shared<rclcpp::Context>();
+  context->init(0, nullptr);
+  auto node = std::make_shared<rclcpp::Node>(
+    "custom_allocator_test",
+    rclcpp::NodeOptions().context(context).use_intra_process_comms(true));
+
+  uint32_t counter = 0;
+  auto callback =
+    [&counter](std::shared_ptr<const test_msgs::msg::Empty>) {
+      ++counter;
+    };
+
+  using Alloc = MyAllocator<void>;
+  auto alloc = std::make_shared<Alloc>();
+  rclcpp::PublisherOptionsWithAllocator<Alloc> publisher_options;
+  publisher_options.allocator = alloc;
+  auto publisher =
+    node->create_publisher<test_msgs::msg::Empty>("custom_allocator_test", 10, publisher_options);
+
+  rclcpp::SubscriptionOptionsWithAllocator<Alloc> subscription_options;
+  subscription_options.allocator = alloc;
+  auto msg_mem_strat =
+    std::make_shared<
+      rclcpp::message_memory_strategy::MessageMemoryStrategy<test_msgs::msg::Empty, Alloc>
+    >(alloc);
+  auto subscriber = node->create_subscription<test_msgs::msg::Empty>(
+    "custom_allocator_test", 10, callback, subscription_options, msg_mem_strat);
+
+  using rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy;
+  std::shared_ptr<rclcpp::memory_strategy::MemoryStrategy> memory_strategy =
+    std::make_shared<AllocatorMemoryStrategy<Alloc>>(alloc);
+
+  rclcpp::ExecutorOptions options;
+  options.memory_strategy = memory_strategy;
+  options.context = context;
+  rclcpp::executors::SingleThreadedExecutor executor(options);
+
+  executor.add_node(node);
+
+  using MessageAllocTraits =
+    rclcpp::allocator::AllocRebind<test_msgs::msg::Empty, Alloc>;
+  using MessageAlloc = MessageAllocTraits::allocator_type;
+  using MessageDeleter = rclcpp::allocator::Deleter<MessageAlloc, test_msgs::msg::Empty>;
+  MessageDeleter message_deleter;
+  MessageAlloc message_alloc = *alloc;
+  rclcpp::allocator::set_allocator_for_deleter(&message_deleter, &message_alloc);
+
+  auto ptr = MessageAllocTraits::allocate(message_alloc, 1);
+  MessageAllocTraits::construct(message_alloc, ptr);
+  std::unique_ptr<test_msgs::msg::Empty, MessageDeleter> msg(ptr, message_deleter);
+  EXPECT_NO_THROW({
+    publisher->publish(std::move(msg));
+    executor.spin_some();
+  });
+}
+
+/*
+   This tests the case where a custom allocator is used incorrectly, i.e. different
+   custom allocators on both sides.
+ */
+TEST(TestIntraProcessManagerWithAllocators, custom_allocator_wrong) {
+  auto context = std::make_shared<rclcpp::Context>();
+  context->init(0, nullptr);
+  auto node = std::make_shared<rclcpp::Node>(
+    "custom_allocator_test",
+    rclcpp::NodeOptions().context(context).use_intra_process_comms(true));
+
+  uint32_t counter = 0;
+  auto callback =
+    [&counter](std::shared_ptr<const test_msgs::msg::Empty>) {
+      ++counter;
+    };
+
+  using Alloc = MyAllocator<void>;
+  auto alloc = std::make_shared<Alloc>();
+  rclcpp::PublisherOptionsWithAllocator<Alloc> publisher_options;
+  publisher_options.allocator = alloc;
+  auto publisher =
+    node->create_publisher<test_msgs::msg::Empty>("custom_allocator_test", 10, publisher_options);
+
+  // Explicitly use std::allocator<void>
+  rclcpp::SubscriptionOptionsWithAllocator<std::allocator<void>> subscription_options;
+  auto std_alloc = std::make_shared<std::allocator<void>>();
+  subscription_options.allocator = std_alloc;
+  auto msg_mem_strat =
+    std::make_shared<
+      rclcpp::message_memory_strategy::MessageMemoryStrategy<test_msgs::msg::Empty, std::allocator<void>>
+    >(std_alloc);
+  auto subscriber = node->create_subscription<test_msgs::msg::Empty>(
+    "custom_allocator_test", 10, callback, subscription_options, msg_mem_strat);
+
+  using rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy;
+  std::shared_ptr<rclcpp::memory_strategy::MemoryStrategy> memory_strategy =
+    std::make_shared<AllocatorMemoryStrategy<Alloc>>(alloc);
+
+  rclcpp::ExecutorOptions options;
+  options.memory_strategy = memory_strategy;
+  options.context = context;
+  rclcpp::executors::SingleThreadedExecutor executor(options);
+
+  executor.add_node(node);
+
+  using MessageAllocTraits =
+    rclcpp::allocator::AllocRebind<test_msgs::msg::Empty, Alloc>;
+  using MessageAlloc = MessageAllocTraits::allocator_type;
+  using MessageDeleter = rclcpp::allocator::Deleter<MessageAlloc, test_msgs::msg::Empty>;
+  MessageDeleter message_deleter;
+  MessageAlloc message_alloc = *alloc;
+  rclcpp::allocator::set_allocator_for_deleter(&message_deleter, &message_alloc);
+
+  auto ptr = MessageAllocTraits::allocate(message_alloc, 1);
+  MessageAllocTraits::construct(message_alloc, ptr);
+  std::unique_ptr<test_msgs::msg::Empty, MessageDeleter> msg(ptr, message_deleter);
+  EXPECT_THROW({
+    publisher->publish(std::move(msg));
+    executor.spin_some();
+  }, std::runtime_error);
+}


### PR DESCRIPTION
We believe this is the root cause of https://github.com/ros2/demos/issues/501