### PR TITLE
Update client API to be able to remove pending requests

### DIFF
--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -419,11 +419,12 @@ public:
     std::shared_ptr<rmw_request_id_t> request_header,
     std::shared_ptr<void> response) override
   {
-    auto opt = this->get_and_erase_pending_request(request_header->sequence_number);
-    if (!opt) {
+    std::optional<PendingRequestsMapValue>
+    optional_pending_request = this->get_and_erase_pending_request(request_header->sequence_number);
+    if (!optional_pending_request) {
       return;
     }
-    auto & value = *opt;
+    auto & value = *optional_pending_request;
     auto typed_response = std::static_pointer_cast<typename ServiceT::Response>(
       std::move(response));
     if (std::holds_alternative<Promise>(value)) {

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -25,6 +25,7 @@
 #include <tuple>
 #include <utility>
 #include <variant>  // NOLINT
+#include <vector>
 
 #include "rcl/client.h"
 #include "rcl/error_handling.h"

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -660,7 +660,6 @@ protected:
     CallbackTypeValueVariant,
     CallbackWithRequestTypeValueVariant>;
 
-  RCLCPP_PUBLIC
   int64_t
   async_send_request_impl(const Request & request, CallbackInfoVariant value)
   {
@@ -678,7 +677,6 @@ protected:
     return sequence_number;
   }
 
-  RCLCPP_PUBLIC
   std::optional<CallbackInfoVariant>
   get_and_erase_pending_request(int64_t request_number)
   {

--- a/rclcpp/test/rclcpp/test_client.cpp
+++ b/rclcpp/test/rclcpp/test_client.cpp
@@ -216,7 +216,7 @@ protected:
         received_response = true;
       };
 
-    auto future = client->async_send_request(request, std::move(callback));
+    auto req_id = client->async_send_request(request, std::move(callback));
 
     auto start = std::chrono::steady_clock::now();
     while (!received_response &&
@@ -227,6 +227,9 @@ protected:
 
     if (!received_response) {
       return ::testing::AssertionFailure() << "Waiting for response timed out";
+    }
+    if (client->remove_pending_request(req_id)) {
+      return ::testing::AssertionFailure() << "Should not be able to remove a finished request";
     }
 
     return request_result;
@@ -256,7 +259,7 @@ TEST_F(TestClientWithServer, async_send_request_callback_with_request) {
       EXPECT_NE(nullptr, request_response_pair.second);
       received_response = true;
     };
-  auto future = client->async_send_request(request, std::move(callback));
+  auto req_id = client->async_send_request(request, std::move(callback));
 
   auto start = std::chrono::steady_clock::now();
   while (!received_response &&
@@ -265,6 +268,15 @@ TEST_F(TestClientWithServer, async_send_request_callback_with_request) {
     rclcpp::spin_some(node);
   }
   EXPECT_TRUE(received_response);
+  EXPECT_FALSE(client->remove_pending_request(req_id));
+}
+
+TEST_F(TestClientWithServer, test_client_remove_pending_request) {
+  auto client = node->create_client<test_msgs::srv::Empty>("no_service_server_available_here");
+  auto request = std::make_shared<test_msgs::srv::Empty::Request>();
+  auto future = client->async_send_request(request);
+
+  EXPECT_TRUE(client->remove_pending_request(future));
 }
 
 TEST_F(TestClientWithServer, async_send_request_rcl_send_request_error) {

--- a/rclcpp_components/test/test_component_manager_api.cpp
+++ b/rclcpp_components/test/test_component_manager_api.cpp
@@ -57,13 +57,14 @@ TEST_F(TestComponentManager, components_api)
     request->package_name = "rclcpp_components";
     request->plugin_name = "test_rclcpp_components::TestComponentFoo";
 
-    auto result = composition_client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+    auto future = composition_client->async_send_request(request);
+    auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
+    auto result = future.get();
     EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
-    EXPECT_EQ(result.get()->success, true);
-    EXPECT_EQ(result.get()->error_message, "");
-    EXPECT_EQ(result.get()->full_node_name, "/test_component_foo");
-    EXPECT_EQ(result.get()->unique_id, 1u);
+    EXPECT_EQ(result->success, true);
+    EXPECT_EQ(result->error_message, "");
+    EXPECT_EQ(result->full_node_name, "/test_component_foo");
+    EXPECT_EQ(result->unique_id, 1u);
   }
 
   {
@@ -71,13 +72,14 @@ TEST_F(TestComponentManager, components_api)
     request->package_name = "rclcpp_components";
     request->plugin_name = "test_rclcpp_components::TestComponentBar";
 
-    auto result = composition_client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+    auto future = composition_client->async_send_request(request);
+    auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
+    auto result = future.get();
     EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
-    EXPECT_EQ(result.get()->success, true);
-    EXPECT_EQ(result.get()->error_message, "");
-    EXPECT_EQ(result.get()->full_node_name, "/test_component_bar");
-    EXPECT_EQ(result.get()->unique_id, 2u);
+    EXPECT_EQ(result->success, true);
+    EXPECT_EQ(result->error_message, "");
+    EXPECT_EQ(result->full_node_name, "/test_component_bar");
+    EXPECT_EQ(result->unique_id, 2u);
   }
 
   // Test remapping the node name
@@ -87,13 +89,14 @@ TEST_F(TestComponentManager, components_api)
     request->plugin_name = "test_rclcpp_components::TestComponentFoo";
     request->node_name = "test_component_baz";
 
-    auto result = composition_client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+    auto future = composition_client->async_send_request(request);
+    auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
+    auto result = future.get();
     EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
-    EXPECT_EQ(result.get()->success, true);
-    EXPECT_EQ(result.get()->error_message, "");
-    EXPECT_EQ(result.get()->full_node_name, "/test_component_baz");
-    EXPECT_EQ(result.get()->unique_id, 3u);
+    EXPECT_EQ(result->success, true);
+    EXPECT_EQ(result->error_message, "");
+    EXPECT_EQ(result->full_node_name, "/test_component_baz");
+    EXPECT_EQ(result->unique_id, 3u);
   }
 
   // Test remapping the node namespace
@@ -104,13 +107,14 @@ TEST_F(TestComponentManager, components_api)
     request->node_namespace = "/ns";
     request->node_name = "test_component_bing";
 
-    auto result = composition_client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+    auto future = composition_client->async_send_request(request);
+    auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
+    auto result = future.get();
     EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
-    EXPECT_EQ(result.get()->success, true);
-    EXPECT_EQ(result.get()->error_message, "");
-    EXPECT_EQ(result.get()->full_node_name, "/ns/test_component_bing");
-    EXPECT_EQ(result.get()->unique_id, 4u);
+    EXPECT_EQ(result->success, true);
+    EXPECT_EQ(result->error_message, "");
+    EXPECT_EQ(result->full_node_name, "/ns/test_component_bing");
+    EXPECT_EQ(result->unique_id, 4u);
   }
 
   {
@@ -119,13 +123,14 @@ TEST_F(TestComponentManager, components_api)
     request->package_name = "rclcpp_components";
     request->plugin_name = "test_rclcpp_components::TestComponent";
 
-    auto result = composition_client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+    auto future = composition_client->async_send_request(request);
+    auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
     EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
-    EXPECT_EQ(result.get()->success, false);
-    EXPECT_EQ(result.get()->error_message, "Failed to find class with the requested plugin name.");
-    EXPECT_EQ(result.get()->full_node_name, "");
-    EXPECT_EQ(result.get()->unique_id, 0u);
+    auto result = future.get();
+    EXPECT_EQ(result->success, false);
+    EXPECT_EQ(result->error_message, "Failed to find class with the requested plugin name.");
+    EXPECT_EQ(result->full_node_name, "");
+    EXPECT_EQ(result->unique_id, 0u);
   }
 
   {
@@ -134,13 +139,14 @@ TEST_F(TestComponentManager, components_api)
     request->package_name = "rclcpp_components_foo";
     request->plugin_name = "test_rclcpp_components::TestComponentFoo";
 
-    auto result = composition_client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+    auto future = composition_client->async_send_request(request);
+    auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
     EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
-    EXPECT_EQ(result.get()->success, false);
-    EXPECT_EQ(result.get()->error_message, "Could not find requested resource in ament index");
-    EXPECT_EQ(result.get()->full_node_name, "");
-    EXPECT_EQ(result.get()->unique_id, 0u);
+    auto result = future.get();
+    EXPECT_EQ(result->success, false);
+    EXPECT_EQ(result->error_message, "Could not find requested resource in ament index");
+    EXPECT_EQ(result->full_node_name, "");
+    EXPECT_EQ(result->unique_id, 0u);
   }
 
   {
@@ -151,13 +157,14 @@ TEST_F(TestComponentManager, components_api)
     request->node_name = "test_component_remap";
     request->remap_rules.push_back("alice:=bob");
 
-    auto result = composition_client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+    auto future = composition_client->async_send_request(request);
+    auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
+    auto result = future.get();
     EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
-    EXPECT_EQ(result.get()->success, true);
-    EXPECT_EQ(result.get()->error_message, "");
-    EXPECT_EQ(result.get()->full_node_name, "/test_component_remap");
-    EXPECT_EQ(result.get()->unique_id, 5u);
+    EXPECT_EQ(result->success, true);
+    EXPECT_EQ(result->error_message, "");
+    EXPECT_EQ(result->full_node_name, "/test_component_remap");
+    EXPECT_EQ(result->unique_id, 5u);
   }
 
   {
@@ -170,14 +177,15 @@ TEST_F(TestComponentManager, components_api)
       rclcpp::ParameterValue(true));
     request->extra_arguments.push_back(use_intraprocess_comms.to_parameter_msg());
 
-    auto result = composition_client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+    auto future = composition_client->async_send_request(request);
+    auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
+    auto result = future.get();
     EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
-    EXPECT_EQ(result.get()->success, true);
-    EXPECT_EQ(result.get()->error_message, "");
-    std::cout << result.get()->full_node_name << std::endl;
-    EXPECT_EQ(result.get()->full_node_name, "/test_component_intra_process");
-    EXPECT_EQ(result.get()->unique_id, 6u);
+    EXPECT_EQ(result->success, true);
+    EXPECT_EQ(result->error_message, "");
+    std::cout << result->full_node_name << std::endl;
+    EXPECT_EQ(result->full_node_name, "/test_component_intra_process");
+    EXPECT_EQ(result->unique_id, 6u);
   }
 
   {
@@ -191,15 +199,16 @@ TEST_F(TestComponentManager, components_api)
       rclcpp::ParameterValue("hello"));
     request->extra_arguments.push_back(use_intraprocess_comms.to_parameter_msg());
 
-    auto result = composition_client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+    auto future = composition_client->async_send_request(request);
+    auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
+    auto result = future.get();
     EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
-    EXPECT_EQ(result.get()->success, false);
+    EXPECT_EQ(result->success, false);
     EXPECT_EQ(
-      result.get()->error_message,
+      result->error_message,
       "Extra component argument 'use_intra_process_comms' must be a boolean");
-    EXPECT_EQ(result.get()->full_node_name, "");
-    EXPECT_EQ(result.get()->unique_id, 0u);
+    EXPECT_EQ(result->full_node_name, "");
+    EXPECT_EQ(result->unique_id, 0u);
   }
 
   auto node_names = node->get_node_names();
