### PR TITLE
Do not attempt to use void allocators for memory allocation.

### DIFF
--- a/rclcpp/include/rclcpp/publisher_options.hpp
+++ b/rclcpp/include/rclcpp/publisher_options.hpp
@@ -85,7 +85,7 @@ struct PublisherOptionsWithAllocator : public PublisherOptionsBase
   to_rcl_publisher_options(const rclcpp::QoS & qos) const
   {
     rcl_publisher_options_t result = rcl_publisher_get_default_options();
-    result.allocator = rclcpp::allocator::get_rcl_allocator<void>(*this->get_allocator());
+    result.allocator = this->get_rcl_allocator();
     result.qos = qos.get_rmw_qos_profile();
     result.rmw_publisher_options.require_unique_network_flow_endpoints =
       this->require_unique_network_flow_endpoints;
@@ -113,9 +113,26 @@ struct PublisherOptionsWithAllocator : public PublisherOptionsBase
   }
 
 private:
+  using PlainAllocator =
+    typename std::allocator_traits<Allocator>::template rebind_alloc<char>;
+
+  rcl_allocator_t
+  get_rcl_allocator() const
+  {
+    if (!plain_allocator_storage_) {
+      plain_allocator_storage_ =
+        std::make_shared<PlainAllocator>(*this->get_allocator());
+    }
+    return rclcpp::allocator::get_rcl_allocator<char>(*plain_allocator_storage_);
+  }
+
   // This is a temporal workaround, to make sure that get_allocator()
   // always returns a copy of the same allocator.
   mutable std::shared_ptr<Allocator> allocator_storage_;
+
+  // This is a temporal workaround, to keep the plain allocator that backs
+  // up the rcl allocator returned in rcl_publisher_options_t alive.
+  mutable std::shared_ptr<PlainAllocator> plain_allocator_storage_;
 };
 
 using PublisherOptions = PublisherOptionsWithAllocator<std::allocator<void>>;

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -112,7 +112,7 @@ struct SubscriptionOptionsWithAllocator : public SubscriptionOptionsBase
   to_rcl_subscription_options(const rclcpp::QoS & qos) const
   {
     rcl_subscription_options_t result = rcl_subscription_get_default_options();
-    result.allocator = allocator::get_rcl_allocator<void>(*this->get_allocator());
+    result.allocator = this->get_rcl_allocator();
     result.qos = qos.get_rmw_qos_profile();
     result.rmw_subscription_options.ignore_local_publications = this->ignore_local_publications;
     result.rmw_subscription_options.require_unique_network_flow_endpoints =
@@ -139,9 +139,26 @@ struct SubscriptionOptionsWithAllocator : public SubscriptionOptionsBase
   }
 
 private:
+  using PlainAllocator =
+    typename std::allocator_traits<Allocator>::template rebind_alloc<char>;
+
+  rcl_allocator_t
+  get_rcl_allocator() const
+  {
+    if (!plain_allocator_storage_) {
+      plain_allocator_storage_ =
+        std::make_shared<PlainAllocator>(*this->get_allocator());
+    }
+    return rclcpp::allocator::get_rcl_allocator<char>(*plain_allocator_storage_);
+  }
+
   // This is a temporal workaround, to make sure that get_allocator()
   // always returns a copy of the same allocator.
   mutable std::shared_ptr<Allocator> allocator_storage_;
+
+  // This is a temporal workaround, to keep the plain allocator that backs
+  // up the rcl allocator returned in rcl_subscription_options_t alive.
+  mutable std::shared_ptr<PlainAllocator> plain_allocator_storage_;
 };
 
 using SubscriptionOptions = SubscriptionOptionsWithAllocator<std::allocator<void>>;


### PR DESCRIPTION
Void allocators are not supposed to even have `allocate` nor `deallocate` methods (see [cppreference](https://en.cppreference.com/w/cpp/memory/allocator)). `allocator::get_rcl_allocator` has an [specialization](https://github.com/ros2/rclcpp/blob/1fc2d58799a6d4530522be5c236c70be53455e60/rclcpp/include/rclcpp/allocator/allocator_common.hpp#L85-L94) to bypass itself if `Allocator` is `std::allocator<void>`, but it doesn't cover custom void allocators (which shouldn't have `allocate` nor `deallocate` methods to begin with).

This patch amends this, keeping a rebound allocator for byte-sized memory blocks around for publisher and subscription options.

Follow-up after 1fc2d58799a6d4530522be5c236c70be53455e60.
