### PR TITLE
use regex for wildcard matching

### DIFF
--- a/rclcpp/include/rclcpp/parameter_map.hpp
+++ b/rclcpp/include/rclcpp/parameter_map.hpp
@@ -35,6 +35,8 @@ using ParameterMap = std::unordered_map<std::string, std::vector<Parameter>>;
 
 /// Convert parameters from rcl_yaml_param_parser into C++ class instances.
 /// \param[in] c_params C structures containing parameters for multiple nodes.
+/// \param[in] node_fqn a Fully Qualified Name of node, default value is nullptr.
+///   If it's not nullptr, return the relative node parameters belonging to this node_fqn.
 /// \returns a map where the keys are fully qualified node names and values a list of parameters.
 /// \throws InvalidParametersException if the `rcl_params_t` is inconsistent or invalid.
 RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/parameter_map.hpp
+++ b/rclcpp/include/rclcpp/parameter_map.hpp
@@ -19,7 +19,7 @@
 #include <rcl_yaml_param_parser/types.h>
 
 #include <string>
-#include <map>
+#include <unordered_map>
 #include <vector>
 
 #include "rclcpp/exceptions.hpp"
@@ -31,7 +31,7 @@ namespace rclcpp
 {
 
 /// A map of fully qualified node names to a list of parameters
-using ParameterMap = std::map<std::string, std::vector<Parameter>>;
+using ParameterMap = std::unordered_map<std::string, std::vector<Parameter>>;
 
 /// Convert parameters from rcl_yaml_param_parser into C++ class instances.
 /// \param[in] c_params C structures containing parameters for multiple nodes.
@@ -39,7 +39,7 @@ using ParameterMap = std::map<std::string, std::vector<Parameter>>;
 /// \throws InvalidParametersException if the `rcl_params_t` is inconsistent or invalid.
 RCLCPP_PUBLIC
 ParameterMap
-parameter_map_from(const rcl_params_t * const c_params);
+parameter_map_from(const rcl_params_t * const c_params, const char * node_fqn = nullptr);
 
 /// Convert parameter value from rcl_yaml_param_parser into a C++ class instance.
 /// \param[in] c_value C structure containing a value of a parameter.

--- a/rclcpp/include/rclcpp/parameter_map.hpp
+++ b/rclcpp/include/rclcpp/parameter_map.hpp
@@ -19,7 +19,7 @@
 #include <rcl_yaml_param_parser/types.h>
 
 #include <string>
-#include <unordered_map>
+#include <map>
 #include <vector>
 
 #include "rclcpp/exceptions.hpp"
@@ -31,7 +31,7 @@ namespace rclcpp
 {
 
 /// A map of fully qualified node names to a list of parameters
-using ParameterMap = std::unordered_map<std::string, std::vector<Parameter>>;
+using ParameterMap = std::map<std::string, std::vector<Parameter>>;
 
 /// Convert parameters from rcl_yaml_param_parser into C++ class instances.
 /// \param[in] c_params C structures containing parameters for multiple nodes.

--- a/rclcpp/src/rclcpp/detail/resolve_parameter_overrides.cpp
+++ b/rclcpp/src/rclcpp/detail/resolve_parameter_overrides.cpp
@@ -53,14 +53,9 @@ rclcpp::detail::resolve_parameter_overrides(
         [params]() {
           rcl_yaml_node_struct_fini(params);
         });
-      // TODO(iuhilnehc-ynos) use map instead of unordered_map for ParameterMap
-      // to set param with contents of parameter file by order
       rclcpp::ParameterMap initial_map = rclcpp::parameter_map_from(params);
 
       for (auto & item : initial_map) {
-        if (item.first == node_fqn) {
-          continue;
-        }
         // Update the regular expression ["/*" -> "(/\\w+)" and "/**" -> "(/\\w+)*"]
         std::string regex = rcpputils::find_and_replace(item.first, "/*", "(/\\w+)");
         if (std::regex_match(node_fqn, std::regex(regex))) {
@@ -68,13 +63,6 @@ rclcpp::detail::resolve_parameter_overrides(
             result[param.get_name()] =
               rclcpp::ParameterValue(param.get_value_message());
           }
-        }
-      }
-      if (initial_map.count(node_fqn) > 0) {
-        // Combine parameter yaml files, overwriting values in older ones
-        for (const rclcpp::Parameter & param : initial_map.at(node_fqn)) {
-          result[param.get_name()] =
-            rclcpp::ParameterValue(param.get_value_message());
         }
       }
     }

--- a/rclcpp/src/rclcpp/parameter_map.cpp
+++ b/rclcpp/src/rclcpp/parameter_map.cpp
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 #include <string>
+#include <regex>
 #include <vector>
 
+#include "rcpputils/find_and_replace.hpp"
 #include "rclcpp/parameter_map.hpp"
 
 using rclcpp::exceptions::InvalidParametersException;
@@ -23,7 +25,7 @@ using rclcpp::ParameterMap;
 using rclcpp::ParameterValue;
 
 ParameterMap
-rclcpp::parameter_map_from(const rcl_params_t * const c_params)
+rclcpp::parameter_map_from(const rcl_params_t * const c_params, const char * node_fqn)
 {
   if (NULL == c_params) {
     throw InvalidParametersException("parameters struct is NULL");
@@ -49,6 +51,17 @@ rclcpp::parameter_map_from(const rcl_params_t * const c_params)
       node_name = c_node_name;
     }
 
+    if (node_fqn) {
+      // Update the regular expression ["/*" -> "(/\\w+)" and "/**" -> "(/\\w+)*"]
+      std::string regex = rcpputils::find_and_replace(node_name, "/*", "(/\\w+)");
+      if (!std::regex_match(node_fqn, std::regex(regex))) {
+        // No need to parse the items because the user just care about node_fqn
+        continue;
+      }
+
+      node_name = node_fqn;
+    }
+
     const rcl_node_params_t * const c_params_node = &(c_params->params[n]);
 
     std::vector<Parameter> & params_node = parameters[node_name];
@@ -65,6 +78,7 @@ rclcpp::parameter_map_from(const rcl_params_t * const c_params)
       params_node.emplace_back(c_param_name, parameter_value_from(c_param_value));
     }
   }
