### PR TITLE
Bump the benchmark timeout for benchmark_action_client

### DIFF
--- a/rclcpp_action/test/benchmark/CMakeLists.txt
+++ b/rclcpp_action/test/benchmark/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(performance_test_fixture REQUIRED)
 add_performance_test(
   benchmark_action_client
   benchmark_action_client.cpp
-  TIMEOUT 120)
+  TIMEOUT 240)
 if(TARGET benchmark_action_client)
   target_link_libraries(benchmark_action_client ${PROJECT_NAME})
   ament_target_dependencies(benchmark_action_client rclcpp test_msgs)


### PR DESCRIPTION
Pausing and resuming the measurement inside the timing loop can cause the initial run duration calculation to underestimate how long the benchmark is taking to run, which results in the recorded run taking a lot longer than it should. This is a known issue in libbenchmark.

This test is affected by that behavior, and typically takes a bit longer than the others. The easiest thing to do right now is to just bump the timeout. My tests show that 180 seconds is typically sufficient for this test, so 240 should be a safe point to conclude that the test is malfunctioning.

This test has been timing out for the past 121 consecutive attempts in Rolling: https://build.ros2.org/view/Rci/job/Rci__benchmark_ubuntu_focal_amd64/370/testReport/junit/projectroot.test/benchmark/benchmark_action_client/

[![Build Status](https://build.ros2.org/buildStatus/icon?job=Rci__overlay_ubuntu_focal_amd64&build=24)](https://build.ros2.org/view/Rci/job/Rci__overlay_ubuntu_focal_amd64/24/)