### PR TITLE
make node base sharable

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
@@ -34,7 +34,7 @@ namespace node_interfaces
 {
 
 /// Implementation of the NodeBase part of the Node API.
-class NodeBase : public NodeBaseInterface
+class NodeBase : public NodeBaseInterface, public std::enable_shared_from_this<NodeBase>
 {
 public:
   RCLCPP_SMART_PTR_ALIASES_ONLY(NodeBase)

--- a/rclcpp/include/rclcpp/subscription_factory.hpp
+++ b/rclcpp/include/rclcpp/subscription_factory.hpp
@@ -88,11 +88,7 @@ create_subscription_factory(
   subscription_topic_stats = nullptr
 )
 {
-  rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> options_copy = options;
-  // reset callback group as the Subscription is unnecessary to hold it
-  options_copy.callback_group.reset();
-
-  auto allocator = options_copy.get_allocator();
+  auto allocator = options.get_allocator();
 
   using rclcpp::AnySubscriptionCallback;
   AnySubscriptionCallback<MessageT, AllocatorT> any_subscription_callback(*allocator);
@@ -100,8 +96,7 @@ create_subscription_factory(
 
   SubscriptionFactory factory {
     // factory function that creates a MessageT specific SubscriptionT
-    [options = std::move(options_copy), msg_mem_strat, any_subscription_callback,
-      subscription_topic_stats](
+    [options, msg_mem_strat, any_subscription_callback, subscription_topic_stats](
       rclcpp::node_interfaces::NodeBaseInterface * node_base,
       const std::string & topic_name,
       const rclcpp::QoS & qos

--- a/rclcpp/include/rclcpp/subscription_factory.hpp
+++ b/rclcpp/include/rclcpp/subscription_factory.hpp
@@ -88,7 +88,11 @@ create_subscription_factory(
   subscription_topic_stats = nullptr
 )
 {
-  auto allocator = options.get_allocator();
+  rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> options_copy = options;
+  // reset callback group as the Subscription is unnecessary to hold it
+  options_copy.callback_group.reset();
+
+  auto allocator = options_copy.get_allocator();
 
   using rclcpp::AnySubscriptionCallback;
   AnySubscriptionCallback<MessageT, AllocatorT> any_subscription_callback(*allocator);
@@ -96,7 +100,8 @@ create_subscription_factory(
 
   SubscriptionFactory factory {
     // factory function that creates a MessageT specific SubscriptionT
-    [options, msg_mem_strat, any_subscription_callback, subscription_topic_stats](
+    [options = std::move(options_copy), msg_mem_strat, any_subscription_callback,
+      subscription_topic_stats](
       rclcpp::node_interfaces::NodeBaseInterface * node_base,
       const std::string & topic_name,
       const rclcpp::QoS & qos

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -15,7 +15,6 @@
 #include <string>
 #include <limits>
 #include <memory>
-#include <utility>
 #include <vector>
 
 #include "rclcpp/node_interfaces/node_base.hpp"
@@ -31,93 +30,6 @@
 using rclcpp::exceptions::throw_from_rcl_error;
 
 using rclcpp::node_interfaces::NodeBase;
-
-namespace
-{
-/// A class to manage the lifetime of a node handle and its context
-/**
- * This class bundles together the lifetime of the rcl_node_t handle with the
- * lifetime of the RCL context. This ensures that the context will remain alive
- * for as long as the rcl_node_t handle is alive.
- */
-class NodeHandleWithContext
-{
-public:
-  /// Make an instance of a NodeHandleWithContext
-  /**
-   * The make function returns a std::shared_ptr<rcl_node_t> which is actually
-   * an alias for a std::shared_ptr<NodeHandleWithContext>. There is no use for
-   * accessing a NodeHandleWithContext instance directly, because its only job
-   * is to couple together the lifetime of a context with the lifetime of a
-   * node handle that depends on it.
-   */
-  static std::shared_ptr<rcl_node_t>
-  make(
-    rclcpp::Context::SharedPtr context,
-    std::shared_ptr<std::recursive_mutex> logging_mutex,
-    rcl_node_t * node_handle)
-  {
-    auto aliased_ptr = std::make_shared<NodeHandleWithContext>(
-      NodeHandleWithContext(
-        std::move(context),
-        std::move(logging_mutex),
-        node_handle));
-
-    return std::shared_ptr<rcl_node_t>(std::move(aliased_ptr), node_handle);
-  }
-
-  // This class should not be copied. It should only exist in the
-  // std::shared_ptr that it was originally provided in.
-  NodeHandleWithContext(const NodeHandleWithContext &) = delete;
-  NodeHandleWithContext & operator=(const NodeHandleWithContext &) = delete;
-  NodeHandleWithContext & operator=(NodeHandleWithContext &&) = delete;
-
-  NodeHandleWithContext(NodeHandleWithContext && other)
-  : context_(std::move(other.context_)),
-    logging_mutex_(std::move(other.logging_mutex_)),
-    node_handle_(other.node_handle_)
-  {
-    other.node_handle_ = nullptr;
-  }
-
-  ~NodeHandleWithContext()
-  {
-    if (!node_handle_) {
-      // If the node_handle_ is null, then this object was moved-from. We don't
-      // need to do any cleanup.
-      return;
-    }
-
-    std::lock_guard<std::recursive_mutex> guard(*logging_mutex_);
-    // TODO(ivanpauno): Instead of mutually excluding rcl_node_fini with the global logger mutex,
-    // rcl_logging_rosout_fini_publisher_for_node could be decoupled from there and be called
-    // here directly.
-    if (rcl_node_fini(node_handle_) != RCL_RET_OK) {
-      RCUTILS_LOG_ERROR_NAMED(
-        "rclcpp",
-        "Error in destruction of rcl node handle: %s", rcl_get_error_string().str);
-    }
-    delete node_handle_;
-  }
-
-private:
-  // The constructor is private because this class is only meant to be aliased
-  // into a std::shared_ptr<rcl_node_t> and should not be constructed any other
-  // way.
-  NodeHandleWithContext(
-    rclcpp::Context::SharedPtr context,
-    std::shared_ptr<std::recursive_mutex> logging_mutex,
-    rcl_node_t * node_handle)
-  : context_(std::move(context)),
-    logging_mutex_(std::move(logging_mutex)),
-    node_handle_(node_handle)
-  {}
-
-  rclcpp::Context::SharedPtr context_;
-  std::shared_ptr<std::recursive_mutex> logging_mutex_;
-  rcl_node_t * node_handle_;
-};
-}  // anonymous namespace
 
 NodeBase::NodeBase(
   const std::string & node_name,
@@ -201,7 +113,20 @@ NodeBase::NodeBase(
     throw_from_rcl_error(ret, "failed to initialize rcl node");
   }
 
-  node_handle_ = NodeHandleWithContext::make(context_, logging_mutex, rcl_node.release());
+  node_handle_.reset(
+    rcl_node.release(),
+    [logging_mutex](rcl_node_t * node) -> void {
+      std::lock_guard<std::recursive_mutex> guard(*logging_mutex);
+      // TODO(ivanpauno): Instead of mutually excluding rcl_node_fini with the global logger mutex,
+      // rcl_logging_rosout_fini_publisher_for_node could be decoupled from there and be called
+      // here directly.
+      if (rcl_node_fini(node) != RCL_RET_OK) {
+        RCUTILS_LOG_ERROR_NAMED(
+          "rclcpp",
+          "Error in destruction of rcl node handle: %s", rcl_get_error_string().str);
+      }
+      delete node;
+    });
 
   // Create the default callback group.
   using rclcpp::CallbackGroupType;
@@ -259,13 +184,13 @@ NodeBase::get_rcl_node_handle() const
 std::shared_ptr<rcl_node_t>
 NodeBase::get_shared_rcl_node_handle()
 {
-  return node_handle_;
+  return std::shared_ptr<rcl_node_t>(shared_from_this(), node_handle_.get());
 }
 
 std::shared_ptr<const rcl_node_t>
 NodeBase::get_shared_rcl_node_handle() const
 {
-  return node_handle_;
+  return std::shared_ptr<const rcl_node_t>(shared_from_this(), node_handle_.get());
 }
 
 rclcpp::CallbackGroup::SharedPtr

--- a/rclcpp/test/rclcpp/test_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/test_memory_strategy.cpp
@@ -365,7 +365,7 @@ TEST_F(TestMemoryStrategy, get_group_by_subscription) {
       callback_group,
       memory_strategy()->get_group_by_subscription(subscription, weak_groups_to_nodes));
   }  // Node goes out of scope
-  // callback_group and NodeBase(SubscriptionBase->rcl_node_t->NodeBase) is still alive.
+  // NodeBase(SubscriptionBase->rcl_node_t->NodeBase) is still alive.
   EXPECT_EQ(
     callback_group,
     memory_strategy()->get_group_by_subscription(subscription, weak_groups_to_nodes));

--- a/rclcpp/test/rclcpp/test_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/test_memory_strategy.cpp
@@ -307,6 +307,8 @@ TEST_F(TestMemoryStrategy, get_node_by_group) {
     EXPECT_EQ(
       node_handle,
       memory_strategy()->get_node_by_group(callback_group, weak_groups_to_nodes));
+    // Clear the handles to not hold NodeBase.
+    memory_strategy()->clear_handles();
   }  // Node goes out of scope
   // Callback group still exists, so lookup returns nullptr because node is destroyed.
   EXPECT_EQ(
@@ -317,7 +319,6 @@ TEST_F(TestMemoryStrategy, get_node_by_group) {
 TEST_F(TestMemoryStrategy, get_group_by_subscription) {
   WeakCallbackGroupsToNodesMap weak_groups_to_nodes;
   rclcpp::SubscriptionBase::SharedPtr subscription = nullptr;
-  rclcpp::CallbackGroup::SharedPtr callback_group = nullptr;
   {
     auto node = std::make_shared<rclcpp::Node>("node", "ns");
     node->for_each_callback_group(
@@ -336,15 +337,12 @@ TEST_F(TestMemoryStrategy, get_group_by_subscription) {
       auto non_persistant_group =
         node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
-      callback_group =
+      auto callback_group =
         node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
       auto subscription_callback = [](test_msgs::msg::Empty::ConstSharedPtr) {};
       const rclcpp::QoS qos(10);
 
       rclcpp::SubscriptionOptions subscription_options;
-
-      // This callback group is held as a shared_ptr in subscription_options, which means it
-      // stays alive as long as subscription does.
       subscription_options.callback_group = callback_group;
 
       subscription = node->create_subscription<
@@ -360,7 +358,7 @@ TEST_F(TestMemoryStrategy, get_group_by_subscription) {
         memory_strategy()->get_group_by_subscription(subscription, weak_groups_to_nodes));
     }  // callback_group goes out of scope
     EXPECT_EQ(
-      callback_group,
+      nullptr,
       memory_strategy()->get_group_by_subscription(subscription, weak_groups_to_nodes));
   }  // Node goes out of scope
   EXPECT_EQ(


### PR DESCRIPTION
It's intent to use another way to fix https://github.com/ros2/rclcpp/pull/1754 to prevent the separation of `rcl_node_init` and `rcl_node_fini`.

<del>and changing the creation behavior of subscription that not holding callback group to keep the consistency of other entities to make the test passed.</del>
