### PR TITLE
not to hold callback group in subscription

### DIFF
--- a/rclcpp/include/rclcpp/create_generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_generic_subscription.hpp
@@ -54,7 +54,8 @@ std::shared_ptr<GenericSubscription> create_generic_subscription(
   std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback,
   const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options = (
     rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>()
-  )
+  ),
+  rclcpp::CallbackGroup::SharedPtr group = nullptr
 )
 {
   auto ts_lib = rclcpp::get_typesupport_library(
@@ -69,7 +70,7 @@ std::shared_ptr<GenericSubscription> create_generic_subscription(
     callback,
     options);
 
-  topics_interface->add_subscription(subscription, options.callback_group);
+  topics_interface->add_subscription(subscription, group);
 
   return subscription;
 }

--- a/rclcpp/include/rclcpp/create_generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_generic_subscription.hpp
@@ -41,9 +41,10 @@ namespace rclcpp
  * \param topic_type Topic type
  * \param qos %QoS settings
  * \param callback Callback for new messages of serialized form
- * \param options %Publisher options.
- * Not all publisher options are currently respected, the only relevant options for this
- * publisher are `event_callbacks`, `use_default_callbacks`, and `%callback_group`.
+ * \param options %Subscription options.
+ * Not all subscription options are currently respected, the only relevant options for this
+ * subscription are `event_callbacks` and `use_default_callbacks`.
+ * \param group Callback group to execute this subscription's callback.
  */
 template<typename AllocatorT = std::allocator<void>>
 std::shared_ptr<GenericSubscription> create_generic_subscription(

--- a/rclcpp/include/rclcpp/create_generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_generic_subscription.hpp
@@ -70,6 +70,22 @@ std::shared_ptr<GenericSubscription> create_generic_subscription(
     callback,
     options);
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else
+# pragma warning(push)
+# pragma warning(disable: 4996)
+#endif
+  if (group == nullptr) {
+    group = options.callback_group;
+  }
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
+#endif
+
   topics_interface->add_subscription(subscription, group);
 
   return subscription;

--- a/rclcpp/include/rclcpp/create_generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_generic_subscription.hpp
@@ -44,7 +44,7 @@ namespace rclcpp
  * \param options %Subscription options.
  * Not all subscription options are currently respected, the only relevant options for this
  * subscription are `event_callbacks` and `use_default_callbacks`.
- * \param group Callback group to execute this subscription's callback.
+ * \param callback_group Callback group to execute this subscription's callback.
  */
 template<typename AllocatorT = std::allocator<void>>
 std::shared_ptr<GenericSubscription> create_generic_subscription(
@@ -56,7 +56,7 @@ std::shared_ptr<GenericSubscription> create_generic_subscription(
   const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options = (
     rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>()
   ),
-  rclcpp::CallbackGroup::SharedPtr group = nullptr
+  rclcpp::CallbackGroup::SharedPtr callback_group = nullptr
 )
 {
   auto ts_lib = rclcpp::get_typesupport_library(
@@ -78,8 +78,8 @@ std::shared_ptr<GenericSubscription> create_generic_subscription(
 # pragma warning(push)
 # pragma warning(disable: 4996)
 #endif
-  if (group == nullptr) {
-    group = options.callback_group;
+  if (callback_group == nullptr) {
+    callback_group = options.callback_group;
   }
 #ifndef _WIN32
 # pragma GCC diagnostic pop
@@ -87,7 +87,7 @@ std::shared_ptr<GenericSubscription> create_generic_subscription(
 # pragma warning(pop)
 #endif
 
-  topics_interface->add_subscription(subscription, group);
+  topics_interface->add_subscription(subscription, callback_group);
 
   return subscription;
 }

--- a/rclcpp/include/rclcpp/create_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_subscription.hpp
@@ -62,7 +62,7 @@ create_subscription(
   const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options = (
     rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>()
   ),
-  rclcpp::CallbackGroup::SharedPtr group = nullptr,
+  rclcpp::CallbackGroup::SharedPtr callback_group = nullptr,
   typename MessageMemoryStrategyT::SharedPtr msg_mem_strat = (
     MessageMemoryStrategyT::create_default()
   )
@@ -112,7 +112,7 @@ create_subscription(
       std::chrono::duration_cast<std::chrono::nanoseconds>(
         options.topic_stats_options.publish_period),
       sub_call_back,
-      group,
+      callback_group,
       node_topics_interface->get_node_base_interface(),
       node_timer_interface
     );
@@ -143,8 +143,8 @@ create_subscription(
 # pragma warning(push)
 # pragma warning(disable: 4996)
 #endif
-  if (group == nullptr) {
-    group = options.callback_group;
+  if (callback_group == nullptr) {
+    callback_group = options.callback_group;
   }
 #ifndef _WIN32
 # pragma GCC diagnostic pop
@@ -152,7 +152,7 @@ create_subscription(
 # pragma warning(pop)
 #endif
 
-  node_topics_interface->add_subscription(sub, group);
+  node_topics_interface->add_subscription(sub, callback_group);
 
   return std::dynamic_pointer_cast<SubscriptionT>(sub);
 }
@@ -230,7 +230,7 @@ create_subscription(
  * \param qos
  * \param callback
  * \param options
- * \param group
+ * \param callback_group
  * \param msg_mem_strat
  * \return the created subscription
  * \throws std::invalid_argument if topic statistics is enabled and the publish period is
@@ -252,7 +252,7 @@ create_subscription(
   const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options = (
     rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>()
   ),
-  rclcpp::CallbackGroup::SharedPtr group = nullptr,
+  rclcpp::CallbackGroup::SharedPtr callback_group = nullptr,
   typename MessageMemoryStrategyT::SharedPtr msg_mem_strat = (
     MessageMemoryStrategyT::create_default()
   )
@@ -260,7 +260,8 @@ create_subscription(
 {
   return rclcpp::detail::create_subscription<
     MessageT, CallbackT, AllocatorT, SubscriptionT, MessageMemoryStrategyT>(
-    node, node, topic_name, qos, std::forward<CallbackT>(callback), options, group, msg_mem_strat);
+    node, node, topic_name, qos, std::forward<CallbackT>(callback), options, callback_group,
+    msg_mem_strat);
 }
 
 /// Create and return a subscription of the given MessageT type.
@@ -310,7 +311,7 @@ create_subscription(
   const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options = (
     rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>()
   ),
-  rclcpp::CallbackGroup::SharedPtr group = nullptr,
+  rclcpp::CallbackGroup::SharedPtr callback_group = nullptr,
   typename MessageMemoryStrategyT::SharedPtr msg_mem_strat = (
     MessageMemoryStrategyT::create_default()
   )
@@ -319,7 +320,7 @@ create_subscription(
   return rclcpp::detail::create_subscription<
     MessageT, CallbackT, AllocatorT, SubscriptionT, MessageMemoryStrategyT>(
     node_parameters, node_topics, topic_name, qos,
-    std::forward<CallbackT>(callback), options, group, msg_mem_strat);
+    std::forward<CallbackT>(callback), options, callback_group, msg_mem_strat);
 }
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/create_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_subscription.hpp
@@ -191,7 +191,6 @@ template<
   typename SubscriptionT = rclcpp::Subscription<MessageT, AllocatorT>,
   typename MessageMemoryStrategyT = typename SubscriptionT::MessageMemoryStrategyType,
   typename NodeT>
-[[deprecated("use another overloaded method create_subscription instead")]]
 typename std::shared_ptr<SubscriptionT>
 create_subscription(
   NodeT & node,
@@ -273,14 +272,13 @@ template<
   typename SubscriptionT = rclcpp::Subscription<MessageT, AllocatorT>,
   typename MessageMemoryStrategyT = typename SubscriptionT::MessageMemoryStrategyType>
 typename std::shared_ptr<SubscriptionT>
-[[deprecated("use another overloaded method create_subscription instead")]]
 create_subscription(
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node_parameters,
   rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr & node_topics,
   const std::string & topic_name,
   const rclcpp::QoS & qos,
   CallbackT && callback,
-  const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>&options,
+  const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
   typename MessageMemoryStrategyT::SharedPtr msg_mem_strat
 )
 {

--- a/rclcpp/include/rclcpp/create_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_subscription.hpp
@@ -62,6 +62,7 @@ create_subscription(
   const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options = (
     rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>()
   ),
+  rclcpp::CallbackGroup::SharedPtr group = nullptr,
   typename MessageMemoryStrategyT::SharedPtr msg_mem_strat = (
     MessageMemoryStrategyT::create_default()
   )
@@ -111,7 +112,7 @@ create_subscription(
       std::chrono::duration_cast<std::chrono::nanoseconds>(
         options.topic_stats_options.publish_period),
       sub_call_back,
-      options.callback_group,
+      group,
       node_topics_interface->get_node_base_interface(),
       node_timer_interface
     );
@@ -134,7 +135,7 @@ create_subscription(
     qos;
 
   auto sub = node_topics_interface->create_subscription(topic_name, factory, actual_qos);
-  node_topics_interface->add_subscription(sub, options.callback_group);
+  node_topics_interface->add_subscription(sub, group);
 
   return std::dynamic_pointer_cast<SubscriptionT>(sub);
 }
@@ -173,6 +174,57 @@ template<
   typename SubscriptionT = rclcpp::Subscription<MessageT, AllocatorT>,
   typename MessageMemoryStrategyT = typename SubscriptionT::MessageMemoryStrategyType,
   typename NodeT>
+[[deprecated("use another overloaded method create_subscription instead")]]
+typename std::shared_ptr<SubscriptionT>
+create_subscription(
+  NodeT & node,
+  const std::string & topic_name,
+  const rclcpp::QoS & qos,
+  CallbackT && callback,
+  const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+  typename MessageMemoryStrategyT::SharedPtr msg_mem_strat
+)
+{
+  return rclcpp::detail::create_subscription<
+    MessageT, CallbackT, AllocatorT, SubscriptionT, MessageMemoryStrategyT>(
+    node, node, topic_name, qos, std::forward<CallbackT>(callback), options,
+    options.callback_group, msg_mem_strat);
+}
+
+/// Create and return a subscription of the given MessageT type.
+/**
+ * The NodeT type only needs to have a method called get_node_topics_interface()
+ * which returns a shared_ptr to a NodeTopicsInterface, or be a
+ * NodeTopicsInterface pointer itself.
+ *
+ * In case `options.qos_overriding_options` is enabling qos parameter overrides,
+ * NodeT must also have a method called get_node_parameters_interface()
+ * which returns a shared_ptr to a NodeParametersInterface.
+ *
+ * \tparam MessageT
+ * \tparam CallbackT
+ * \tparam AllocatorT
+ * \tparam SubscriptionT
+ * \tparam MessageMemoryStrategyT
+ * \tparam NodeT
+ * \param node
+ * \param topic_name
+ * \param qos
+ * \param callback
+ * \param options
+ * \param group
+ * \param msg_mem_strat
+ * \return the created subscription
+ * \throws std::invalid_argument if topic statistics is enabled and the publish period is
+ * less than or equal to zero.
+ */
+template<
+  typename MessageT,
+  typename CallbackT,
+  typename AllocatorT = std::allocator<void>,
+  typename SubscriptionT = rclcpp::Subscription<MessageT, AllocatorT>,
+  typename MessageMemoryStrategyT = typename SubscriptionT::MessageMemoryStrategyType,
+  typename NodeT>
 typename std::shared_ptr<SubscriptionT>
 create_subscription(
   NodeT & node,
@@ -182,6 +234,7 @@ create_subscription(
   const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options = (
     rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>()
   ),
+  rclcpp::CallbackGroup::SharedPtr group = nullptr,
   typename MessageMemoryStrategyT::SharedPtr msg_mem_strat = (
     MessageMemoryStrategyT::create_default()
   )
@@ -189,7 +242,35 @@ create_subscription(
 {
   return rclcpp::detail::create_subscription<
     MessageT, CallbackT, AllocatorT, SubscriptionT, MessageMemoryStrategyT>(
-    node, node, topic_name, qos, std::forward<CallbackT>(callback), options, msg_mem_strat);
+    node, node, topic_name, qos, std::forward<CallbackT>(callback), options, group, msg_mem_strat);
+}
+
+/// Create and return a subscription of the given MessageT type.
+/**
+ * See \ref create_subscription().
+ */
+template<
+  typename MessageT,
+  typename CallbackT,
+  typename AllocatorT = std::allocator<void>,
+  typename SubscriptionT = rclcpp::Subscription<MessageT, AllocatorT>,
+  typename MessageMemoryStrategyT = typename SubscriptionT::MessageMemoryStrategyType>
+typename std::shared_ptr<SubscriptionT>
+[[deprecated("use another overloaded method create_subscription instead")]]
+create_subscription(
+  rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node_parameters,
+  rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr & node_topics,
+  const std::string & topic_name,
+  const rclcpp::QoS & qos,
+  CallbackT && callback,
+  const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>&options,
+  typename MessageMemoryStrategyT::SharedPtr msg_mem_strat
+)
+{
+  return rclcpp::detail::create_subscription<
+    MessageT, CallbackT, AllocatorT, SubscriptionT, MessageMemoryStrategyT>(
+    node_parameters, node_topics, topic_name, qos,
+    std::forward<CallbackT>(callback), options, options.callback_group, msg_mem_strat);
 }
 
 /// Create and return a subscription of the given MessageT type.
@@ -212,6 +293,7 @@ create_subscription(
   const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options = (
     rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>()
   ),
+  rclcpp::CallbackGroup::SharedPtr group = nullptr,
   typename MessageMemoryStrategyT::SharedPtr msg_mem_strat = (
     MessageMemoryStrategyT::create_default()
   )
@@ -220,7 +302,7 @@ create_subscription(
   return rclcpp::detail::create_subscription<
     MessageT, CallbackT, AllocatorT, SubscriptionT, MessageMemoryStrategyT>(
     node_parameters, node_topics, topic_name, qos,
-    std::forward<CallbackT>(callback), options, msg_mem_strat);
+    std::forward<CallbackT>(callback), options, group, msg_mem_strat);
 }
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/create_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_subscription.hpp
@@ -135,6 +135,23 @@ create_subscription(
     qos;
 
   auto sub = node_topics_interface->create_subscription(topic_name, factory, actual_qos);
+
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else
+# pragma warning(push)
+# pragma warning(disable: 4996)
+#endif
+  if (group == nullptr) {
+    group = options.callback_group;
+  }
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
+#endif
+
   node_topics_interface->add_subscription(sub, group);
 
   return std::dynamic_pointer_cast<SubscriptionT>(sub);

--- a/rclcpp/include/rclcpp/create_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_subscription.hpp
@@ -168,8 +168,6 @@ create_subscription(
  * NodeT must also have a method called get_node_parameters_interface()
  * which returns a shared_ptr to a NodeParametersInterface.
  *
- * \deprecated use another overloaded method create_subscription instead.
- *
  * \tparam MessageT
  * \tparam CallbackT
  * \tparam AllocatorT
@@ -193,6 +191,7 @@ template<
   typename SubscriptionT = rclcpp::Subscription<MessageT, AllocatorT>,
   typename MessageMemoryStrategyT = typename SubscriptionT::MessageMemoryStrategyType,
   typename NodeT>
+[[deprecated("use another overloaded method create_subscription instead")]]
 typename std::shared_ptr<SubscriptionT>
 create_subscription(
   NodeT & node,

--- a/rclcpp/include/rclcpp/create_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_subscription.hpp
@@ -168,6 +168,8 @@ create_subscription(
  * NodeT must also have a method called get_node_parameters_interface()
  * which returns a shared_ptr to a NodeParametersInterface.
  *
+ * \deprecated use another overloaded method create_subscription instead.
+ *
  * \tparam MessageT
  * \tparam CallbackT
  * \tparam AllocatorT

--- a/rclcpp/include/rclcpp/generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/generic_subscription.hpp
@@ -64,8 +64,7 @@ public:
    * \param callback Callback for new messages of serialized form
    * \param options %Subscription options.
    * Not all subscription options are currently respected, the only relevant options for this
-   * subscription are `event_callbacks`, `use_default_callbacks`, `ignore_local_publications`, and
-   * `%callback_group`.
+   * subscription are `event_callbacks`, `use_default_callbacks` and `ignore_local_publications`.
    */
   template<typename AllocatorT = std::allocator<void>>
   GenericSubscription(

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -201,6 +201,8 @@ public:
 
   /// Create and return a Subscription.
   /**
+   * \deprecated use another overloaded method create_subscription instead.
+   *
    * \param[in] topic_name The topic to subscribe on.
    * \param[in] qos QoS profile for Subcription.
    * \param[in] callback The user-defined callback function to receive a message

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -201,8 +201,6 @@ public:
 
   /// Create and return a Subscription.
   /**
-   * \deprecated use another overloaded method create_subscription instead.
-   *
    * \param[in] topic_name The topic to subscribe on.
    * \param[in] qos QoS profile for Subcription.
    * \param[in] callback The user-defined callback function to receive a message
@@ -217,6 +215,7 @@ public:
     typename SubscriptionT = rclcpp::Subscription<MessageT, AllocatorT>,
     typename MessageMemoryStrategyT = typename SubscriptionT::MessageMemoryStrategyType
   >
+  [[deprecated("use another overloaded method create_subscription instead")]]
   std::shared_ptr<SubscriptionT>
   create_subscription(
     const std::string & topic_name,

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -232,7 +232,7 @@ public:
    * \param[in] qos QoS profile for Subcription.
    * \param[in] callback The user-defined callback function to receive a message
    * \param[in] options Additional options for the creation of the Subscription.
-   * \param[in] group Callback group to execute this subscription's callback.
+   * \param[in] callback_group Callback group to execute this subscription's callback.
    * \param[in] msg_mem_strat The message memory strategy to use for allocating messages.
    * \return Shared pointer to the created subscription.
    */
@@ -250,7 +250,7 @@ public:
     CallbackT && callback,
     const SubscriptionOptionsWithAllocator<AllocatorT> & options =
     SubscriptionOptionsWithAllocator<AllocatorT>(),
-    rclcpp::CallbackGroup::SharedPtr group = nullptr,
+    rclcpp::CallbackGroup::SharedPtr callback_group = nullptr,
     typename MessageMemoryStrategyT::SharedPtr msg_mem_strat = (
       MessageMemoryStrategyT::create_default()
     )
@@ -334,7 +334,7 @@ public:
    * \param[in] options %Subscription options.
    * Not all subscription options are currently respected, the only relevant options for this
    * subscription are `event_callbacks`, `use_default_callbacks` and `ignore_local_publications`.
-   * \param[in] group Callback group to execute this subscription's callback.
+   * \param[in] callback_group Callback group to execute this subscription's callback.
    * \return Shared pointer to the created generic subscription.
    */
   template<typename AllocatorT = std::allocator<void>>
@@ -346,7 +346,7 @@ public:
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options = (
       rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>()
     ),
-    rclcpp::CallbackGroup::SharedPtr group = nullptr
+    rclcpp::CallbackGroup::SharedPtr callback_group = nullptr
   );
 
   /// Declare and initialize a parameter, return the effective value.

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -215,6 +215,33 @@ public:
     typename SubscriptionT = rclcpp::Subscription<MessageT, AllocatorT>,
     typename MessageMemoryStrategyT = typename SubscriptionT::MessageMemoryStrategyType
   >
+  [[deprecated("use another overloaded method create_subscription instead")]]
+  std::shared_ptr<SubscriptionT>
+  create_subscription(
+    const std::string & topic_name,
+    const rclcpp::QoS & qos,
+    CallbackT && callback,
+    const SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    typename MessageMemoryStrategyT::SharedPtr msg_mem_strat
+  );
+
+  /// Create and return a Subscription.
+  /**
+   * \param[in] topic_name The topic to subscribe on.
+   * \param[in] qos QoS profile for Subcription.
+   * \param[in] callback The user-defined callback function to receive a message
+   * \param[in] options Additional options for the creation of the Subscription.
+   * \param[in] group Callback group to execute this subscription's callback.
+   * \param[in] msg_mem_strat The message memory strategy to use for allocating messages.
+   * \return Shared pointer to the created subscription.
+   */
+  template<
+    typename MessageT,
+    typename CallbackT,
+    typename AllocatorT = std::allocator<void>,
+    typename SubscriptionT = rclcpp::Subscription<MessageT, AllocatorT>,
+    typename MessageMemoryStrategyT = typename SubscriptionT::MessageMemoryStrategyType
+  >
   std::shared_ptr<SubscriptionT>
   create_subscription(
     const std::string & topic_name,
@@ -222,6 +249,7 @@ public:
     CallbackT && callback,
     const SubscriptionOptionsWithAllocator<AllocatorT> & options =
     SubscriptionOptionsWithAllocator<AllocatorT>(),
+    rclcpp::CallbackGroup::SharedPtr group = nullptr,
     typename MessageMemoryStrategyT::SharedPtr msg_mem_strat = (
       MessageMemoryStrategyT::create_default()
     )
@@ -303,6 +331,7 @@ public:
    * \param[in] qos %QoS settings
    * \param[in] callback Callback for new messages of serialized form
    * \param[in] options %Subscription options.
+   * \param[in] group Callback group to execute this subscription's callback.
    * Not all subscription options are currently respected, the only relevant options for this
  * subscription are `event_callbacks`, `use_default_callbacks`, `ignore_local_publications`, and
  * `%callback_group`.
@@ -316,7 +345,8 @@ public:
     std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback,
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options = (
       rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>()
-    )
+    ),
+    rclcpp::CallbackGroup::SharedPtr group = nullptr
   );
 
   /// Declare and initialize a parameter, return the effective value.

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -215,7 +215,6 @@ public:
     typename SubscriptionT = rclcpp::Subscription<MessageT, AllocatorT>,
     typename MessageMemoryStrategyT = typename SubscriptionT::MessageMemoryStrategyType
   >
-  [[deprecated("use another overloaded method create_subscription instead")]]
   std::shared_ptr<SubscriptionT>
   create_subscription(
     const std::string & topic_name,

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -332,10 +332,9 @@ public:
    * \param[in] qos %QoS settings
    * \param[in] callback Callback for new messages of serialized form
    * \param[in] options %Subscription options.
-   * \param[in] group Callback group to execute this subscription's callback.
    * Not all subscription options are currently respected, the only relevant options for this
- * subscription are `event_callbacks`, `use_default_callbacks`, `ignore_local_publications`, and
- * `%callback_group`.
+   * subscription are `event_callbacks`, `use_default_callbacks` and `ignore_local_publications`.
+   * \param[in] group Callback group to execute this subscription's callback.
    * \return Shared pointer to the created generic subscription.
    */
   template<typename AllocatorT = std::allocator<void>>

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -102,6 +102,32 @@ Node::create_subscription(
     qos,
     std::forward<CallbackT>(callback),
     options,
+    options.callback_group,
+    msg_mem_strat);
+}
+
+template<
+  typename MessageT,
+  typename CallbackT,
+  typename AllocatorT,
+  typename SubscriptionT,
+  typename MessageMemoryStrategyT>
+std::shared_ptr<SubscriptionT>
+Node::create_subscription(
+  const std::string & topic_name,
+  const rclcpp::QoS & qos,
+  CallbackT && callback,
+  const SubscriptionOptionsWithAllocator<AllocatorT> & options,
+  rclcpp::CallbackGroup::SharedPtr group,
+  typename MessageMemoryStrategyT::SharedPtr msg_mem_strat)
+{
+  return rclcpp::create_subscription<MessageT>(
+    *this,
+    extend_name_with_sub_namespace(topic_name, this->get_sub_namespace()),
+    qos,
+    std::forward<CallbackT>(callback),
+    options,
+    group,
     msg_mem_strat);
 }
 
@@ -177,7 +203,8 @@ Node::create_generic_subscription(
   const std::string & topic_type,
   const rclcpp::QoS & qos,
   std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback,
-  const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options)
+  const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+  rclcpp::CallbackGroup::SharedPtr group)
 {
   return rclcpp::create_generic_subscription(
     node_topics_,
@@ -185,7 +212,8 @@ Node::create_generic_subscription(
     topic_type,
     qos,
     std::move(callback),
-    options
+    options,
+    group
   );
 }
 

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -118,7 +118,7 @@ Node::create_subscription(
   const rclcpp::QoS & qos,
   CallbackT && callback,
   const SubscriptionOptionsWithAllocator<AllocatorT> & options,
-  rclcpp::CallbackGroup::SharedPtr group,
+  rclcpp::CallbackGroup::SharedPtr callback_group,
   typename MessageMemoryStrategyT::SharedPtr msg_mem_strat)
 {
   return rclcpp::create_subscription<MessageT>(
@@ -127,7 +127,7 @@ Node::create_subscription(
     qos,
     std::forward<CallbackT>(callback),
     options,
-    group,
+    callback_group,
     msg_mem_strat);
 }
 
@@ -204,7 +204,7 @@ Node::create_generic_subscription(
   const rclcpp::QoS & qos,
   std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback,
   const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
-  rclcpp::CallbackGroup::SharedPtr group)
+  rclcpp::CallbackGroup::SharedPtr callback_group)
 {
   return rclcpp::create_generic_subscription(
     node_topics_,
@@ -213,7 +213,7 @@ Node::create_generic_subscription(
     qos,
     std::move(callback),
     options,
-    group
+    callback_group
   );
 }
 

--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -213,13 +213,15 @@ public:
     ),
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options = (
       rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>()
-  ))
+    ),
+    rclcpp::CallbackGroup::SharedPtr group = nullptr)
   {
     return this->on_parameter_event(
       this->node_topics_interface_,
       callback,
       qos,
-      options);
+      options,
+      group);
   }
 
   /**
@@ -240,14 +242,16 @@ public:
     ),
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options = (
       rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>()
-  ))
+    ),
+    rclcpp::CallbackGroup::SharedPtr group = nullptr)
   {
     return rclcpp::create_subscription<rcl_interfaces::msg::ParameterEvent>(
       node,
       "/parameter_events",
       qos,
       std::forward<CallbackT>(callback),
-      options);
+      options,
+      group);
   }
 
   /// Return if the parameter services are ready.

--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -214,14 +214,14 @@ public:
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options = (
       rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>()
     ),
-    rclcpp::CallbackGroup::SharedPtr group = nullptr)
+    rclcpp::CallbackGroup::SharedPtr callback_group = nullptr)
   {
     return this->on_parameter_event(
       this->node_topics_interface_,
       callback,
       qos,
       options,
-      group);
+      callback_group);
   }
 
   /**
@@ -243,7 +243,7 @@ public:
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options = (
       rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>()
     ),
-    rclcpp::CallbackGroup::SharedPtr group = nullptr)
+    rclcpp::CallbackGroup::SharedPtr callback_group = nullptr)
   {
     return rclcpp::create_subscription<rcl_interfaces::msg::ParameterEvent>(
       node,
@@ -251,7 +251,7 @@ public:
       qos,
       std::forward<CallbackT>(callback),
       options,
-      group);
+      callback_group);
   }
 
   /// Return if the parameter services are ready.

--- a/rclcpp/include/rclcpp/subscription_factory.hpp
+++ b/rclcpp/include/rclcpp/subscription_factory.hpp
@@ -87,11 +87,7 @@ create_subscription_factory(
   subscription_topic_stats = nullptr
 )
 {
-  rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> options_copy = options;
-  // reset callback group as the Subscription is unnecessary to hold it
-  options_copy.callback_group.reset();
-
-  auto allocator = options_copy.get_allocator();
+  auto allocator = options.get_allocator();
 
   using rclcpp::AnySubscriptionCallback;
   AnySubscriptionCallback<MessageT, AllocatorT> any_subscription_callback(*allocator);
@@ -99,8 +95,7 @@ create_subscription_factory(
 
   SubscriptionFactory factory {
     // factory function that creates a MessageT specific SubscriptionT
-    [options = std::move(options_copy), msg_mem_strat, any_subscription_callback,
-      subscription_topic_stats](
+    [options, msg_mem_strat, any_subscription_callback, subscription_topic_stats](
       rclcpp::node_interfaces::NodeBaseInterface * node_base,
       const std::string & topic_name,
       const rclcpp::QoS & qos

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -35,6 +35,13 @@
 namespace rclcpp
 {
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else
+# pragma warning(push)
+# pragma warning(disable: 4996)
+#endif
 /// Non-template base class for subscription options.
 struct SubscriptionOptionsBase
 {
@@ -53,7 +60,7 @@ struct SubscriptionOptionsBase
     RMW_UNIQUE_NETWORK_FLOW_ENDPOINTS_NOT_REQUIRED;
 
   /// The callback group for this subscription. NULL to use the default callback group.
-  rclcpp::CallbackGroup::SharedPtr callback_group = nullptr;
+  [[deprecated]] rclcpp::CallbackGroup::SharedPtr callback_group = nullptr;
 
   /// Setting to explicitly set intraprocess communications.
   IntraProcessSetting use_intra_process_comm = IntraProcessSetting::NodeDefault;
@@ -85,6 +92,11 @@ struct SubscriptionOptionsBase
 
   ContentFilterOptions content_filter_options;
 };
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
+#endif
 
 /// Structure containing optional configuration for Subscriptions.
 template<typename Allocator>

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -60,7 +60,8 @@ struct SubscriptionOptionsBase
     RMW_UNIQUE_NETWORK_FLOW_ENDPOINTS_NOT_REQUIRED;
 
   /// The callback group for this subscription. NULL to use the default callback group.
-  [[deprecated]] rclcpp::CallbackGroup::SharedPtr callback_group = nullptr;
+  [[deprecated("use create_subscription with a dedicated callback_group instead")]]
+  rclcpp::CallbackGroup::SharedPtr callback_group = nullptr;
 
   /// Setting to explicitly set intraprocess communications.
   IntraProcessSetting use_intra_process_comm = IntraProcessSetting::NodeDefault;

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -373,7 +373,6 @@ private:
         rclcpp::CallbackGroupType::MutuallyExclusive,
         false
       );
-      options.callback_group = clock_callback_group_;
       rclcpp::ExecutorOptions exec_options;
       exec_options.context = node_base_->get_context();
       clock_executor_ =
@@ -402,7 +401,8 @@ private:
           clock_cb(msg);
         }
       },
-      options
+      options,
+      clock_callback_group_
     );
   }
 
@@ -417,6 +417,7 @@ private:
       clock_executor_->remove_callback_group(clock_callback_group_);
     }
     clock_subscription_.reset();
+    clock_callback_group_.reset();
   }
 
   // Parameter Event subscription

--- a/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
@@ -136,12 +136,11 @@ protected:
       node_with_subscription->create_callback_group(
       rclcpp::CallbackGroupType::MutuallyExclusive);
 
-    subscription_options.callback_group = callback_group;
     callback_groups_.push_back(callback_group);
 
     auto subscription = node_with_subscription->create_subscription<
       test_msgs::msg::Empty, decltype(subscription_callback)>(
-      "topic", qos, std::move(subscription_callback), subscription_options);
+      "topic", qos, std::move(subscription_callback), subscription_options, callback_group);
     subscriptions_.push_back(subscription);
 
     return node_with_subscription;
@@ -753,14 +752,12 @@ TEST_F(TestAllocatorMemoryStrategy, get_next_subscription_out_of_scope) {
       node->create_callback_group(
       rclcpp::CallbackGroupType::MutuallyExclusive);
 
-    subscription_options.callback_group = callback_group;
-
     auto subscription_callback = [](test_msgs::msg::Empty::ConstSharedPtr) {};
     const rclcpp::QoS qos(10);
 
     auto subscription = node->create_subscription<
       test_msgs::msg::Empty, decltype(subscription_callback)>(
-      "topic", qos, std::move(subscription_callback), subscription_options);
+      "topic", qos, std::move(subscription_callback), subscription_options, callback_group);
 
     node->for_each_callback_group(
       [node, &weak_groups_to_nodes](rclcpp::CallbackGroup::SharedPtr group_ptr)

--- a/rclcpp/test/rclcpp/test_add_callback_groups_to_executor.cpp
+++ b/rclcpp/test/rclcpp/test_add_callback_groups_to_executor.cpp
@@ -99,9 +99,8 @@ TYPED_TEST(TestAddCallbackGroupsToExecutor, add_callback_groups) {
   auto callback = [](test_msgs::msg::Empty::ConstSharedPtr) {};
   rclcpp::CallbackGroup::SharedPtr cb_grp2 = node->create_callback_group(
     rclcpp::CallbackGroupType::MutuallyExclusive);
-  options.callback_group = cb_grp2;
   auto subscription =
-    node->create_subscription<test_msgs::msg::Empty>("topic_name", qos, callback, options);
+    node->create_subscription<test_msgs::msg::Empty>("topic_name", qos, callback, options, cb_grp2);
   executor.add_callback_group(cb_grp2, node->get_node_base_interface());
   ASSERT_EQ(executor.get_all_callback_groups().size(), 2u);
   ASSERT_EQ(executor.get_manually_added_callback_groups().size(), 2u);
@@ -142,9 +141,8 @@ TYPED_TEST(TestAddCallbackGroupsToExecutor, remove_callback_groups) {
   auto callback = [](test_msgs::msg::Empty::ConstSharedPtr) {};
   rclcpp::CallbackGroup::SharedPtr cb_grp2 = node->create_callback_group(
     rclcpp::CallbackGroupType::MutuallyExclusive);
-  options.callback_group = cb_grp2;
   auto subscription =
-    node->create_subscription<test_msgs::msg::Empty>("topic_name", qos, callback, options);
+    node->create_subscription<test_msgs::msg::Empty>("topic_name", qos, callback, options, cb_grp2);
   executor.add_callback_group(cb_grp2, node->get_node_base_interface());
 
   executor.remove_callback_group(cb_grp);
@@ -225,9 +223,8 @@ TYPED_TEST(TestAddCallbackGroupsToExecutor, add_unallowable_callback_groups)
   auto callback = [](test_msgs::msg::Empty::ConstSharedPtr) {};
   rclcpp::CallbackGroup::SharedPtr cb_grp2 = node->create_callback_group(
     rclcpp::CallbackGroupType::MutuallyExclusive, false);
-  options.callback_group = cb_grp2;
   auto subscription =
-    node->create_subscription<test_msgs::msg::Empty>("topic_name", qos, callback, options);
+    node->create_subscription<test_msgs::msg::Empty>("topic_name", qos, callback, options, cb_grp2);
   executor.add_callback_group(cb_grp2, node->get_node_base_interface());
   ASSERT_EQ(executor.get_all_callback_groups().size(), 2u);
 
@@ -259,9 +256,8 @@ TYPED_TEST(TestAddCallbackGroupsToExecutor, one_node_many_callback_groups_many_e
   auto callback = [](test_msgs::msg::Empty::ConstSharedPtr) {};
   rclcpp::CallbackGroup::SharedPtr cb_grp2 = node->create_callback_group(
     rclcpp::CallbackGroupType::MutuallyExclusive, false);
-  options.callback_group = cb_grp2;
   auto subscription =
-    node->create_subscription<test_msgs::msg::Empty>("topic_name", qos, callback, options);
+    node->create_subscription<test_msgs::msg::Empty>("topic_name", qos, callback, options, cb_grp2);
   sub_executor.add_callback_group(cb_grp2, node->get_node_base_interface());
   ASSERT_EQ(sub_executor.get_all_callback_groups().size(), 1u);
   ASSERT_EQ(timer_executor.get_all_callback_groups().size(), 1u);

--- a/rclcpp/test/rclcpp/test_intra_process_manager_with_allocators.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager_with_allocators.cpp
@@ -206,6 +206,7 @@ do_custom_allocator_test(
     10,
     std::forward<decltype(callback)>(callback),
     subscription_options,
+    nullptr,
     msg_mem_strat);
 
   // executor memory strategy

--- a/rclcpp/test/rclcpp/test_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/test_memory_strategy.cpp
@@ -343,11 +343,9 @@ TEST_F(TestMemoryStrategy, get_group_by_subscription) {
       const rclcpp::QoS qos(10);
 
       rclcpp::SubscriptionOptions subscription_options;
-      subscription_options.callback_group = callback_group;
-
       subscription = node->create_subscription<
         test_msgs::msg::Empty, decltype(subscription_callback)>(
-        "topic", qos, std::move(subscription_callback), subscription_options);
+        "topic", qos, std::move(subscription_callback), subscription_options, callback_group);
       weak_groups_to_nodes.insert(
         std::pair<rclcpp::CallbackGroup::WeakPtr,
         rclcpp::node_interfaces::NodeBaseInterface::WeakPtr>(

--- a/rclcpp/test/rclcpp/test_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/test_memory_strategy.cpp
@@ -319,7 +319,6 @@ TEST_F(TestMemoryStrategy, get_node_by_group) {
 TEST_F(TestMemoryStrategy, get_group_by_subscription) {
   WeakCallbackGroupsToNodesMap weak_groups_to_nodes;
   rclcpp::SubscriptionBase::SharedPtr subscription = nullptr;
-  rclcpp::CallbackGroup::SharedPtr callback_group = nullptr;
   {
     auto node = std::make_shared<rclcpp::Node>("node", "ns");
     node->for_each_callback_group(
@@ -338,15 +337,12 @@ TEST_F(TestMemoryStrategy, get_group_by_subscription) {
       auto non_persistant_group =
         node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
-      callback_group =
+      auto callback_group =
         node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
       auto subscription_callback = [](test_msgs::msg::Empty::ConstSharedPtr) {};
       const rclcpp::QoS qos(10);
 
       rclcpp::SubscriptionOptions subscription_options;
-
-      // This callback group is held as a shared_ptr in subscription_options, which means it
-      // stays alive as long as subscription does.
       subscription_options.callback_group = callback_group;
 
       subscription = node->create_subscription<
@@ -362,12 +358,13 @@ TEST_F(TestMemoryStrategy, get_group_by_subscription) {
         memory_strategy()->get_group_by_subscription(subscription, weak_groups_to_nodes));
     }  // callback_group goes out of scope
     EXPECT_EQ(
-      callback_group,
+      nullptr,
       memory_strategy()->get_group_by_subscription(subscription, weak_groups_to_nodes));
   }  // Node goes out of scope
-  // NodeBase(SubscriptionBase->rcl_node_t->NodeBase) is still alive.
+  // NodeBase(SubscriptionBase->rcl_node_t->NodeBase) is still alive,
+  // but Subscription does not hold the callback_group in its subscription_options.
   EXPECT_EQ(
-    callback_group,
+    nullptr,
     memory_strategy()->get_group_by_subscription(subscription, weak_groups_to_nodes));
 }
 

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -330,7 +330,8 @@ public:
     std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback,
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options = (
       rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>()
-    )
+    ),
+    rclcpp::CallbackGroup::SharedPtr group = nullptr
   );
 
   /// Declare and initialize a parameter, return the effective value.

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -247,7 +247,7 @@ public:
    * \param[in] callback The user-defined callback function.
    * \param[in] qos The quality of service for this subscription.
    * \param[in] options The subscription options for this subscription.
-   * \param[in] group Callback group to execute this subscription's callback.
+   * \param[in] callback_group Callback group to execute this subscription's callback.
    * \param[in] msg_mem_strat The message memory strategy to use for allocating messages.
    * \return Shared pointer to the created subscription.
    */
@@ -264,7 +264,7 @@ public:
     CallbackT && callback,
     const SubscriptionOptionsWithAllocator<AllocatorT> & options =
     create_default_subscription_options<AllocatorT>(),
-    rclcpp::CallbackGroup::SharedPtr group = nullptr,
+    rclcpp::CallbackGroup::SharedPtr callback_group = nullptr,
     typename MessageMemoryStrategyT::SharedPtr msg_mem_strat = (
       MessageMemoryStrategyT::create_default()
     )
@@ -333,7 +333,7 @@ public:
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options = (
       rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>()
     ),
-    rclcpp::CallbackGroup::SharedPtr group = nullptr
+    rclcpp::CallbackGroup::SharedPtr callback_group = nullptr
   );
 
   /// Declare and initialize a parameter, return the effective value.

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -230,6 +230,31 @@ public:
     typename AllocatorT = std::allocator<void>,
     typename SubscriptionT = rclcpp::Subscription<MessageT, AllocatorT>,
     typename MessageMemoryStrategyT = typename SubscriptionT::MessageMemoryStrategyType>
+  [[deprecated("use another overloaded method create_subscription instead")]]
+  std::shared_ptr<SubscriptionT>
+  create_subscription(
+    const std::string & topic_name,
+    const rclcpp::QoS & qos,
+    CallbackT && callback,
+    const SubscriptionOptionsWithAllocator<AllocatorT> & options,
+    typename MessageMemoryStrategyT::SharedPtr msg_mem_strat
+  );
+
+  /// Create and return a Subscription.
+  /**
+   * \param[in] topic_name The topic to subscribe on.
+   * \param[in] callback The user-defined callback function.
+   * \param[in] qos The quality of service for this subscription.
+   * \param[in] options The subscription options for this subscription.
+   * \param[in] msg_mem_strat The message memory strategy to use for allocating messages.
+   * \return Shared pointer to the created subscription.
+   */
+  template<
+    typename MessageT,
+    typename CallbackT,
+    typename AllocatorT = std::allocator<void>,
+    typename SubscriptionT = rclcpp::Subscription<MessageT, AllocatorT>,
+    typename MessageMemoryStrategyT = typename SubscriptionT::MessageMemoryStrategyType>
   std::shared_ptr<SubscriptionT>
   create_subscription(
     const std::string & topic_name,
@@ -237,6 +262,7 @@ public:
     CallbackT && callback,
     const SubscriptionOptionsWithAllocator<AllocatorT> & options =
     create_default_subscription_options<AllocatorT>(),
+    rclcpp::CallbackGroup::SharedPtr group = nullptr,
     typename MessageMemoryStrategyT::SharedPtr msg_mem_strat = (
       MessageMemoryStrategyT::create_default()
     )

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -217,6 +217,8 @@ public:
 
   /// Create and return a Subscription.
   /**
+   * \deprecated use another overloaded method create_subscription instead.
+   *
    * \param[in] topic_name The topic to subscribe on.
    * \param[in] callback The user-defined callback function.
    * \param[in] qos The quality of service for this subscription.
@@ -245,6 +247,7 @@ public:
    * \param[in] callback The user-defined callback function.
    * \param[in] qos The quality of service for this subscription.
    * \param[in] options The subscription options for this subscription.
+   * \param[in] group Callback group to execute this subscription's callback.
    * \param[in] msg_mem_strat The message memory strategy to use for allocating messages.
    * \return Shared pointer to the created subscription.
    */

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -230,7 +230,6 @@ public:
     typename AllocatorT = std::allocator<void>,
     typename SubscriptionT = rclcpp::Subscription<MessageT, AllocatorT>,
     typename MessageMemoryStrategyT = typename SubscriptionT::MessageMemoryStrategyType>
-  [[deprecated("use another overloaded method create_subscription instead")]]
   std::shared_ptr<SubscriptionT>
   create_subscription(
     const std::string & topic_name,

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
@@ -185,7 +185,8 @@ LifecycleNode::create_generic_subscription(
   const std::string & topic_type,
   const rclcpp::QoS & qos,
   std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback,
-  const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options)
+  const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+  rclcpp::CallbackGroup::SharedPtr group)
 {
   return rclcpp::create_generic_subscription(
     node_topics_,
@@ -195,7 +196,8 @@ LifecycleNode::create_generic_subscription(
     topic_type,
     qos,
     std::move(callback),
-    options
+    options,
+    group
   );
 }
 

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
@@ -95,7 +95,7 @@ LifecycleNode::create_subscription(
   const rclcpp::QoS & qos,
   CallbackT && callback,
   const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
-  rclcpp::CallbackGroup::SharedPtr group,
+  rclcpp::CallbackGroup::SharedPtr callback_group,
   typename MessageMemoryStrategyT::SharedPtr msg_mem_strat)
 {
   return rclcpp::create_subscription<MessageT>(
@@ -104,7 +104,7 @@ LifecycleNode::create_subscription(
     qos,
     std::forward<CallbackT>(callback),
     options,
-    group,
+    callback_group,
     msg_mem_strat);
 }
 
@@ -186,7 +186,7 @@ LifecycleNode::create_generic_subscription(
   const rclcpp::QoS & qos,
   std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback,
   const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
-  rclcpp::CallbackGroup::SharedPtr group)
+  rclcpp::CallbackGroup::SharedPtr callback_group)
 {
   return rclcpp::create_generic_subscription(
     node_topics_,
@@ -197,7 +197,7 @@ LifecycleNode::create_generic_subscription(
     qos,
     std::move(callback),
     options,
-    group
+    callback_group
   );
 }
 

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
@@ -79,6 +79,32 @@ LifecycleNode::create_subscription(
     qos,
     std::forward<CallbackT>(callback),
     options,
+    options.callback_group,
+    msg_mem_strat);
+}
+
+template<
+  typename MessageT,
+  typename CallbackT,
+  typename AllocatorT,
+  typename SubscriptionT,
+  typename MessageMemoryStrategyT>
+std::shared_ptr<SubscriptionT>
+LifecycleNode::create_subscription(
+  const std::string & topic_name,
+  const rclcpp::QoS & qos,
+  CallbackT && callback,
+  const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options,
+  rclcpp::CallbackGroup::SharedPtr group,
+  typename MessageMemoryStrategyT::SharedPtr msg_mem_strat)
+{
+  return rclcpp::create_subscription<MessageT>(
+    *this,
+    topic_name,
+    qos,
+    std::forward<CallbackT>(callback),
+    options,
+    group,
     msg_mem_strat);
 }
 


### PR DESCRIPTION
keep consistency with other cases to not hold callback group in subscription

https://github.com/ros2/rclcpp/pull/1832#discussion_r761027390
<details><summary> The above link can jump but not show the correct location. Copy comments</summary>

> Because I want to make the subscription keep consistent behavior with other entities.
I found other entities not to hold the callback group, refer to #1754 (comment), so I think it's better not to hold a callback group in the subscription.

That sounds fine, but it doesn't seem to be needed in this PR (which seems to be a replacement of https://github.com/ros2/rclcpp/pull/1754).
I would rather see this done in another PR if it's not needed here.

</details>

NOTE:
the callback group for subscription is needed (kept) here, 
https://github.com/ros2/rclcpp/blob/536df11ee0fdac3e4753754d11052068983c4d5c/rclcpp/include/rclcpp/create_subscription.hpp#L137
not in the subscription
https://github.com/ros2/rclcpp/blob/536df11ee0fdac3e4753754d11052068983c4d5c/rclcpp/include/rclcpp/subscription.hpp#L146