### PR TITLE
Add arguments to configure number of threads

### DIFF
--- a/rclcpp_components/src/component_container_mt.cpp
+++ b/rclcpp_components/src/component_container_mt.cpp
@@ -29,12 +29,12 @@ int main(int argc, char * argv[])
     for (auto itr = vargv.begin() + 1; itr != vargv.end(); ++itr) {
       if (*itr == "--help" || *itr == "-h") {
         RCLCPP_INFO_STREAM(logger,
-          "Usage: component_container_mt --thread-num <number of thread>" << std::endl);
+          "Usage: component_container_mt --thread-num <number of thread>");
         return 0;
       } else if (*itr == "--thread-num" || *itr == "-t") {
         if (itr == vargv.end() - 1) {
           RCLCPP_ERROR_STREAM(logger, "Empty thread number" << std::endl
-            << "Usage: component_container_mt --thread-num <number of thread>" << std::endl);
+            << "Usage: component_container_mt --thread-num <number of thread>");
           return 0;
         }
         try {
@@ -56,7 +56,7 @@ int main(int argc, char * argv[])
         }
       } else {
         RCLCPP_ERROR_STREAM(logger, "Invalid argument" << std::endl
-          << "Usage: component_container_mt --thread-num <number of thread>" << std::endl);
+          << "Usage: component_container_mt --thread-num <number of thread>");
         return 0;
       }
     }

