### PR TITLE
Galactic-backport: handle sigterm in the same way we handle sigint

### DIFF
--- a/rclcpp/include/rclcpp/context.hpp
+++ b/rclcpp/include/rclcpp/context.hpp
@@ -75,7 +75,7 @@ public:
    * Every context which is constructed is added to a global vector of contexts,
    * which is used by the signal handler to conditionally shutdown each context
    * on SIGINT.
-   * See the shutdown_on_sigint option in the InitOptions class.
+   * See the shutdown_on_signal option in the InitOptions class.
    */
   RCLCPP_PUBLIC
   Context();
@@ -92,8 +92,8 @@ public:
    *
    * Note that this function does not setup any signal handlers, so if you want
    * it to be shutdown by the signal handler, then you need to either install
-   * them manually with rclcpp::install_signal_handers() or use rclcpp::init().
-   * In addition to installing the signal handlers, the shutdown_on_sigint
+   * them manually with rclcpp::install_signal_handlers() or use rclcpp::init().
+   * In addition to installing the signal handlers, the shutdown_on_signal
    * of the InitOptions needs to be `true` for this context to be shutdown by
    * the signal handler, otherwise it will be passed over.
    *
@@ -268,7 +268,7 @@ public:
    *
    *   - this context is shutdown()
    *   - this context is destructed (resulting in shutdown)
-   *   - this context has shutdown_on_sigint=true and SIGINT occurs (resulting in shutdown)
+   *   - this context has shutdown_on_signal=true and SIGINT/SIGTERM occurs (resulting in shutdown)
    *   - interrupt_all_sleep_for() is called
    *
    * \param[in] nanoseconds A std::chrono::duration representing how long to sleep for.

--- a/rclcpp/include/rclcpp/context.hpp
+++ b/rclcpp/include/rclcpp/context.hpp
@@ -75,7 +75,7 @@ public:
    * Every context which is constructed is added to a global vector of contexts,
    * which is used by the signal handler to conditionally shutdown each context
    * on SIGINT.
-   * See the shutdown_on_signal option in the InitOptions class.
+   * See the shutdown_on_sigint option in the InitOptions class.
    */
   RCLCPP_PUBLIC
   Context();
@@ -93,7 +93,7 @@ public:
    * Note that this function does not setup any signal handlers, so if you want
    * it to be shutdown by the signal handler, then you need to either install
    * them manually with rclcpp::install_signal_handlers() or use rclcpp::init().
-   * In addition to installing the signal handlers, the shutdown_on_signal
+   * In addition to installing the signal handlers, the shutdown_on_sigint
    * of the InitOptions needs to be `true` for this context to be shutdown by
    * the signal handler, otherwise it will be passed over.
    *
@@ -268,7 +268,7 @@ public:
    *
    *   - this context is shutdown()
    *   - this context is destructed (resulting in shutdown)
-   *   - this context has shutdown_on_signal=true and SIGINT/SIGTERM occurs (resulting in shutdown)
+   *   - this context has shutdown_on_sigint=true and SIGINT/SIGTERM occurs (resulting in shutdown)
    *   - interrupt_all_sleep_for() is called
    *
    * \param[in] nanoseconds A std::chrono::duration representing how long to sleep for.

