### PR TITLE
Deprecate method names that use CamelCase in rclcpp_components

### DIFF
--- a/rclcpp_components/include/rclcpp_components/component_manager.hpp
+++ b/rclcpp_components/include/rclcpp_components/component_manager.hpp
@@ -109,7 +109,7 @@ public:
   virtual ~ComponentManager();
 
   /// Return a list of valid loadable components in a given package.
-  /*
+  /**
    * \param package_name name of the package
    * \param resource_index name of the executable
    * \throws ComponentManagerException if the resource was not found or a invalid resource entry
@@ -122,7 +122,7 @@ public:
     const std::string & resource_index = "rclcpp_components") const;
 
   /// Instantiate a component from a dynamic library.
-  /*
+  /**
    * \param resource a component resource (class name + library path)
    * \return a NodeFactory interface
    */
@@ -132,16 +132,16 @@ public:
 
 protected:
   /// Create node options for loaded component
-  /*
+  /**
    * \param request information with the node to load
    * \return node options
    */
   RCLCPP_COMPONENTS_PUBLIC
   virtual rclcpp::NodeOptions
-  CreateNodeOptions(const std::shared_ptr<LoadNode::Request> request);
+  create_node_options(const std::shared_ptr<LoadNode::Request> request);
 
   /// Service callback to load a new node in the component
-  /*
+  /**
    * This function allows to add parameters, remap rules, a specific node, name a namespace
    * and/or additional arguments.
    *
@@ -155,13 +155,13 @@ protected:
    */
   RCLCPP_COMPONENTS_PUBLIC
   virtual void
-  OnLoadNode(
+  on_load_node(
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<LoadNode::Request> request,
     std::shared_ptr<LoadNode::Response> response);
 
   /// Service callback to unload a node in the component
-  /*
+  /**
    * \param request_header unused
    * \param request unique identifier to remove from the component
    * \param response true on the success field if the node unload was succefully, otherwise false
@@ -169,13 +169,13 @@ protected:
    */
   RCLCPP_COMPONENTS_PUBLIC
   virtual void
-  OnUnloadNode(
+  on_unload_node(
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<UnloadNode::Request> request,
     std::shared_ptr<UnloadNode::Response> response);
 
   /// Service callback to get the list of nodes in the component
-  /*
+  /**
    * Return a two list: one with the unique identifiers and other with full name of the nodes.
    *
    * \param request_header unused
@@ -184,7 +184,7 @@ protected:
    */
   RCLCPP_COMPONENTS_PUBLIC
   virtual void
-  OnListNodes(
+  on_list_nodes(
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<ListNodes::Request> request,
     std::shared_ptr<ListNodes::Response> response);

--- a/rclcpp_components/include/rclcpp_components/component_manager.hpp
+++ b/rclcpp_components/include/rclcpp_components/component_manager.hpp
@@ -160,6 +160,20 @@ protected:
     const std::shared_ptr<LoadNode::Request> request,
     std::shared_ptr<LoadNode::Response> response);
 
+  /**
+   * \deprecated Use on_load_node() instead
+   */
+  [[deprecated("Use on_load_node() instead")]]
+  RCLCPP_COMPONENTS_PUBLIC
+  virtual void
+  OnLoadNode(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<LoadNode::Request> request,
+    std::shared_ptr<LoadNode::Response> response)
+  {
+    on_load_node(request_header, request, response);
+  }
+
   /// Service callback to unload a node in the component
   /**
    * \param request_header unused
@@ -173,6 +187,20 @@ protected:
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<UnloadNode::Request> request,
     std::shared_ptr<UnloadNode::Response> response);
+
+  /**
+   * \deprecated Use on_unload_node() instead
+   */
+  [[deprecated("Use on_unload_node() instead")]]
+  RCLCPP_COMPONENTS_PUBLIC
+  virtual void
+  OnUnloadNode(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<UnloadNode::Request> request,
+    std::shared_ptr<UnloadNode::Response> response)
+  {
+    on_unload_node(request_header, request, response);
+  }
 
   /// Service callback to get the list of nodes in the component
   /**
@@ -188,6 +216,20 @@ protected:
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<ListNodes::Request> request,
     std::shared_ptr<ListNodes::Response> response);
+
+  /**
+   * \deprecated Use on_list_nodes() instead
+   */
+  [[deprecated("Use on_list_nodes() instead")]]
+  RCLCPP_COMPONENTS_PUBLIC
+  virtual void
+  OnListNodes(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<ListNodes::Request> request,
+    std::shared_ptr<ListNodes::Response> response)
+  {
+    on_list_nodes(request_header, request, response);
+  }
 
 private:
   std::weak_ptr<rclcpp::Executor> executor_;

--- a/rclcpp_components/src/component_manager.cpp
+++ b/rclcpp_components/src/component_manager.cpp
@@ -39,13 +39,13 @@ ComponentManager::ComponentManager(
 {
   loadNode_srv_ = create_service<LoadNode>(
     "~/_container/load_node",
-    std::bind(&ComponentManager::OnLoadNode, this, _1, _2, _3));
+    std::bind(&ComponentManager::on_load_node, this, _1, _2, _3));
   unloadNode_srv_ = create_service<UnloadNode>(
     "~/_container/unload_node",
-    std::bind(&ComponentManager::OnUnloadNode, this, _1, _2, _3));
+    std::bind(&ComponentManager::on_unload_node, this, _1, _2, _3));
   listNodes_srv_ = create_service<ListNodes>(
     "~/_container/list_nodes",
-    std::bind(&ComponentManager::OnListNodes, this, _1, _2, _3));
+    std::bind(&ComponentManager::on_list_nodes, this, _1, _2, _3));
 }
 
 ComponentManager::~ComponentManager()
