### PR TITLE
Handle sigterm, in the same way we handle sigint

### DIFF
--- a/rclcpp/src/rclcpp/signal_handler.cpp
+++ b/rclcpp/src/rclcpp/signal_handler.cpp
@@ -57,7 +57,7 @@ set_signal_handler(
     char error_string[1024];
     rcutils_strerror(error_string, sizeof(error_string));
     auto msg =
-      "Failed to set SIGINT signal handler (" + std::to_string(errno) + "): " + error_string;
+      "Failed to set signal handler (" + std::to_string(errno) + "): " + error_string;
     throw std::runtime_error(msg);
   }
   return old_signal_handler;
@@ -281,7 +281,7 @@ SignalHandler::signal_handler_common()
   instance.signal_received_.store(true);
   RCLCPP_DEBUG(
     get_logger(),
-    "signal_handler(): SIGINT received, notifying deferred signal handler");
+    "signal_handler(): notifying deferred signal handler");
   instance.notify_signal_handler();
 }
 
@@ -290,7 +290,7 @@ SignalHandler::deferred_signal_handler()
 {
   while (true) {
     if (signal_received_.exchange(false)) {
-      RCLCPP_DEBUG(get_logger(), "deferred_signal_handler(): SIGINT received, shutting down");
+      RCLCPP_DEBUG(get_logger(), "deferred_signal_handler(): shutting down");
       for (auto context_ptr : rclcpp::get_contexts()) {
         if (context_ptr->get_init_options().shutdown_on_sigint) {
           RCLCPP_DEBUG(
@@ -306,9 +306,9 @@ SignalHandler::deferred_signal_handler()
       RCLCPP_DEBUG(get_logger(), "deferred_signal_handler(): signal handling uninstalled");
       break;
     }
-    RCLCPP_DEBUG(get_logger(), "deferred_signal_handler(): waiting for SIGINT or uninstall");
+    RCLCPP_DEBUG(get_logger(), "deferred_signal_handler(): waiting for SIGINT/SIGTERM or uninstall");
     wait_for_signal();
-    RCLCPP_DEBUG(get_logger(), "deferred_signal_handler(): woken up due to SIGINT or uninstall");
+    RCLCPP_DEBUG(get_logger(), "deferred_signal_handler(): woken up due to SIGINT/SIGTERM or uninstall");
   }
 }
 

--- a/rclcpp/src/rclcpp/signal_handler.cpp
+++ b/rclcpp/src/rclcpp/signal_handler.cpp
@@ -35,36 +35,15 @@
 
 using rclcpp::SignalHandler;
 
-// The logger must be initialized before the local static variable signal_handler,
-// from the method get_global_signal_handler(), so that it is destructed after
-// it, because the destructor of SignalHandler uses this logger object.
-static rclcpp::Logger g_logger = rclcpp::get_logger("rclcpp");
-
 rclcpp::Logger &
 SignalHandler::get_logger()
 {
-  return g_logger;
+  return SignalHandler::get_global_signal_handler().logger_;
 }
 
 SignalHandler &
 SignalHandler::get_global_signal_handler()
 {
-  // This is initialized after the g_logger static global, ensuring
-  // SignalHandler::get_logger() may be called from the destructor of
-  // SignalHandler, according to this:
-  //
-  //   Variables declared at block scope with the specifier static have static
-  //   storage duration but are initialized the first time control passes
-  //   through their declaration (unless their initialization is zero- or
-  //   constant-initialization, which can be performed before the block is
-  //   first entered). On all further calls, the declaration is skipped.
-  //
-  // -- https://en.cppreference.com/w/cpp/language/storage_duration#Static_local_variables
-  //
-  // Which is guaranteed to occur after static initialization for global (see:
-  // https://en.cppreference.com/w/cpp/language/initialization#Static_initialization),
-  // which is when g_logger will be initialized.
-  // And destruction will occur in the reverse order.
   static SignalHandler signal_handler;
   return signal_handler;
 }

--- a/rclcpp/src/rclcpp/signal_handler.hpp
+++ b/rclcpp/src/rclcpp/signal_handler.hpp
@@ -88,21 +88,26 @@ private:
 
   ~SignalHandler();
 
+  SignalHandler(const SignalHandler &) = delete;
+  SignalHandler(SignalHandler &&) = delete;
+  SignalHandler &
+  operator=(const SignalHandler &) = delete;
+  SignalHandler &&
+  operator=(SignalHandler &&) = delete;
+
 #if defined(RCLCPP_HAS_SIGACTION)
   using signal_handler_type = struct sigaction;
 #else
   using signal_handler_type = void (*)(int);
 #endif
   // POSIX signal handler structure storage for the existing signal handler.
-  static SignalHandler::signal_handler_type old_signal_handler_;
+  SignalHandler::signal_handler_type old_signal_handler_;
 
   /// Set the signal handler function.
-  static
   SignalHandler::signal_handler_type
   set_signal_handler(int signal_value, const SignalHandler::signal_handler_type & signal_handler);
 
   /// Common signal handler code between sigaction and non-sigaction versions.
-  static
   void
   signal_handler_common();
 
@@ -127,7 +132,6 @@ private:
    * This must be called before wait_for_signal() or notify_signal_handler().
    * This is not thread-safe.
    */
-  static
   void
   setup_wait_for_signal();
 
@@ -137,7 +141,6 @@ private:
    *
    * This is not thread-safe.
    */
-  static
   void
   teardown_wait_for_signal() noexcept;
 
@@ -147,7 +150,6 @@ private:
    *
    * This is not thread-safe.
    */
-  static
   void
   wait_for_signal();
 
@@ -158,29 +160,28 @@ private:
    *
    * This is thread-safe.
    */
-  static
   void
   notify_signal_handler() noexcept;
 
   // Whether or not a signal has been received.
-  static std::atomic_bool signal_received_;
+  std::atomic_bool signal_received_ = false;
   // A thread to which singal handling tasks are deferred.
   std::thread signal_handler_thread_;
 
   // A mutex used to synchronize the install() and uninstall() methods.
   std::mutex install_mutex_;
   // Whether or not the signal handler has been installed.
-  std::atomic_bool installed_{false};
+  std::atomic_bool installed_ = false;
 
   // Whether or not the semaphore for wait_for_signal is setup.
-  static std::atomic_bool wait_for_signal_is_setup_;
+  std::atomic_bool wait_for_signal_is_setup_;
   // Storage for the wait_for_signal semaphore.
 #if defined(_WIN32)
-  static HANDLE signal_handler_sem_;
+  HANDLE signal_handler_sem_;
 #elif defined(__APPLE__)
-  static dispatch_semaphore_t signal_handler_sem_;
+  dispatch_semaphore_t signal_handler_sem_;
 #else  // posix
-  static sem_t signal_handler_sem_;
+  sem_t signal_handler_sem_;
 #endif
 };
 

--- a/rclcpp/src/rclcpp/signal_handler.hpp
+++ b/rclcpp/src/rclcpp/signal_handler.hpp
@@ -39,6 +39,60 @@
 namespace rclcpp
 {
 
+// forward declare
+class SignalHandler;
+
+namespace detail
+{
+/// Handles one signal, e.g. sigint or sigterm.
+class OneSignalHandler final
+{
+  friend ::rclcpp::SignalHandler;
+
+public:
+  /// Signal handler type, platform dependent.
+#if defined(RCLCPP_HAS_SIGACTION)
+  using signal_handler_type = struct sigaction;
+#else
+  using signal_handler_type = void (*)(int);
+#endif
+
+private:
+  /// Construct signal handler for `signum` signal.
+  explicit OneSignalHandler(int signum);
+
+  /// Destruct.
+  ~OneSignalHandler();
+
+  /// Install the specified signal handler, return true if successful.
+  bool
+  install(const signal_handler_type & signal_handler);
+
+  bool
+  /// Uninstall the specified signal handler and reinstall the old one, return true if successful.
+  uninstall();
+
+  /// Deleted copy constructor.
+  OneSignalHandler(const OneSignalHandler &) = delete;
+  /// Deleted move constructor.
+  OneSignalHandler(OneSignalHandler &&) = delete;
+  /// Deleted copy assignment.
+  OneSignalHandler &
+  operator=(const OneSignalHandler &) = delete;
+  /// Deleted move assignment.
+  OneSignalHandler &
+  operator=(OneSignalHandler &&) = delete;
+
+  /// signal number
+  int signum_;
+  /// true if a signal handler was already installed
+  bool installed_;
+  /// POSIX signal handler structure storage for the existing signal handler.
+  signal_handler_type old_signal_handler_;
+};
+}  // namespace detail
+
+
 /// Responsible for manaaging the SIGINT signal handling.
 /**
  * This class is responsible for:
@@ -95,32 +149,30 @@ private:
   SignalHandler &&
   operator=(SignalHandler &&) = delete;
 
-#if defined(RCLCPP_HAS_SIGACTION)
-  using signal_handler_type = struct sigaction;
-#else
-  using signal_handler_type = void (*)(int);
-#endif
-  // POSIX signal handler structure storage for the existing signal handler.
-  SignalHandler::signal_handler_type old_signal_handler_;
-
-  /// Set the signal handler function.
-  SignalHandler::signal_handler_type
-  set_signal_handler(int signal_value, const SignalHandler::signal_handler_type & signal_handler);
-
   /// Common signal handler code between sigaction and non-sigaction versions.
   void
   signal_handler_common();
 
 #if defined(RCLCPP_HAS_SIGACTION)
-  /// Signal handler function.
+  /// Signal handler function for SIGINT.
   static
   void
-  signal_handler(int signal_value, siginfo_t * siginfo, void * context);
+  signal_handler_sigint(int signal_value, siginfo_t * siginfo, void * context);
+
+  /// Signal handler function for SIGTERM.
+  static
+  void
+  signal_handler_sigterm(int signal_value, siginfo_t * siginfo, void * context);
 #else
-  /// Signal handler function.
+  /// Signal handler function for SIGINT.
   static
   void
-  signal_handler(int signal_value);
+  signal_handler_sigint(int signal_value);
+
+  /// Signal handler function for SIGTERM.
+  static
+  void
+  signal_handler_sigterm(int signal_value);
 #endif
 
   /// Target of the dedicated signal handling thread.
@@ -162,6 +214,17 @@ private:
    */
   void
   notify_signal_handler() noexcept;
+
+  using OneSignalHandler = detail::OneSignalHandler;
+
+  OneSignalHandler::signal_handler_type
+  get_sigint_old_handler();
+
+  OneSignalHandler::signal_handler_type
+  get_sigterm_old_handler();
+
+  OneSignalHandler sigint_handler_ = OneSignalHandler{SIGINT};
+  OneSignalHandler sigterm_handler_ = OneSignalHandler{SIGTERM};
 
   // logger instance
   rclcpp::Logger logger_ = rclcpp::get_logger("rclcpp");

--- a/rclcpp/src/rclcpp/signal_handler.hpp
+++ b/rclcpp/src/rclcpp/signal_handler.hpp
@@ -163,6 +163,9 @@ private:
   void
   notify_signal_handler() noexcept;
 
+  // logger instance
+  rclcpp::Logger logger_ = rclcpp::get_logger("rclcpp");
+
   // Whether or not a signal has been received.
   std::atomic_bool signal_received_ = false;
   // A thread to which singal handling tasks are deferred.


### PR DESCRIPTION
Fixes https://github.com/ros2/rclcpp/issues/1704.

Done:
- Cleanup previous code.
- Refactor code to be able to handle more than one signal type.
  This could be improved though, maybe storing a map from signal numbers to old signal handlers and using the same handler for all signals (?).
- Handle sigterm.

TODO:

- [ ] Add option, so users can decide if the want to install the rclcpp default sigint handler, sigterm handler, or both.
  Currently it's only possible to install both or nothing.
- [ ] Discuss what's the desired default: installing only a sigint handler (previous behavior), or both sigint and sigterm (current behavior of this PR).