+
   return parameters;
 }
 

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_parameters.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_parameters.cpp
@@ -214,7 +214,7 @@ TEST_F(TestNodeParameters, wildcard_with_namespace)
     "--params-file", (test_resources_path / "wildcards.yaml").string()
   });
 
-  std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("node", "ns", opts);
+  std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("node2", "ns", opts);
 
   auto * node_parameters =
     dynamic_cast<rclcpp::node_interfaces::NodeParameters *>(
@@ -248,7 +248,7 @@ TEST_F(TestNodeParameters, wildcard_no_namespace)
     "--params-file", (test_resources_path / "wildcards.yaml").string()
   });
 
-  std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("node", opts);
+  std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("node2", opts);
 
   auto * node_parameters =
     dynamic_cast<rclcpp::node_interfaces::NodeParameters *>(
@@ -278,7 +278,7 @@ TEST_F(TestNodeParameters, params_by_order)
     "--params-file", (test_resources_path / "params_by_order.yaml").string()
   });
 
-  std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("node", "ns", opts);
+  std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("node2", "ns", opts);
 
   auto * node_parameters =
     dynamic_cast<rclcpp::node_interfaces::NodeParameters *>(
@@ -287,7 +287,7 @@ TEST_F(TestNodeParameters, params_by_order)
 
   const auto & parameter_overrides = node_parameters->get_parameter_overrides();
   EXPECT_EQ(3u, parameter_overrides.size());
-  EXPECT_EQ(parameter_overrides.at("a_value").get<std::string>(), "win");
+  EXPECT_EQ(parameter_overrides.at("a_value").get<std::string>(), "last_one_win");
   EXPECT_EQ(parameter_overrides.at("foo").get<std::string>(), "foo");
   EXPECT_EQ(parameter_overrides.at("bar").get<std::string>(), "bar");
 }
