### PR TITLE
Expose JumpHandler constructor as RCLCPP_PUBLIC

### DIFF
--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -41,6 +41,7 @@ public:
   using pre_callback_t = std::function<void ()>;
   using post_callback_t = std::function<void (const rcl_time_jump_t &)>;
 
+  RCLCPP_PUBLIC
   JumpHandler(
     pre_callback_t pre_callback,
     post_callback_t post_callback,


### PR DESCRIPTION
I am building a feature in rosbag2 for playback using ros-time. (https://github.com/ros2/rosbag2/pull/935 is the first PR). The build fails on windows because this constructor is not `dllexport`ed. See https://ci.ros2.org/job/ci_windows/15999/console
