### PR TITLE
wait for message

### DIFF
--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -289,58 +289,6 @@ RCLCPP_PUBLIC
 const char *
 get_c_string(const std::string & string_in);
 
-/// Wait for the next incoming message.
-/**
- * Given an already initialized subscription,
- * wait for the next incoming message to arrive before the specified timeout.
- *
- * \param[out] out is the message to be filled when a new message is arriving.
- * \param[in] subscription shared pointer to a previously initialized subscription.
- * \param[in] time_to_wait parameter specifying the timeout before returning.
- * \return true if a message was successfully received, false otherwise.
- */
-template<class MsgT, class Rep = int64_t, class Period = std::milli>
-bool wait_for_message(
-  MsgT & out,
-  std::shared_ptr<rclcpp::Subscription<MsgT>> subscription,
-  std::chrono::duration<Rep, Period> time_to_wait = std::chrono::duration<Rep, Period>(-1))
-{
-    rclcpp::WaitSet wait_set;
-    wait_set.add_subscription(subscription);
-    auto ret = wait_set.wait(time_to_wait);
-    if (ret.kind() != rclcpp::WaitResultKind::Ready) {
-      return false;
-    }
-
-    rclcpp::MessageInfo info;
-    if (!subscription->take(out, info)) {
-      return false;
-    }
-
-    return true;
-}
-
-/// Wait for the next incoming message.
-/**
- * Wait for the next incoming message to arrive on a specified topic before the specified timeout.
- *
- * \param[out] out is the message to be filled when a new message is arriving.
- * \param[in] node the node pointer to initialize the subscription on.
- * \param[in] topic the topic to wait for messages.
- * \param[in] time_to_wait parameter specifying the timeout before returning.
- * \return true if a message was successfully received, false otherwise.
- */
-template<class MsgT, class Rep = int64_t, class Period = std::milli>
-bool wait_for_message(
-  MsgT & out,
-  rclcpp::Node::SharedPtr node,
-  const std::string & topic,
-  std::chrono::duration<Rep, Period> time_to_wait = std::chrono::duration<Rep, Period>(-1))
-{
-  auto sub = node->create_subscription<MsgT>(topic, 1, [](const std::shared_ptr<MsgT>) {});
-  return wait_for_message<MsgT, Rep, Period>(out, sub, time_to_wait);
-}
-
 }  // namespace rclcpp
 
 #endif  // RCLCPP__UTILITIES_HPP_

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -289,6 +289,58 @@ RCLCPP_PUBLIC
 const char *
 get_c_string(const std::string & string_in);
 
+/// Wait for the next incoming message.
+/**
+ * Given an already initialized subscription,
+ * wait for the next incoming message to arrive before the specified timeout.
+ *
+ * \param[out] out is the message to be filled when a new message is arriving.
+ * \param[in] subscription shared pointer to a previously initialized subscription.
+ * \param[in] time_to_wait parameter specifying the timeout before returning.
+ * \return true if a message was successfully received, false otherwise.
+ */
+template<class MsgT, class Rep = int64_t, class Period = std::milli>
+bool wait_for_message(
+  MsgT & out,
+  std::shared_ptr<rclcpp::Subscription<MsgT>> subscription,
+  std::chrono::duration<Rep, Period> time_to_wait = std::chrono::duration<Rep, Period>(-1))
+{
+    rclcpp::WaitSet wait_set;
+    wait_set.add_subscription(subscription);
+    auto ret = wait_set.wait(time_to_wait);
+    if (ret.kind() != rclcpp::WaitResultKind::Ready) {
+      return false;
+    }
+
+    rclcpp::MessageInfo info;
+    if (!subscription->take(out, info)) {
+      return false;
+    }
+
+    return true;
+}
+
+/// Wait for the next incoming message.
+/**
+ * Wait for the next incoming message to arrive on a specified topic before the specified timeout.
+ *
+ * \param[out] out is the message to be filled when a new message is arriving.
+ * \param[in] node the node pointer to initialize the subscription on.
+ * \param[in] topic the topic to wait for messages.
+ * \param[in] time_to_wait parameter specifying the timeout before returning.
+ * \return true if a message was successfully received, false otherwise.
+ */
+template<class MsgT, class Rep = int64_t, class Period = std::milli>
+bool wait_for_message(
+  MsgT & out,
+  rclcpp::Node::SharedPtr node,
+  const std::string & topic,
+  std::chrono::duration<Rep, Period> time_to_wait = std::chrono::duration<Rep, Period>(-1))
+{
+  auto sub = node->create_subscription<MsgT>(topic, 1, [](const std::shared_ptr<MsgT>) {});
+  return wait_for_message<MsgT, Rep, Period>(out, sub, time_to_wait);
+}
+
 }  // namespace rclcpp
 
 #endif  // RCLCPP__UTILITIES_HPP_

