### PR TITLE
[rclcpp] Generate version header

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -253,3 +253,5 @@ if(TEST cppcheck)
   # must set the property after ament_package()
   set_tests_properties(cppcheck PROPERTIES TIMEOUT 500)
 endif()
+
+ament_cmake_gen_version_h()

--- a/rclcpp/package.xml
+++ b/rclcpp/package.xml
@@ -11,6 +11,7 @@
   <author email="dthomas@openrobotics.org">Dirk Thomas</author>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake_gen_version_h</buildtool_depend>
   <buildtool_depend>python3</buildtool_depend>
 
   <build_depend>ament_index_cpp</build_depend>


### PR DESCRIPTION
Calls the `ament_cmake_gen_version_h` function to generate and
install a header file containing `rclcpp` version information.

Provides compile-time version information for `rclcpp`.

Closes #1804.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>
