### PR TITLE
Fix unused QoS profile for clock subscription and make ClockQoS the default

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/node_time_source.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_time_source.hpp
@@ -48,7 +48,7 @@ public:
     rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
     rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock,
     rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
-    const rclcpp::QoS & qos = rclcpp::RosoutQoS(),
+    const rclcpp::QoS & qos = rclcpp::ClockQoS(),
     bool use_clock_thread = true
   );
 

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -420,7 +420,7 @@ private:
       node_parameters_,
       node_topics_,
       "/clock",
-      rclcpp::QoS(KeepLast(1)).best_effort(),
+      qos_,
       [state = std::weak_ptr<NodeState>(this->shared_from_this())](
         std::shared_ptr<const rosgraph_msgs::msg::Clock> msg) {
         if (auto state_ptr = state.lock()) {


### PR DESCRIPTION
This is a followup to the discussion in https://github.com/ros2/rclcpp/pull/1375.