### PR TITLE
add APIs to force undeclaring parameters

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -578,14 +578,6 @@ public:
   rcl_interfaces::msg::SetParametersResult
   set_parameter(const rclcpp::Parameter & parameter);
 
-  /// Set a single parameter, ignoring "read_only" and "dynamic_typing" flags.
-  /**
-   * \sa rclcpp::Node::set_parameter
-   */
-  RCLCPP_PUBLIC
-  rcl_interfaces::msg::SetParametersResult
-  force_set_parameter(const rclcpp::Parameter & parameter);
-
   /// Set one or more parameters, one at a time.
   /**
    * Set the given parameters, one at a time, and then return result of each
@@ -624,14 +616,6 @@ public:
   std::vector<rcl_interfaces::msg::SetParametersResult>
   set_parameters(const std::vector<rclcpp::Parameter> & parameters);
 
-  /// Set one or more parameters, one at a time, ignoring "read_only" and "dynamic_typing" flags.
-  /**
-   * \sa rclcpp::Node::set_parameters
-   */
-  RCLCPP_PUBLIC
-  std::vector<rcl_interfaces::msg::SetParametersResult>
-  force_set_parameters(const std::vector<rclcpp::Parameter> & parameters);
-
   /// Set one or more parameters, all at once.
   /**
    * Set the given parameters, all at one time, and then aggregate result.
@@ -665,14 +649,6 @@ public:
   RCLCPP_PUBLIC
   rcl_interfaces::msg::SetParametersResult
   set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters);
-
-  /// Set one or more parameters, all at once, ignoring "read_only" and "dynamic_typing" flags.
-  /**
-   * \sa rclcpp::Node::set_parameters_atomically
-   */
-  RCLCPP_PUBLIC
-  rcl_interfaces::msg::SetParametersResult
-  force_set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters);
 
   /// Return the parameter by the given name.
   /**

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -528,6 +528,14 @@ public:
   void
   undeclare_parameter(const std::string & name);
 
+  /// Undeclare a previously declared parameter ignoring "read_only" and "dynamic_typing" flags.
+  /**
+   * \sa rclcpp::Node::undeclare_parameter
+   */
+  RCLCPP_PUBLIC
+  void
+  force_undeclare_parameter(const std::string & name);
+
   /// Return true if a given parameter is declared.
   /**
    * \param[in] name The name of the parameter to check for being declared.
@@ -570,6 +578,14 @@ public:
   rcl_interfaces::msg::SetParametersResult
   set_parameter(const rclcpp::Parameter & parameter);
 
+  /// Set a single parameter, ignoring "read_only" and "dynamic_typing" flags.
+  /**
+   * \sa rclcpp::Node::set_parameter
+   */
+  RCLCPP_PUBLIC
+  rcl_interfaces::msg::SetParametersResult
+  force_set_parameter(const rclcpp::Parameter & parameter);
+
   /// Set one or more parameters, one at a time.
   /**
    * Set the given parameters, one at a time, and then return result of each
@@ -608,6 +624,14 @@ public:
   std::vector<rcl_interfaces::msg::SetParametersResult>
   set_parameters(const std::vector<rclcpp::Parameter> & parameters);
 
+  /// Set one or more parameters, one at a time, ignoring "read_only" and "dynamic_typing" flags.
+  /**
+   * \sa rclcpp::Node::set_parameters
+   */
+  RCLCPP_PUBLIC
+  std::vector<rcl_interfaces::msg::SetParametersResult>
+  force_set_parameters(const std::vector<rclcpp::Parameter> & parameters);
+
   /// Set one or more parameters, all at once.
   /**
    * Set the given parameters, all at one time, and then aggregate result.
@@ -641,6 +665,14 @@ public:
   RCLCPP_PUBLIC
   rcl_interfaces::msg::SetParametersResult
   set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters);
+
+  /// Set one or more parameters, all at once, ignoring "read_only" and "dynamic_typing" flags.
+  /**
+   * \sa rclcpp::Node::set_parameters_atomically
+   */
+  RCLCPP_PUBLIC
+  rcl_interfaces::msg::SetParametersResult
+  force_set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters);
 
   /// Return the parameter by the given name.
   /**

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -519,22 +519,15 @@ public:
    * add_on_set_parameters_callback to be called.
    *
    * \param[in] name The name of the parameter to be undeclared.
+   * \param[in] force Whether to ignore immutable parameter constraints.
    * \throws rclcpp::exceptions::ParameterNotDeclaredException if the parameter
    *   has not been declared.
    * \throws rclcpp::exceptions::ParameterImmutableException if the parameter
-   *   was create as read_only (immutable).
+   *   was create as read_only (immutable) and the force flag was false.
    */
   RCLCPP_PUBLIC
   void
