### PR TITLE
add use_global_arguments for node options of component nodes

### DIFF
--- a/rclcpp_components/src/component_manager.cpp
+++ b/rclcpp_components/src/component_manager.cpp
@@ -160,6 +160,18 @@ ComponentManager::create_node_options(const std::shared_ptr<LoadNode::Request> r
                 "Extra component argument 'use_intra_process_comms' must be a boolean");
       }
       options.use_intra_process_comms(extra_argument.get_value<bool>());
+    } else if (extra_argument.get_name() == "use_global_arguments") {
+      if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
+        throw ComponentManagerException(
+                "Extra component argument 'use_global_arguments' must be a boolean");
+      }
+      options.use_global_arguments(extra_argument.get_value<bool>());
+      if (extra_argument.get_value<bool>()) {
+        RCLCPP_WARN(
+          get_logger(), "use_global_arguments is true by default in nodes, but is not "
+          "recommended in a component manager. If true, this will cause this node's behavior "
+          "to be influenced by global arguments, not only those targeted at this node.");
+      }
     }
   }
 

--- a/rclcpp_components/src/component_manager.cpp
+++ b/rclcpp_components/src/component_manager.cpp
@@ -160,15 +160,15 @@ ComponentManager::create_node_options(const std::shared_ptr<LoadNode::Request> r
                 "Extra component argument 'use_intra_process_comms' must be a boolean");
       }
       options.use_intra_process_comms(extra_argument.get_value<bool>());
-    } else if (extra_argument.get_name() == "use_global_arguments") {
+    } else if (extra_argument.get_name() == "forward_global_arguments") {
       if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
         throw ComponentManagerException(
-                "Extra component argument 'use_global_arguments' must be a boolean");
+                "Extra component argument 'forward_global_arguments' must be a boolean");
       }
       options.use_global_arguments(extra_argument.get_value<bool>());
       if (extra_argument.get_value<bool>()) {
         RCLCPP_WARN(
-          get_logger(), "use_global_arguments is true by default in nodes, but is not "
+          get_logger(), "forward_global_arguments is true by default in nodes, but is not "
           "recommended in a component manager. If true, this will cause this node's behavior "
           "to be influenced by global arguments, not only those targeted at this node.");
       }

--- a/rclcpp_components/test/test_component_manager_api.cpp
+++ b/rclcpp_components/test/test_component_manager_api.cpp
@@ -211,6 +211,50 @@ TEST_F(TestComponentManager, components_api)
     EXPECT_EQ(result->unique_id, 0u);
   }
 
+  {
+    // use_global_arguments
+    auto request = std::make_shared<composition_interfaces::srv::LoadNode::Request>();
+    request->package_name = "rclcpp_components";
+    request->plugin_name = "test_rclcpp_components::TestComponentFoo";
+    request->node_name = "test_component_global_arguments";
+    rclcpp::Parameter use_global_arguments("use_global_arguments",
+      rclcpp::ParameterValue(true));
+    request->extra_arguments.push_back(use_global_arguments.to_parameter_msg());
+
+    auto future = composition_client->async_send_request(request);
+    auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
+    auto result = future.get();
+    EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
+    EXPECT_EQ(result->success, true);
+    EXPECT_EQ(result->error_message, "");
+    std::cout << result->full_node_name << std::endl;
+    EXPECT_EQ(result->full_node_name, "/test_component_global_arguments");
+    EXPECT_EQ(result->unique_id, 7u);
+  }
+
+  {
+    // use_global_arguments is not a bool type parameter
+    auto request = std::make_shared<composition_interfaces::srv::LoadNode::Request>();
+    request->package_name = "rclcpp_components";
+    request->plugin_name = "test_rclcpp_components::TestComponentFoo";
+    request->node_name = "test_component_global_arguments_str";
+
+    rclcpp::Parameter use_global_arguments("use_global_arguments",
+      rclcpp::ParameterValue("hello"));
+    request->extra_arguments.push_back(use_global_arguments.to_parameter_msg());
+
+    auto future = composition_client->async_send_request(request);
+    auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
+    auto result = future.get();
+    EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
+    EXPECT_EQ(result->success, false);
+    EXPECT_EQ(
+      result->error_message,
+      "Extra component argument 'use_global_arguments' must be a boolean");
+    EXPECT_EQ(result->full_node_name, "");
+    EXPECT_EQ(result->unique_id, 0u);
+  }
+
   auto node_names = node->get_node_names();
 
   auto find_in_nodes = [node_names](std::string name) {
@@ -239,20 +283,22 @@ TEST_F(TestComponentManager, components_api)
       auto result_node_names = result->full_node_names;
       auto result_unique_ids = result->unique_ids;
 
-      EXPECT_EQ(result_node_names.size(), 6u);
+      EXPECT_EQ(result_node_names.size(), 7u);
       EXPECT_EQ(result_node_names[0], "/test_component_foo");
       EXPECT_EQ(result_node_names[1], "/test_component_bar");
       EXPECT_EQ(result_node_names[2], "/test_component_baz");
       EXPECT_EQ(result_node_names[3], "/ns/test_component_bing");
       EXPECT_EQ(result_node_names[4], "/test_component_remap");
       EXPECT_EQ(result_node_names[5], "/test_component_intra_process");
-      EXPECT_EQ(result_unique_ids.size(), 6u);
+      EXPECT_EQ(result_node_names[6], "/test_component_global_arguments");
+      EXPECT_EQ(result_unique_ids.size(), 7u);
       EXPECT_EQ(result_unique_ids[0], 1u);
       EXPECT_EQ(result_unique_ids[1], 2u);
       EXPECT_EQ(result_unique_ids[2], 3u);
       EXPECT_EQ(result_unique_ids[3], 4u);
       EXPECT_EQ(result_unique_ids[4], 5u);
       EXPECT_EQ(result_unique_ids[5], 6u);
+      EXPECT_EQ(result_unique_ids[6], 7u);
     }
   }
 
