### PR TITLE
Fix windows CI

### DIFF
--- a/rclcpp/include/rclcpp/any_service_callback.hpp
+++ b/rclcpp/include/rclcpp/any_service_callback.hpp
@@ -63,7 +63,43 @@ public:
   void
   set(CallbackT && callback)
   {
-    callback_ = std::forward<CallbackT>(callback);
+    // Workaround Windows issue with std::bind
+    if constexpr (
+      rclcpp::function_traits::same_arguments<
+        CallbackT,
+        SharedPtrCallback
+      >::value)
+    {
+      // one would think that the following works:
+      // callback_.emplace<SharedPtrCallback>(callback);
+      // but it does not for some reason.
+      callback_.emplace<1>(callback);
+    } else if constexpr (
+      rclcpp::function_traits::same_arguments<
+        CallbackT,
+        SharedPtrWithRequestHeaderCallback
+      >::value)
+    {
+      callback_.emplace<2>(callback);
+    } else if constexpr (
+      rclcpp::function_traits::same_arguments<
+        CallbackT,
+        SharedPtrDeferResponseCallback
+      >::value)
+    {
+      callback_.emplace<3>(callback);
+    } else if constexpr (
+      rclcpp::function_traits::same_arguments<
+        CallbackT,
+        SharedPtrDeferResponseCallbackWithServiceHandle
+      >::value)
+    {
+      callback_.emplace<4>(callback);
+    } else {
+      // the else clause is not needed, but anyways we should only be doing this instead
+      // of all the above workaround ...
+      callback_ = std::forward<CallbackT>(callback);
+    }
   }
 
   template<

