### PR TITLE
Set parameters from inside callbacks 

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -929,7 +929,7 @@ public:
   RCLCPP_PUBLIC
   RCUTILS_WARN_UNUSED
   OnSetParametersCallbackHandle::SharedPtr
-  add_on_set_parameters_callback(OnParametersSetCallbackType callback);
+  add_on_set_parameters_callback(OnParametersSetCallbackType callback, bool allowRecursion = false);
 
   /// Remove a callback registered with `add_on_set_parameters_callback`.
   /**

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
@@ -39,6 +39,8 @@
 #include "rclcpp/publisher.hpp"
 #include "rclcpp/visibility_control.hpp"
 
+#include <iostream>
+
 namespace rclcpp
 {
 namespace node_interfaces
@@ -61,6 +63,7 @@ public:
   explicit ParameterMutationRecursionGuard(bool & allow_mod)
   : allow_modification_(allow_mod)
   {
+    std::cout << "Locking mutation guard" << std::endl;
     if (!allow_modification_) {
       throw rclcpp::exceptions::ParameterModifiedInCallbackException(
               "cannot set or declare a parameter, or change the callback from within set callback");
@@ -71,6 +74,7 @@ public:
 
   ~ParameterMutationRecursionGuard()
   {
+    std::cout << "Unlocking mutation guard" << std::endl;
     allow_modification_ = true;
   }
 
@@ -193,7 +197,7 @@ public:
   RCLCPP_PUBLIC
   RCUTILS_WARN_UNUSED
   OnSetParametersCallbackHandle::SharedPtr
-  add_on_set_parameters_callback(OnParametersSetCallbackType callback) override;
+  add_on_set_parameters_callback(OnParametersSetCallbackType callback, bool allowRecursion) override;
 
   RCLCPP_PUBLIC
   void
@@ -218,6 +222,8 @@ private:
   OnParametersSetCallbackType on_parameters_set_callback_ = nullptr;
 
   CallbacksContainerType on_parameters_set_callback_container_;
+
+  CallbacksContainerType on_parameters_set_callback_container_recursive_;
 
   std::map<std::string, ParameterInfo> parameters_;
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -214,7 +214,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   OnSetParametersCallbackHandle::SharedPtr
-  add_on_set_parameters_callback(OnParametersSetCallbackType callback) = 0;
+  add_on_set_parameters_callback(OnParametersSetCallbackType callback, bool allowRecursion) = 0;
 
   /// Remove a callback registered with `add_on_set_parameters_callback`.
   /**

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -435,9 +435,9 @@ Node::list_parameters(const std::vector<std::string> & prefixes, uint64_t depth)
 }
 
 rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr
-Node::add_on_set_parameters_callback(OnParametersSetCallbackType callback)
+Node::add_on_set_parameters_callback(OnParametersSetCallbackType callback, bool allowRecursion)
 {
-  return node_parameters_->add_on_set_parameters_callback(callback);
+  return node_parameters_->add_on_set_parameters_callback(callback, allowRecursion);
 }
 
 void

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -124,7 +124,8 @@ void TimeSource::attachNode(
         }
       }
       return result;
-    });
+    },
+    false);
 
   // TODO(tfoote) use parameters interface not subscribe to events via topic ticketed #609
   parameter_subscription_ = rclcpp::AsyncParametersClient::on_parameter_event(

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_parameters.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_parameters.cpp
@@ -187,7 +187,7 @@ TEST_F(TestNodeParameters, add_remove_parameters_callback) {
       return result;
     };
 
-  auto handle = node_parameters->add_on_set_parameters_callback(callback);
+  auto handle = node_parameters->add_on_set_parameters_callback(callback, false);
   auto result = node_parameters->set_parameters(parameters);
   ASSERT_EQ(1u, result.size());
   EXPECT_FALSE(result[0].successful);

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -537,7 +537,7 @@ public:
   RCUTILS_WARN_UNUSED
   rclcpp_lifecycle::LifecycleNode::OnSetParametersCallbackHandle::SharedPtr
   add_on_set_parameters_callback(
-    rclcpp_lifecycle::LifecycleNode::OnParametersSetCallbackType callback);
+    rclcpp_lifecycle::LifecycleNode::OnParametersSetCallbackType callback, bool allowRecursion = false);
 
   /// Remove a callback registered with `add_on_set_parameters_callback`.
   /**

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -302,9 +302,9 @@ LifecycleNode::list_parameters(
 }
 
 rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr
-LifecycleNode::add_on_set_parameters_callback(OnParametersSetCallbackType callback)
+LifecycleNode::add_on_set_parameters_callback(OnParametersSetCallbackType callback, bool allowRecursion)
 {
-  return node_parameters_->add_on_set_parameters_callback(callback);
+  return node_parameters_->add_on_set_parameters_callback(callback, allowRecursion);
 }
 
 void


### PR DESCRIPTION
This PR aims to add a way to set parameters from inside another parameter's callback. 

## Current approach : 
* Maintain a separate vector container for callbacks passed using the ``allowRecursion`` boolean flag to ``add_on_set_parameters`` method.
* Maintain a loop counter and a context tracker to allow only recursive container callbacks to be called when ``set_parameters_atomically`` is called from inside another parameter's callback.

## TODO for current approach : 
* Manage loop counter and recursive access to ``add_on_set_parameters``, ``remove_on_set_parameters``, ``undeclare_parameters``
* Clean up code, remove debug prints

## Concerns
* Complicated locking and overall approach 
* Thread safety
* Order in which callbacks are run can be difficult to understand for the user, which may lead to unexpected behavior of parameter actions

## Suggested alternatives
* Have a new action called ``update_parameters`` which would update the parameters without triggering their callbacks. This would not solve the overall problem exactly, but would be much simpler to debug and understand.
* Maybe have this action inside ``get_parameters`` ?

## Original model :

![image](https://user-images.githubusercontent.com/18661155/135154602-c60d9e92-b893-4b73-8ec8-0fa46bb78b03.png)

## Current approach : 

![image](https://user-images.githubusercontent.com/18661155/135154731-6714110e-fe44-48e7-9011-d7a89fceaf2c.png)