--- a/rclcpp/include/rclcpp/init_options.hpp
+++ b/rclcpp/include/rclcpp/init_options.hpp
@@ -29,7 +29,7 @@ class InitOptions
 {
 public:
   /// If true, the context will be shutdown on SIGINT by the signal handler (if it was installed).
-  bool shutdown_on_sigint = true;
+  bool shutdown_on_signal = true;
 
   /// Constructor
   /**

--- a/rclcpp/include/rclcpp/init_options.hpp
+++ b/rclcpp/include/rclcpp/init_options.hpp
@@ -28,7 +28,8 @@ namespace rclcpp
 class InitOptions
 {
 public:
-  /// If true, the context will be shutdown on SIGINT/SIGTERM by the signal handler (if it was installed).
+  /// If true, the context will be shutdown on SIGINT/SIGTERM by the signal handler
+  /// (if it was installed).
   /**
    * Note: the variable name mention sigint but it also handles SIGTERM.
    * The variable has been renamed in newer ROS versions but not here to

--- a/rclcpp/include/rclcpp/init_options.hpp
+++ b/rclcpp/include/rclcpp/init_options.hpp
@@ -28,8 +28,13 @@ namespace rclcpp
 class InitOptions
 {
 public:
-  /// If true, the context will be shutdown on SIGINT by the signal handler (if it was installed).
-  bool shutdown_on_signal = true;
+  /// If true, the context will be shutdown on SIGINT/SIGTERM by the signal handler (if it was installed).
+  /**
+   * Note: the variable name mention sigint but it also handles SIGTERM.
+   * The variable has been renamed in newer ROS versions but not here to
+   * maintain API compatibility.
+   */
+  bool shutdown_on_sigint = true;
 
   /// Constructor
   /**

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -42,6 +42,20 @@ std::string to_string(T value)
 
 namespace rclcpp
 {
+
+/// Option to indicate which signal handlers rclcpp should install.
+enum class SignalHandlerOptions
+{
+  /// Install both sigint and sigterm, this is the default behavior.
+  All,
+  /// Install only a sigint handler.
+  SigInt,
+  /// Install only a sigterm handler.
+  SigTerm,
+  /// Do not install any signal handler.
+  None,
+};
+
 /// Initialize communications via the rmw implementation and set up a global signal handler.
 /**
  * Initializes the global context which is accessible via the function
@@ -50,10 +64,16 @@ namespace rclcpp
  * rclcpp::install_signal_handlers().
  *
  * \sa rclcpp::Context::init() for more details on arguments and possible exceptions
+ *
+ * \param signal_handler_options option to indicate which signal handlers should be installed.
  */
 RCLCPP_PUBLIC
 void
-init(int argc, char const * const argv[], const InitOptions & init_options = InitOptions());
+init(
+  int argc,
+  char const * const argv[],
+  const InitOptions & init_options = InitOptions(),
+  SignalHandlerOptions signal_handler_options = SignalHandlerOptions::All);
 
 /// Install the global signal handler for rclcpp.
 /**
@@ -67,16 +87,25 @@ init(int argc, char const * const argv[], const InitOptions & init_options = Ini
  *
  * This function is thread-safe.
  *
+ * \param signal_handler_options option to indicate which signal handlers should be installed.
  * \return true if signal handler was installed by this function, false if already installed.
  */
 RCLCPP_PUBLIC
 bool
-install_signal_handlers();
+install_signal_handlers(SignalHandlerOptions signal_handler_options = SignalHandlerOptions::All);
 
 /// Return true if the signal handlers are installed, otherwise false.
 RCLCPP_PUBLIC
 bool
 signal_handlers_installed();
+
+/// Get the current signal handler options.
+/**
+ * If no signal handler is installed, SignalHandlerOptions::None is returned.
+ */
+RCLCPP_PUBLIC
+SignalHandlerOptions
+get_current_signal_handler_options();
 
 /// Uninstall the global signal handler for rclcpp.
 /**

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -62,7 +62,7 @@ enum class SignalHandlerOptions
  *
  * Initializes the global context which is accessible via the function
  * rclcpp::contexts::get_global_default_context().
- * Also, installs the global signal handlers to SignalHandlerOptions::SigTerm
+ * Also, installs the global signal handlers to SignalHandlerOptions::SigInt
  *
  * \sa rclcpp::Context::init() for more details on arguments and possible exceptions
  */

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -73,7 +73,7 @@ init(
   int argc,
   char const * const argv[],
   const InitOptions & init_options = InitOptions(),
-  SignalHandlerOptions signal_handler_options = SignalHandlerOptions::All);
+  SignalHandlerOptions signal_handler_options = SignalHandlerOptions::SigTerm);
 
 /// Install the global signal handler for rclcpp.
 /**
@@ -92,7 +92,7 @@ init(
  */
 RCLCPP_PUBLIC
 bool
