### PR TITLE
Fix occasionally missing goal result caused by race condition

### DIFF
--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -627,6 +627,17 @@ ServerBase::publish_result(const GoalUUID & uuid, std::shared_ptr<void> result_m
   }
 
   {
+    /**
+    * NOTE: There is a potential deadlock issue if both unordered_map_mutex_ and
+    * action_server_reentrant_mutex_ locked in other block scopes. Unless using
+    * std::scoped_lock, locking order must be consistent with the current.
+    *
+    * Current locking order:
+    *
+    *   1. unordered_map_mutex_
+    *   2. action_server_reentrant_mutex_
+    *
+    */
     std::lock_guard<std::recursive_mutex> unordered_map_lock(pimpl_->unordered_map_mutex_);
     pimpl_->goal_results_[uuid] = result_msg;
 

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -633,8 +633,8 @@ ServerBase::publish_result(const GoalUUID & uuid, std::shared_ptr<void> result_m
     // if there are clients who already asked for the result, send it to them
     auto iter = pimpl_->result_requests_.find(uuid);
     if (iter != pimpl_->result_requests_.end()) {
+      std::lock_guard<std::recursive_mutex> lock(pimpl_->action_server_reentrant_mutex_);
       for (auto & request_header : iter->second) {
-        std::lock_guard<std::recursive_mutex> lock(pimpl_->action_server_reentrant_mutex_);
         rcl_ret_t ret = rcl_action_send_result_response(
           pimpl_->action_server_.get(), &request_header, result_msg.get());
         if (RCL_RET_OK != ret) {


### PR DESCRIPTION
Fix occasionally missing goal result when a action finished quickly (one thread enter to `execute_result_request_received` and the other enter to `publish_result`).

