### PR TITLE
Fix destruction order in lifecycle benchmark

### DIFF
--- a/rclcpp_lifecycle/test/benchmark/benchmark_lifecycle_client.cpp
+++ b/rclcpp_lifecycle/test/benchmark/benchmark_lifecycle_client.cpp
@@ -212,8 +212,9 @@ public:
     performance_test_fixture::PerformanceTest::TearDown(state);
     executor->cancel();
     spinner_.join();
-    lifecycle_node.reset();
+    executor.reset();
     lifecycle_client.reset();
+    lifecycle_node.reset();
     rclcpp::shutdown();
   }
 


### PR DESCRIPTION
This should be the last issue to get the benchmark jobs green, and I intend to backport it to Galactic as well.

Before: [![Build Status](https://build.ros2.org/buildStatus/icon?job=Rci__overlay_ubuntu_focal_amd64&build=25)](https://build.ros2.org/view/Rci/job/Rci__overlay_ubuntu_focal_amd64/25/)
After: [![Build Status](https://build.ros2.org/buildStatus/icon?job=Rci__overlay_ubuntu_focal_amd64&build=26)](https://build.ros2.org/view/Rci/job/Rci__overlay_ubuntu_focal_amd64/26/)