-  undeclare_parameter(const std::string & name);
-
-  /// Undeclare a previously declared parameter ignoring "read_only" and "dynamic_typing" flags.
-  /**
-   * \sa rclcpp::Node::undeclare_parameter
-   */
-  RCLCPP_PUBLIC
-  void
-  force_undeclare_parameter(const std::string & name);
+  undeclare_parameter(const std::string & name, bool force = false);
 
   /// Return true if a given parameter is declared.
   /**

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
@@ -151,14 +151,12 @@ public:
   RCLCPP_PUBLIC
   std::vector<rcl_interfaces::msg::SetParametersResult>
   set_parameters(
-    const std::vector<rclcpp::Parameter> & parameters,
-    bool force) override;
+    const std::vector<rclcpp::Parameter> & parameters) override;
 
   RCLCPP_PUBLIC
   rcl_interfaces::msg::SetParametersResult
   set_parameters_atomically(
-    const std::vector<rclcpp::Parameter> & parameters,
-    bool force) override;
+    const std::vector<rclcpp::Parameter> & parameters) override;
 
   RCLCPP_PUBLIC
   std::vector<rclcpp::Parameter>

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
@@ -142,11 +142,7 @@ public:
 
   RCLCPP_PUBLIC
   void
-  undeclare_parameter(const std::string & name) override;
-
-  RCLCPP_PUBLIC
-  void
-  force_undeclare_parameter(const std::string & name) override;
+  undeclare_parameter(const std::string & name, bool force) override;
 
   RCLCPP_PUBLIC
   bool
@@ -155,22 +151,14 @@ public:
   RCLCPP_PUBLIC
   std::vector<rcl_interfaces::msg::SetParametersResult>
   set_parameters(
-    const std::vector<rclcpp::Parameter> & parameters) override;
-
-  RCLCPP_PUBLIC
-  std::vector<rcl_interfaces::msg::SetParametersResult>
-  force_set_parameters(
-    const std::vector<rclcpp::Parameter> & parameters) override;
+    const std::vector<rclcpp::Parameter> & parameters,
+    bool force) override;
 
   RCLCPP_PUBLIC
   rcl_interfaces::msg::SetParametersResult
   set_parameters_atomically(
-    const std::vector<rclcpp::Parameter> & parameters) override;
-
-  RCLCPP_PUBLIC
-  rcl_interfaces::msg::SetParametersResult
-  force_set_parameters_atomically(
-    const std::vector<rclcpp::Parameter> & parameters) override;
+    const std::vector<rclcpp::Parameter> & parameters,
+    bool force) override;
 
   RCLCPP_PUBLIC
   std::vector<rclcpp::Parameter>
@@ -221,19 +209,6 @@ public:
 
 private:
   RCLCPP_DISABLE_COPY(NodeParameters)
-
-  void
-  undeclare_parameter(const std::string & name, bool force);
-
-  std::vector<rcl_interfaces::msg::SetParametersResult>
-  set_parameters(
-    const std::vector<rclcpp::Parameter> & parameters,
-    bool force);
-
-  rcl_interfaces::msg::SetParametersResult
-  set_parameters_atomically(
-    const std::vector<rclcpp::Parameter> & parameters,
-    bool force);
 
   mutable std::recursive_mutex mutex_;
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
@@ -145,6 +145,10 @@ public:
   undeclare_parameter(const std::string & name) override;
 
   RCLCPP_PUBLIC
+  void
+  force_undeclare_parameter(const std::string & name) override;
+
+  RCLCPP_PUBLIC
   bool
   has_parameter(const std::string & name) const override;
 
@@ -154,8 +158,18 @@ public:
     const std::vector<rclcpp::Parameter> & parameters) override;
 
   RCLCPP_PUBLIC
+  std::vector<rcl_interfaces::msg::SetParametersResult>
+  force_set_parameters(
+    const std::vector<rclcpp::Parameter> & parameters) override;
+
+  RCLCPP_PUBLIC
   rcl_interfaces::msg::SetParametersResult
   set_parameters_atomically(
+    const std::vector<rclcpp::Parameter> & parameters) override;
+
+  RCLCPP_PUBLIC
+  rcl_interfaces::msg::SetParametersResult
+  force_set_parameters_atomically(
     const std::vector<rclcpp::Parameter> & parameters) override;
 
   RCLCPP_PUBLIC
@@ -207,6 +221,19 @@ public:
 
 private:
   RCLCPP_DISABLE_COPY(NodeParameters)
+
+  void
+  undeclare_parameter(const std::string & name, bool force);
+
+  std::vector<rcl_interfaces::msg::SetParametersResult>
+  set_parameters(
+    const std::vector<rclcpp::Parameter> & parameters,
+    bool force);
+
+  rcl_interfaces::msg::SetParametersResult
+  set_parameters_atomically(
+    const std::vector<rclcpp::Parameter> & parameters,
+    bool force);
 
   mutable std::recursive_mutex mutex_;
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -110,16 +110,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   void
-  undeclare_parameter(const std::string & name) = 0;
-
-  /// Undeclare a parameter ignoring "read_only" and "dynamic_typing" flags.
-  /**
-   * \sa rclcpp::Node::undeclare_parameter
-   */
-  RCLCPP_PUBLIC
-  virtual
-  void
-  force_undeclare_parameter(const std::string & name) = 0;
+  undeclare_parameter(const std::string & name, bool force) = 0;
 
   /// Return true if the parameter has been declared, otherwise false.
   /**
@@ -137,16 +128,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   std::vector<rcl_interfaces::msg::SetParametersResult>
-  set_parameters(const std::vector<rclcpp::Parameter> & parameters) = 0;
-
-  /// Set one or more parameters, one at a time, ignoring "read_only" and "dynamic_typing" flags.
-  /**
-   * \sa rclcpp::Node::set_parameters
-   */
-  RCLCPP_PUBLIC
-  virtual
-  std::vector<rcl_interfaces::msg::SetParametersResult>
-  force_set_parameters(const std::vector<rclcpp::Parameter> & parameters) = 0;
+  set_parameters(const std::vector<rclcpp::Parameter> & parameters, bool force) = 0;
 
   /// Set one or more parameters, all at once.
   /**
@@ -155,16 +137,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   rcl_interfaces::msg::SetParametersResult
-  set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters) = 0;
-
-  /// Set one or more parameters, all at once, ignoring "read_only" and "dynamic_typing" flags.
-  /**
-   * \sa rclcpp::Node::set_parameters_atomically
-   */
-  RCLCPP_PUBLIC
-  virtual
-  rcl_interfaces::msg::SetParametersResult
-  force_set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters) = 0;
+  set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters, bool force) = 0;
 
   /// Get descriptions of parameters given their names.
   /*

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -128,7 +128,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   std::vector<rcl_interfaces::msg::SetParametersResult>
-  set_parameters(const std::vector<rclcpp::Parameter> & parameters, bool force) = 0;
+  set_parameters(const std::vector<rclcpp::Parameter> & parameters) = 0;
 
   /// Set one or more parameters, all at once.
   /**
@@ -137,7 +137,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   rcl_interfaces::msg::SetParametersResult
-  set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters, bool force) = 0;
+  set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters) = 0;
 
   /// Get descriptions of parameters given their names.
   /*

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -137,7 +137,8 @@ public:
   RCLCPP_PUBLIC
   virtual
   rcl_interfaces::msg::SetParametersResult
-  set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters) = 0;
+  set_parameters_atomically(
+    const std::vector<rclcpp::Parameter> & parameters) = 0;
 
   /// Get descriptions of parameters given their names.
   /*

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -112,6 +112,15 @@ public:
   void
   undeclare_parameter(const std::string & name) = 0;
 
+  /// Undeclare a parameter ignoring "read_only" and "dynamic_typing" flags.
+  /**
+   * \sa rclcpp::Node::undeclare_parameter
+   */
+  RCLCPP_PUBLIC
+  virtual
+  void
+  force_undeclare_parameter(const std::string & name) = 0;
+
   /// Return true if the parameter has been declared, otherwise false.
   /**
    * \sa rclcpp::Node::has_parameter
@@ -130,6 +139,15 @@ public:
   std::vector<rcl_interfaces::msg::SetParametersResult>
   set_parameters(const std::vector<rclcpp::Parameter> & parameters) = 0;
 
+  /// Set one or more parameters, one at a time, ignoring "read_only" and "dynamic_typing" flags.
+  /**
+   * \sa rclcpp::Node::set_parameters
+   */
+  RCLCPP_PUBLIC
+  virtual
+  std::vector<rcl_interfaces::msg::SetParametersResult>
+  force_set_parameters(const std::vector<rclcpp::Parameter> & parameters) = 0;
+
   /// Set one or more parameters, all at once.
   /**
    * \sa rclcpp::Node::set_parameters_atomically
@@ -137,8 +155,16 @@ public:
   RCLCPP_PUBLIC
   virtual
   rcl_interfaces::msg::SetParametersResult
-  set_parameters_atomically(
-    const std::vector<rclcpp::Parameter> & parameters) = 0;
+  set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters) = 0;
+
+  /// Set one or more parameters, all at once, ignoring "read_only" and "dynamic_typing" flags.
+  /**
+   * \sa rclcpp::Node::set_parameters_atomically
+   */
+  RCLCPP_PUBLIC
+  virtual
+  rcl_interfaces::msg::SetParametersResult
+  force_set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters) = 0;
 
   /// Get descriptions of parameters given their names.
   /*

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -359,7 +359,7 @@ Node::declare_parameter(
 void
 Node::undeclare_parameter(const std::string & name)
 {
-  this->node_parameters_->undeclare_parameter(name);
+  this->node_parameters_->force_undeclare_parameter(name);
 }
 
 bool
@@ -377,13 +377,13 @@ Node::set_parameter(const rclcpp::Parameter & parameter)
 std::vector<rcl_interfaces::msg::SetParametersResult>
 Node::set_parameters(const std::vector<rclcpp::Parameter> & parameters)
 {
-  return node_parameters_->set_parameters(parameters);
+  return node_parameters_->force_set_parameters(parameters);
 }
 
 rcl_interfaces::msg::SetParametersResult
 Node::set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters)
 {
-  return node_parameters_->set_parameters_atomically(parameters);
+  return node_parameters_->force_set_parameters_atomically(parameters);
 }
 
 rclcpp::Parameter

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -359,7 +359,13 @@ Node::declare_parameter(
 void
 Node::undeclare_parameter(const std::string & name)
 {
-  this->node_parameters_->force_undeclare_parameter(name);
+  this->node_parameters_->undeclare_parameter(name, false);
+}
+
+void
+Node::force_undeclare_parameter(const std::string & name)
+{
+  this->node_parameters_->undeclare_parameter(name, true);
 }
 
 bool
@@ -374,16 +380,34 @@ Node::set_parameter(const rclcpp::Parameter & parameter)
   return this->set_parameters_atomically({parameter});
 }
 
+rcl_interfaces::msg::SetParametersResult
+Node::force_set_parameter(const rclcpp::Parameter & parameter)
+{
+  return this->force_set_parameters_atomically({parameter});
+}
+
 std::vector<rcl_interfaces::msg::SetParametersResult>
 Node::set_parameters(const std::vector<rclcpp::Parameter> & parameters)
 {
-  return node_parameters_->force_set_parameters(parameters);
+  return node_parameters_->set_parameters(parameters, false);
+}
+
+std::vector<rcl_interfaces::msg::SetParametersResult>
+Node::force_set_parameters(const std::vector<rclcpp::Parameter> & parameters)
+{
+  return node_parameters_->set_parameters(parameters, true);
 }
 
 rcl_interfaces::msg::SetParametersResult
 Node::set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters)
 {
-  return node_parameters_->force_set_parameters_atomically(parameters);
+  return node_parameters_->set_parameters_atomically(parameters, false);
+}
+
+rcl_interfaces::msg::SetParametersResult
+Node::force_set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters)
+{
+  return node_parameters_->set_parameters_atomically(parameters, true);
 }
 
 rclcpp::Parameter

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -377,13 +377,13 @@ Node::set_parameter(const rclcpp::Parameter & parameter)
 std::vector<rcl_interfaces::msg::SetParametersResult>
 Node::set_parameters(const std::vector<rclcpp::Parameter> & parameters)
 {
-  return node_parameters_->set_parameters(parameters, false);
+  return node_parameters_->set_parameters(parameters);
 }
 
 rcl_interfaces::msg::SetParametersResult
 Node::set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters)
 {
-  return node_parameters_->set_parameters_atomically(parameters, false);
+  return node_parameters_->set_parameters_atomically(parameters);
 }
 
 rclcpp::Parameter

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -357,15 +357,9 @@ Node::declare_parameter(
 }
 
 void
-Node::undeclare_parameter(const std::string & name)
+Node::undeclare_parameter(const std::string & name, bool force)
 {
-  this->node_parameters_->undeclare_parameter(name, false);
-}
-
-void
-Node::force_undeclare_parameter(const std::string & name)
-{
-  this->node_parameters_->undeclare_parameter(name, true);
+  this->node_parameters_->undeclare_parameter(name, force);
 }
 
 bool

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -380,34 +380,16 @@ Node::set_parameter(const rclcpp::Parameter & parameter)
   return this->set_parameters_atomically({parameter});
 }
 
-rcl_interfaces::msg::SetParametersResult
-Node::force_set_parameter(const rclcpp::Parameter & parameter)
-{
-  return this->force_set_parameters_atomically({parameter});
-}
-
 std::vector<rcl_interfaces::msg::SetParametersResult>
 Node::set_parameters(const std::vector<rclcpp::Parameter> & parameters)
 {
   return node_parameters_->set_parameters(parameters, false);
 }
 
-std::vector<rcl_interfaces::msg::SetParametersResult>
-Node::force_set_parameters(const std::vector<rclcpp::Parameter> & parameters)
-{
-  return node_parameters_->set_parameters(parameters, true);
-}
-
 rcl_interfaces::msg::SetParametersResult
 Node::set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters)
 {
   return node_parameters_->set_parameters_atomically(parameters, false);
-}
-
-rcl_interfaces::msg::SetParametersResult
-Node::force_set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters)
-{
-  return node_parameters_->set_parameters_atomically(parameters, true);
 }
 
 rclcpp::Parameter

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -306,7 +306,7 @@ __set_parameters_atomically_common(
   } else {
     // Check if the value being set complies with the descriptor.
     result = __check_parameters(
-      parameterrcl_interfaces_infos, parameters, allow_undeclared, force);
+      parameter_infos, parameters, allow_undeclared);
     if (!result.successful) {
       return result;
     }

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -534,18 +534,6 @@ NodeParameters::declare_parameter(
 }
 
 void
-NodeParameters::undeclare_parameter(const std::string & name)
-{
-  undeclare_parameter(name, false);
-}
-
-void
-NodeParameters::force_undeclare_parameter(const std::string & name)
-{
-  undeclare_parameter(name, true);
-}
-
-void
 NodeParameters::undeclare_parameter(const std::string & name, bool force)
 {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
@@ -579,18 +567,6 @@ NodeParameters::has_parameter(const std::string & name) const
 }
 
 std::vector<rcl_interfaces::msg::SetParametersResult>
-NodeParameters::set_parameters(const std::vector<rclcpp::Parameter> & parameters)
-{
-  return set_parameters(parameters, false);
-}
-
-std::vector<rcl_interfaces::msg::SetParametersResult>
-NodeParameters::force_set_parameters(const std::vector<rclcpp::Parameter> & parameters)
-{
-  return set_parameters(parameters, true);
-}
-
-std::vector<rcl_interfaces::msg::SetParametersResult>
 NodeParameters::set_parameters(
   const std::vector<rclcpp::Parameter> & parameters,
   bool force)
@@ -616,18 +592,6 @@ __find_parameter_by_name(
     parameters.begin(),
     parameters.end(),
     [&](auto parameter) {return parameter.get_name() == name;});
-}
-
-rcl_interfaces::msg::SetParametersResult
-NodeParameters::set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters)
-{
-  return set_parameters_atomically(parameters, false);
-}
-
-rcl_interfaces::msg::SetParametersResult
-NodeParameters::force_set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters)
-{
-  return set_parameters_atomically(parameters, true);
 }
 
 rcl_interfaces::msg::SetParametersResult

--- a/rclcpp/src/rclcpp/parameter_service.cpp
+++ b/rclcpp/src/rclcpp/parameter_service.cpp
@@ -87,7 +87,8 @@ ParameterService::ParameterService(
       for (auto & p : request->parameters) {
         try {
           result = node_params->set_parameters_atomically(
-            {rclcpp::Parameter::from_parameter_msg(p)});
+            {rclcpp::Parameter::from_parameter_msg(p)},
+            false);
         } catch (const rclcpp::exceptions::ParameterNotDeclaredException & ex) {
           RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "Failed to set parameter: %s", ex.what());
           result.successful = false;
@@ -114,7 +115,7 @@ ParameterService::ParameterService(
           return rclcpp::Parameter::from_parameter_msg(p);
         });
       try {
-        auto result = node_params->set_parameters_atomically(pvariants);
+        auto result = node_params->set_parameters_atomically(pvariants, false);
         response->result = result;
       } catch (const rclcpp::exceptions::ParameterNotDeclaredException & ex) {
         RCLCPP_DEBUG(

--- a/rclcpp/src/rclcpp/parameter_service.cpp
+++ b/rclcpp/src/rclcpp/parameter_service.cpp
@@ -87,8 +87,7 @@ ParameterService::ParameterService(
       for (auto & p : request->parameters) {
         try {
           result = node_params->set_parameters_atomically(
-            {rclcpp::Parameter::from_parameter_msg(p)},
-            false);
+            {rclcpp::Parameter::from_parameter_msg(p)});
         } catch (const rclcpp::exceptions::ParameterNotDeclaredException & ex) {
           RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "Failed to set parameter: %s", ex.what());
           result.successful = false;
@@ -115,7 +114,7 @@ ParameterService::ParameterService(
           return rclcpp::Parameter::from_parameter_msg(p);
         });
       try {
-        auto result = node_params->set_parameters_atomically(pvariants, false);
+        auto result = node_params->set_parameters_atomically(pvariants);
         response->result = result;
       } catch (const rclcpp::exceptions::ParameterNotDeclaredException & ex) {
         RCLCPP_DEBUG(

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_parameters.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_parameters.cpp
@@ -153,7 +153,7 @@ TEST_F(TestNodeParameters, set_parameters) {
     rclcpp::Parameter("bool_parameter", true),
     rclcpp::Parameter("read_only_parameter", 42),
   };
-  auto result = node_parameters->set_parameters(parameters, false);
+  auto result = node_parameters->set_parameters(parameters);
   ASSERT_EQ(parameters.size(), result.size());
   EXPECT_TRUE(result[0].successful);
   EXPECT_FALSE(result[1].successful);
@@ -161,18 +161,11 @@ TEST_F(TestNodeParameters, set_parameters) {
     "parameter 'read_only_parameter' cannot be set because it is read-only",
     result[1].reason.c_str());
 
-  result = node_parameters->set_parameters({rclcpp::Parameter("read_only_parameter", 55)}, true);
-  ASSERT_EQ(1u, result.size());
-  EXPECT_TRUE(result[0].successful);
-
   RCLCPP_EXPECT_THROW_EQ(
-    node_parameters->set_parameters({rclcpp::Parameter("", true)}, false),
+    node_parameters->set_parameters({rclcpp::Parameter("", true)}),
     rclcpp::exceptions::InvalidParametersException("parameter name must not be empty"));
 
-  result = node_parameters->set_parameters(
-    {rclcpp::Parameter(
-        "undeclared_parameter",
-        3.14159)}, false);
+  result = node_parameters->set_parameters({rclcpp::Parameter("undeclared_parameter", 3.14159)});
   ASSERT_EQ(1u, result.size());
   EXPECT_TRUE(result[0].successful);
 }
@@ -252,7 +245,7 @@ TEST_F(TestNodeParameters, add_remove_parameters_callback) {
     };
 
   auto handle = node_parameters->add_on_set_parameters_callback(callback);
-  auto result = node_parameters->set_parameters(parameters, false);
+  auto result = node_parameters->set_parameters(parameters);
   ASSERT_EQ(1u, result.size());
   EXPECT_FALSE(result[0].successful);
   EXPECT_EQ(reason, result[0].reason);

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -1917,64 +1917,6 @@ TEST_F(TestNode, set_parameters_atomically_undeclared_parameters_allowed) {
   }
 }
 
-// test force_set_parameters
-TEST_F(TestNode, force_set_parameters) {
-  auto node = std::make_shared<rclcpp::Node>(
-    "force_set_parameters"_unq);
-  {
-    // Read only parameter
-    auto name = "parameter"_unq;
-    EXPECT_FALSE(node->has_parameter(name));
-    rcl_interfaces::msg::ParameterDescriptor descriptor;
-    descriptor.read_only = true;
-    node->declare_parameter(name, 42, descriptor);
-    EXPECT_TRUE(node->has_parameter(name));
-    EXPECT_EQ(node->get_parameter(name).get_value<int>(), 42);
-
-    // Regular methods will fail
-    EXPECT_FALSE(node->set_parameter({name, 43}).successful);
-    EXPECT_FALSE(node->set_parameters_atomically({{name, 43}}).successful);
-    EXPECT_FALSE(node->set_parameters({{name, 43}})[0].successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<int>(), 42);
-
-    // Forced methods will succeed
-    EXPECT_TRUE(node->force_set_parameter({name, 43}).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<int>(), 43);
-
-    EXPECT_TRUE(node->force_set_parameters_atomically({{name, 44}}).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<int>(), 44);
-
-    EXPECT_TRUE(node->force_set_parameters({{name, 45}})[0].successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<int>(), 45);
-  }
-  {
-    // Static type parameter
-    auto name = "parameter"_unq;
-    EXPECT_FALSE(node->has_parameter(name));
-    rcl_interfaces::msg::ParameterDescriptor descriptor;
-    descriptor.dynamic_typing = false;
-    node->declare_parameter(name, 42, descriptor);
-    EXPECT_TRUE(node->has_parameter(name));
-    EXPECT_EQ(node->get_parameter(name).get_value<int>(), 42);
-
-    // Regular methods will fail
-    EXPECT_FALSE(node->set_parameter({name, "this is a string"}).successful);
-    EXPECT_FALSE(node->set_parameters_atomically({{name, "this is a string"}}).successful);
-    EXPECT_FALSE(node->set_parameters({{name, "this is a string"}})[0].successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<int>(), 42);
-
-    // Forced methods will succeed
-    EXPECT_TRUE(node->force_set_parameter({name, "this is a string"}).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::string>(), "this is a string");
-
-    EXPECT_TRUE(node->force_set_parameters_atomically({{name, 44}}).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<int>(), 44);
-
-    EXPECT_TRUE(node->force_set_parameters({{name, "this is another string"}})[0].successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::string>(), "this is another string");
-  }
-}
-
 // test get_parameter with undeclared not allowed
 TEST_F(TestNode, get_parameter_undeclared_parameters_not_allowed) {
   auto node = std::make_shared<rclcpp::Node>(

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -917,7 +917,7 @@ TEST_F(TestNode, undeclare_parameter) {
     descriptor.dynamic_typing = true;
     node->declare_parameter(name, rclcpp::ParameterValue{}, descriptor);
     EXPECT_TRUE(node->has_parameter(name));
-    node->undeclare_parameter(name);
+    node->undeclare_parameter(name, false);
     EXPECT_FALSE(node->has_parameter(name));
   }
   {
@@ -925,7 +925,7 @@ TEST_F(TestNode, undeclare_parameter) {
     auto name = "parameter"_unq;
     EXPECT_FALSE(node->has_parameter(name));
     EXPECT_THROW(
-      {node->undeclare_parameter(name);},
+      {node->undeclare_parameter(name, false);},
       rclcpp::exceptions::ParameterNotDeclaredException);
   }
   {
@@ -934,7 +934,7 @@ TEST_F(TestNode, undeclare_parameter) {
     node->declare_parameter(name, 42);
     EXPECT_TRUE(node->has_parameter(name));
     EXPECT_THROW(
-      {node->undeclare_parameter(name);},
+      {node->undeclare_parameter(name, false);},
       rclcpp::exceptions::InvalidParameterTypeException);
     EXPECT_TRUE(node->has_parameter(name));
   }
@@ -943,7 +943,7 @@ TEST_F(TestNode, undeclare_parameter) {
     auto name = "parameter"_unq;
     node->declare_parameter(name, 42);
     EXPECT_TRUE(node->has_parameter(name));
-    EXPECT_NO_THROW(node->force_undeclare_parameter(name));
+    EXPECT_NO_THROW(node->undeclare_parameter(name, true));
     EXPECT_FALSE(node->has_parameter(name));
   }
   {
@@ -954,7 +954,7 @@ TEST_F(TestNode, undeclare_parameter) {
     node->declare_parameter(name, 42, descriptor);
     EXPECT_TRUE(node->has_parameter(name));
     EXPECT_THROW(
-      {node->undeclare_parameter(name);},
+      {node->undeclare_parameter(name, false);},
       rclcpp::exceptions::ParameterImmutableException);
     EXPECT_TRUE(node->has_parameter(name));
   }
@@ -965,7 +965,7 @@ TEST_F(TestNode, undeclare_parameter) {
     descriptor.read_only = true;
     node->declare_parameter(name, 42, descriptor);
     EXPECT_TRUE(node->has_parameter(name));
-    EXPECT_NO_THROW(node->force_undeclare_parameter(name));
+    EXPECT_NO_THROW(node->undeclare_parameter(name, true));
     EXPECT_FALSE(node->has_parameter(name));
   }
 }
@@ -979,7 +979,7 @@ TEST_F(TestNode, has_parameter) {
   descriptor.dynamic_typing = true;
   node->declare_parameter(name, rclcpp::ParameterValue{}, descriptor);
   EXPECT_TRUE(node->has_parameter(name));
-  node->undeclare_parameter(name);
+  node->undeclare_parameter(name, false);
   EXPECT_FALSE(node->has_parameter(name));
 }
 
@@ -992,7 +992,7 @@ TEST_F(TestNode, list_parameters) {
   descriptor.dynamic_typing = true;
   node->declare_parameter(name, rclcpp::ParameterValue{}, descriptor);
   EXPECT_EQ(1u + before_size, node->list_parameters({}, 1u).names.size());
-  node->undeclare_parameter(name);
+  node->undeclare_parameter(name, false);
   EXPECT_EQ(before_size, node->list_parameters({}, 1u).names.size());
 }
 

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -929,26 +929,22 @@ TEST_F(TestNode, undeclare_parameter) {
       rclcpp::exceptions::ParameterNotDeclaredException);
   }
   {
-    // statically typed parameter throws
+    // statically typed parameter can be undeclared from its node
     auto name = "parameter"_unq;
     node->declare_parameter(name, 42);
     EXPECT_TRUE(node->has_parameter(name));
-    EXPECT_THROW(
-      {node->undeclare_parameter(name);},
-      rclcpp::exceptions::InvalidParameterTypeException);
-    EXPECT_TRUE(node->has_parameter(name));
+    EXPECT_NO_THROW(node->undeclare_parameter(name));
+    EXPECT_FALSE(node->has_parameter(name));
   }
   {
-    // read only parameter throws
+    // read only parameter can be undeclared from its node
     auto name = "parameter"_unq;
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.read_only = true;
     node->declare_parameter(name, 42, descriptor);
     EXPECT_TRUE(node->has_parameter(name));
-    EXPECT_THROW(
-      {node->undeclare_parameter(name);},
-      rclcpp::exceptions::ParameterImmutableException);
-    EXPECT_TRUE(node->has_parameter(name));
+    EXPECT_NO_THROW(node->undeclare_parameter(name));
+    EXPECT_FALSE(node->has_parameter(name));
   }
 }
 

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -405,6 +405,14 @@ public:
   void
   undeclare_parameter(const std::string & name);
 
+  /// Undeclare a previously declared parameter ignoring "read_only" and "dynamic_typing" flags.
+  /**
+   * \sa rclcpp::Node::undeclare_parameter
+   */
+  RCLCPP_LIFECYCLE_PUBLIC
+  void
+  force_undeclare_parameter(const std::string & name);
+
   /// Return true if a given parameter is declared.
   /**
    * \sa rclcpp::Node::has_parameter
@@ -421,6 +429,14 @@ public:
   rcl_interfaces::msg::SetParametersResult
   set_parameter(const rclcpp::Parameter & parameter);
 
+  /// Set a single parameter ignoring "read_only" and "dynamic_typing" flags.
+  /**
+   * \sa rclcpp::Node::set_parameter
+   */
+  RCLCPP_LIFECYCLE_PUBLIC
+  rcl_interfaces::msg::SetParametersResult
+  force_set_parameter(const rclcpp::Parameter & parameter);
+
   /// Set one or more parameters, one at a time.
   /**
    * \sa rclcpp::Node::set_parameters
@@ -429,6 +445,14 @@ public:
   std::vector<rcl_interfaces::msg::SetParametersResult>
   set_parameters(const std::vector<rclcpp::Parameter> & parameters);
 
+  /// Set one or more parameters, one at a time, ignoring "read_only" and "dynamic_typing" flags.
+  /**
+   * \sa rclcpp::Node::set_parameters
+   */
+  RCLCPP_LIFECYCLE_PUBLIC
+  std::vector<rcl_interfaces::msg::SetParametersResult>
+  force_set_parameters(const std::vector<rclcpp::Parameter> & parameters);
+
   /// Set one or more parameters, all at once.
   /**
    * \sa rclcpp::Node::set_parameters_atomically
@@ -436,6 +460,14 @@ public:
   RCLCPP_LIFECYCLE_PUBLIC
   rcl_interfaces::msg::SetParametersResult
   set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters);
+
+  /// Set one or more parameters, all at once, ignoring "read_only" and "dynamic_typing" flags.
+  /**
+   * \sa rclcpp::Node::set_parameters_atomically
+   */
+  RCLCPP_LIFECYCLE_PUBLIC
+  rcl_interfaces::msg::SetParametersResult
+  force_set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters);
 
   /// Return the parameter by the given name.
   /**

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -403,15 +403,7 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   void
-  undeclare_parameter(const std::string & name);
-
-  /// Undeclare a previously declared parameter ignoring "read_only" and "dynamic_typing" flags.
-  /**
-   * \sa rclcpp::Node::undeclare_parameter
-   */
-  RCLCPP_LIFECYCLE_PUBLIC
-  void
-  force_undeclare_parameter(const std::string & name);
+  undeclare_parameter(const std::string & name, bool force = false);
 
   /// Return true if a given parameter is declared.
   /**

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -429,14 +429,6 @@ public:
   rcl_interfaces::msg::SetParametersResult
   set_parameter(const rclcpp::Parameter & parameter);
 
-  /// Set a single parameter ignoring "read_only" and "dynamic_typing" flags.
-  /**
-   * \sa rclcpp::Node::set_parameter
-   */
-  RCLCPP_LIFECYCLE_PUBLIC
-  rcl_interfaces::msg::SetParametersResult
-  force_set_parameter(const rclcpp::Parameter & parameter);
-
   /// Set one or more parameters, one at a time.
   /**
    * \sa rclcpp::Node::set_parameters
@@ -445,14 +437,6 @@ public:
   std::vector<rcl_interfaces::msg::SetParametersResult>
   set_parameters(const std::vector<rclcpp::Parameter> & parameters);
 
-  /// Set one or more parameters, one at a time, ignoring "read_only" and "dynamic_typing" flags.
-  /**
-   * \sa rclcpp::Node::set_parameters
-   */
-  RCLCPP_LIFECYCLE_PUBLIC
-  std::vector<rcl_interfaces::msg::SetParametersResult>
-  force_set_parameters(const std::vector<rclcpp::Parameter> & parameters);
-
   /// Set one or more parameters, all at once.
   /**
    * \sa rclcpp::Node::set_parameters_atomically
@@ -460,14 +444,6 @@ public:
   RCLCPP_LIFECYCLE_PUBLIC
   rcl_interfaces::msg::SetParametersResult
   set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters);
-
-  /// Set one or more parameters, all at once, ignoring "read_only" and "dynamic_typing" flags.
-  /**
-   * \sa rclcpp::Node::set_parameters_atomically
-   */
-  RCLCPP_LIFECYCLE_PUBLIC
-  rcl_interfaces::msg::SetParametersResult
-  force_set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters);
 
   /// Return the parameter by the given name.
   /**

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -238,12 +238,6 @@ LifecycleNode::set_parameter(const rclcpp::Parameter & parameter)
   return this->set_parameters_atomically({parameter});
 }
 
-rcl_interfaces::msg::SetParametersResult
-LifecycleNode::force_set_parameter(const rclcpp::Parameter & parameter)
-{
-  return this->force_set_parameters_atomically({parameter});
-}
-
 std::vector<rcl_interfaces::msg::SetParametersResult>
 LifecycleNode::set_parameters(
   const std::vector<rclcpp::Parameter> & parameters)
@@ -251,25 +245,11 @@ LifecycleNode::set_parameters(
   return node_parameters_->set_parameters(parameters, false);
 }
 
-std::vector<rcl_interfaces::msg::SetParametersResult>
-LifecycleNode::force_set_parameters(
-  const std::vector<rclcpp::Parameter> & parameters)
-{
-  return node_parameters_->set_parameters(parameters, true);
-}
-
 rcl_interfaces::msg::SetParametersResult
 LifecycleNode::set_parameters_atomically(
   const std::vector<rclcpp::Parameter> & parameters)
 {
   return node_parameters_->set_parameters_atomically(parameters, false);
-}
-
-rcl_interfaces::msg::SetParametersResult
-LifecycleNode::force_set_parameters_atomically(
-  const std::vector<rclcpp::Parameter> & parameters)
-{
-  return node_parameters_->set_parameters_atomically(parameters, true);
 }
 
 std::vector<rclcpp::Parameter>

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -215,15 +215,9 @@ LifecycleNode::declare_parameter(
 }
 
 void
-LifecycleNode::undeclare_parameter(const std::string & name)
+LifecycleNode::undeclare_parameter(const std::string & name, bool force)
 {
-  this->node_parameters_->undeclare_parameter(name, false);
-}
-
-void
-LifecycleNode::force_undeclare_parameter(const std::string & name)
-{
-  this->node_parameters_->undeclare_parameter(name, true);
+  this->node_parameters_->undeclare_parameter(name, force);
 }
 
 bool

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -235,13 +235,13 @@ LifecycleNode::has_parameter(const std::string & name) const
 rcl_interfaces::msg::SetParametersResult
 LifecycleNode::set_parameter(const rclcpp::Parameter & parameter)
 {
-  return this->set_parameters_atomically({parameter}, false);
+  return this->set_parameters_atomically({parameter});
 }
 
 rcl_interfaces::msg::SetParametersResult
 LifecycleNode::force_set_parameter(const rclcpp::Parameter & parameter)
 {
-  return this->set_parameters_atomically({parameter}, true);
+  return this->force_set_parameters_atomically({parameter});
 }
 
 std::vector<rcl_interfaces::msg::SetParametersResult>

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -236,14 +236,14 @@ std::vector<rcl_interfaces::msg::SetParametersResult>
 LifecycleNode::set_parameters(
   const std::vector<rclcpp::Parameter> & parameters)
 {
-  return node_parameters_->set_parameters(parameters, false);
+  return node_parameters_->set_parameters(parameters);
 }
 
 rcl_interfaces::msg::SetParametersResult
 LifecycleNode::set_parameters_atomically(
   const std::vector<rclcpp::Parameter> & parameters)
 {
-  return node_parameters_->set_parameters_atomically(parameters, false);
+  return node_parameters_->set_parameters_atomically(parameters);
 }
 
 std::vector<rclcpp::Parameter>

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -217,7 +217,13 @@ LifecycleNode::declare_parameter(
 void
 LifecycleNode::undeclare_parameter(const std::string & name)
 {
-  this->node_parameters_->undeclare_parameter(name);
+  this->node_parameters_->undeclare_parameter(name, false);
+}
+
+void
+LifecycleNode::force_undeclare_parameter(const std::string & name)
+{
+  this->node_parameters_->undeclare_parameter(name, true);
 }
 
 bool
@@ -229,21 +235,41 @@ LifecycleNode::has_parameter(const std::string & name) const
 rcl_interfaces::msg::SetParametersResult
 LifecycleNode::set_parameter(const rclcpp::Parameter & parameter)
 {
-  return this->set_parameters_atomically({parameter});
+  return this->set_parameters_atomically({parameter}, false);
+}
+
+rcl_interfaces::msg::SetParametersResult
+LifecycleNode::force_set_parameter(const rclcpp::Parameter & parameter)
+{
+  return this->set_parameters_atomically({parameter}, true);
 }
 
 std::vector<rcl_interfaces::msg::SetParametersResult>
 LifecycleNode::set_parameters(
   const std::vector<rclcpp::Parameter> & parameters)
 {
-  return node_parameters_->set_parameters(parameters);
+  return node_parameters_->set_parameters(parameters, false);
+}
+
+std::vector<rcl_interfaces::msg::SetParametersResult>
+LifecycleNode::force_set_parameters(
+  const std::vector<rclcpp::Parameter> & parameters)
+{
+  return node_parameters_->set_parameters(parameters, true);
 }
 
 rcl_interfaces::msg::SetParametersResult
 LifecycleNode::set_parameters_atomically(
   const std::vector<rclcpp::Parameter> & parameters)
 {
-  return node_parameters_->set_parameters_atomically(parameters);
+  return node_parameters_->set_parameters_atomically(parameters, false);
+}
+
+rcl_interfaces::msg::SetParametersResult
+LifecycleNode::force_set_parameters_atomically(
+  const std::vector<rclcpp::Parameter> & parameters)
+{
+  return node_parameters_->set_parameters_atomically(parameters, true);
 }
 
 std::vector<rclcpp::Parameter>


### PR DESCRIPTION
This PR addresses https://github.com/ros2/rclcpp/issues/1762

It adds new APIs to the `node_parameters` interface that allow to bypass `read_only` and `dynamic_typing` restrictions.
These APIs are used by the node that owns the parameters, while parameter servers (which control changes coming from external nodes) still use old APIs.


Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>