### PR TITLE
remove left over is_initialized() implementation

### DIFF
--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -157,12 +157,6 @@ ok(Context::SharedPtr context)
 }
 
 bool
-is_initialized(Context::SharedPtr context)
-{
-  return ok(context);
-}
-
-bool
 shutdown(Context::SharedPtr context, const std::string & reason)
 {
   using rclcpp::contexts::get_global_default_context;


### PR DESCRIPTION
Leftover from https://github.com/ros2/rclcpp/pull/1622

@marcoag fyi, thanks for pointing it out :)