### PR TITLE
Improve documentation for auto declaration from overrides

### DIFF
--- a/rclcpp/include/rclcpp/node_options.hpp
+++ b/rclcpp/include/rclcpp/node_options.hpp
@@ -350,7 +350,8 @@ public:
    * not explicitly declared will not appear on the node at all, even if
    * `allow_undeclared_parameters` is true.
    * Parameter declaration from overrides is done in the node's base constructor,
-   * so user takes care if some parameter is already (e.g. automatically) declared.
+   * so the user must take care to check if the parameter is already (e.g.
+   * automatically) declared before declaring it themselves.
    * Already declared parameters will not be re-declared, and parameters
    * declared in this way will use the default constructed ParameterDescriptor.
    */

--- a/rclcpp/include/rclcpp/node_options.hpp
+++ b/rclcpp/include/rclcpp/node_options.hpp
@@ -349,7 +349,7 @@ public:
    * global arguments (e.g. parameter overrides from a YAML file), which are
    * not explicitly declared will not appear on the node at all, even if
    * `allow_undeclared_parameters` is true.
-   * Parameter declaration from overrides is done in the node's base construcor,
+   * Parameter declaration from overrides is done in the node's base constructor,
    * so user takes care if some parameter is already (e.g. automatically) declared.
    * Already declared parameters will not be re-declared, and parameters
    * declared in this way will use the default constructed ParameterDescriptor.

--- a/rclcpp/include/rclcpp/node_options.hpp
+++ b/rclcpp/include/rclcpp/node_options.hpp
@@ -349,6 +349,8 @@ public:
    * global arguments (e.g. parameter overrides from a YAML file), which are
    * not explicitly declared will not appear on the node at all, even if
    * `allow_undeclared_parameters` is true.
+   * Parameter declaration from overrides is done in the node's base construcor,
+   * so user takes care if some parameter is already (e.g. automatically) declared.
    * Already declared parameters will not be re-declared, and parameters
    * declared in this way will use the default constructed ParameterDescriptor.
    */


### PR DESCRIPTION
PR makes clear what the `automatically_declare_parameters_from_overrides` flag does and emphasizes that the user should check if parameter already exists on the potential parameter declaration.

PR tackles #1749.