### PR TITLE
Add Clock::sleep_for()

### DIFF
--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -104,6 +104,30 @@ public:
     Context::SharedPtr context = contexts::get_global_default_context());
 
   /**
+   * Sleep for a specified Duration.
+   *
+   * Equivalent to
+   *
+   * ```cpp
+   * clock->sleep_until(clock->now() + rel_time, context)
+   * ```
+   *
+   * The function will return immediately if `rel_time` is zero or negative.
+   *
+   * \param rel_time the length of time to sleep for.
+   * \param context the rclcpp context the clock should use to check that ROS is still initialized.
+   * \return true when the end time is reached
+   * \return false if time cannot be reached reliably, for example from shutdown or a change
+   *    of time source.
+   * \throws std::runtime_error if the context is invalid
+   */
+  RCLCPP_PUBLIC
+  bool
+  sleep_for(
+    Duration rel_time,
+    Context::SharedPtr context = contexts::get_global_default_context());
+
+  /**
    * Returns the clock of the type `RCL_ROS_TIME` is active.
    *
    * \return true if the clock is active

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -173,6 +173,12 @@ Clock::sleep_until(Time until, Context::SharedPtr context)
 }
 
 bool
+Clock::sleep_for(Duration rel_time, Context::SharedPtr context)
+{
+  return sleep_until(now() + rel_time, context);
+}
+
+bool
 Clock::ros_time_is_active()
 {
   if (!rcl_clock_valid(&impl_->rcl_clock_)) {


### PR DESCRIPTION
Resolves #1730

This PR adds a new method`Clock::sleep_for()`. Internally it calls `sleep_until()`. This pattern of reusing the `_until()` method matches [`gcc`'s implementation of `condition_variable::wait_for()` using `condition_variable::wait_until()`](https://github.com/gcc-mirror/gcc/blob/a6e0d593707ae44dec0bdf2bcdc4f539050b46db/libstdc%2B%2B-v3/include/std/condition_variable#L158-L165).