### PR TITLE
Add tests for function templates of declare_parameter

### DIFF
--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -2632,7 +2632,7 @@ TEST_F(TestNode, declare_parameter_allowed_simple_types_function_templates) {
     node->declare_parameter<int>(name2, 1234);
     node->declare_parameter<int64_t>(name3, 12340);
     node->declare_parameter<float>(name4, static_cast<float>(12.34));
-    node->declare_parameter<double>(name5, 12.34); // called float64 in ros2 design parameters page
+    node->declare_parameter<double>(name5, 12.34);  // called float64 in ros2 design parameters page
     node->declare_parameter<std::string>(name6, "test string");
     auto str = "test param";
     node->declare_parameter<const char *>(name7, str);
@@ -2669,7 +2669,7 @@ TEST_F(TestNode, declare_parameter_allowed_simple_types_function_templates) {
     node->declare_parameter<int>(name2, 4321);
     node->declare_parameter<int64_t>(name3, 43210);
     node->declare_parameter<float>(name4, static_cast<float>(43.21));
-    node->declare_parameter<double>(name5, 12.34); // called float64 in ros2 design parameters page
+    node->declare_parameter<double>(name5, 12.34);  // called float64 in ros2 design parameters page
     node->declare_parameter<std::string>(name6, "test string");
     auto str = "test param";
     node->declare_parameter<const char *>(name7, str);
@@ -2706,9 +2706,15 @@ TEST_F(TestNode, declare_parameter_allowed_array_types_function_templates) {
     node->declare_parameter<std::vector<bool>>(name2, bool_arr);
     node->declare_parameter<std::vector<int>>(name3, std::vector<int>{1234, 2345});
     node->declare_parameter<std::vector<int64_t>>(name4, std::vector<int64_t>{12340, 9876});
-    node->declare_parameter<std::vector<float>>(name5, std::vector<float>{static_cast<float>(12.34), static_cast<float>(98.78)});
-    node->declare_parameter<std::vector<double>>(name6, std::vector<double>{12.34, 55.66}); // called float64 in ros2 design parameters page
-    node->declare_parameter<std::vector<std::string>>(name7, std::vector<std::string>{"test string", "another test str"});
+    node->declare_parameter<std::vector<float>>(
+      name5, std::vector<float>{static_cast<float>(12.34),
+        static_cast<float>(98.78)});
+    node->declare_parameter<std::vector<double>>(
+      name6,
+      std::vector<double>{12.34, 55.66});  // called float64 in ros2 design parameters page
+    node->declare_parameter<std::vector<std::string>>(
+      name7, std::vector<std::string>{"test string",
+        "another test str"});
 
     EXPECT_TRUE(node->has_parameter(name1));
     EXPECT_TRUE(node->has_parameter(name2));
@@ -2743,9 +2749,15 @@ TEST_F(TestNode, declare_parameter_allowed_array_types_function_templates) {
     node->declare_parameter<std::vector<bool>>(name2, std::vector<bool>{true, false, true});
     node->declare_parameter<std::vector<int>>(name3, std::vector<int>{22, 33, 55, 77});
     node->declare_parameter<std::vector<int64_t>>(name4, std::vector<int64_t>{456, 765});
-    node->declare_parameter<std::vector<float>>(name5, std::vector<float>{static_cast<float>(99.11), static_cast<float>(11.99)});
-    node->declare_parameter<std::vector<double>>(name6, std::vector<double>{12.21, 55.55, 98.89}); // called float64 in ros2 design parameters page
-    node->declare_parameter<std::vector<std::string>>(name7, std::vector<std::string>{"ros2", "colcon", "ignition"});
+    node->declare_parameter<std::vector<float>>(
+      name5, std::vector<float>{static_cast<float>(99.11),
+        static_cast<float>(11.99)});
+    node->declare_parameter<std::vector<double>>(
+      name6,
+      std::vector<double>{12.21, 55.55, 98.89});  // called float64 in ros2 design parameters page
+    node->declare_parameter<std::vector<std::string>>(
+      name7, std::vector<std::string>{"ros2",
+        "colcon", "ignition"});
 
     std::vector<rclcpp::Parameter> expected = {
       {name1, std::vector<uint8_t>{0xD, 0xE, 0xA, 0xD}},

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -2614,6 +2614,56 @@ TEST_F(TestNode, declare_parameter_with_vector) {
   }
 }
 
+// test allowed non-array data types for declare parameter function templates
+TEST_F(TestNode, declare_parameter_allowed_simple_types_function_templates) {
+  auto node = std::make_shared<rclcpp::Node>(
+    "test_declare_parameter_allowed_simple_types_function_templates"_unq);
+  {
+    // declare parameter and then get types to check
+    auto name1 = "parameter"_unq;
+    auto name2 = "parameter"_unq;
+    auto name3 = "parameter"_unq;
+    auto name4 = "parameter"_unq;
+
+    node->declare_parameter<bool>(name1, false);
+    node->declare_parameter<int64_t>(name2, 1234);
+    node->declare_parameter<double>(name3, 12.34); // float64
+    node->declare_parameter<std::string>(name4, "test string");
+
+    EXPECT_TRUE(node->has_parameter(name1));
+    EXPECT_TRUE(node->has_parameter(name2));
+    EXPECT_TRUE(node->has_parameter(name3));
+    EXPECT_TRUE(node->has_parameter(name4));
+
+    auto results = node->get_parameter_types({name1, name2, name3, name4});
+    EXPECT_EQ(results.size(), 4u);
+    EXPECT_EQ(results[0], rcl_interfaces::msg::ParameterType::PARAMETER_BOOL);
+    EXPECT_EQ(results[1], rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER);
+    EXPECT_EQ(results[2], rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE);
+    EXPECT_EQ(results[3], rcl_interfaces::msg::ParameterType::PARAMETER_STRING);
+  }
+  {
+    // declare parameter and then get values to check
+    auto name1 = "parameter"_unq;
+    auto name2 = "parameter"_unq;
+    auto name3 = "parameter"_unq;
+    auto name4 = "parameter"_unq;
+
+    node->declare_parameter<bool>(name1, false);
+    node->declare_parameter<int64_t>(name2, 1234);
+    node->declare_parameter<double>(name3, 12.34);
+    node->declare_parameter<std::string>(name4, "test string");
+
+    std::vector<rclcpp::Parameter> expected = {
+      {name1, false},
+      {name2, 1234},
+      {name3, 12.34},
+      {name4, "test string"},
+    };
+    EXPECT_EQ(node->get_parameters({name1, name2, name3, name4}), expected);
+  }
+}
+
 void expect_qos_profile_eq(
   const rmw_qos_profile_t & qos1, const rmw_qos_profile_t & qos2, bool is_publisher)
 {

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -2614,7 +2614,7 @@ TEST_F(TestNode, declare_parameter_with_vector) {
   }
 }
 
-// test allowed non-array data types for declare parameter function templates
+// test non-array data types for declare parameter function templates that are explicitly defined
 TEST_F(TestNode, declare_parameter_allowed_simple_types_function_templates) {
   auto node = std::make_shared<rclcpp::Node>(
     "test_declare_parameter_allowed_simple_types_function_templates"_unq);
@@ -2624,23 +2624,36 @@ TEST_F(TestNode, declare_parameter_allowed_simple_types_function_templates) {
     auto name2 = "parameter"_unq;
     auto name3 = "parameter"_unq;
     auto name4 = "parameter"_unq;
+    auto name5 = "parameter"_unq;
+    auto name6 = "parameter"_unq;
+    auto name7 = "parameter"_unq;
 
     node->declare_parameter<bool>(name1, false);
-    node->declare_parameter<int64_t>(name2, 1234);
-    node->declare_parameter<double>(name3, 12.34); // float64
-    node->declare_parameter<std::string>(name4, "test string");
+    node->declare_parameter<int>(name2, 1234);
+    node->declare_parameter<int64_t>(name3, 12340);
+    node->declare_parameter<float>(name4, static_cast<float>(12.34));
+    node->declare_parameter<double>(name5, 12.34); // called float64 in ros2 design parameters page
+    node->declare_parameter<std::string>(name6, "test string");
+    auto str = "test param";
+    node->declare_parameter<const char *>(name7, str);
 
     EXPECT_TRUE(node->has_parameter(name1));
     EXPECT_TRUE(node->has_parameter(name2));
     EXPECT_TRUE(node->has_parameter(name3));
     EXPECT_TRUE(node->has_parameter(name4));
+    EXPECT_TRUE(node->has_parameter(name5));
+    EXPECT_TRUE(node->has_parameter(name6));
+    EXPECT_TRUE(node->has_parameter(name7));
 
-    auto results = node->get_parameter_types({name1, name2, name3, name4});
-    EXPECT_EQ(results.size(), 4u);
+    auto results = node->get_parameter_types({name1, name2, name3, name4, name5, name6, name7});
+    EXPECT_EQ(results.size(), 7u);
     EXPECT_EQ(results[0], rcl_interfaces::msg::ParameterType::PARAMETER_BOOL);
     EXPECT_EQ(results[1], rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER);
-    EXPECT_EQ(results[2], rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE);
-    EXPECT_EQ(results[3], rcl_interfaces::msg::ParameterType::PARAMETER_STRING);
+    EXPECT_EQ(results[2], rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER);
+    EXPECT_EQ(results[3], rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE);
+    EXPECT_EQ(results[4], rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE);
+    EXPECT_EQ(results[5], rcl_interfaces::msg::ParameterType::PARAMETER_STRING);
+    EXPECT_EQ(results[6], rcl_interfaces::msg::ParameterType::PARAMETER_STRING);
   }
   {
     // declare parameter and then get values to check
@@ -2648,19 +2661,102 @@ TEST_F(TestNode, declare_parameter_allowed_simple_types_function_templates) {
     auto name2 = "parameter"_unq;
     auto name3 = "parameter"_unq;
     auto name4 = "parameter"_unq;
+    auto name5 = "parameter"_unq;
+    auto name6 = "parameter"_unq;
+    auto name7 = "parameter"_unq;
 
     node->declare_parameter<bool>(name1, false);
-    node->declare_parameter<int64_t>(name2, 1234);
-    node->declare_parameter<double>(name3, 12.34);
-    node->declare_parameter<std::string>(name4, "test string");
+    node->declare_parameter<int>(name2, 4321);
+    node->declare_parameter<int64_t>(name3, 43210);
+    node->declare_parameter<float>(name4, static_cast<float>(43.21));
+    node->declare_parameter<double>(name5, 12.34); // called float64 in ros2 design parameters page
+    node->declare_parameter<std::string>(name6, "test string");
+    auto str = "test param";
+    node->declare_parameter<const char *>(name7, str);
 
     std::vector<rclcpp::Parameter> expected = {
       {name1, false},
-      {name2, 1234},
-      {name3, 12.34},
-      {name4, "test string"},
+      {name2, 4321},
+      {name3, 43210},
+      {name4, static_cast<float>(43.21)},
+      {name5, 12.34},
+      {name6, "test string"},
+      {name7, str}
     };
-    EXPECT_EQ(node->get_parameters({name1, name2, name3, name4}), expected);
+    EXPECT_EQ(node->get_parameters({name1, name2, name3, name4, name5, name6, name7}), expected);
+  }
+}
+
+// test array data types for declare parameter function templates that are explicitly defined
+TEST_F(TestNode, declare_parameter_allowed_array_types_function_templates) {
+  auto node = std::make_shared<rclcpp::Node>(
+    "test_declare_parameter_allowed_array_types_function_templates"_unq);
+  {
+    // declare parameter and then get types to check
+    auto name1 = "parameter"_unq;
+    auto name2 = "parameter"_unq;
+    auto name3 = "parameter"_unq;
+    auto name4 = "parameter"_unq;
+    auto name5 = "parameter"_unq;
+    auto name6 = "parameter"_unq;
+    auto name7 = "parameter"_unq;
+
+    node->declare_parameter<std::vector<uint8_t>>(name1, std::vector<uint8_t>{3, 4, 5, 7, 9});
+    std::vector<bool> bool_arr = {false, true};
+    node->declare_parameter<std::vector<bool>>(name2, bool_arr);
+    node->declare_parameter<std::vector<int>>(name3, std::vector<int>{1234, 2345});
+    node->declare_parameter<std::vector<int64_t>>(name4, std::vector<int64_t>{12340, 9876});
+    node->declare_parameter<std::vector<float>>(name5, std::vector<float>{static_cast<float>(12.34), static_cast<float>(98.78)});
+    node->declare_parameter<std::vector<double>>(name6, std::vector<double>{12.34, 55.66}); // called float64 in ros2 design parameters page
+    node->declare_parameter<std::vector<std::string>>(name7, std::vector<std::string>{"test string", "another test str"});
+
+    EXPECT_TRUE(node->has_parameter(name1));
+    EXPECT_TRUE(node->has_parameter(name2));
+    EXPECT_TRUE(node->has_parameter(name3));
+    EXPECT_TRUE(node->has_parameter(name4));
+    EXPECT_TRUE(node->has_parameter(name5));
+    EXPECT_TRUE(node->has_parameter(name6));
+    EXPECT_TRUE(node->has_parameter(name7));
+
+    auto results = node->get_parameter_types({name1, name2, name3, name4, name5, name6, name7});
+    EXPECT_EQ(results.size(), 7u);
+    EXPECT_EQ(results[0], rcl_interfaces::msg::ParameterType::PARAMETER_BYTE_ARRAY);
+    EXPECT_EQ(results[1], rcl_interfaces::msg::ParameterType::PARAMETER_BOOL_ARRAY);
+    EXPECT_EQ(results[2], rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER_ARRAY);
+    EXPECT_EQ(results[3], rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER_ARRAY);
+    EXPECT_EQ(results[4], rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE_ARRAY);
+    EXPECT_EQ(results[5], rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE_ARRAY);
+    EXPECT_EQ(results[6], rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY);
+  }
+  {
+    // declare parameter and then get values to check
+    auto name1 = "parameter"_unq;
+    auto name2 = "parameter"_unq;
+    auto name3 = "parameter"_unq;
+    auto name4 = "parameter"_unq;
+    auto name5 = "parameter"_unq;
+    auto name6 = "parameter"_unq;
+    auto name7 = "parameter"_unq;
+
+    std::vector<uint8_t> byte_arr = {0xD, 0xE, 0xA, 0xD};
+    node->declare_parameter<std::vector<uint8_t>>(name1, byte_arr);
+    node->declare_parameter<std::vector<bool>>(name2, std::vector<bool>{true, false, true});
+    node->declare_parameter<std::vector<int>>(name3, std::vector<int>{22, 33, 55, 77});
+    node->declare_parameter<std::vector<int64_t>>(name4, std::vector<int64_t>{456, 765});
+    node->declare_parameter<std::vector<float>>(name5, std::vector<float>{static_cast<float>(99.11), static_cast<float>(11.99)});
+    node->declare_parameter<std::vector<double>>(name6, std::vector<double>{12.21, 55.55, 98.89}); // called float64 in ros2 design parameters page
+    node->declare_parameter<std::vector<std::string>>(name7, std::vector<std::string>{"ros2", "colcon", "ignition"});
+
+    std::vector<rclcpp::Parameter> expected = {
+      {name1, std::vector<uint8_t>{0xD, 0xE, 0xA, 0xD}},
+      {name2, std::vector<bool>{true, false, true}},
+      {name3, std::vector<int>{22, 33, 55, 77}},
+      {name4, std::vector<int64_t>{456, 765}},
+      {name5, std::vector<float>{static_cast<float>(99.11), static_cast<float>(11.99)}},
+      {name6, std::vector<double>{12.21, 55.55, 98.89}},
+      {name7, std::vector<std::string>{"ros2", "colcon", "ignition"}}
+    };
+    EXPECT_EQ(node->get_parameters({name1, name2, name3, name4, name5, name6, name7}), expected);
   }
 }
 

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -2702,8 +2702,7 @@ TEST_F(TestNode, declare_parameter_allowed_array_types_function_templates) {
     auto name7 = "parameter"_unq;
 
     node->declare_parameter<std::vector<uint8_t>>(name1, std::vector<uint8_t>{3, 4, 5, 7, 9});
-    std::vector<bool> bool_arr = {false, true};
-    node->declare_parameter<std::vector<bool>>(name2, bool_arr);
+    node->declare_parameter<std::vector<bool>>(name2, std::vector<bool>{false, true});
     node->declare_parameter<std::vector<int>>(name3, std::vector<int>{1234, 2345});
     node->declare_parameter<std::vector<int64_t>>(name4, std::vector<int64_t>{12340, 9876});
     node->declare_parameter<std::vector<float>>(


### PR DESCRIPTION
This test is only for simple types (no arrays) mentioned in documentation chapter "[About parameters in ROS 2](https://docs.ros.org/en/galactic/Concepts/About-ROS-2-Parameters.html)". It's a follow up of #1743 since not all types with function templates are tested yet. The type mappings can be found [here](https://docs.ros.org/en/foxy/Concepts/About-ROS-Interfaces.html#field-types).