@@ -223,11 +232,12 @@ TEST_F(TestComponentManager, components_api)
 
     {
       auto request = std::make_shared<composition_interfaces::srv::ListNodes::Request>();
-      auto result = client->async_send_request(request);
-      auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+      auto future = client->async_send_request(request);
+      auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
       EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
-      auto result_node_names = result.get()->full_node_names;
-      auto result_unique_ids = result.get()->unique_ids;
+      auto result = future.get();
+      auto result_node_names = result->full_node_names;
+      auto result_unique_ids = result->unique_ids;
 
       EXPECT_EQ(result_node_names.size(), 6u);
       EXPECT_EQ(result_node_names[0], "/test_component_foo");
@@ -258,22 +268,24 @@ TEST_F(TestComponentManager, components_api)
       auto request = std::make_shared<composition_interfaces::srv::UnloadNode::Request>();
       request->unique_id = 1;
 
-      auto result = client->async_send_request(request);
-      auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+      auto future = client->async_send_request(request);
+      auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
+      auto result = future.get();
       EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
-      EXPECT_EQ(result.get()->success, true);
-      EXPECT_EQ(result.get()->error_message, "");
+      EXPECT_EQ(result->success, true);
+      EXPECT_EQ(result->error_message, "");
     }
 
     {
       auto request = std::make_shared<composition_interfaces::srv::UnloadNode::Request>();
       request->unique_id = 1;
 
-      auto result = client->async_send_request(request);
-      auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+      auto future = client->async_send_request(request);
+      auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
+      auto result = future.get();
       EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
-      EXPECT_EQ(result.get()->success, false);
-      EXPECT_EQ(result.get()->error_message, "No node found with unique_id: 1");
+      EXPECT_EQ(result->success, false);
+      EXPECT_EQ(result->error_message, "No node found with unique_id: 1");
     }
   }
 
