### PR TITLE
Updating client API to be able to remove pending requests

### DIFF
--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -448,7 +448,7 @@ private:
    *
    * If the callback is never called, because we never got a reply for the service server, remove_pending_request()
    * has to be called with the returned request id or prune_pending_requests().
-   * Not doing so will make the `Client` instance to use more memory each time a response is not
+   * Not doing so will make the `Client` instance use more memory each time a response is not
    * received from the service server.
    * In this case, it's convenient to setup a timer to cleanup the pending requests.
    *

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -444,7 +444,7 @@ private:
 
   /// Send a request to the service server and schedule a callback in the executor.
   /**
-   * Similar to the previous overload, but a callback will automatically be called when a response is get.
+   * Similar to the previous overload, but a callback will automatically be called when a response is received.
    *
    * If the callback is never called, because we never got a reply for the service server, remove_pending_request()
    * has to be called with the returned request id or prune_pending_requests().

--- a/rclcpp/test/rclcpp/test_client.cpp
+++ b/rclcpp/test/rclcpp/test_client.cpp
@@ -216,7 +216,7 @@ protected:
         received_response = true;
       };
 
-    auto future = client->async_send_request(request, std::move(callback));
+    auto req_id = client->async_send_request(request, std::move(callback));
 
     auto start = std::chrono::steady_clock::now();
     while (!received_response &&
@@ -227,6 +227,9 @@ protected:
 
     if (!received_response) {
       return ::testing::AssertionFailure() << "Waiting for response timed out";
+    }
+    if (client->remove_pending_request(req_id)) {
+      return ::testing::AssertionFailure() << "Should not be able to remove a finished request";
     }
 
     return request_result;
@@ -256,7 +259,7 @@ TEST_F(TestClientWithServer, async_send_request_callback_with_request) {
       EXPECT_NE(nullptr, request_response_pair.second);
       received_response = true;
     };
-  auto future = client->async_send_request(request, std::move(callback));
+  auto req_id = client->async_send_request(request, std::move(callback));
 
   auto start = std::chrono::steady_clock::now();
   while (!received_response &&
@@ -265,6 +268,15 @@ TEST_F(TestClientWithServer, async_send_request_callback_with_request) {
     rclcpp::spin_some(node);
   }
   EXPECT_TRUE(received_response);
+  EXPECT_FALSE(client->remove_pending_request(req_id));
+}
+
+TEST_F(TestClientWithServer, test_client_remove_pending_request) {
+  auto client = node->create_client<test_msgs::srv::Empty>("no_service_server_available_here");
+  auto request = std::make_shared<test_msgs::srv::Empty::Request>();
+  auto future = client->async_send_request(request);
+
+  EXPECT_TRUE(client->remove_pending_request(future));
 }
 
 TEST_F(TestClientWithServer, async_send_request_rcl_send_request_error) {


### PR DESCRIPTION
Fixes https://github.com/ros2/rclcpp/issues/1697.

This modifies a few things in the client API:

- Modifies the async_send_request() methods that take a callback as a second argument to not return a future anymore.
  Though this breaks API, nobody was actually using that in the ROS 2 core.
  If someone wants to have both a callback and a future, they can capture the future in a lambda and set it.
  - Alternative: create a `SharedFutureAndRequestID` class, similar to the `FutureAndRequestID` class introduced here.
  - I'm planning to deprecate the current callback signatures that accept a `Future`, and instead have the two listed below.
    That wasn't done here to avoid having to create simultaneous PRs in other repos.
    - void (SharedResponse)
    - void (SharedRequest, SharedResponse)
- Modifies the async_send_request() methods that take only one argument to return a `FutureAndRequestID`.
  - This is a future like class.
    Though it breaks ABI, it has some implicit conversions to `std::future` to not break API.
    The implicit conversion by value was only added to not break existing code and generates a deprecation warning.
- Adds a `remove_pending_request()` method, the return value of any of the async_send_request() overloads can be passed to it.

Examples:

```cpp
auto future = client->async_send_request(request);
auto result = executor->spin_until_complete(future, timeout);
if (result == timeout) {
  client->remove_request(future);
  // handle timeout
}
```

When using callbacks, you need to combine the client with a Timer to prune the old ones:

```cpp
  // this example supposes you're only waiting for one response at a time
  //
  // setup timer
  this->timer = this->create_wall_timer(prune_old_requests, [this] () {
    if (this->client->remove_request(this->last_request_id)) {
      // handle timeout
    }
  };
  this->timer.cancel();

  // when sending a request
  this->last_request_id = client->send_async_request(request, [this] (SharedResponse response) {
    this->handle_response(response);
    this->timer.cancel();
  }
  this->timer.reset();
```