-install_signal_handlers(SignalHandlerOptions signal_handler_options = SignalHandlerOptions::All);
+install_signal_handlers(SignalHandlerOptions signal_handler_options = SignalHandlerOptions::SigTerm);
 
 /// Return true if the signal handlers are installed, otherwise false.
 RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -98,6 +98,25 @@ init(
  * It is implicitly run by rclcpp::init(), and therefore this function does not
  * need to be run manually if rclcpp::init() has already been run.
  *
+ * The signal handler will shutdown all initialized context by default under the
+ * SIGINT signal. It will also interrupt any blocking functions in ROS
+ * allowing them react to any changes in the state of the system (like
+ * shutdown).
+ *
+ * This function is thread-safe.
+ *
+ * \return true if signal handler was installed by this function, false if already installed.
+ */
+RCLCPP_PUBLIC
+bool
+install_signal_handlers();
+
+/// Install the global signal handler for rclcpp.
+/**
+ * This function should only need to be run one time per process.
+ * It is implicitly run by rclcpp::init(), and therefore this function does not
+ * need to be run manually if rclcpp::init() has already been run.
+ *
  * The signal handler will shutdown all initialized context.
  * It will also interrupt any blocking functions in ROS allowing them react to
  * any changes in the state of the system (like shutdown).
@@ -109,8 +128,8 @@ init(
  */
 RCLCPP_PUBLIC
 bool
-install_signal_handlers(
-  SignalHandlerOptions signal_handler_options = SignalHandlerOptions::SigTerm);
+install_signal_handlers(SignalHandlerOptions signal_handler_options);
+
 
 /// Return true if the signal handlers are installed, otherwise false.
 RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -58,6 +58,23 @@ enum class SignalHandlerOptions
 
 /// Initialize communications via the rmw implementation and set up a global signal handler.
 /**
+ * Note: signature of this init function is here to keep ABI compatibility.
+ *
+ * Initializes the global context which is accessible via the function
+ * rclcpp::contexts::get_global_default_context().
+ * Also, installs the global signal handlers to SignalHandlerOptions::SigTerm
+ *
+ * \sa rclcpp::Context::init() for more details on arguments and possible exceptions
+ */
+RCLCPP_PUBLIC
+void
+init(
+  int argc,
+  char const * const argv[],
+  const InitOptions & init_options = InitOptions());
+
+/// Initialize communications via the rmw implementation and set up a global signal handler.
+/**
  * Initializes the global context which is accessible via the function
  * rclcpp::contexts::get_global_default_context().
  * Also, installs the global signal handlers with the function
@@ -72,8 +89,8 @@ void
 init(
   int argc,
   char const * const argv[],
-  const InitOptions & init_options = InitOptions(),
-  SignalHandlerOptions signal_handler_options = SignalHandlerOptions::SigTerm);
+  const InitOptions & init_options,
+  SignalHandlerOptions signal_handler_options);
 
 /// Install the global signal handler for rclcpp.
 /**

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -109,7 +109,8 @@ init(
  */
 RCLCPP_PUBLIC
 bool
-install_signal_handlers(SignalHandlerOptions signal_handler_options = SignalHandlerOptions::SigTerm);
+install_signal_handlers(
+  SignalHandlerOptions signal_handler_options = SignalHandlerOptions::SigTerm);
 
 /// Return true if the signal handlers are installed, otherwise false.
 RCLCPP_PUBLIC

--- a/rclcpp/src/rclcpp/init_options.cpp
+++ b/rclcpp/src/rclcpp/init_options.cpp
@@ -43,7 +43,7 @@ InitOptions::InitOptions(const rcl_init_options_t & init_options)
 InitOptions::InitOptions(const InitOptions & other)
 : InitOptions(*other.get_rcl_init_options())
 {
-  shutdown_on_signal = other.shutdown_on_signal;
+  shutdown_on_sigint = other.shutdown_on_sigint;
   initialize_logging_ = other.initialize_logging_;
 }
 
@@ -70,7 +70,7 @@ InitOptions::operator=(const InitOptions & other)
     if (RCL_RET_OK != ret) {
       rclcpp::exceptions::throw_from_rcl_error(ret, "failed to copy rcl init options");
     }
-    this->shutdown_on_signal = other.shutdown_on_signal;
+    this->shutdown_on_sigint = other.shutdown_on_sigint;
     this->initialize_logging_ = other.initialize_logging_;
   }
   return *this;

--- a/rclcpp/src/rclcpp/init_options.cpp
+++ b/rclcpp/src/rclcpp/init_options.cpp
@@ -43,7 +43,7 @@ InitOptions::InitOptions(const rcl_init_options_t & init_options)
 InitOptions::InitOptions(const InitOptions & other)
 : InitOptions(*other.get_rcl_init_options())
 {
-  shutdown_on_sigint = other.shutdown_on_sigint;
+  shutdown_on_signal = other.shutdown_on_signal;
   initialize_logging_ = other.initialize_logging_;
 }
 