--- a/rclcpp_components/src/component_container_mt.cpp
+++ b/rclcpp_components/src/component_container_mt.cpp
@@ -38,8 +38,14 @@ int main(int argc, char * argv[])
           return 0;
         }
         try {
-          number_of_threads = static_cast<size_t>(std::stoi(*(itr + 1)));
-          RCLCPP_INFO_STREAM(logger, "Number of threads: " << number_of_threads);
+          const auto arg_number_of_threads{std::stoi(*(itr + 1))};
+          if (arg_number_of_threads > 0) {
+            number_of_threads = static_cast<size_t>(arg_number_of_threads);
+            RCLCPP_INFO_STREAM(logger, "Number of threads: " << number_of_threads);
+          } else if (arg_number_of_threads < 0) {
+            RCLCPP_ERROR_STREAM(logger, "Number of threads is minus: " << *(itr + 1));
+            return 0;
+          }
           ++itr;
         } catch (const std::invalid_argument & ex) {
           RCLCPP_ERROR_STREAM(logger, "Invalid number of threads: " << *(itr + 1));

--- a/rclcpp_components/src/component_container_mt.cpp
+++ b/rclcpp_components/src/component_container_mt.cpp
@@ -25,14 +25,18 @@ int main(int argc, char * argv[])
   size_t number_of_threads{0};
   rclcpp::Logger logger{rclcpp::get_logger("component_container_mt")};
 
-  if (vargv.size() == 3 && (vargv.at(1) == "--thread-num" || vargv.at(1) == "-t")) {
-    try {
-      number_of_threads = static_cast<size_t>(std::stoi(vargv.at(2)));
-      RCLCPP_INFO_STREAM(logger, "number of threads: " << number_of_threads);
-    } catch (const std::invalid_argument & ex) {
-      RCLCPP_ERROR_STREAM(logger, ex.what());
-    } catch (const std::out_of_range & ex) {
-      RCLCPP_ERROR_STREAM(logger, ex.what());
+  if (!vargv.empty()) {
+    for (auto itr = vargv.begin(); itr != vargv.end() - 1; ++itr) {
+      if (*itr == "--thread-num" || *itr == "-t") {
+        try {
+          number_of_threads = static_cast<size_t>(std::stoi(*(itr + 1)));
+          RCLCPP_INFO_STREAM(logger, "Number of threads: " << number_of_threads);
+        } catch (const std::invalid_argument & ex) {
+          RCLCPP_ERROR_STREAM(logger, "Invalid number of threads: " << *(itr + 1));
+        } catch (const std::out_of_range & ex) {
+          RCLCPP_ERROR_STREAM(logger, "Number of threads is out of range: " << *(itr + 1));
+        }
+      }
     }
   }
 

--- a/rclcpp_components/src/component_container_mt.cpp
+++ b/rclcpp_components/src/component_container_mt.cpp
@@ -28,13 +28,15 @@ int main(int argc, char * argv[])
   if (vargv.size() > 1) {
     for (auto itr = vargv.begin() + 1; itr != vargv.end(); ++itr) {
       if (*itr == "--help" || *itr == "-h") {
-        RCLCPP_INFO_STREAM(logger,
+        RCLCPP_INFO_STREAM(
+          logger,
           "Usage: component_container_mt --thread-num <number of thread>");
         return 0;
       } else if (*itr == "--thread-num" || *itr == "-t") {
         if (itr == vargv.end() - 1) {
-          RCLCPP_ERROR_STREAM(logger, "Empty thread number" << std::endl
-            << "Usage: component_container_mt --thread-num <number of thread>");
+          RCLCPP_ERROR_STREAM(
+            logger, "Empty thread number" << std::endl <<
+              "Usage: component_container_mt --thread-num <number of thread>");
           return 0;
         }
         try {
@@ -55,8 +57,9 @@ int main(int argc, char * argv[])
           return 0;
         }
       } else {
-        RCLCPP_ERROR_STREAM(logger, "Invalid argument" << std::endl
-          << "Usage: component_container_mt --thread-num <number of thread>");
+        RCLCPP_ERROR_STREAM(
+          logger, "Invalid argument" << std::endl <<
+            "Usage: component_container_mt --thread-num <number of thread>");
         return 0;
       }
     }

--- a/rclcpp_components/src/component_container_mt.cpp
+++ b/rclcpp_components/src/component_container_mt.cpp
@@ -25,17 +25,33 @@ int main(int argc, char * argv[])
   size_t number_of_threads{0};
   rclcpp::Logger logger{rclcpp::get_logger("component_container_mt")};
 
-  if (!vargv.empty()) {
-    for (auto itr = vargv.begin(); itr != vargv.end() - 1; ++itr) {
-      if (*itr == "--thread-num" || *itr == "-t") {
+  if (vargv.size() > 1) {
+    for (auto itr = vargv.begin() + 1; itr != vargv.end(); ++itr) {
+      if (*itr == "--help" || *itr == "-h") {
+        RCLCPP_INFO_STREAM(logger,
+          "Usage: component_container_mt --thread-num <number of thread>" << std::endl);
+        return 0;
+      } else if (*itr == "--thread-num" || *itr == "-t") {
+        if (itr == vargv.end() - 1) {
+          RCLCPP_ERROR_STREAM(logger, "Empty thread number" << std::endl
+            << "Usage: component_container_mt --thread-num <number of thread>" << std::endl);
+          return 0;
+        }
         try {
           number_of_threads = static_cast<size_t>(std::stoi(*(itr + 1)));
           RCLCPP_INFO_STREAM(logger, "Number of threads: " << number_of_threads);
+          ++itr;
         } catch (const std::invalid_argument & ex) {
           RCLCPP_ERROR_STREAM(logger, "Invalid number of threads: " << *(itr + 1));
+          return 0;
         } catch (const std::out_of_range & ex) {
           RCLCPP_ERROR_STREAM(logger, "Number of threads is out of range: " << *(itr + 1));
+          return 0;
         }
+      } else {
+        RCLCPP_ERROR_STREAM(logger, "Invalid argument" << std::endl
+          << "Usage: component_container_mt --thread-num <number of thread>" << std::endl);
+        return 0;
       }
     }
   }


### PR DESCRIPTION
This PR enables to configure number of threads in `component_container_mt` as below.
```
    container = ComposableNodeContainer(
            name='my_container',
            namespace='',
            package='rclcpp_components',
            executable='component_container_mt',
            composable_node_descriptions=[component],
            output='screen',
            arguments=['-t', '5'],
    )
```