### PR TITLE
Add return value version of get_parameter_or

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -720,10 +720,9 @@ public:
     ParameterT & parameter,
     const ParameterT & alternative_value) const;
 
-  /// Get the parameter value, or the "alternative_value" if not set, and assign it to "parameter".
+  /// Return the parameter value, or the "alternative_value" if not set.
   /**
-   * If the parameter was not set, then the "parameter" argument is assigned
-   * the "alternative_value".
+   * If the parameter was not set, then the "alternative_value" argument is returned.
    *
    * This method will not throw the rclcpp::exceptions::ParameterNotDeclaredException exception.
    *

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -720,6 +720,25 @@ public:
     ParameterT & parameter,
     const ParameterT & alternative_value) const;
 
+  /// Get the parameter value, or the "alternative_value" if not set, and assign it to "parameter".
+  /**
+   * If the parameter was not set, then the "parameter" argument is assigned
+   * the "alternative_value".
+   *
+   * This method will not throw the rclcpp::exceptions::ParameterNotDeclaredException exception.
+   *
+   * In all cases, the parameter is never set or declared within the node.
+   *
+   * \param[in] name The name of the parameter to get.
+   * \param[in] alternative_value Value to be stored in output if the parameter was not set.
+   * \returns The value of the parameter.
+   */
+  template<typename ParameterT>
+  ParameterT
+  get_parameter_or(
+    const std::string & name,
+    const ParameterT & alternative_value) const;
+
   /// Return the parameters by the given parameter names.
   /**
    * Like get_parameters(), this method may throw the

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -313,6 +313,17 @@ Node::get_parameter_or(
   return got_parameter;
 }
 
+template<typename ParameterT>
+ParameterT
+Node::get_parameter_or(
+  const std::string & name,
+  const ParameterT & alternative_value) const
+{
+  ParameterT parameter;
+  get_parameter_or(name, parameter, alternative_value);
+  return parameter;
+}
+
 // this is a partially-specialized version of get_parameter above,
 // where our concrete type for ParameterT is std::map, but the to-be-determined
 // type is the value in the map.

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -2075,6 +2075,33 @@ TEST_F(TestNode, get_parameter_or_undeclared_parameters_allowed) {
   }
 }
 
+// test get_parameter_or with return value
+TEST_F(TestNode, get_parameter_or_with_return_value) {
+  auto node = std::make_shared<rclcpp::Node>(
+    "test_get_parameter_or_node"_unq);
+  {
+    // normal use (declare first) still works
+    auto name = "parameter"_unq;
+
+    node->declare_parameter(name, 42);
+    EXPECT_TRUE(node->has_parameter(name));
+
+    {
+      const int value = node->get_parameter_or(name, 43);
+      EXPECT_EQ(value, 42);
+    }
+  }
+  {
+    // normal use, no declare first
+    auto name = "parameter"_unq;
+
+    {
+      const int value = node->get_parameter_or(name, 43);
+      EXPECT_EQ(value, 43);
+    }
+  }
+}
+
 // test get_parameters with undeclared not allowed
 TEST_F(TestNode, get_parameters_undeclared_parameters_not_allowed) {
   auto node = std::make_shared<rclcpp::Node>(


### PR DESCRIPTION
I think it's useful if we can use the return value version of `get_parameter_or` because we can make the variable const.

Normally, we can get the parameter value by `declare_parameter`, but I guess it can't be used when we use `automatically_declare_parameters_from_overrides`.

Is it possible to add this or are there any other ways?