@@ -304,7 +304,7 @@ TEST_F(TestNodeParameters, complicated_wildcards)
   {
     // regex matched: /**/foo/*/bar
     std::shared_ptr<rclcpp::Node> node =
-      std::make_shared<rclcpp::Node>("node", "/a/b/c/foo/d/bar", opts);
+      std::make_shared<rclcpp::Node>("node2", "/a/b/c/foo/d/bar", opts);
 
     auto * node_parameters =
       dynamic_cast<rclcpp::node_interfaces::NodeParameters *>(
@@ -320,7 +320,7 @@ TEST_F(TestNodeParameters, complicated_wildcards)
   {
     // regex not matched: /**/foo/*/bar
     std::shared_ptr<rclcpp::Node> node =
-      std::make_shared<rclcpp::Node>("node", "/a/b/c/foo/bar", opts);
+      std::make_shared<rclcpp::Node>("node2", "/a/b/c/foo/bar", opts);
 
     auto * node_parameters =
       dynamic_cast<rclcpp::node_interfaces::NodeParameters *>(

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_parameters.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_parameters.cpp
@@ -31,6 +31,8 @@
 #include "../../mocking_utils/patch.hpp"
 #include "../../utils/rclcpp_gtest_macros.hpp"
 
+#include "rcpputils/filesystem_helper.hpp"
+
 class TestNodeParameters : public ::testing::Test
 {
 public:
@@ -47,6 +49,7 @@ public:
       dynamic_cast<rclcpp::node_interfaces::NodeParameters *>(
       node->get_node_parameters_interface().get());
     ASSERT_NE(nullptr, node_parameters);
+    test_resources_path /= "test_node_parameters";
   }
 
   void TearDown()
@@ -57,6 +60,8 @@ public:
 protected:
   std::shared_ptr<rclcpp::Node> node;
   rclcpp::node_interfaces::NodeParameters * node_parameters;
+
+  rcpputils::fs::path test_resources_path{TEST_RESOURCES_DIRECTORY};
 };
 
 TEST_F(TestNodeParameters, construct_destruct_rcl_errors) {
@@ -198,4 +203,68 @@ TEST_F(TestNodeParameters, add_remove_parameters_callback) {
   RCLCPP_EXPECT_THROW_EQ(
     node_parameters->remove_on_set_parameters_callback(handle.get()),
     std::runtime_error("Callback doesn't exist"));
+}
+
+TEST_F(TestNodeParameters, wildcard_with_namespace)
+{
+  rclcpp::NodeOptions opts;
+  opts.arguments(
+  {
+    "--ros-args",
+    "--params-file", (test_resources_path / "wildcards.yaml").string()
+  });
+
+  std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("node", "ns", opts);
+
+  auto * node_parameters =
+    dynamic_cast<rclcpp::node_interfaces::NodeParameters *>(
+    node->get_node_parameters_interface().get());
+  ASSERT_NE(nullptr, node_parameters);
+
+  const auto & parameter_overrides = node_parameters->get_parameter_overrides();
+  EXPECT_EQ(7u, parameter_overrides.size());
+  EXPECT_EQ(parameter_overrides.at("full_wild").get<std::string>(), "full_wild");
+  EXPECT_EQ(parameter_overrides.at("namespace_wild").get<std::string>(), "namespace_wild");
+  EXPECT_EQ(
+    parameter_overrides.at("namespace_wild_another").get<std::string>(),
+    "namespace_wild_another");
+  EXPECT_EQ(
+    parameter_overrides.at("namespace_wild_one_star").get<std::string>(),
+    "namespace_wild_one_star");
+  EXPECT_EQ(parameter_overrides.at("node_wild_in_ns").get<std::string>(), "node_wild_in_ns");
+  EXPECT_EQ(
+    parameter_overrides.at("node_wild_in_ns_another").get<std::string>(),
+    "node_wild_in_ns_another");
+  EXPECT_EQ(parameter_overrides.at("explicit_in_ns").get<std::string>(), "explicit_in_ns");
+  EXPECT_EQ(parameter_overrides.count("should_not_appear"), 0u);
+}
+
+TEST_F(TestNodeParameters, wildcard_no_namespace)
+{
+  rclcpp::NodeOptions opts;
+  opts.arguments(
+  {
+    "--ros-args",
+    "--params-file", (test_resources_path / "wildcards.yaml").string()
+  });
+
+  std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("node", opts);
+
+  auto * node_parameters =
+    dynamic_cast<rclcpp::node_interfaces::NodeParameters *>(
+    node->get_node_parameters_interface().get());
+  ASSERT_NE(nullptr, node_parameters);
+
+  const auto & parameter_overrides = node_parameters->get_parameter_overrides();
+  EXPECT_EQ(5u, parameter_overrides.size());
+  EXPECT_EQ(parameter_overrides.at("full_wild").get<std::string>(), "full_wild");
+  EXPECT_EQ(parameter_overrides.at("namespace_wild").get<std::string>(), "namespace_wild");
+  EXPECT_EQ(
+    parameter_overrides.at("namespace_wild_another").get<std::string>(),
+    "namespace_wild_another");
+  EXPECT_EQ(parameter_overrides.at("node_wild_no_ns").get<std::string>(), "node_wild_no_ns");
+  EXPECT_EQ(parameter_overrides.at("explicit_no_ns").get<std::string>(), "explicit_no_ns");
+  EXPECT_EQ(parameter_overrides.count("should_not_appear"), 0u);
+  // "/*" match exactly one token, not expect to get `namespace_wild_one_star`
+  EXPECT_EQ(parameter_overrides.count("namespace_wild_one_star"), 0u);
 }

--- a/rclcpp/test/resources/test_node_parameters/complicated_wildcards.yaml
+++ b/rclcpp/test/resources/test_node_parameters/complicated_wildcards.yaml
@@ -1,0 +1,5 @@
+/**/foo/*/bar:
+  node:
+    ros__parameters:
+      foo: "foo"
+      bar: "bar"

--- a/rclcpp/test/resources/test_node_parameters/complicated_wildcards.yaml
+++ b/rclcpp/test/resources/test_node_parameters/complicated_wildcards.yaml
@@ -1,5 +1,5 @@
 /**/foo/*/bar:
-  node:
+  node2:
     ros__parameters:
       foo: "foo"
       bar: "bar"

--- a/rclcpp/test/resources/test_node_parameters/params_by_order.yaml
+++ b/rclcpp/test/resources/test_node_parameters/params_by_order.yaml
@@ -1,0 +1,17 @@
+# stored in the ordered map (less<string>) by '*' < '/' < alpha('lower_case' > 'upper_case')
+/**:
+  node:
+    ros__parameters:
+      a_value: "first"
+      foo: "foo"
+
+/ns:
+  node:
+    ros__parameters:
+      a_value: "win"
+      bar: "bar"
+
+/*:
+  node:
+    ros__parameters:
+      a_value: "second"

--- a/rclcpp/test/resources/test_node_parameters/params_by_order.yaml
+++ b/rclcpp/test/resources/test_node_parameters/params_by_order.yaml
@@ -1,4 +1,3 @@
-# stored in the ordered map (less<string>) by '*' < '/' < alpha('lower_case' > 'upper_case')
 /**:
   node:
     ros__parameters:
@@ -8,10 +7,10 @@
 /ns:
   node:
     ros__parameters:
-      a_value: "win"
+      a_value: "second"
       bar: "bar"
 
 /*:
   node:
     ros__parameters:
-      a_value: "second"
+      a_value: "last_one_win"

--- a/rclcpp/test/resources/test_node_parameters/params_by_order.yaml
+++ b/rclcpp/test/resources/test_node_parameters/params_by_order.yaml
@@ -1,16 +1,16 @@
 /**:
-  node:
+  node2:
     ros__parameters:
       a_value: "first"
       foo: "foo"
 
 /ns:
-  node:
+  node2:
     ros__parameters:
       a_value: "second"
       bar: "bar"
 
 /*:
-  node:
+  node2:
     ros__parameters:
       a_value: "last_one_win"

--- a/rclcpp/test/resources/test_node_parameters/wildcards.yaml
+++ b/rclcpp/test/resources/test_node_parameters/wildcards.yaml
@@ -1,0 +1,57 @@
+/**:
+  ros__parameters:
+    full_wild: "full_wild"
+
+/**:
+  node:
+    ros__parameters:
+      namespace_wild: "namespace_wild"
+
+/**/node:
+  ros__parameters:
+    namespace_wild_another: "namespace_wild_another"
+
+/*:
+  node:
+    ros__parameters:
+      namespace_wild_one_star: "namespace_wild_one_star"
+
+ns:
+  "*":
+    ros__parameters:
+      node_wild_in_ns: "node_wild_in_ns"
+
+/ns/*:
+  ros__parameters:
+    node_wild_in_ns_another: "node_wild_in_ns_another"
+
+ns:
+  node:
+    ros__parameters:
+      explicit_in_ns: "explicit_in_ns"
+
+"*":
+  ros__parameters:
+    node_wild_no_ns: "node_wild_no_ns"
+
+node:
+  ros__parameters:
+    explicit_no_ns: "explicit_no_ns"
+
+ns:
+  nodeX:
+    ros__parameters:
+      should_not_appear: "incorrect_node_name"
+
+/**/nodeX:
+  ros__parameters:
+    should_not_appear: "incorrect_node_name"
+
+nsX:
+  node:
+    ros__parameters:
+      should_not_appear: "incorrect_namespace"
+
+/nsX/*:
+  ros__parameters:
+    should_not_appear: "incorrect_namespace"

--- a/rclcpp/test/resources/test_node_parameters/wildcards.yaml
+++ b/rclcpp/test/resources/test_node_parameters/wildcards.yaml
@@ -3,16 +3,16 @@
     full_wild: "full_wild"
 
 /**:
-  node:
+  node2:
     ros__parameters:
       namespace_wild: "namespace_wild"
 
-/**/node:
+/**/node2:
   ros__parameters:
     namespace_wild_another: "namespace_wild_another"
 
 /*:
-  node:
+  node2:
     ros__parameters:
       namespace_wild_one_star: "namespace_wild_one_star"
 
@@ -26,7 +26,7 @@ ns:
     node_wild_in_ns_another: "node_wild_in_ns_another"
 
 ns:
-  node:
+  node2:
     ros__parameters:
       explicit_in_ns: "explicit_in_ns"
 
@@ -34,7 +34,7 @@ ns:
   ros__parameters:
     node_wild_no_ns: "node_wild_no_ns"
 
-node:
+node2:
   ros__parameters:
     explicit_no_ns: "explicit_no_ns"
 
@@ -48,7 +48,7 @@ ns:
     should_not_appear: "incorrect_node_name"
 
 nsX:
-  node:
+  node2:
     ros__parameters:
       should_not_appear: "incorrect_namespace"
 


### PR DESCRIPTION
to fix https://github.com/ros2/rcl/issues/954

My intent is to use regex for supporting some complicated wildcard, such as `/**/a/b/*/c/d/*/node`.

I think that the same param name in a node of param file parsed by order seems more reasonable than the order(`/**`, `specific_node`).  Because if there are more wildcards items, such `/**/node`, `/ns/**/node`, etc, I don't think users would like to memory these special rules.

Note: I can also use a 'std::set<..,std::less>' to store the node keys(`*` < `/` < `alpha/num`), and then move all the relative items iterator into `{specific_node, {}}`

Signed-off-by: Chen Lihui <lihui.chen@sony.com>