### PR TITLE
Reset timer trigger time before execute.

### DIFF
--- a/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
@@ -16,6 +16,7 @@
 
 #include <chrono>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "rcpputils/scope_exit.hpp"

--- a/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
@@ -237,7 +237,9 @@ StaticSingleThreadedExecutor::execute_ready_executables(bool spin_once)
   for (size_t i = 0; i < wait_set_.size_of_timers; ++i) {
     if (i < entities_collector_->get_number_of_timers()) {
       if (wait_set_.timers[i] && entities_collector_->get_timer(i)->is_ready()) {
-        execute_timer(entities_collector_->get_timer(i));
+        auto timer = entities_collector_->get_timer(i);
+        timer->call();
+        execute_timer(std::move(timer));
         if (spin_once) {
           return true;
         }


### PR DESCRIPTION
This PR fixes an issue with StaticSingleThreadedExecutor not reseting the timers, so they were always ready and executing callbacks continuosly.

https://github.com/ros2/rclcpp/pull/1692#issuecomment-891791168

Signed-off-by: Mauro Passerino <mpasserino@irobot.com>

