### PR TITLE
Add Clock::sleep_until method

### DIFF
--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -79,6 +79,23 @@ public:
   now();
 
   /**
+   * Sleep until a specified Time, according to clock type.
+   *
+   * Notes for RCL_ROS_TIME clock type:
+   *   - Can sleep forever if ros time is active and received clock never reaches `until`
+   *   - If ROS time enabled state changes during the sleep, this method will immediately return
+   *     false. There is not a consistent choice of sleeping time when the time source changes,
+   *     so this is up to the caller to call again if needed.
+   *
+   * \param until absolute time according to current clock type to sleep until
+   * \return true if the time `until` is reached
+   * \return false if time cannot be reached reliably, such as on shutdown
+   */
+  RCLCPP_PUBLIC
+  bool
+  sleep_until(Time until);
+
+  /**
    * Returns the clock of the type `RCL_ROS_TIME` is active.
    *
    * \return true if the clock is active

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -87,9 +87,11 @@ public:
    *     false. There is not a consistent choice of sleeping time when the time source changes,
    *     so this is up to the caller to call again if needed.
    *
-   * \param until absolute time according to current clock type to sleep until
-   * \return true if the time `until` is reached
-   * \return false if time cannot be reached reliably, such as on shutdown
+   * \param until absolute time according to current clock type to sleep until.
+   * \return true immediately if `until` is in the past
+   * \return true when the time `until` is reached
+   * \return false if time cannot be reached reliably, for example from shutdown or a change
+   *    of time source.
    */
   RCLCPP_PUBLIC
   bool

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -95,7 +95,8 @@ Clock::sleep_until(Time until)
 {
   const auto this_clock_type = get_clock_type();
   if (until.get_clock_type() != this_clock_type) {
-    RCUTILS_LOG_ERROR("sleep_until Time clock type %d does not match this clock's type %d.",
+    RCUTILS_LOG_ERROR(
+      "sleep_until Time clock type %d does not match this clock's type %d.",
       until.get_clock_type(), this_clock_type);
     return false;
   }

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -112,7 +112,8 @@ Clock::sleep_until(Time until)
       impl_->cv_.wait_until(lock, steady_time);
     }
   } else if (this_clock_type == RCL_SYSTEM_TIME) {
-    auto system_time = std::chrono::system_clock::time_point(
+    auto system_time = std::chrono::time_point<
+      std::chrono::system_clock, std::chrono::nanoseconds>(
       std::chrono::nanoseconds(until.nanoseconds()));
 
     // loop over spurious wakeups but notice shutdown
@@ -136,7 +137,8 @@ Clock::sleep_until(Time until)
       threshold);
 
     if (!ros_time_is_active()) {
-      auto system_time = std::chrono::system_clock::time_point(
+      auto system_time = std::chrono::time_point<
+        std::chrono::system_clock, std::chrono::nanoseconds>(
         std::chrono::nanoseconds(until.nanoseconds()));
 
       // loop over spurious wakeups but notice shutdown or time source change

--- a/rclcpp/test/rclcpp/test_time.cpp
+++ b/rclcpp/test/rclcpp/test_time.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <chrono>
 #include <limits>
+#include <memory>
 #include <string>
 
 #include "rcl/error_handling.h"
@@ -24,6 +25,7 @@
 #include "rclcpp/clock.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/time.hpp"
+#include "rclcpp/time_source.hpp"
 #include "rclcpp/utilities.hpp"
 
 #include "../utils/rclcpp_gtest_macros.hpp"
@@ -446,4 +448,135 @@ TEST_F(TestTime, test_overflow_underflow_throws) {
   RCLCPP_EXPECT_THROW_EQ(
     test_time = rclcpp::Duration::from_nanoseconds(INT64_MIN) + rclcpp::Time(-1),
     std::underflow_error("addition leads to int64_t underflow"));
+}
+
+class TestClockSleep : public ::testing::Test
+{
+protected:
+  void SetUp()
+  {
+    // Shutdown in case there was a dangling global context from other test fixtures
+    rclcpp::shutdown();
+    rclcpp::init(0, nullptr);
+    node = std::make_shared<rclcpp::Node>("clock_sleep_node");
+    param_client = std::make_shared<rclcpp::SyncParametersClient>(node);
+    ASSERT_TRUE(param_client->wait_for_service(5s));
+  }
+
+  void TearDown()
+  {
+    node.reset();
+    rclcpp::shutdown();
+  }
+
+  rclcpp::Node::SharedPtr node;
+  rclcpp::SyncParametersClient::SharedPtr param_client;
+};
+
+TEST_F(TestClockSleep, sleep_until_basic_system) {
+  static const auto MILLION = 1000L * 1000L;
+  const auto milliseconds = 300;
+  rclcpp::Clock clock(RCL_SYSTEM_TIME);
+  auto delay = rclcpp::Duration(0, milliseconds * MILLION);
+  auto sleep_until = clock.now() + delay;
+
+  auto steady_start = std::chrono::steady_clock::now();
+  ASSERT_TRUE(clock.sleep_until(sleep_until));
+  auto steady_end = std::chrono::steady_clock::now();
+
+  EXPECT_GE(clock.now(), sleep_until);
+  EXPECT_GE(steady_end - steady_start, std::chrono::milliseconds(milliseconds));
+}
+
+TEST_F(TestClockSleep, sleep_until_basic_steady) {
+  static const auto MILLION = 1000L * 1000L;
+  const auto milliseconds = 100;
+  rclcpp::Clock clock(RCL_STEADY_TIME);
+  auto delay = rclcpp::Duration(0, milliseconds * MILLION);
+  auto sleep_until = clock.now() + delay;
+
+  auto steady_start = std::chrono::steady_clock::now();
+  ASSERT_TRUE(clock.sleep_until(sleep_until));
+  auto steady_end = std::chrono::steady_clock::now();
+
+  EXPECT_GE(clock.now(), sleep_until);
+  EXPECT_GE(steady_end - steady_start, std::chrono::milliseconds(milliseconds));
+}
+
+TEST_F(TestClockSleep, sleep_until_ros_time_enable_interrupt)
+{
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  rclcpp::TimeSource time_source;
+  time_source.attachNode(node);
+  time_source.attachClock(clock);
+
+  // 5 second timeout, but it should be interrupted right away
+  const auto until = clock->now() + rclcpp::Duration(5, 0);
+
+  // Try sleeping with ROS time off, then turn it on to interrupt
+  bool sleep_succeeded = true;
+  auto sleep_thread = std::thread(
+    [clock, until, &sleep_succeeded]() {
+      sleep_succeeded = clock->sleep_until(until);
+    });
+  // yield execution long enough to let the sleep thread get to waiting on the condition variable
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  auto set_parameters_results = param_client->set_parameters(
+    {rclcpp::Parameter("use_sim_time", true)});
+  for (auto & result : set_parameters_results) {
+    ASSERT_TRUE(result.successful);
+  }
+  sleep_thread.join();
+  EXPECT_FALSE(sleep_succeeded);
+}
+
+TEST_F(TestClockSleep, sleep_until_ros_time_disable_interrupt)
+{
+  param_client->set_parameters({rclcpp::Parameter("use_sim_time", true)});
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  rclcpp::TimeSource time_source;
+  time_source.attachNode(node);
+  time_source.attachClock(clock);
+
+  // /clock shouldn't be publishing, shouldn't be possible to reach timeout
+  const auto until = clock->now() + rclcpp::Duration(600, 0);
+
+  // Try sleeping with ROS time off, then turn it on to interrupt
+  bool sleep_succeeded = true;
+  auto sleep_thread = std::thread(
+    [clock, until, &sleep_succeeded]() {
+      sleep_succeeded = clock->sleep_until(until);
+    });
+  // yield execution long enough to let the sleep thread get to waiting on the condition variable
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  auto set_parameters_results = param_client->set_parameters(
+    {rclcpp::Parameter("use_sim_time", false)});
+  for (auto & result : set_parameters_results) {
+    ASSERT_TRUE(result.successful);
+  }
+  sleep_thread.join();
+  EXPECT_FALSE(sleep_succeeded);
+}
+
+TEST_F(TestClockSleep, sleep_until_shutdown_interrupt)
+{
+  param_client->set_parameters({rclcpp::Parameter("use_sim_time", true)});
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  rclcpp::TimeSource time_source;
+  time_source.attachNode(node);
+  time_source.attachClock(clock);
+
+  // the timeout doesn't matter here - no /clock is being published, so it should never wake
+  const auto until = clock->now() + rclcpp::Duration(5, 0);
+
+  bool sleep_succeeded = true;
+  auto sleep_thread = std::thread(
+    [clock, until, &sleep_succeeded]() {
+      sleep_succeeded = clock->sleep_until(until);
+    });
+  // yield execution long enough to let the sleep thread get to waiting on the condition variable
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  rclcpp::shutdown();
+  sleep_thread.join();
+  EXPECT_FALSE(sleep_succeeded);
 }

--- a/rclcpp/test/rclcpp/test_time.cpp
+++ b/rclcpp/test/rclcpp/test_time.cpp
@@ -547,36 +547,8 @@ TEST_F(TestClockSleep, sleep_until_ros_time_disable_interrupt)
     [clock, until, &sleep_succeeded]() {
       sleep_succeeded = clock->sleep_until(until);
     });
-
-
-  // WIP test - checking if we are receiving clock messages in test environment
-  // which shouldn't be happening, but seems to be
-  rcl_jump_threshold_t threshold;
-  threshold.on_clock_change = true;
-  threshold.min_backward.nanoseconds = 0;
-  threshold.min_forward.nanoseconds = 0;
-  auto handler = clock->create_jump_callback(
-    []() {},
-    [](const rcl_time_jump_t & jump) {
-      switch (jump.clock_change) {
-        case RCL_ROS_TIME_NO_CHANGE:
-          RCUTILS_LOG_ERROR("Time Jump: ROS Time - /clock received... bad");
-          break;
-        case RCL_SYSTEM_TIME_NO_CHANGE:
-          RCUTILS_LOG_ERROR("Time Jump: Why is it system time??");
-          break;
-        case RCL_ROS_TIME_ACTIVATED:
-          RCUTILS_LOG_ERROR("ROS TIME ACTIVATED");
-          break;
-        case RCL_ROS_TIME_DEACTIVATED:
-          RCUTILS_LOG_ERROR("ROS TIME DEACTIVATED: the sleep is done and the test should end.");
-          break;
-      }
-    },
-    threshold);
-
   // yield execution long enough to let the sleep thread get to waiting on the condition variable
-  std::this_thread::sleep_for(std::chrono::seconds(10));
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
   auto set_parameters_results = param_client->set_parameters(
     {rclcpp::Parameter("use_sim_time", false)});
   for (auto & result : set_parameters_results) {

--- a/rclcpp/test/rclcpp/test_time.cpp
+++ b/rclcpp/test/rclcpp/test_time.cpp
@@ -547,8 +547,36 @@ TEST_F(TestClockSleep, sleep_until_ros_time_disable_interrupt)
     [clock, until, &sleep_succeeded]() {
       sleep_succeeded = clock->sleep_until(until);
     });
+
+
+  // WIP test - checking if we are receiving clock messages in test environment
+  // which shouldn't be happening, but seems to be
+  rcl_jump_threshold_t threshold;
+  threshold.on_clock_change = true;
+  threshold.min_backward.nanoseconds = 0;
+  threshold.min_forward.nanoseconds = 0;
+  auto handler = clock->create_jump_callback(
+    []() {},
+    [](const rcl_time_jump_t & jump) {
+      switch (jump.clock_change) {
+        case RCL_ROS_TIME_NO_CHANGE:
+          RCUTILS_LOG_ERROR("Time Jump: ROS Time - /clock received... bad");
+          break;
+        case RCL_SYSTEM_TIME_NO_CHANGE:
+          RCUTILS_LOG_ERROR("Time Jump: Why is it system time??");
+          break;
+        case RCL_ROS_TIME_ACTIVATED:
+          RCUTILS_LOG_ERROR("ROS TIME ACTIVATED");
+          break;
+        case RCL_ROS_TIME_DEACTIVATED:
+          RCUTILS_LOG_ERROR("ROS TIME DEACTIVATED: the sleep is done and the test should end.");
+          break;
+      }
+    },
+    threshold);
+
   // yield execution long enough to let the sleep thread get to waiting on the condition variable
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  std::this_thread::sleep_for(std::chrono::seconds(10));
   auto set_parameters_results = param_client->set_parameters(
     {rclcpp::Parameter("use_sim_time", false)});
   for (auto & result : set_parameters_results) {

--- a/rclcpp/test/rclcpp/test_time.cpp
+++ b/rclcpp/test/rclcpp/test_time.cpp
@@ -480,12 +480,12 @@ TEST_F(TestClockSleep, sleep_until_basic_system) {
   auto delay = rclcpp::Duration(0, milliseconds * MILLION);
   auto sleep_until = clock.now() + delay;
 
-  auto steady_start = std::chrono::steady_clock::now();
+  auto start = std::chrono::system_clock::now();
   ASSERT_TRUE(clock.sleep_until(sleep_until));
-  auto steady_end = std::chrono::steady_clock::now();
+  auto end = std::chrono::system_clock::now();
 
   EXPECT_GE(clock.now(), sleep_until);
-  EXPECT_GE(steady_end - steady_start, std::chrono::milliseconds(milliseconds));
+  EXPECT_GE(end - start, std::chrono::milliseconds(milliseconds));
 }
 
 TEST_F(TestClockSleep, sleep_until_basic_steady) {

--- a/rclcpp/test/rclcpp/test_time.cpp
+++ b/rclcpp/test/rclcpp/test_time.cpp
@@ -499,7 +499,7 @@ TEST_F(TestClockSleep, sleep_until_basic_system) {
 
 TEST_F(TestClockSleep, sleep_until_basic_steady) {
   static const auto MILLION = 1000L * 1000L;
-  const auto milliseconds = 100;
+  const auto milliseconds = 300;
   rclcpp::Clock clock(RCL_STEADY_TIME);
   auto delay = rclcpp::Duration(0, milliseconds * MILLION);
   auto sleep_until = clock.now() + delay;

--- a/rclcpp/test/rclcpp/test_time_source.cpp
+++ b/rclcpp/test/rclcpp/test_time_source.cpp
@@ -742,3 +742,36 @@ TEST_F(TestTimeSource, check_sim_time_updated_in_callback_if_use_clock_thread) {
   // Node should have get out of timer callback
   ASSERT_FALSE(clock_thread_testing_node.GetIsCallbackFrozen());
 }
+
+TEST_F(TestTimeSource, clock_sleep_until_with_ros_time_basic) {
+  SimClockPublisherNode pub_node;
+  pub_node.SpinNode();
+
+  node->set_parameter({"use_sim_time", true});
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  rclcpp::TimeSource time_source;
+  time_source.attachNode(node);
+  time_source.attachClock(clock);
+
+  // Wait until time source has definitely received a first ROS time from the pub node
+  {
+    rcl_jump_threshold_t threshold;
+    threshold.on_clock_change = false;
+    threshold.min_backward.nanoseconds = 0;
+    threshold.min_forward.nanoseconds = 0;
+
+    std::condition_variable cv;
+    std::mutex mutex;
+    auto handler = clock->create_jump_callback(
+      []() {},
+      [&cv](const rcl_time_jump_t &) {cv.notify_all();},
+      threshold);
+    std::unique_lock lock(mutex);
+    cv.wait(lock);
+  }
+
+  auto now = clock->now();
+  // Any amount of time will do, just need to make sure that we awake and return true
+  auto until = now + rclcpp::Duration(0, 500);
+  EXPECT_TRUE(clock->sleep_until(until));
+}


### PR DESCRIPTION
Part of #1730 
Related to ros2/rosbag2#694

Add a `Clock::sleep_until` method. Handle all 3 clock types, and edge cases for shutdown and enabling/disabling ROS time.

Adds test cases for enable/disable ROStime, and `rclcpp::shutdown` - which needed special interrupts. Tests ROS time via `/clock` messages, and has basic testing for steady/system times, though those are much simpler cases.