@@ -306,18 +352,20 @@ TEST_F(TestComponentManager, components_api)
       auto result_node_names = result->full_node_names;
       auto result_unique_ids = result->unique_ids;
 
-      EXPECT_EQ(result_node_names.size(), 5u);
+      EXPECT_EQ(result_node_names.size(), 6u);
       EXPECT_EQ(result_node_names[0], "/test_component_bar");
       EXPECT_EQ(result_node_names[1], "/test_component_baz");
       EXPECT_EQ(result_node_names[2], "/ns/test_component_bing");
       EXPECT_EQ(result_node_names[3], "/test_component_remap");
       EXPECT_EQ(result_node_names[4], "/test_component_intra_process");
-      EXPECT_EQ(result_unique_ids.size(), 5u);
+      EXPECT_EQ(result_node_names[5], "/test_component_global_arguments");
+      EXPECT_EQ(result_unique_ids.size(), 6u);
       EXPECT_EQ(result_unique_ids[0], 2u);
       EXPECT_EQ(result_unique_ids[1], 3u);
       EXPECT_EQ(result_unique_ids[2], 4u);
       EXPECT_EQ(result_unique_ids[3], 5u);
       EXPECT_EQ(result_unique_ids[4], 6u);
+      EXPECT_EQ(result_unique_ids[5], 7u);
     }
   }
 }

--- a/rclcpp_components/test/test_component_manager_api.cpp
+++ b/rclcpp_components/test/test_component_manager_api.cpp
@@ -212,14 +212,14 @@ TEST_F(TestComponentManager, components_api)
   }
 
   {
-    // use_global_arguments
+    // forward_global_arguments
     auto request = std::make_shared<composition_interfaces::srv::LoadNode::Request>();
     request->package_name = "rclcpp_components";
     request->plugin_name = "test_rclcpp_components::TestComponentFoo";
     request->node_name = "test_component_global_arguments";
-    rclcpp::Parameter use_global_arguments("use_global_arguments",
+    rclcpp::Parameter forward_global_arguments("forward_global_arguments",
       rclcpp::ParameterValue(true));
-    request->extra_arguments.push_back(use_global_arguments.to_parameter_msg());
+    request->extra_arguments.push_back(forward_global_arguments.to_parameter_msg());
 
     auto future = composition_client->async_send_request(request);
     auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
@@ -227,21 +227,20 @@ TEST_F(TestComponentManager, components_api)
     EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
     EXPECT_EQ(result->success, true);
     EXPECT_EQ(result->error_message, "");
-    std::cout << result->full_node_name << std::endl;
     EXPECT_EQ(result->full_node_name, "/test_component_global_arguments");
     EXPECT_EQ(result->unique_id, 7u);
   }
 
   {
-    // use_global_arguments is not a bool type parameter
+    // forward_global_arguments is not a bool type parameter
     auto request = std::make_shared<composition_interfaces::srv::LoadNode::Request>();
     request->package_name = "rclcpp_components";
     request->plugin_name = "test_rclcpp_components::TestComponentFoo";
     request->node_name = "test_component_global_arguments_str";
 
-    rclcpp::Parameter use_global_arguments("use_global_arguments",
+    rclcpp::Parameter forward_global_arguments("forward_global_arguments",
       rclcpp::ParameterValue("hello"));
-    request->extra_arguments.push_back(use_global_arguments.to_parameter_msg());
+    request->extra_arguments.push_back(forward_global_arguments.to_parameter_msg());
 
     auto future = composition_client->async_send_request(request);
     auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
@@ -250,7 +249,7 @@ TEST_F(TestComponentManager, components_api)
     EXPECT_EQ(result->success, false);
     EXPECT_EQ(
       result->error_message,
-      "Extra component argument 'use_global_arguments' must be a boolean");
+      "Extra component argument 'forward_global_arguments' must be a boolean");
     EXPECT_EQ(result->full_node_name, "");
     EXPECT_EQ(result->unique_id, 0u);
   }


### PR DESCRIPTION
Signed-off-by: zhenpeng ge <zhenpeng.ge@qq.com>

related to https://github.com/ros2/rclcpp/issues/978#. 

i'm trying to implement composed bringup for Nav2, but it can't work as expected. the reason is that internal nodes (like `local_costmap`, `global_costmap`) in Nav2 couldn't  load parameters from param's file(`use_global_arguments` is setting `false`) https://github.com/ros2/rclcpp/blob/f30329fbec79cb699f41a37cc27c0c475de3edc1/rclcpp_components/src/component_manager.cpp#L164

according to @wjwwood opinion( https://github.com/ros2/rclcpp/issues/978#issuecomment-593718794 ),    `allow_undeclared_parameters` and `use_global_arguments` shouldn't be a parameter,  but the `use_global_arguments`  does have a legitimate use case here (for Nav2), and i think it's useful when we have a large params file to configure all nodes (or component nodes).

`use_global_arguments = true` is default behavior for all other situations so its strange that we cannot set it to true at all due to "its generally bad" advise for the component container. It creates a situations where component container nodes have a different behavior from everywhere else and it silently fails if a user is clever enough to know that that is the problem. 

I still offer a warning to tell people not to do it but gives the flexibility to get the behavior that is expected every where else from the component container if explicitly called out in the extra parameters.

some extra details here: https://github.com/ros2/rclcpp/issues/978#issuecomment-920398249