--- a/rclcpp/include/rclcpp/wait_for_message.hpp
+++ b/rclcpp/include/rclcpp/wait_for_message.hpp
@@ -15,6 +15,9 @@
 #ifndef RCLCPP__WAIT_FOR_MESSAGE_HPP_
 #define RCLCPP__WAIT_FOR_MESSAGE_HPP_
 
+#include <memory>
+#include <string>
+
 #include "rclcpp/node.hpp"
 #include "rclcpp/visibility_control.hpp"
 #include "rclcpp/wait_set.hpp"
@@ -37,19 +40,19 @@ bool wait_for_message(
   std::shared_ptr<rclcpp::Subscription<MsgT>> subscription,
   std::chrono::duration<Rep, Period> time_to_wait = std::chrono::duration<Rep, Period>(-1))
 {
-    rclcpp::WaitSet wait_set;
-    wait_set.add_subscription(subscription);
-    auto ret = wait_set.wait(time_to_wait);
-    if (ret.kind() != rclcpp::WaitResultKind::Ready) {
-      return false;
-    }
+  rclcpp::WaitSet wait_set;
+  wait_set.add_subscription(subscription);
+  auto ret = wait_set.wait(time_to_wait);
+  if (ret.kind() != rclcpp::WaitResultKind::Ready) {
+    return false;
+  }
 
-    rclcpp::MessageInfo info;
-    if (!subscription->take(out, info)) {
-      return false;
-    }
+  rclcpp::MessageInfo info;
+  if (!subscription->take(out, info)) {
+    return false;
+  }
 
-    return true;
+  return true;
 }
 
 /// Wait for the next incoming message.

