### PR TITLE
Support a bunch of SingleThreadedExecutor for component nodes

### DIFF
--- a/rclcpp_components/include/rclcpp_components/component_manager.hpp
+++ b/rclcpp_components/include/rclcpp_components/component_manager.hpp
@@ -93,13 +93,11 @@ public:
    * Initializes the component manager. It creates the services: load node, unload node
    * and list nodes.
    *
-   * \param executor the executor which will spin the node.
    * \param node_name the name of the node that the data originates from.
    * \param node_options additional options to control creation of the node.
    */
   RCLCPP_COMPONENTS_PUBLIC
   ComponentManager(
-    std::weak_ptr<rclcpp::Executor> executor,
     std::string node_name = "ComponentManager",
     const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions()
     .start_parameter_services(false)
@@ -232,7 +230,14 @@ protected:
   }
 
 private:
-  std::weak_ptr<rclcpp::Executor> executor_;
+  bool use_multi_threads_{false};
+  bool use_multi_executors_{false};
+  // used by single executor mode
+  std::shared_ptr<rclcpp::Executor> executor_;
+  std::shared_ptr<std::thread> executor_thread_;
+  // used by multi executor mode (one executor for each node)
+  std::map<uint64_t, std::shared_ptr<rclcpp::Executor>> executors_;
+  std::map<uint64_t, std::shared_ptr<std::thread>> executor_threads_;
 
   uint64_t unique_id_ {1};
   std::map<std::string, std::unique_ptr<class_loader::ClassLoader>> loaders_;

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -23,7 +23,7 @@ int main(int argc, char * argv[])
   /// Component container with a single-threaded executor.
   rclcpp::init(argc, argv);
   auto exec = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-  auto node = std::make_shared<rclcpp_components::ComponentManager>(exec);
+  auto node = std::make_shared<rclcpp_components::ComponentManager>();
   exec->add_node(node);
   exec->spin();
 }

--- a/rclcpp_components/src/component_container_mt.cpp
+++ b/rclcpp_components/src/component_container_mt.cpp
@@ -22,8 +22,12 @@ int main(int argc, char * argv[])
 {
   /// Component container with a multi-threaded executor.
   rclcpp::init(argc, argv);
-  auto exec = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
-  auto node = std::make_shared<rclcpp_components::ComponentManager>(exec);
+  auto exec = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+  auto options = rclcpp::NodeOptions()
+    .start_parameter_services(false)
+    .start_parameter_event_publisher(false);
+  options.append_parameter_override("use_multi_threads", true);
+  auto node = std::make_shared<rclcpp_components::ComponentManager>("ComponentManager", options);
   exec->add_node(node);
   exec->spin();
 }

--- a/rclcpp_components/test/benchmark/benchmark_components.cpp
+++ b/rclcpp_components/test/benchmark/benchmark_components.cpp
@@ -47,7 +47,7 @@ public:
     executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>(exec_options);
 
     manager = std::make_shared<rclcpp_components::ComponentManager>(
-      executor, component_manager_name, rclcpp::NodeOptions().context(context));
+      component_manager_name, rclcpp::NodeOptions().context(context));
     executor->add_node(manager);
   }
 

--- a/rclcpp_components/test/test_component_manager.cpp
+++ b/rclcpp_components/test/test_component_manager.cpp
@@ -32,7 +32,7 @@ protected:
 TEST_F(TestComponentManager, get_component_resources_invalid)
 {
   auto exec = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-  auto manager = std::make_shared<rclcpp_components::ComponentManager>(exec);
+  auto manager = std::make_shared<rclcpp_components::ComponentManager>();
 
   EXPECT_THROW(
     manager->get_component_resources("invalid_package"),
@@ -42,7 +42,7 @@ TEST_F(TestComponentManager, get_component_resources_invalid)
 TEST_F(TestComponentManager, get_component_resources_valid)
 {
   auto exec = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-  auto manager = std::make_shared<rclcpp_components::ComponentManager>(exec);
+  auto manager = std::make_shared<rclcpp_components::ComponentManager>();
 
   auto resources = manager->get_component_resources("rclcpp_components");
   EXPECT_EQ(3u, resources.size());
@@ -60,7 +60,7 @@ TEST_F(TestComponentManager, get_component_resources_valid)
 TEST_F(TestComponentManager, create_component_factory_valid)
 {
   auto exec = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-  auto manager = std::make_shared<rclcpp_components::ComponentManager>(exec);
+  auto manager = std::make_shared<rclcpp_components::ComponentManager>();
 
   auto resources = manager->get_component_resources("rclcpp_components");
   EXPECT_EQ(3u, resources.size());
@@ -78,7 +78,7 @@ TEST_F(TestComponentManager, create_component_factory_valid)
 TEST_F(TestComponentManager, create_component_factory_invalid)
 {
   auto exec = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-  auto manager = std::make_shared<rclcpp_components::ComponentManager>(exec);
+  auto manager = std::make_shared<rclcpp_components::ComponentManager>();
 
   // Test invalid library
   EXPECT_THROW(

--- a/rclcpp_components/test/test_component_manager_api.cpp
+++ b/rclcpp_components/test/test_component_manager_api.cpp
@@ -40,7 +40,7 @@ TEST_F(TestComponentManager, components_api)
 {
   auto exec = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
   auto node = rclcpp::Node::make_shared("test_component_manager");
-  auto manager = std::make_shared<rclcpp_components::ComponentManager>(exec);
+  auto manager = std::make_shared<rclcpp_components::ComponentManager>();
 
   exec->add_node(manager);
   exec->add_node(node);


### PR DESCRIPTION
Signed-off-by: zhenpeng ge <zhenpeng.ge@qq.com>

related to https://github.com/ros2/rclcpp/issues/1772. make `component_container` more flexible.

With these changes, we could choose `SingleThreadedExecutor`,  `MultiThreadedExecutor`, or a bunch of `SingleThreadedExecutor` to spin component nodes by setting parameters (`use_multi_executors` and `use_multi_threads`) for `component_container` .

in addition, `component_container_mt` should be deprecated in the future.