### PR TITLE
Keep custom allocator in publisher and subscription options alive.

### DIFF
--- a/rclcpp/include/rclcpp/publisher_options.hpp
+++ b/rclcpp/include/rclcpp/publisher_options.hpp
@@ -104,15 +104,18 @@ struct PublisherOptionsWithAllocator : public PublisherOptionsBase
   get_allocator() const
   {
     if (!this->allocator) {
-      if constexpr (std::is_same_v<Allocator, std::allocator<void>>) {
-        auto g_instance = std::make_shared<std::allocator<void>>();
-        return g_instance;
-      } else {
-        throw std::runtime_error("allocator is nullptr");
+      if (!allocator_storage_) {
+        allocator_storage_ = std::make_shared<Allocator>();
       }
+      return allocator_storage_;
     }
     return this->allocator;
   }
+
+private:
+  // This is a temporal workaround, to make sure that get_allocator()
+  // always returns a copy of the same allocator.
+  mutable std::shared_ptr<Allocator> allocator_storage_;
 };
 
 using PublisherOptions = PublisherOptionsWithAllocator<std::allocator<void>>;

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -126,20 +126,22 @@ struct SubscriptionOptionsWithAllocator : public SubscriptionOptionsBase
     return result;
   }
 
-  /// Get the allocator, creating one if needed.
   std::shared_ptr<Allocator>
   get_allocator() const
   {
     if (!this->allocator) {
-      if constexpr (std::is_same_v<Allocator, std::allocator<void>>) {
-        auto g_instance = std::make_shared<std::allocator<void>>();
-        return g_instance;
-      } else {
-        throw std::runtime_error("allocator is nullptr");
+      if (!allocator_storage_) {
+        allocator_storage_ = std::make_shared<Allocator>();
       }
+      return allocator_storage_;
     }
     return this->allocator;
   }
+
+private:
+  // This is a temporal workaround, to make sure that get_allocator()
+  // always returns a copy of the same allocator.
+  mutable std::shared_ptr<Allocator> allocator_storage_;
 };
 
 using SubscriptionOptions = SubscriptionOptionsWithAllocator<std::allocator<void>>;

--- a/rclcpp/test/rclcpp/test_intra_process_manager_with_allocators.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager_with_allocators.cpp
@@ -18,6 +18,7 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 #include "test_msgs/msg/empty.hpp"
@@ -57,7 +58,10 @@ public:
       return nullptr;
     }
     num_allocs++;
-    return static_cast<T *>(std::malloc(size * sizeof(T)));
+    // Use sizeof(char) in place for sizeof(void)
+    constexpr size_t value_size = sizeof(
+      typename std::conditional<!std::is_void<T>::value, T, char>::type);
+    return static_cast<T *>(std::malloc(size * value_size));
   }
 
   void deallocate(T * ptr, size_t size)


### PR DESCRIPTION
Also, enforce an allocator bound to void is used to avoid surprises. Connected to #1643.

I used `mutable` and kept `MessageT` as template parameter to keep changes local (i.e. not force a change all the way up the call stack due template signature and `const`-ness changes).

CI up to `rclcpp` and `demo_nodes_cpp`:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14524)](http://ci.ros2.org/job/ci_linux/14524/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9281)](http://ci.ros2.org/job/ci_linux-aarch64/9281/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12190)](http://ci.ros2.org/job/ci_osx/12190/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14627)](http://ci.ros2.org/job/ci_windows/14627/)

though I don't think we can easily write a regression test for this (i.e. in a way that's accurate and cross-platform). 

Fixes https://github.com/ros2/rclcpp/issues/1339