### PR TITLE
Declare parameters uninitialized

### DIFF
--- a/rclcpp/include/rclcpp/exceptions/exceptions.hpp
+++ b/rclcpp/include/rclcpp/exceptions/exceptions.hpp
@@ -282,20 +282,6 @@ class ParameterModifiedInCallbackException : public std::runtime_error
   using std::runtime_error::runtime_error;
 };
 
-/// Thrown when a parameter override wasn't provided and one was required.
-class NoParameterOverrideProvided : public std::runtime_error
-{
-public:
-  /// Construct an instance.
-  /**
-   * \param[in] name the name of the parameter.
-   * \param[in] message custom exception message.
-   */
-  explicit NoParameterOverrideProvided(const std::string & name)
-  : std::runtime_error("parameter '" + name + "' requires an user provided parameter override")
-  {}
-};
-
 /// Thrown when an uninitialized parameter is accessed.
 class ParameterUninitializedException : public std::runtime_error
 {

--- a/rclcpp/include/rclcpp/exceptions/exceptions.hpp
+++ b/rclcpp/include/rclcpp/exceptions/exceptions.hpp
@@ -296,6 +296,20 @@ public:
   {}
 };
 
+/// Thrown when an uninitialized parameter is accessed.
+class ParameterUninitializedException : public std::runtime_error
+{
+public:
+  /// Construct an instance.
+  /**
+   * \param[in] name the name of the parameter.
+   * \param[in] message custom exception message.
+   */
+  explicit ParameterUninitializedException(const std::string & name)
+  : std::runtime_error("parameter '" + name + "' is not initialized")
+  {}
+};
+
 /// Thrown if the QoS overrides provided aren't valid.
 class InvalidQosOverridesException : public std::runtime_error
 {

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -351,8 +351,6 @@ __declare_parameter_common(
 
   // If there is no initial value, then skip initialization
   if (initial_value->get_type() == rclcpp::PARAMETER_NOT_SET) {
-    // descriptor type should be set
-    assert(parameter_descriptor.type != rclcpp::PARAMETER_NOT_SET);
     // Add declared parameters to storage (without a value)
     parameter_infos[name].descriptor.name = name;
     parameter_infos[name].descriptor.type = parameter_descriptor.type;

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -827,7 +827,7 @@ NodeParameters::get_parameter(const std::string & name) const
   } else if (parameters_.end() == param_iter) {
     throw rclcpp::exceptions::ParameterNotDeclaredException(name);
   } else {
-    throw rclcpp::exceptions::NoParameterOverrideProvided(name);
+    throw rclcpp::exceptions::ParameterUninitializedException(name);
   }
 }
 

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -353,7 +353,11 @@ __declare_parameter_common(
   if (initial_value->get_type() == rclcpp::PARAMETER_NOT_SET) {
     // Add declared parameters to storage (without a value)
     parameter_infos[name].descriptor.name = name;
-    parameter_infos[name].descriptor.type = parameter_descriptor.type;
+    if (parameter_descriptor.dynamic_typing) {
+      parameter_infos[name].descriptor.type = rclcpp::PARAMETER_NOT_SET;
+    } else {
+      parameter_infos[name].descriptor.type = parameter_descriptor.type;
+    }
     parameters_out[name] = parameter_infos.at(name);
     rcl_interfaces::msg::SetParametersResult result;
     result.successful = true;
@@ -814,7 +818,8 @@ NodeParameters::get_parameter(const std::string & name) const
   auto param_iter = parameters_.find(name);
   if (
     parameters_.end() != param_iter &&
-    param_iter->second.value.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET)
+    (param_iter->second.value.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET ||
+      param_iter->second.descriptor.dynamic_typing))
   {
     return rclcpp::Parameter{name, param_iter->second.value};
   } else if (this->allow_undeclared_) {

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -819,7 +819,7 @@ NodeParameters::get_parameter(const std::string & name) const
   if (
     parameters_.end() != param_iter &&
     (param_iter->second.value.get_type() != rclcpp::ParameterType::PARAMETER_NOT_SET ||
-      param_iter->second.descriptor.dynamic_typing))
+    param_iter->second.descriptor.dynamic_typing))
   {
     return rclcpp::Parameter{name, param_iter->second.value};
   } else if (this->allow_undeclared_) {

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -2808,7 +2808,7 @@ TEST_F(TestNode, static_and_dynamic_typing) {
     // Throws if not set before access
     EXPECT_THROW(
       node->get_parameter("integer_override_not_given"),
-      rclcpp::exceptions::NoParameterOverrideProvided);
+      rclcpp::exceptions::ParameterUninitializedException);
   }
   {
     auto param = node->declare_parameter("integer_set_after_declare", rclcpp::PARAMETER_INTEGER);

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -339,10 +339,10 @@ TEST_F(TestNode, declare_parameter_with_no_initial_values) {
     rclcpp::ParameterValue value = node->declare_parameter(
       parameter_name, rclcpp::ParameterValue{}, descriptor);
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_NOT_SET);
-    // Throws if not set before access
-    EXPECT_THROW(
-      node->get_parameter(parameter_name),
-      rclcpp::exceptions::NoParameterOverrideProvided);
+    // Does not throw if unset before access
+    EXPECT_EQ(
+      rclcpp::PARAMETER_NOT_SET,
+      node->get_parameter(parameter_name).get_parameter_value().get_type());
   }
   {
     // int default, no initial

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -334,16 +334,15 @@ TEST_F(TestNode, declare_parameter_with_no_initial_values) {
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.dynamic_typing = true;
-    // no default, no initial, dynamic typing
+    // no default, no initial
+    const std::string parameter_name = "parameter"_unq;
     rclcpp::ParameterValue value = node->declare_parameter(
-      "parameter"_unq, rclcpp::ParameterValue{}, descriptor);
+      parameter_name, rclcpp::ParameterValue{}, descriptor);
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_NOT_SET);
-  }
-  {
-    // no default, no initial, static typing
-    rclcpp::ParameterValue value = node->declare_parameter(
-      "parameter"_unq, rclcpp::ParameterType::PARAMETER_INTEGER);
-    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_NOT_SET);
+    // Throws if not set before access
+    EXPECT_THROW(
+      node->get_parameter(parameter_name),
+      rclcpp::exceptions::NoParameterOverrideProvided);
   }
   {
     // int default, no initial
@@ -2806,6 +2805,10 @@ TEST_F(TestNode, static_and_dynamic_typing) {
   {
     auto param = node->declare_parameter("integer_override_not_given", rclcpp::PARAMETER_INTEGER);
     EXPECT_EQ(rclcpp::PARAMETER_NOT_SET, param.get_type());
+    // Throws if not set before access
+    EXPECT_THROW(
+      node->get_parameter("integer_override_not_given"),
+      rclcpp::exceptions::NoParameterOverrideProvided);
   }
   {
     EXPECT_THROW(

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -334,9 +334,15 @@ TEST_F(TestNode, declare_parameter_with_no_initial_values) {
   {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.dynamic_typing = true;
-    // no default, no initial
+    // no default, no initial, dynamic typing
     rclcpp::ParameterValue value = node->declare_parameter(
       "parameter"_unq, rclcpp::ParameterValue{}, descriptor);
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_NOT_SET);
+  }
+  {
+    // no default, no initial, static typing
+    rclcpp::ParameterValue value = node->declare_parameter(
+      "parameter"_unq, rclcpp::ParameterType::PARAMETER_INTEGER);
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_NOT_SET);
   }
   {
@@ -2798,9 +2804,8 @@ TEST_F(TestNode, static_and_dynamic_typing) {
     EXPECT_EQ("hello!", param);
   }
   {
-    EXPECT_THROW(
-      node->declare_parameter("integer_override_not_given", rclcpp::PARAMETER_INTEGER),
-      rclcpp::exceptions::NoParameterOverrideProvided);
+    auto param = node->declare_parameter("integer_override_not_given", rclcpp::PARAMETER_INTEGER);
+    EXPECT_EQ(rclcpp::PARAMETER_NOT_SET, param.get_type());
   }
   {
     EXPECT_THROW(

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -2811,6 +2811,14 @@ TEST_F(TestNode, static_and_dynamic_typing) {
       rclcpp::exceptions::NoParameterOverrideProvided);
   }
   {
+    auto param = node->declare_parameter("integer_set_after_declare", rclcpp::PARAMETER_INTEGER);
+    EXPECT_EQ(rclcpp::PARAMETER_NOT_SET, param.get_type());
+    auto result = node->set_parameter(rclcpp::Parameter{"integer_set_after_declare", 44});
+    ASSERT_TRUE(result.successful) << result.reason;
+    auto get_param = node->get_parameter("integer_set_after_declare");
+    EXPECT_EQ(44, get_param.as_int());
+  }
+  {
     EXPECT_THROW(
       node->declare_parameter("parameter_not_set_is_not_a_valid_type", rclcpp::PARAMETER_NOT_SET),
       std::invalid_argument);


### PR DESCRIPTION
Fixes #1649

Allow declaring parameters without an initial value or override.
This was possible prior to Galactic, but was made impossible since we started enforcing the types of parameters in Galactic.

---

Opening for early feedback. I still need to test this more thoroughly for my use-case and add documentation.