@@ -70,7 +70,7 @@ InitOptions::operator=(const InitOptions & other)
     if (RCL_RET_OK != ret) {
       rclcpp::exceptions::throw_from_rcl_error(ret, "failed to copy rcl init options");
     }
-    this->shutdown_on_sigint = other.shutdown_on_sigint;
+    this->shutdown_on_signal = other.shutdown_on_signal;
     this->initialize_logging_ = other.initialize_logging_;
   }
   return *this;

--- a/rclcpp/src/rclcpp/signal_handler.cpp
+++ b/rclcpp/src/rclcpp/signal_handler.cpp
@@ -260,11 +260,11 @@ SignalHandler::deferred_signal_handler()
     if (signal_received_.exchange(false)) {
       RCLCPP_DEBUG(get_logger(), "deferred_signal_handler(): shutting down");
       for (auto context_ptr : rclcpp::get_contexts()) {
-        if (context_ptr->get_init_options().shutdown_on_signal) {
+        if (context_ptr->get_init_options().shutdown_on_sigint) {
           RCLCPP_DEBUG(
             get_logger(),
             "deferred_signal_handler(): "
-            "shutting down rclcpp::Context @ %p, because it had shutdown_on_signal == true",
+            "shutting down rclcpp::Context @ %p, because it had shutdown_on_sigint == true",
             static_cast<void *>(context_ptr.get()));
           context_ptr->shutdown("signal handler");
         }

--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -31,18 +31,22 @@ namespace rclcpp
 {
 
 void
-init(int argc, char const * const argv[], const InitOptions & init_options)
+init(
+  int argc,
+  char const * const argv[],
+  const InitOptions & init_options,
+  SignalHandlerOptions signal_handler_options)
 {
   using rclcpp::contexts::get_global_default_context;
   get_global_default_context()->init(argc, argv, init_options);
   // Install the signal handlers.
-  install_signal_handlers();
+  install_signal_handlers(signal_handler_options);
 }
 
 bool
-install_signal_handlers()
+install_signal_handlers(SignalHandlerOptions signal_handler_options)
 {
-  return SignalHandler::get_global_signal_handler().install();
+  return SignalHandler::get_global_signal_handler().install(signal_handler_options);
 }
 
 bool
@@ -50,6 +54,13 @@ signal_handlers_installed()
 {
   return SignalHandler::get_global_signal_handler().is_installed();
 }
+
+SignalHandlerOptions
+get_current_signal_handler_options()
+{
+  return SignalHandler::get_global_signal_handler().get_current_signal_handler_options();
+}
+
 
 bool
 uninstall_signal_handlers()

--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -36,7 +36,7 @@ init(
   char const * const argv[],
   const InitOptions & init_options)
 {
-  init(argc, argv, init_options, SignalHandlerOptions::SigTerm);
+  init(argc, argv, init_options, SignalHandlerOptions::SigInt);
 }
 
 void

--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -53,6 +53,12 @@ init(
 }
 
 bool
+install_signal_handlers()
+{
+  return SignalHandler::get_global_signal_handler().install(SignalHandlerOptions::SigInt);
+}
+
+bool
 install_signal_handlers(SignalHandlerOptions signal_handler_options)
 {
   return SignalHandler::get_global_signal_handler().install(signal_handler_options);

--- a/rclcpp/src/rclcpp/utilities.cpp
+++ b/rclcpp/src/rclcpp/utilities.cpp
@@ -34,6 +34,15 @@ void
 init(
   int argc,
   char const * const argv[],
+  const InitOptions & init_options)
+{
+  init(argc, argv, init_options, SignalHandlerOptions::SigTerm);
+}
+
+void
+init(
+  int argc,
+  char const * const argv[],
   const InitOptions & init_options,
   SignalHandlerOptions signal_handler_options)
 {


### PR DESCRIPTION
Mostly a backport of #1771 but the default behavior for handling SIGINT is not enabled to preserve backwards compatibility.

The PR was done in three steps:
 * Backport #1771 7c1bd17
 * Turn off the default for SIGINT 03267bf

In a final step, I realized that adding a new parameter we will be kiling the ABI of `rclcpp::init` which sounds to me not a nice thing to do. I tried to avoid it by keeping the current signature of `rclcpp::init,`making it to call a new signature that includes the `SignalHandlerOptions` with the option of only enabling SigTerm. Hopefully the change in e0dad49 will make the `rclcpp::init` options in the same way but keeping ABI stable.