--- a/rclcpp/include/rclcpp/any_service_callback.hpp
+++ b/rclcpp/include/rclcpp/any_service_callback.hpp
@@ -71,30 +71,30 @@ public:
       >::value)
     {
       // one would think that the following works:
-      // callback_.emplace<SharedPtrCallback>(callback);
+      // callback_.template emplace<SharedPtrCallback>(callback);
       // but it does not for some reason.
-      callback_.emplace<1>(callback);
+      callback_.template emplace<SharedPtrCallback>(callback);
     } else if constexpr (
       rclcpp::function_traits::same_arguments<
         CallbackT,
         SharedPtrWithRequestHeaderCallback
       >::value)
     {
-      callback_.emplace<2>(callback);
+      callback_.template emplace<SharedPtrWithRequestHeaderCallback>(callback);
     } else if constexpr (
       rclcpp::function_traits::same_arguments<
         CallbackT,
         SharedPtrDeferResponseCallback
       >::value)
     {
-      callback_.emplace<3>(callback);
+      callback_.template emplace<SharedPtrDeferResponseCallback>(callback);
     } else if constexpr (
       rclcpp::function_traits::same_arguments<
         CallbackT,
         SharedPtrDeferResponseCallbackWithServiceHandle
       >::value)
     {
-      callback_.emplace<4>(callback);
+      callback_.template emplace<SharedPtrDeferResponseCallbackWithServiceHandle>(callback);
     } else {
       // the else clause is not needed, but anyways we should only be doing this instead
       // of all the above workaround ...
@@ -119,30 +119,30 @@ public:
       >::value)
     {
       // one would think that the following works:
-      // callback_.emplace<SharedPtrCallback>(callback);
+      // callback_.template emplace<SharedPtrCallback>(callback);
       // but it does not for some reason.
-      callback_.emplace<1>(callback);
+      callback_.template emplace<SharedPtrCallback>(callback);
     } else if constexpr (
       rclcpp::function_traits::same_arguments<
         CallbackT,
         SharedPtrWithRequestHeaderCallback
       >::value)
     {
-      callback_.emplace<2>(callback);
+      callback_.template emplace<SharedPtrWithRequestHeaderCallback>(callback);
     } else if constexpr (
       rclcpp::function_traits::same_arguments<
         CallbackT,
         SharedPtrDeferResponseCallback
       >::value)
     {
-      callback_.emplace<3>(callback);
+      callback_.template emplace<SharedPtrDeferResponseCallback>(callback);
     } else if constexpr (
       rclcpp::function_traits::same_arguments<
         CallbackT,
         SharedPtrDeferResponseCallbackWithServiceHandle
       >::value)
     {
-      callback_.emplace<4>(callback);
+      callback_.template emplace<SharedPtrDeferResponseCallbackWithServiceHandle>(callback);
     } else {
       // the else clause is not needed, but anyways we should only be doing this instead
       // of all the above workaround ...

--- a/rclcpp/include/rclcpp/any_service_callback.hpp
+++ b/rclcpp/include/rclcpp/any_service_callback.hpp
@@ -70,9 +70,6 @@ public:
         SharedPtrCallback
       >::value)
     {
-      // one would think that the following works:
-      // callback_.template emplace<SharedPtrCallback>(callback);
-      // but it does not for some reason.
       callback_.template emplace<SharedPtrCallback>(callback);
     } else if constexpr (
       rclcpp::function_traits::same_arguments<
@@ -118,9 +115,6 @@ public:
         SharedPtrCallback
       >::value)
     {
-      // one would think that the following works:
-      // callback_.template emplace<SharedPtrCallback>(callback);
-      // but it does not for some reason.
       callback_.template emplace<SharedPtrCallback>(callback);
     } else if constexpr (
       rclcpp::function_traits::same_arguments<

--- a/rclcpp/include/rclcpp/any_service_callback.hpp
+++ b/rclcpp/include/rclcpp/any_service_callback.hpp
@@ -71,21 +71,21 @@ public:
       >::value)
     {
       callback_.template emplace<SharedPtrCallback>(callback);
-    } else if constexpr (
+    } else if constexpr (  // NOLINT, can't satisfy both cpplint and uncrustify
       rclcpp::function_traits::same_arguments<
         CallbackT,
         SharedPtrWithRequestHeaderCallback
       >::value)
     {
       callback_.template emplace<SharedPtrWithRequestHeaderCallback>(callback);
-    } else if constexpr (
+    } else if constexpr (  // NOLINT
       rclcpp::function_traits::same_arguments<
         CallbackT,
         SharedPtrDeferResponseCallback
       >::value)
     {
       callback_.template emplace<SharedPtrDeferResponseCallback>(callback);
-    } else if constexpr (
+    } else if constexpr (  // NOLINT
       rclcpp::function_traits::same_arguments<
         CallbackT,
         SharedPtrDeferResponseCallbackWithServiceHandle
@@ -116,21 +116,21 @@ public:
       >::value)
     {
       callback_.template emplace<SharedPtrCallback>(callback);
-    } else if constexpr (
+    } else if constexpr (  // NOLINT
       rclcpp::function_traits::same_arguments<
         CallbackT,
         SharedPtrWithRequestHeaderCallback
       >::value)
     {
       callback_.template emplace<SharedPtrWithRequestHeaderCallback>(callback);
-    } else if constexpr (
+    } else if constexpr (  // NOLINT
       rclcpp::function_traits::same_arguments<
         CallbackT,
         SharedPtrDeferResponseCallback
       >::value)
     {
       callback_.template emplace<SharedPtrDeferResponseCallback>(callback);
-    } else if constexpr (
+    } else if constexpr (  // NOLINT
       rclcpp::function_traits::same_arguments<
         CallbackT,
         SharedPtrDeferResponseCallbackWithServiceHandle


### PR DESCRIPTION
https://github.com/ros2/rclcpp/pull/1709 broke `rclcpp_components` on Windows nighties, e.g.: https://ci.ros2.org/view/nightly/job/nightly_win_rel/2002/.
I think this is a bug on Windows implementation of `std::bind`, as the previous code really should work.

This does some `if constexpr` magic using function traits to workaround the issue.
I'm surprised we didn't hit a similar issue when using `std::variant` in `AnySubscriptionCallback` implementation, I have no idea of what's the difference.