--- a/rclcpp/include/rclcpp/wait_for_message.hpp
+++ b/rclcpp/include/rclcpp/wait_for_message.hpp
@@ -1,0 +1,78 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__WAIT_FOR_MESSAGE_HPP_
+#define RCLCPP__WAIT_FOR_MESSAGE_HPP_
+
+#include "rclcpp/node.hpp"
+#include "rclcpp/visibility_control.hpp"
+#include "rclcpp/wait_set.hpp"
+
+namespace rclcpp
+{
+/// Wait for the next incoming message.
+/**
+ * Given an already initialized subscription,
+ * wait for the next incoming message to arrive before the specified timeout.
+ *
+ * \param[out] out is the message to be filled when a new message is arriving.
+ * \param[in] subscription shared pointer to a previously initialized subscription.
+ * \param[in] time_to_wait parameter specifying the timeout before returning.
+ * \return true if a message was successfully received, false otherwise.
+ */
+template<class MsgT, class Rep = int64_t, class Period = std::milli>
+bool wait_for_message(
+  MsgT & out,
+  std::shared_ptr<rclcpp::Subscription<MsgT>> subscription,
+  std::chrono::duration<Rep, Period> time_to_wait = std::chrono::duration<Rep, Period>(-1))
+{
+    rclcpp::WaitSet wait_set;
+    wait_set.add_subscription(subscription);
+    auto ret = wait_set.wait(time_to_wait);
+    if (ret.kind() != rclcpp::WaitResultKind::Ready) {
+      return false;
+    }
+
+    rclcpp::MessageInfo info;
+    if (!subscription->take(out, info)) {
+      return false;
+    }
+
+    return true;
+}
+
+/// Wait for the next incoming message.
+/**
+ * Wait for the next incoming message to arrive on a specified topic before the specified timeout.
+ *
+ * \param[out] out is the message to be filled when a new message is arriving.
+ * \param[in] node the node pointer to initialize the subscription on.
+ * \param[in] topic the topic to wait for messages.
+ * \param[in] time_to_wait parameter specifying the timeout before returning.
+ * \return true if a message was successfully received, false otherwise.
+ */
+template<class MsgT, class Rep = int64_t, class Period = std::milli>
+bool wait_for_message(
+  MsgT & out,
+  rclcpp::Node::SharedPtr node,
+  const std::string & topic,
+  std::chrono::duration<Rep, Period> time_to_wait = std::chrono::duration<Rep, Period>(-1))
+{
+  auto sub = node->create_subscription<MsgT>(topic, 1, [](const std::shared_ptr<MsgT>) {});
+  return wait_for_message<MsgT, Rep, Period>(out, sub, time_to_wait);
+}
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__WAIT_FOR_MESSAGE_HPP_

--- a/rclcpp/include/rclcpp/wait_for_message.hpp
+++ b/rclcpp/include/rclcpp/wait_for_message.hpp
@@ -33,7 +33,8 @@ namespace rclcpp
  * \param[in] subscription shared pointer to a previously initialized subscription.
  * \param[in] context shared pointer to a context to watch for SIGINT requests.
  * \param[in] time_to_wait parameter specifying the timeout before returning.
- * \return true if a message was successfully received, false otherwise.
+ * \return true if a message was successfully received, false if message could not
+ * be obtained or shutdown was triggered asynchronously on the context.
  */
 template<class MsgT, class Rep = int64_t, class Period = std::milli>
 bool wait_for_message(
@@ -80,7 +81,8 @@ bool wait_for_message(
  * \param[in] node the node pointer to initialize the subscription on.
  * \param[in] topic the topic to wait for messages.
  * \param[in] time_to_wait parameter specifying the timeout before returning.
- * \return true if a message was successfully received, false otherwise.
+ * \return true if a message was successfully received, false if message could not
+ * be obtained or shutdown was triggered asynchronously on the context.
  */
 template<class MsgT, class Rep = int64_t, class Period = std::milli>
 bool wait_for_message(

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -599,6 +599,13 @@ if(TARGET test_utilities)
   target_link_libraries(test_utilities ${PROJECT_NAME} mimick)
 endif()
 
+ament_add_gtest(test_wait_for_message test_wait_for_message.cpp)
+if(TARGET test_wait_for_message)
+  ament_target_dependencies(test_wait_for_message
+    "test_msgs")
+  target_link_libraries(test_wait_for_message ${PROJECT_NAME})
+endif()
+
 ament_add_gtest(test_interface_traits test_interface_traits.cpp
   APPEND_LIBRARY_DIRS "${append_library_dirs}")
 if(TARGET test_interface_traits)

--- a/rclcpp/test/rclcpp/test_wait_for_message.cpp
+++ b/rclcpp/test/rclcpp/test_wait_for_message.cpp
@@ -1,0 +1,51 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/node.hpp"
+#include "rclcpp/wait_for_message.hpp"
+
+#include "test_msgs/msg/strings.hpp"
+#include "test_msgs/message_fixtures.hpp"
+
+using namespace std::chrono_literals;
+
+TEST(TestUtilities, wait_for_message) {
+  rclcpp::init(0, nullptr);
+
+  auto node = std::make_shared<rclcpp::Node>("wait_for_message_node");
+
+  using MsgT = test_msgs::msg::Strings;
+  auto pub = node->create_publisher<MsgT>("wait_for_message_topic", 10);
+
+  MsgT out;
+  auto received = false;
+  auto wait = std::async([&]() {
+      auto ret = rclcpp::wait_for_message(out, node, "wait_for_message_topic", 5s);
+      EXPECT_TRUE(ret);
+      received = true;
+      });
+
+  for (auto i = 0u; i < 10 && received == false; ++i) {
+    pub->publish(*get_messages_strings()[0]);
+    std::this_thread::sleep_for(1s);
+  }
+  ASSERT_TRUE(received);
+  EXPECT_EQ(out, *get_messages_strings()[0]);
+}

--- a/rclcpp/test/rclcpp/test_wait_for_message.cpp
+++ b/rclcpp/test/rclcpp/test_wait_for_message.cpp
@@ -36,11 +36,12 @@ TEST(TestUtilities, wait_for_message) {
 
   MsgT out;
   auto received = false;
-  auto wait = std::async([&]() {
+  auto wait = std::async(
+    [&]() {
       auto ret = rclcpp::wait_for_message(out, node, "wait_for_message_topic", 5s);
       EXPECT_TRUE(ret);
       received = true;
-      });
+    });
 
   for (auto i = 0u; i < 10 && received == false; ++i) {
     pub->publish(*get_messages_strings()[0]);

--- a/rclcpp/test/rclcpp/test_wait_for_message.cpp
+++ b/rclcpp/test/rclcpp/test_wait_for_message.cpp
@@ -49,4 +49,26 @@ TEST(TestUtilities, wait_for_message) {
   }
   ASSERT_TRUE(received);
   EXPECT_EQ(out, *get_messages_strings()[0]);
+
+  rclcpp::shutdown();
+}
+
+TEST(TestUtilities, wait_for_message_indefinitely) {
+  rclcpp::init(0, nullptr);
+
+  auto node = std::make_shared<rclcpp::Node>("wait_for_message_node2");
+
+  using MsgT = test_msgs::msg::Strings;
+  MsgT out;
+  auto received = false;
+  auto wait = std::async(
+    [&]() {
+      auto ret = rclcpp::wait_for_message(out, node, "wait_for_message_topic" /*, -1 */);
+      EXPECT_TRUE(ret);
+      received = true;
+    });
+
+  rclcpp::shutdown();
+
+  ASSERT_FALSE(received);
 }


### PR DESCRIPTION
Introducing "wait_for_message". Similar to ROS1, given either a node & topic or a previously instantiated subscription object, the function waits for the next incoming message until either received or timed out.
I could further see some more overlays to this explicitly taking some QOS parameters, even though one could achieve this as-is by initializing the subscription explicitly. 

I am using it within some ros control functionality and it'd be great to have this backported to existing distros.