### PR TITLE
Fix lifetime of context so it remains alive while its dependent node handles are still in use

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -34,17 +34,23 @@ using rclcpp::node_interfaces::NodeBase;
 
 namespace
 {
-/// This class bundles together the lifetime of the rcl_node_t handle with the
-/// lifetime of the RCL context. This ensures that the context will remain alive
-/// for as long as the rcl_node_t handle is alive.
+/// A class to manage the lifetime of a node handle and its context
+/**
+ * This class bundles together the lifetime of the rcl_node_t handle with the
+ * lifetime of the RCL context. This ensures that the context will remain alive
+ * for as long as the rcl_node_t handle is alive.
+ */
 class NodeHandleWithContext
 {
 public:
-  /// The make function returns a std::shared_ptr<rcl_node_t> which is actually
-  /// an alias for a std::shared_ptr<NodeHandleWithContext>. There is no use for
-  /// accessing a NodeHandleWithContext instance directly, because its only job
-  /// is to couple together the lifetime of a context with the lifetime of a
-  /// node handle that depends on it.
+  /// Make an instance of a NodeHandleWithContext
+  /**
+   * The make function returns a std::shared_ptr<rcl_node_t> which is actually
+   * an alias for a std::shared_ptr<NodeHandleWithContext>. There is no use for
+   * accessing a NodeHandleWithContext instance directly, because its only job
+   * is to couple together the lifetime of a context with the lifetime of a
+   * node handle that depends on it.
+   */
   static std::shared_ptr<rcl_node_t>
   make(
     rclcpp::Context::SharedPtr context,
@@ -82,8 +88,9 @@ public:
   }
 
 private:
-  /// The constructor is private because this class is only meant to be aliased
-  /// into a std::shared_ptr<rcl_node_t>.
+  // The constructor is private because this class is only meant to be aliased
+  // into a std::shared_ptr<rcl_node_t> and should not be constructed any other
+  // way.
   NodeHandleWithContext(
     rclcpp::Context::SharedPtr context,
     std::shared_ptr<std::recursive_mutex> logging_mutex,
@@ -91,9 +98,7 @@ private:
   : context_(std::move(context)),
     logging_mutex_(std::move(logging_mutex)),
     node_handle_(node_handle)
-  {
-    // Do nothing
-  }
+  {}
 
   rclcpp::Context::SharedPtr context_;
   std::shared_ptr<std::recursive_mutex> logging_mutex_;
@@ -201,8 +206,7 @@ NodeBase::NodeBase(
     throw_from_rcl_error(ret, "failed to initialize rcl node");
   }
 
-  node_handle_ = NodeHandleWithContext::make(
-    context_, logging_mutex, rcl_node.release());
+  node_handle_ = NodeHandleWithContext::make(context_, logging_mutex, rcl_node.release());
 
   // Create the default callback group.
   using rclcpp::CallbackGroupType;

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -73,17 +73,16 @@ public:
   NodeHandleWithContext & operator=(NodeHandleWithContext &&) = delete;
 
   NodeHandleWithContext(NodeHandleWithContext && other)
-    : context_(std::move(other.context_)),
-      logging_mutex_(std::move(other.logging_mutex_)),
-      node_handle_(other.node_handle_)
+  : context_(std::move(other.context_)),
+    logging_mutex_(std::move(other.logging_mutex_)),
+    node_handle_(other.node_handle_)
   {
     other.node_handle_ = nullptr;
   }
 
   ~NodeHandleWithContext()
   {
-    if (!node_handle_)
-    {
+    if (!node_handle_) {
       // If the node_handle_ is null, then this object was moved-from. We don't
       // need to do any cleanup.
       return;

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -60,6 +60,13 @@ public:
     return std::shared_ptr<rcl_node_t>(std::move(aliased_ptr), node_handle);
   }
 
+  // This class should not be copied or moved. It should only exist in the
+  // std::shared_ptr that it was originally provided in.
+  NodeHandleWithContext(const NodeHandleWithContext&) = delete;
+  NodeHandleWithContext(NodeHandleWithContext&&) = delete;
+  NodeHandleWithContext& operator=(const NodeHandleWithContext&) = delete;
+  NodeHandleWithContext& operator=(NodeHandleWithContext&&) = delete;
+
   ~NodeHandleWithContext()
   {
     std::lock_guard<std::recursive_mutex> guard(*logging_mutex_);

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -62,10 +62,10 @@ public:
 
   // This class should not be copied or moved. It should only exist in the
   // std::shared_ptr that it was originally provided in.
-  NodeHandleWithContext(const NodeHandleWithContext&) = delete;
-  NodeHandleWithContext(NodeHandleWithContext&&) = delete;
-  NodeHandleWithContext& operator=(const NodeHandleWithContext&) = delete;
-  NodeHandleWithContext& operator=(NodeHandleWithContext&&) = delete;
+  NodeHandleWithContext(const NodeHandleWithContext &) = delete;
+  NodeHandleWithContext(NodeHandleWithContext &&) = delete;
+  NodeHandleWithContext& operator=(const NodeHandleWithContext &) = delete;
+  NodeHandleWithContext& operator=(NodeHandleWithContext &&) = delete;
 
   ~NodeHandleWithContext()
   {

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -64,8 +64,8 @@ public:
   // std::shared_ptr that it was originally provided in.
   NodeHandleWithContext(const NodeHandleWithContext &) = delete;
   NodeHandleWithContext(NodeHandleWithContext &&) = delete;
-  NodeHandleWithContext& operator=(const NodeHandleWithContext &) = delete;
-  NodeHandleWithContext& operator=(NodeHandleWithContext &&) = delete;
+  NodeHandleWithContext & operator=(const NodeHandleWithContext &) = delete;
+  NodeHandleWithContext & operator=(NodeHandleWithContext &&) = delete;
 
   ~NodeHandleWithContext()
   {

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -15,6 +15,7 @@
 #include <string>
 #include <limits>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "rclcpp/node_interfaces/node_base.hpp"
@@ -30,6 +31,68 @@
 using rclcpp::exceptions::throw_from_rcl_error;
 
 using rclcpp::node_interfaces::NodeBase;
+
+namespace
+{
+/// This class bundles together the lifetime of the rcl_node_t handle with the
+/// lifetime of the RCL context. This ensures that the context will remain alive
+/// for as long as the rcl_node_t handle is alive.
+class NodeHandleWithContext
+{
+public:
+  /// The make function returns a std::shared_ptr<rcl_node_t> which is actually
+  /// an alias for a std::shared_ptr<NodeHandleWithContext>. There is no use for
+  /// accessing a NodeHandleWithContext instance directly, because its only job
+  /// is to couple together the lifetime of a context with the lifetime of a
+  /// node handle that depends on it.
+  static std::shared_ptr<rcl_node_t>
+  make(
+    rclcpp::Context::SharedPtr context,
+    std::shared_ptr<std::recursive_mutex> logging_mutex,
+    rcl_node_t * node_handle)
+  {
+    auto aliased_ptr = std::shared_ptr<NodeHandleWithContext>(
+      new NodeHandleWithContext(
+        std::move(context),
+        std::move(logging_mutex),
+        node_handle));
+
+    return std::shared_ptr<rcl_node_t>(std::move(aliased_ptr), node_handle);
+  }
+
+  ~NodeHandleWithContext()
+  {
+    std::lock_guard<std::recursive_mutex> guard(*logging_mutex_);
+    // TODO(ivanpauno): Instead of mutually excluding rcl_node_fini with the global logger mutex,
+    // rcl_logging_rosout_fini_publisher_for_node could be decoupled from there and be called
+    // here directly.
+    if (rcl_node_fini(node_handle_) != RCL_RET_OK) {
+      RCUTILS_LOG_ERROR_NAMED(
+        "rclcpp",
+        "Error in destruction of rcl node handle: %s", rcl_get_error_string().str);
+    }
+    delete node_handle_;
+  }
+
+private:
+  /// The constructor is private because this class is only meant to be aliased
+  /// into a std::shared_ptr<rcl_node_t>.
+  NodeHandleWithContext(
+    rclcpp::Context::SharedPtr context,
+    std::shared_ptr<std::recursive_mutex> logging_mutex,
+    rcl_node_t * node_handle)
+  : context_(std::move(context)),
+    logging_mutex_(std::move(logging_mutex)),
+    node_handle_(node_handle)
+  {
+    // Do nothing
+  }
+
+  rclcpp::Context::SharedPtr context_;
+  std::shared_ptr<std::recursive_mutex> logging_mutex_;
+  rcl_node_t * node_handle_;
+};
+}  // anonymous namespace
 
 NodeBase::NodeBase(
   const std::string & node_name,
@@ -131,20 +194,8 @@ NodeBase::NodeBase(
     throw_from_rcl_error(ret, "failed to initialize rcl node");
   }
 
-  node_handle_.reset(
-    rcl_node.release(),
-    [logging_mutex](rcl_node_t * node) -> void {
-      std::lock_guard<std::recursive_mutex> guard(*logging_mutex);
-      // TODO(ivanpauno): Instead of mutually excluding rcl_node_fini with the global logger mutex,
-      // rcl_logging_rosout_fini_publisher_for_node could be decoupled from there and be called
-      // here directly.
-      if (rcl_node_fini(node) != RCL_RET_OK) {
-        RCUTILS_LOG_ERROR_NAMED(
-          "rclcpp",
-          "Error in destruction of rcl node handle: %s", rcl_get_error_string().str);
-      }
-      delete node;
-    });
+  node_handle_ = NodeHandleWithContext::make(
+    context_, logging_mutex, rcl_node.release());
 
   // Create the default callback group.
   using rclcpp::CallbackGroupType;


### PR DESCRIPTION
Currently it is possible for a `rclcpp::Context` to destruct while dependent objects (e.g. `rclcpp::Publisher`, `rclcpp::Subscription`) are still alive. This can lead to segmentation faults, exceptions, or other problems in the RMW layer.

This PR fixes that problem by tying the lifetime of contexts to the lifetimes of the node handles that depend on them. Since the objects that depend on nodes (like Publisher and Subscriber) hold a counted reference to their node handle, we just need to ensure that contexts remain alive as long as any of their dependent node handles are alive. This PR accomplishes that by distributing `std::shared_ptr<rcl_node_t>` instances that are actually an alias for a `std::shared_ptr<NodeHandleWithContext>` which bundles together a `std::shared_ptr<rclcpp::Context>` with a `rcl_node_t*`, and whose destructor will delete the `rcl_node_t*`.

By using an aliased `std::shared_ptr`, we get the benefit of the corrected lifetime without any modification to API or even ABI of `rclcpp`. It should be possible to squash this PR and then cherry-pick the commit onto other branches of rclcpp without any harmful effects.

I've also added a unit test that will result in a seg fault if it gets run without the fix provided by this PR.