### PR TITLE
Suppress clang dead-store warnings in the benchmarks.

### DIFF
--- a/rclcpp/test/benchmark/benchmark_client.cpp
+++ b/rclcpp/test/benchmark/benchmark_client.cpp
@@ -62,6 +62,7 @@ BENCHMARK_F(ClientPerformanceTest, construct_client_no_service)(benchmark::State
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     auto client = node->create_client<test_msgs::srv::Empty>("not_an_existing_service");
     benchmark::DoNotOptimize(client);
     benchmark::ClobberMemory();
@@ -79,6 +80,7 @@ BENCHMARK_F(ClientPerformanceTest, construct_client_empty_srv)(benchmark::State 
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     auto client = node->create_client<test_msgs::srv::Empty>(empty_service_name);
     benchmark::DoNotOptimize(client);
     benchmark::ClobberMemory();
@@ -96,6 +98,7 @@ BENCHMARK_F(ClientPerformanceTest, destroy_client_empty_srv)(benchmark::State & 
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     state.PauseTiming();
     auto client = node->create_client<test_msgs::srv::Empty>(empty_service_name);
     state.ResumeTiming();
@@ -109,6 +112,7 @@ BENCHMARK_F(ClientPerformanceTest, destroy_client_empty_srv)(benchmark::State & 
 BENCHMARK_F(ClientPerformanceTest, wait_for_service)(benchmark::State & state) {
   int count = 0;
   for (auto _ : state) {
+    (void)_;
     state.PauseTiming();
     const std::string service_name = std::string("service_") + std::to_string(count++);
     // Create client before service so it has to 'discover' the service after construction
@@ -132,6 +136,7 @@ BENCHMARK_F(ClientPerformanceTest, async_send_request_only)(benchmark::State & s
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     auto future = client->async_send_request(shared_request);
     benchmark::DoNotOptimize(future);
     benchmark::ClobberMemory();
@@ -144,6 +149,7 @@ BENCHMARK_F(ClientPerformanceTest, async_send_request_and_response)(benchmark::S
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     auto future = client->async_send_request(shared_request);
     rclcpp::spin_until_future_complete(
       node->get_node_base_interface(), future, std::chrono::seconds(1));

--- a/rclcpp/test/benchmark/benchmark_executor.cpp
+++ b/rclcpp/test/benchmark/benchmark_executor.cpp
@@ -78,6 +78,7 @@ BENCHMARK_F(PerformanceTestExecutor, single_thread_executor_spin_some)(benchmark
   reset_heap_counters();
 
   for (auto _ : st) {
+    (void)_;
     st.PauseTiming();
     for (unsigned int i = 0u; i < kNumberOfNodes; i++) {
       publishers[i]->publish(empty_msgs);
@@ -104,6 +105,7 @@ BENCHMARK_F(PerformanceTestExecutor, multi_thread_executor_spin_some)(benchmark:
   reset_heap_counters();
 
   for (auto _ : st) {
+    (void)_;
     st.PauseTiming();
     for (unsigned int i = 0u; i < kNumberOfNodes; i++) {
       publishers[i]->publish(empty_msgs);
@@ -142,6 +144,7 @@ BENCHMARK_F(PerformanceTestExecutorSimple, single_thread_executor_add_node)(benc
 {
   rclcpp::executors::SingleThreadedExecutor executor;
   for (auto _ : st) {
+    (void)_;
     executor.add_node(node);
     st.PauseTiming();
     executor.remove_node(node);
@@ -154,6 +157,7 @@ BENCHMARK_F(
 {
   rclcpp::executors::SingleThreadedExecutor executor;
   for (auto _ : st) {
+    (void)_;
     st.PauseTiming();
     executor.add_node(node);
     st.ResumeTiming();
@@ -165,6 +169,7 @@ BENCHMARK_F(PerformanceTestExecutorSimple, multi_thread_executor_add_node)(bench
 {
   rclcpp::executors::MultiThreadedExecutor executor;
   for (auto _ : st) {
+    (void)_;
     executor.add_node(node);
     st.PauseTiming();
     executor.remove_node(node);
@@ -176,6 +181,7 @@ BENCHMARK_F(PerformanceTestExecutorSimple, multi_thread_executor_remove_node)(be
 {
   rclcpp::executors::MultiThreadedExecutor executor;
   for (auto _ : st) {
+    (void)_;
     st.PauseTiming();
     executor.add_node(node);
     st.ResumeTiming();
@@ -189,6 +195,7 @@ BENCHMARK_F(
 {
   rclcpp::executors::StaticSingleThreadedExecutor executor;
   for (auto _ : st) {
+    (void)_;
     executor.add_node(node);
     st.PauseTiming();
     executor.remove_node(node);
@@ -202,6 +209,7 @@ BENCHMARK_F(
 {
   rclcpp::executors::StaticSingleThreadedExecutor executor;
   for (auto _ : st) {
+    (void)_;
     st.PauseTiming();
     executor.add_node(node);
     st.ResumeTiming();
@@ -228,6 +236,7 @@ BENCHMARK_F(
   reset_heap_counters();
 
   for (auto _ : st) {
+    (void)_;
     // static_single_thread_executor has a special design. We need to add/remove the node each
     // time you call spin
     st.PauseTiming();
@@ -265,6 +274,7 @@ BENCHMARK_F(
   reset_heap_counters();
 
   for (auto _ : st) {
+    (void)_;
     ret = rclcpp::executors::spin_node_until_future_complete(
       executor, node, shared_future, 1s);
     if (ret != rclcpp::FutureReturnCode::SUCCESS) {
@@ -294,6 +304,7 @@ BENCHMARK_F(
   reset_heap_counters();
 
   for (auto _ : st) {
+    (void)_;
     ret = rclcpp::executors::spin_node_until_future_complete(
       executor, node, shared_future, 1s);
     if (ret != rclcpp::FutureReturnCode::SUCCESS) {
@@ -317,6 +328,7 @@ BENCHMARK_F(
   reset_heap_counters();
 
   for (auto _ : st) {
+    (void)_;
     auto ret = rclcpp::executors::spin_node_until_future_complete(
       executor, node, shared_future, 1s);
     if (ret != rclcpp::FutureReturnCode::SUCCESS) {
@@ -342,6 +354,7 @@ BENCHMARK_F(PerformanceTestExecutorSimple, spin_until_future_complete)(benchmark
   reset_heap_counters();
 
   for (auto _ : st) {
+    (void)_;
     ret = rclcpp::spin_until_future_complete(node, shared_future, 1s);
     if (ret != rclcpp::FutureReturnCode::SUCCESS) {
       st.SkipWithError(rcutils_get_error_string().str);
@@ -383,6 +396,7 @@ BENCHMARK_F(
   reset_heap_counters();
 
   for (auto _ : st) {
+    (void)_;
     std::shared_ptr<void> data = entities_collector_->take_data();
     entities_collector_->execute(data);
   }

--- a/rclcpp/test/benchmark/benchmark_init_shutdown.cpp
+++ b/rclcpp/test/benchmark/benchmark_init_shutdown.cpp
@@ -26,6 +26,7 @@ BENCHMARK_F(PerformanceTest, rclcpp_init)(benchmark::State & state)
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     rclcpp::init(0, nullptr);
 
     state.PauseTiming();
@@ -43,6 +44,7 @@ BENCHMARK_F(PerformanceTest, rclcpp_shutdown)(benchmark::State & state)
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     state.PauseTiming();
     rclcpp::init(0, nullptr);
     state.ResumeTiming();

--- a/rclcpp/test/benchmark/benchmark_node.cpp
+++ b/rclcpp/test/benchmark/benchmark_node.cpp
@@ -44,6 +44,7 @@ BENCHMARK_F(NodePerformanceTest, create_node)(benchmark::State & state)
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     // Using pointer to separate construction and destruction in timing
     auto node = std::make_shared<rclcpp::Node>("node");
 #ifndef __clang_analyzer__
@@ -66,6 +67,7 @@ BENCHMARK_F(NodePerformanceTest, destroy_node)(benchmark::State & state)
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     // Using pointer to separate construction and destruction in timing
     state.PauseTiming();
     auto node = std::make_shared<rclcpp::Node>("node");

--- a/rclcpp/test/benchmark/benchmark_node_parameters_interface.cpp
+++ b/rclcpp/test/benchmark/benchmark_node_parameters_interface.cpp
@@ -71,6 +71,7 @@ protected:
 BENCHMARK_F(NodeParametersInterfaceTest, declare_undeclare)(benchmark::State & state)
 {
   for (auto _ : state) {
+    (void)_;
     node->declare_parameter(param3_name, rclcpp::ParameterValue{}, dynamically_typed_descriptor);
     node->undeclare_parameter(param3_name);
   }
@@ -79,6 +80,7 @@ BENCHMARK_F(NodeParametersInterfaceTest, declare_undeclare)(benchmark::State & s
 BENCHMARK_F(NodeParametersInterfaceTest, has_parameter_hit)(benchmark::State & state)
 {
   for (auto _ : state) {
+    (void)_;
     if (!node->has_parameter(param1_name)) {
       state.SkipWithError("Parameter was expected");
       break;
@@ -89,6 +91,7 @@ BENCHMARK_F(NodeParametersInterfaceTest, has_parameter_hit)(benchmark::State & s
 BENCHMARK_F(NodeParametersInterfaceTest, has_parameter_miss)(benchmark::State & state)
 {
   for (auto _ : state) {
+    (void)_;
     if (node->has_parameter(param3_name)) {
       state.SkipWithError("Parameter was not expected");
       break;
@@ -112,6 +115,7 @@ BENCHMARK_F(NodeParametersInterfaceTest, set_parameters_bool)(benchmark::State &
   reset_heap_counters();
 
   for (auto _ : state) {
+    (void)_;
     node->set_parameters(param_values2);
     node->set_parameters(param_values1);
   }
@@ -133,6 +137,7 @@ BENCHMARK_F(NodeParametersInterfaceTest, set_parameters_atomically_bool)(benchma
   reset_heap_counters();
 
   for (auto _ : state) {
+    (void)_;
     node->set_parameters_atomically(param_values2);
     node->set_parameters_atomically(param_values1);
   }
@@ -164,6 +169,7 @@ BENCHMARK_F(NodeParametersInterfaceTest, set_parameters_callback_bool)(benchmark
   reset_heap_counters();
 
   for (auto _ : state) {
+    (void)_;
     node->set_parameters(param_values2);
     node->set_parameters(param_values1);
   }
@@ -191,6 +197,7 @@ BENCHMARK_F(NodeParametersInterfaceTest, set_parameters_string)(benchmark::State
   reset_heap_counters();
 
   for (auto _ : state) {
+    (void)_;
     node->set_parameters(param_values2);
     node->set_parameters(param_values1);
   }
@@ -212,6 +219,7 @@ BENCHMARK_F(NodeParametersInterfaceTest, set_parameters_array)(benchmark::State 
   reset_heap_counters();
 
   for (auto _ : state) {
+    (void)_;
     node->set_parameters(param_values2);
     node->set_parameters(param_values1);
   }
@@ -224,6 +232,7 @@ BENCHMARK_F(NodeParametersInterfaceTest, get_parameter)(benchmark::State & state
   reset_heap_counters();
 
   for (auto _ : state) {
+    (void)_;
     node->get_parameter(param1_name, param1_value);
   }
 }
@@ -239,6 +248,7 @@ BENCHMARK_F(NodeParametersInterfaceTest, list_parameters_hit)(benchmark::State &
   reset_heap_counters();
 
   for (auto _ : state) {
+    (void)_;
     param_list = node->list_parameters(prefixes, 10);
     if (param_list.names.size() != 2) {
       state.SkipWithError("Expected node names");
@@ -258,6 +268,7 @@ BENCHMARK_F(NodeParametersInterfaceTest, list_parameters_miss)(benchmark::State 
   reset_heap_counters();
 
   for (auto _ : state) {
+    (void)_;
     param_list = node->list_parameters(prefixes, 10);
     if (param_list.names.size() != 0) {
       state.SkipWithError("Expected no node names");

--- a/rclcpp/test/benchmark/benchmark_parameter_client.cpp
+++ b/rclcpp/test/benchmark/benchmark_parameter_client.cpp
@@ -136,6 +136,7 @@ static bool result_is_successful(rcl_interfaces::msg::SetParametersResult result
 BENCHMARK_F(ParameterClientTest, create_destroy_client)(benchmark::State & state)
 {
   for (auto _ : state) {
+    (void)_;
     params_client.reset();
     params_client = std::make_shared<rclcpp::SyncParametersClient>(node, remote_node_name);
     if (!params_client->wait_for_service()) {
@@ -148,6 +149,7 @@ BENCHMARK_F(ParameterClientTest, create_destroy_client)(benchmark::State & state
 BENCHMARK_F(ParameterClientTest, has_parameter_hit)(benchmark::State & state)
 {
   for (auto _ : state) {
+    (void)_;
     if (!params_client->has_parameter(param1_name)) {
       state.SkipWithError("Parameter was expected");
       break;
@@ -158,6 +160,7 @@ BENCHMARK_F(ParameterClientTest, has_parameter_hit)(benchmark::State & state)
 BENCHMARK_F(ParameterClientTest, has_parameter_miss)(benchmark::State & state)
 {
   for (auto _ : state) {
+    (void)_;
     if (params_client->has_parameter(param3_name)) {
       state.SkipWithError("Parameter was not expected");
       break;
@@ -179,6 +182,7 @@ BENCHMARK_F(ParameterClientTest, set_parameters_bool)(benchmark::State & state)
   };
 
   for (auto _ : state) {
+    (void)_;
     std::vector<rcl_interfaces::msg::SetParametersResult> results =
       params_client->set_parameters(param_values2);
     if (!std::all_of(results.begin(), results.end(), result_is_successful)) {
@@ -208,6 +212,7 @@ BENCHMARK_F(ParameterClientTest, set_parameters_atomically_bool)(benchmark::Stat
   };
 
   for (auto _ : state) {
+    (void)_;
     rcl_interfaces::msg::SetParametersResult result =
       params_client->set_parameters_atomically(param_values2);
     if (!result.successful) {
@@ -237,6 +242,7 @@ BENCHMARK_F(ParameterClientTest, set_parameters_string)(benchmark::State & state
   };
 
   for (auto _ : state) {
+    (void)_;
     std::vector<rcl_interfaces::msg::SetParametersResult> results =
       params_client->set_parameters(param_values2);
     if (!std::all_of(results.begin(), results.end(), result_is_successful)) {
@@ -266,6 +272,7 @@ BENCHMARK_F(ParameterClientTest, set_parameters_array)(benchmark::State & state)
   };
 
   for (auto _ : state) {
+    (void)_;
     std::vector<rcl_interfaces::msg::SetParametersResult> results =
       params_client->set_parameters(param_values2);
     if (!std::all_of(results.begin(), results.end(), result_is_successful)) {
@@ -284,6 +291,7 @@ BENCHMARK_F(ParameterClientTest, set_parameters_array)(benchmark::State & state)
 BENCHMARK_F(ParameterClientTest, get_parameters)(benchmark::State & state)
 {
   for (auto _ : state) {
+    (void)_;
     std::vector<rclcpp::Parameter> results = params_client->get_parameters({param1_name});
     if (results.size() != 1 || results[0].get_name() != param1_name) {
       state.SkipWithError("Got the wrong parameter(s)");
@@ -300,6 +308,7 @@ BENCHMARK_F(ParameterClientTest, list_parameters_hit)(benchmark::State & state)
   };
 
   for (auto _ : state) {
+    (void)_;
     rcl_interfaces::msg::ListParametersResult param_list =
       params_client->list_parameters(prefixes, 10);
     if (param_list.names.size() != 2) {
@@ -317,6 +326,7 @@ BENCHMARK_F(ParameterClientTest, list_parameters_miss)(benchmark::State & state)
   };
 
   for (auto _ : state) {
+    (void)_;
     rcl_interfaces::msg::ListParametersResult param_list =
       params_client->list_parameters(prefixes, 10);
     if (param_list.names.size() != 0) {

--- a/rclcpp/test/benchmark/benchmark_service.cpp
+++ b/rclcpp/test/benchmark/benchmark_service.cpp
@@ -69,6 +69,7 @@ BENCHMARK_F(ServicePerformanceTest, construct_service_no_client)(benchmark::Stat
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     auto service = node->create_service<test_msgs::srv::Empty>("not_a_service", callback);
     benchmark::DoNotOptimize(service);
     benchmark::ClobberMemory();
@@ -87,6 +88,7 @@ BENCHMARK_F(ServicePerformanceTest, construct_service_empty_srv)(benchmark::Stat
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     auto service = node->create_service<test_msgs::srv::Empty>(empty_service_name, callback);
     benchmark::DoNotOptimize(service);
     benchmark::ClobberMemory();
@@ -105,6 +107,7 @@ BENCHMARK_F(ServicePerformanceTest, destroy_service_empty_srv)(benchmark::State 
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     state.PauseTiming();
     auto service = node->create_service<test_msgs::srv::Empty>(empty_service_name, callback);
     state.ResumeTiming();
@@ -123,6 +126,7 @@ BENCHMARK_F(ServicePerformanceTest, async_send_response)(benchmark::State & stat
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     state.PauseTiming();
     // Clear executor queue
     rclcpp::spin_some(node->get_node_base_interface());

--- a/rclcpp_action/test/benchmark/benchmark_action_client.cpp
+++ b/rclcpp_action/test/benchmark/benchmark_action_client.cpp
@@ -122,6 +122,7 @@ BENCHMARK_F(ActionClientPerformanceTest, construct_client_without_server)(benchm
 {
   constexpr char action_name[] = "no_corresponding_server";
   for (auto _ : state) {
+    (void)_;
     auto client = rclcpp_action::create_client<Fibonacci>(node, action_name);
 
     // Only timing construction, so destruction needs to happen explicitly while timing is paused
@@ -136,6 +137,7 @@ BENCHMARK_F(ActionClientPerformanceTest, construct_client_with_server)(benchmark
   SetUpServer(fibonacci_action_name);
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     auto client = rclcpp_action::create_client<Fibonacci>(node, fibonacci_action_name);
 
     // Only timing construction, so destruction needs to happen explicitly while timing is paused
@@ -148,6 +150,7 @@ BENCHMARK_F(ActionClientPerformanceTest, construct_client_with_server)(benchmark
 BENCHMARK_F(ActionClientPerformanceTest, destroy_client)(benchmark::State & state)
 {
   for (auto _ : state) {
+    (void)_;
     // This client does not have a corresponding server
     state.PauseTiming();
     auto client = rclcpp_action::create_client<Fibonacci>(node, fibonacci_action_name);
@@ -170,6 +173,7 @@ BENCHMARK_F(ActionClientPerformanceTest, async_send_goal_only)(benchmark::State 
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     auto future_goal_handle = client->async_send_goal(goal);
   }
 }
@@ -188,6 +192,7 @@ BENCHMARK_F(ActionClientPerformanceTest, async_send_goal_rejected)(benchmark::St
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     auto future_goal_handle = client->async_send_goal(goal);
     rclcpp::spin_until_future_complete(node, future_goal_handle, std::chrono::seconds(1));
     if (!future_goal_handle.valid()) {
@@ -215,6 +220,7 @@ BENCHMARK_F(ActionClientPerformanceTest, async_send_goal_get_accepted_response)(
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     // This server's execution is deferred
     auto future_goal_handle = client->async_send_goal(goal);
     rclcpp::spin_until_future_complete(node, future_goal_handle, std::chrono::seconds(1));
@@ -246,6 +252,7 @@ BENCHMARK_F(ActionClientPerformanceTest, async_get_result)(benchmark::State & st
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     // Send goal, accept and execute while timing is paused
     state.PauseTiming();
     auto future_goal_handle = client->async_send_goal(goal);
@@ -298,6 +305,7 @@ BENCHMARK_F(ActionClientPerformanceTest, async_cancel_goal)(benchmark::State & s
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     state.PauseTiming();
     auto future_goal_handle = client->async_send_goal(goal);
 
@@ -333,6 +341,7 @@ BENCHMARK_F(ActionClientPerformanceTest, async_cancel_all_goals)(benchmark::Stat
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     state.PauseTiming();
     for (int i = 0; i < num_concurrently_inflight_goals; ++i) {
       auto future_goal_handle = client->async_send_goal(goal);

--- a/rclcpp_action/test/benchmark/benchmark_action_server.cpp
+++ b/rclcpp_action/test/benchmark/benchmark_action_server.cpp
@@ -67,6 +67,7 @@ BENCHMARK_F(ActionServerPerformanceTest, construct_server_without_client)(benchm
 {
   constexpr char action_name[] = "no_corresponding_client";
   for (auto _ : state) {
+    (void)_;
     auto action_server = rclcpp_action::create_server<Fibonacci>(
       node, action_name,
       [](const GoalUUID &, std::shared_ptr<const Fibonacci::Goal>) {
@@ -88,6 +89,7 @@ BENCHMARK_F(ActionServerPerformanceTest, construct_server_without_client)(benchm
 BENCHMARK_F(ActionServerPerformanceTest, construct_server_with_client)(benchmark::State & state)
 {
   for (auto _ : state) {
+    (void)_;
     auto action_server = rclcpp_action::create_server<Fibonacci>(
       node, fibonacci_action_name,
       [](const GoalUUID &, std::shared_ptr<const Fibonacci::Goal>) {
@@ -109,6 +111,7 @@ BENCHMARK_F(ActionServerPerformanceTest, construct_server_with_client)(benchmark
 BENCHMARK_F(ActionServerPerformanceTest, destroy_server)(benchmark::State & state)
 {
   for (auto _ : state) {
+    (void)_;
     state.PauseTiming();
     auto action_server = rclcpp_action::create_server<Fibonacci>(
       node, fibonacci_action_name,
@@ -144,6 +147,7 @@ BENCHMARK_F(ActionServerPerformanceTest, action_server_accept_goal)(benchmark::S
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     state.PauseTiming();
     auto client_goal_handle_future = AsyncSendGoalOfOrder(1);
     state.ResumeTiming();
@@ -176,6 +180,7 @@ BENCHMARK_F(ActionServerPerformanceTest, action_server_cancel_goal)(benchmark::S
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     state.PauseTiming();
     auto client_goal_handle_future = AsyncSendGoalOfOrder(1);
     // This spin completes when the goal has been accepted, but not executed because server
@@ -212,6 +217,7 @@ BENCHMARK_F(ActionServerPerformanceTest, action_server_execute_goal)(benchmark::
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     state.PauseTiming();
     auto client_goal_handle_future = AsyncSendGoalOfOrder(1);
 
@@ -257,6 +263,7 @@ BENCHMARK_F(ActionServerPerformanceTest, action_server_set_success)(benchmark::S
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     state.PauseTiming();
     auto client_goal_handle_future = AsyncSendGoalOfOrder(goal_order);
 
@@ -301,6 +308,7 @@ BENCHMARK_F(ActionServerPerformanceTest, action_server_abort)(benchmark::State &
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     state.PauseTiming();
     auto client_goal_handle_future = AsyncSendGoalOfOrder(goal_order);
 

--- a/rclcpp_components/test/benchmark/benchmark_components.cpp
+++ b/rclcpp_components/test/benchmark/benchmark_components.cpp
@@ -74,6 +74,7 @@ protected:
 BENCHMARK_F(ComponentTest, get_component_resources)(benchmark::State & state)
 {
   for (auto _ : state) {
+    (void)_;
     std::vector<rclcpp_components::ComponentManager::ComponentResource> resources =
       manager->get_component_resources("rclcpp_components");
     if (resources.size() != 3) {
@@ -93,6 +94,7 @@ BENCHMARK_F(ComponentTest, create_component_factory)(benchmark::State & state)
   }
 
   for (auto _ : state) {
+    (void)_;
     manager->create_component_factory(resources[0]).reset();
   }
 }
@@ -114,6 +116,7 @@ BENCHMARK_F(ComponentTest, create_node_instance)(benchmark::State & state)
   const rclcpp::NodeOptions options = rclcpp::NodeOptions().context(context);
 
   for (auto _ : state) {
+    (void)_;
     rclcpp_components::NodeInstanceWrapper node = factory->create_node_instance(options);
     benchmark::DoNotOptimize(node);
     benchmark::ClobberMemory();

--- a/rclcpp_lifecycle/test/benchmark/benchmark_lifecycle_client.cpp
+++ b/rclcpp_lifecycle/test/benchmark/benchmark_lifecycle_client.cpp
@@ -227,6 +227,7 @@ protected:
 
 BENCHMARK_F(BenchmarkLifecycleClient, get_state)(benchmark::State & state) {
   for (auto _ : state) {
+    (void)_;
     const auto lifecycle_state = lifecycle_client->get_state();
     if (lifecycle_state.id != lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED) {
       const std::string msg =
@@ -248,6 +249,7 @@ BENCHMARK_F(BenchmarkLifecycleClient, change_state)(benchmark::State & state) {
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     success =
       lifecycle_client->change_state(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
     if (!success) {
@@ -264,6 +266,7 @@ BENCHMARK_F(BenchmarkLifecycleClient, change_state)(benchmark::State & state) {
 
 BENCHMARK_F(BenchmarkLifecycleClient, get_available_states)(benchmark::State & state) {
   for (auto _ : state) {
+    (void)_;
     constexpr size_t expected_states = 11u;
     const auto states = lifecycle_client->get_available_states();
     if (states.size() != expected_states) {
@@ -279,6 +282,7 @@ BENCHMARK_F(BenchmarkLifecycleClient, get_available_states)(benchmark::State & s
 
 BENCHMARK_F(BenchmarkLifecycleClient, get_available_transitions)(benchmark::State & state) {
   for (auto _ : state) {
+    (void)_;
     constexpr size_t expected_transitions = 2u;
     const auto transitions = lifecycle_client->get_available_transitions();
     if (transitions.size() != expected_transitions) {
@@ -294,6 +298,7 @@ BENCHMARK_F(BenchmarkLifecycleClient, get_available_transitions)(benchmark::Stat
 
 BENCHMARK_F(BenchmarkLifecycleClient, get_transition_graph)(benchmark::State & state) {
   for (auto _ : state) {
+    (void)_;
     constexpr size_t expected_transitions = 25u;
     const auto transitions = lifecycle_client->get_transition_graph();
     if (transitions.size() != expected_transitions) {

--- a/rclcpp_lifecycle/test/benchmark/benchmark_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/benchmark/benchmark_lifecycle_node.cpp
@@ -49,6 +49,7 @@ BENCHMARK_F(BenchmarkLifecycleNodeConstruction, construct_lifecycle_node)(
   benchmark::State & state)
 {
   for (auto _ : state) {
+    (void)_;
     auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("node", "ns");
     PERFORMANCE_TEST_FIXTURE_PAUSE_MEASUREMENTS(
       state,
@@ -60,6 +61,7 @@ BENCHMARK_F(BenchmarkLifecycleNodeConstruction, construct_lifecycle_node)(
 
 BENCHMARK_F(BenchmarkLifecycleNodeConstruction, destroy_lifecycle_node)(benchmark::State & state) {
   for (auto _ : state) {
+    (void)_;
     std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node(nullptr);
     PERFORMANCE_TEST_FIXTURE_PAUSE_MEASUREMENTS(
       state,
@@ -94,6 +96,7 @@ protected:
 // This is a simple getter, but it crosses over into the rcl library.
 BENCHMARK_F(BenchmarkLifecycleNode, get_current_state)(benchmark::State & state) {
   for (auto _ : state) {
+    (void)_;
     const auto & lifecycle_state = node->get_current_state();
     if (lifecycle_state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED) {
       const std::string message =
@@ -107,6 +110,7 @@ BENCHMARK_F(BenchmarkLifecycleNode, get_current_state)(benchmark::State & state)
 
 BENCHMARK_F(BenchmarkLifecycleNode, get_available_states)(benchmark::State & state) {
   for (auto _ : state) {
+    (void)_;
     constexpr size_t expected_states = 11u;
     const auto lifecycle_states = node->get_available_states();
     if (lifecycle_states.size() != expected_states) {
@@ -120,6 +124,7 @@ BENCHMARK_F(BenchmarkLifecycleNode, get_available_states)(benchmark::State & sta
 
 BENCHMARK_F(BenchmarkLifecycleNode, get_available_transitions)(benchmark::State & state) {
   for (auto _ : state) {
+    (void)_;
     constexpr size_t expected_transitions = 2u;
     const auto & transitions = node->get_available_transitions();
     if (transitions.size() != expected_transitions) {
@@ -133,6 +138,7 @@ BENCHMARK_F(BenchmarkLifecycleNode, get_available_transitions)(benchmark::State 
 
 BENCHMARK_F(BenchmarkLifecycleNode, get_transition_graph)(benchmark::State & state) {
   for (auto _ : state) {
+    (void)_;
     constexpr size_t expected_transitions = 25u;
     const auto & transitions = node->get_transition_graph();
     if (transitions.size() != expected_transitions) {
@@ -155,6 +161,7 @@ BENCHMARK_F(BenchmarkLifecycleNode, transition_valid_state)(benchmark::State & s
 
   reset_heap_counters();
   for (auto _ : state) {
+    (void)_;
     const auto & active =
       node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
     if (active.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {

--- a/rclcpp_lifecycle/test/benchmark/benchmark_state.cpp
+++ b/rclcpp_lifecycle/test/benchmark/benchmark_state.cpp
@@ -22,6 +22,7 @@ using PerformanceTest = performance_test_fixture::PerformanceTest;
 BENCHMARK_F(PerformanceTest, construct_destruct_state)(benchmark::State & state)
 {
   for (auto _ : state) {
+    (void)_;
     rclcpp_lifecycle::State lifecycle_state(1, "state");
     benchmark::DoNotOptimize(lifecycle_state);
     benchmark::ClobberMemory();
@@ -32,6 +33,7 @@ BENCHMARK_F(PerformanceTest, copy_destruct_state)(benchmark::State & state)
 {
   rclcpp_lifecycle::State lifecycle_state(1, "state");
   for (auto _ : state) {
+    (void)_;
     rclcpp_lifecycle::State state_copy(lifecycle_state);
     benchmark::DoNotOptimize(state_copy);
     benchmark::ClobberMemory();

--- a/rclcpp_lifecycle/test/benchmark/benchmark_transition.cpp
+++ b/rclcpp_lifecycle/test/benchmark/benchmark_transition.cpp
@@ -22,6 +22,7 @@ using PerformanceTest = performance_test_fixture::PerformanceTest;
 BENCHMARK_F(PerformanceTest, construct_destruct_transition)(benchmark::State & state)
 {
   for (auto _ : state) {
+    (void)_;
     rclcpp_lifecycle::Transition transition(1, "transition");
     benchmark::DoNotOptimize(transition);
     benchmark::ClobberMemory();
@@ -32,6 +33,7 @@ BENCHMARK_F(PerformanceTest, copy_destruct_transition)(benchmark::State & state)
 {
   rclcpp_lifecycle::Transition transition(1, "transition");
   for (auto _ : state) {
+    (void)_;
     rclcpp_lifecycle::Transition transition_copy(transition);
     benchmark::DoNotOptimize(transition_copy);
     benchmark::ClobberMemory();


### PR DESCRIPTION
clang static analysis complains that there are dead stores in
most of the benchmark tests, which is technically correct.
We use an idiom like:

for (auto _ : state) {
}

And never access _.  Silence clang here by doing (void)_;
all of the places this is seen.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>