@@ -122,7 +122,7 @@ ComponentManager::create_component_factory(const ComponentResource & resource)
 }
 
 rclcpp::NodeOptions
-ComponentManager::CreateNodeOptions(const std::shared_ptr<LoadNode::Request> request)
+ComponentManager::create_node_options(const std::shared_ptr<LoadNode::Request> request)
 {
   std::vector<rclcpp::Parameter> parameters;
   for (const auto & p : request->parameters) {
@@ -167,7 +167,7 @@ ComponentManager::CreateNodeOptions(const std::shared_ptr<LoadNode::Request> req
 }
 
 void
-ComponentManager::OnLoadNode(
+ComponentManager::on_load_node(
   const std::shared_ptr<rmw_request_id_t> request_header,
   const std::shared_ptr<LoadNode::Request> request,
   std::shared_ptr<LoadNode::Response> response)
@@ -187,7 +187,7 @@ ComponentManager::OnLoadNode(
         continue;
       }
 
-      auto options = CreateNodeOptions(request);
+      auto options = create_node_options(request);
       auto node_id = unique_id_++;
 
       if (0 == node_id) {
@@ -237,7 +237,7 @@ ComponentManager::OnLoadNode(
 }
 
 void
-ComponentManager::OnUnloadNode(
+ComponentManager::on_unload_node(
   const std::shared_ptr<rmw_request_id_t> request_header,
   const std::shared_ptr<UnloadNode::Request> request,
   std::shared_ptr<UnloadNode::Response> response)
@@ -262,7 +262,7 @@ ComponentManager::OnUnloadNode(
 }
 
 void
-ComponentManager::OnListNodes(
+ComponentManager::on_list_nodes(
   const std::shared_ptr<rmw_request_id_t> request_header,
   const std::shared_ptr<ListNodes::Request> request,
   std::shared_ptr<ListNodes::Response> response)


### PR DESCRIPTION
As a follow-up to #1702, this PR renames the methods to use snake_case so they will be consistent with the other ROS 2 core packages.

Signed-off-by: Rebecca Butler <rebecca@openrobotics.org>