@@ -287,11 +299,12 @@ TEST_F(TestComponentManager, components_api)
 
     {
       auto request = std::make_shared<composition_interfaces::srv::ListNodes::Request>();
-      auto result = client->async_send_request(request);
-      auto ret = exec->spin_until_future_complete(result, 5s);  // Wait for the result.
+      auto future = client->async_send_request(request);
+      auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
       EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
-      auto result_node_names = result.get()->full_node_names;
-      auto result_unique_ids = result.get()->unique_ids;
+      auto result = future.get();
+      auto result_node_names = result->full_node_names;
+      auto result_unique_ids = result->unique_ids;
 
       EXPECT_EQ(result_node_names.size(), 5u);
       EXPECT_EQ(result_node_names[0], "/test_component_bar");

--- a/rclcpp_lifecycle/test/test_lifecycle_service_client.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_service_client.cpp
@@ -98,8 +98,9 @@ public:
       return unknown_state;
     }
 
-    if (future_result.get()) {
-      return future_result.get()->current_state;
+    auto result = future_result.get();
+    if (result) {
+      return result->current_state;
     } else {
       return unknown_state;
     }
@@ -140,9 +141,9 @@ public:
     if (future_status != std::future_status::ready) {
       return std::vector<lifecycle_msgs::msg::State>();
     }
-
-    if (future_result.get()) {
-      return future_result.get()->available_states;
+    auto result = future_result.get();
+    if (result) {
+      return result->available_states;
     }
 
     return std::vector<lifecycle_msgs::msg::State>();
@@ -164,8 +165,9 @@ public:
       return std::vector<lifecycle_msgs::msg::TransitionDescription>();
     }
 
-    if (future_result.get()) {
-      return future_result.get()->available_transitions;
+    auto result = future_result.get();
+    if (result) {
+      return result->available_transitions;
     }
 
     return std::vector<lifecycle_msgs::msg::TransitionDescription>();
@@ -187,8 +189,9 @@ public:
       return std::vector<lifecycle_msgs::msg::TransitionDescription>();
     }
 
-    if (future_result.get()) {
-      return future_result.get()->available_transitions;
+    auto result = future_result.get();
+    if (result) {
+      return result->available_transitions;
     }
 
     return std::vector<lifecycle_msgs::msg::TransitionDescription>();


### PR DESCRIPTION
Replaces https://github.com/ros2/rclcpp/pull/1728 (which was accidentally merged and requested).
The last two commits implement the change suggested here, to make this change more backwards compatible.