### PR TITLE
adding node name to the executor runtime_error

### DIFF
--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -268,7 +268,8 @@ Executor::add_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_pt
   // If the node already has an executor
   std::atomic_bool & has_executor = node_ptr->get_associated_with_executor_atomic();
   if (has_executor.exchange(true)) {
-    throw std::runtime_error("Node has already been added to an executor.");
+    throw std::runtime_error(
+      std::string("Node (%s) has already been added to an executor.", node_ptr->get_name()));
   }
   std::lock_guard<std::mutex> guard{mutex_};
   for (auto & weak_group : node_ptr->get_callback_groups()) {

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -269,9 +269,8 @@ Executor::add_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_pt
   std::atomic_bool & has_executor = node_ptr->get_associated_with_executor_atomic();
   if (has_executor.exchange(true)) {
     throw std::runtime_error(
-            std::string(
-              "Node (%s) has already been added to an executor.",
-              node_ptr->get_fully_qualified_name()));
+            std::string("Node '") + node_ptr->get_fully_qualified_name() +
+            "' has already been added to an executor.");
   }
   std::lock_guard<std::mutex> guard{mutex_};
   for (auto & weak_group : node_ptr->get_callback_groups()) {

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -269,7 +269,9 @@ Executor::add_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_pt
   std::atomic_bool & has_executor = node_ptr->get_associated_with_executor_atomic();
   if (has_executor.exchange(true)) {
     throw std::runtime_error(
-      std::string("Node (%s) has already been added to an executor.", node_ptr->get_name()));
+            std::string(
+              "Node (%s) has already been added to an executor.",
+              node_ptr->get_fully_qualified_name()));
   }
   std::lock_guard<std::mutex> guard{mutex_};
   for (auto & weak_group : node_ptr->get_callback_groups()) {


### PR DESCRIPTION
I'm trying to debug an issue in rviz2 where it crashes with this warning and it would be really nice to know the name of the specific node that's giving me trouble. I half expect to just see "rviz" which won't be very helpful, but this isn't the first time I've run into the hunt for "which node am I?".

In general, when new software is ported to ROS2 (and folks are learning about spinning mechanisms in ROS2), this error comes up **alot** and it would be really helpful in debugging to know where to look when launching a large system. 