### PR TITLE
Use UninitializedStaticallyTypedParameterException

### DIFF
--- a/rclcpp/include/rclcpp/exceptions/exceptions.hpp
+++ b/rclcpp/include/rclcpp/exceptions/exceptions.hpp
@@ -254,6 +254,23 @@ public:
   {}
 };
 
+/// Thrown if user attempts to create an uninitialized statically typed parameter
+/**
+ * (see https://github.com/ros2/rclcpp/issues/1691)
+ */
+class UninitializedStaticallyTypedParameterException : public std::runtime_error
+{
+public:
+  /// Construct an instance.
+  /**
+   * \param[in] name the name of the parameter.
+   */
+  RCLCPP_PUBLIC
+  explicit UninitializedStaticallyTypedParameterException(const std::string & name)
+  : std::runtime_error("Statically typed parameter '" + name + "' must be initialized.")
+  {}
+};
+
 /// Thrown if parameter is already declared.
 class ParameterAlreadyDeclaredException : public std::runtime_error
 {

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -227,7 +227,7 @@ Node::declare_parameter(
       parameter_descriptor,
       ignore_override
     ).get<ParameterT>();
-  } catch (const ParameterTypeException & ex) {
+  } catch (const ParameterTypeException &) {
     throw exceptions::UninitializedStaticallyTypedParameterException(name);
   }
 }

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -220,12 +220,16 @@ Node::declare_parameter(
   // get advantage of parameter value template magic to get
   // the correct rclcpp::ParameterType from ParameterT
   rclcpp::ParameterValue value{ParameterT{}};
-  return this->declare_parameter(
-    name,
-    value.get_type(),
-    parameter_descriptor,
-    ignore_override
-  ).get<ParameterT>();
+  try {
+    return this->declare_parameter(
+      name,
+      value.get_type(),
+      parameter_descriptor,
+      ignore_override
+    ).get<ParameterT>();
+  } catch (const ParameterTypeException & ex) {
+    throw exceptions::UninitializedStaticallyTypedParameterException(name);
+  }
 }
 
 template<typename ParameterT>

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -716,6 +716,12 @@ TEST_F(TestNode, declare_parameter_with_overrides) {
       rclcpp::exceptions::InvalidParameterTypeException);
   }
   {
+    // statically typed parameter must be initialized
+    EXPECT_THROW(
+      {node->declare_parameter<std::string>("static_and_uninitialized");},
+      rclcpp::exceptions::UninitializedStaticallyTypedParameterException);
+  }
+  {
     // cannot pass an expected type and a descriptor with dynamic_typing=True
     rcl_interfaces::msg::ParameterDescriptor descriptor{};
     descriptor.dynamic_typing = true;


### PR DESCRIPTION
A previous commit (fd8cfa8fe3e61c9dc2bf2e7918a24c883982b6b6) introduced `InvalidParameterTypeException` which was an improved version of `ParameterTypeException` in the sense that it also included parameter name in the error message.

One of the places that raised this exception was `declare_parameter` function. Now as you can see in [this git-blame piece](https://github.com/ros2/rclcpp/blame/master/rclcpp/include/rclcpp/node_impl.hpp#L201-L230), a later commit (24bb65305d47bf8562e2b38432bfb5ed248d9047) added a second version of `declare_parameter` but the author forgot to use `InvalidParameterTypeException` there which leads to less useful messages. This PR fixes the issue.