### PR TITLE
[service] Don't use a weak_ptr to avoid leaking

### DIFF
--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -180,22 +180,14 @@ public:
     std::weak_ptr<rcl_node_t> weak_node_handle(node_handle_);
     // rcl does the static memory allocation here
     service_handle_ = std::shared_ptr<rcl_service_t>(
-      new rcl_service_t, [weak_node_handle, service_name](rcl_service_t * service)
+      new rcl_service_t, [handle = node_handle_, service_name](rcl_service_t * service)
       {
-        auto handle = weak_node_handle.lock();
-        if (handle) {
-          if (rcl_service_fini(service, handle.get()) != RCL_RET_OK) {
-            RCLCPP_ERROR(
-              rclcpp::get_node_logger(handle.get()).get_child("rclcpp"),
-              "Error in destruction of rcl service handle: %s",
-              rcl_get_error_string().str);
-            rcl_reset_error();
-          }
-        } else {
-          RCLCPP_ERROR_STREAM(
-            rclcpp::get_logger("rclcpp"),
-            "Error in destruction of rcl service handle " << service_name <<
-              ": the Node Handle was destructed too early. You will leak memory");
+        if (rcl_service_fini(service, handle.get()) != RCL_RET_OK) {
+          RCLCPP_ERROR(
+            rclcpp::get_node_logger(handle.get()).get_child("rclcpp"),
+            "Error in destruction of rcl service handle: %s",
+            rcl_get_error_string().str);
+          rcl_reset_error();
         }
         delete service;
       });

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -177,7 +177,6 @@ public:
     using rosidl_typesupport_cpp::get_service_type_support_handle;
     auto service_type_support_handle = get_service_type_support_handle<ServiceT>();
 
-    std::weak_ptr<rcl_node_t> weak_node_handle(node_handle_);
     // rcl does the static memory allocation here
     service_handle_ = std::shared_ptr<rcl_service_t>(
       new rcl_service_t, [handle = node_handle_, service_name](rcl_service_t * service)


### PR DESCRIPTION
Fixes https://github.com/ros2/rmw_connextdds/issues/40.

I don't see why we were using a weak_ptr, and that causes unexpected bugs when something external (e.g. the executor) is holding the rcl service handle but not the rcl node handle.

-----

Ownership diagram:

parent =====> child
weak_parent -----> weak_child

```
                                   (through a rclcpp::Node weak_ptr)
rclcpp::Executor --------------------------------------------
                                 |                          |
                                 |                          |
                                 V  (captured by deleter)   |
rclcpp::Service =======> rcl_service handle=======||        |
      ||                                          ||        |
      ||                                          VV        V
      ||=======================================> rcl_node handle
```

Based on the diagram above, I don't see any problem with keeping a shared_ptr instead of a weak_ptr in the deleter.
I will run some tests with valgrind just in case.