### PR TITLE
Enable all QoS override policies

### DIFF
--- a/rclcpp/include/rclcpp/qos_overriding_options.hpp
+++ b/rclcpp/include/rclcpp/qos_overriding_options.hpp
@@ -140,6 +140,18 @@ public:
   QosOverridingOptions
   with_default_policies(QosCallback validation_callback = nullptr, std::string id = {});
 
+  /// Construct passing a list of QoS policies and a verification callback.
+  /**
+   * Same as `QosOverridingOptions` constructor, but declares all policies:
+   *
+   * AvoidRosNamespaceConventions, Deadline, Depth, Durability, History, Lifespan,
+   * Liveliness, LivelinessLeaseDuration, and Reliability.
+   */
+  RCLCPP_PUBLIC
+  static
+  QosOverridingOptions
+  with_all_policies(QosCallback validation_callback = nullptr, std::string id = {});
+
 private:
   /// \internal Id of the entity requesting to create parameters.
   std::string id_;

--- a/rclcpp/src/rclcpp/qos_overriding_options.cpp
+++ b/rclcpp/src/rclcpp/qos_overriding_options.cpp
@@ -46,6 +46,18 @@ operator<<(std::ostream & oss, const QosPolicyKind & qpk)
 static std::initializer_list<QosPolicyKind> kDefaultPolicies =
 {QosPolicyKind::History, QosPolicyKind::Depth, QosPolicyKind::Reliability};
 
+static std::initializer_list<QosPolicyKind> kAllPolicies = {
+  QosPolicyKind::AvoidRosNamespaceConventions,
+  QosPolicyKind::Deadline,
+  QosPolicyKind::Depth,
+  QosPolicyKind::Durability,
+  QosPolicyKind::History,
+  QosPolicyKind::Lifespan,
+  QosPolicyKind::Liveliness,
+  QosPolicyKind::LivelinessLeaseDuration,
+  QosPolicyKind::Reliability
+};
+
 QosOverridingOptions::QosOverridingOptions(
   std::initializer_list<QosPolicyKind> policy_kinds,
   QosCallback validation_callback,
@@ -61,6 +73,14 @@ QosOverridingOptions::with_default_policies(
   std::string id)
 {
   return QosOverridingOptions{kDefaultPolicies, validation_callback, id};
+}
+
+QosOverridingOptions
+QosOverridingOptions::with_all_policies(
+  QosCallback validation_callback,
+  std::string id)
+{
+  return QosOverridingOptions{kAllPolicies, validation_callback, id};
 }
 
 const std::string &


### PR DESCRIPTION
This makes it so that all QoS options can be overridden.