### PR TITLE
Support intra-process communication between Clients and Services

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -38,6 +38,7 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/any_executable.cpp
   src/rclcpp/callback_group.cpp
   src/rclcpp/client.cpp
+  src/rclcpp/client_intra_process_base.cpp
   src/rclcpp/clock.cpp
   src/rclcpp/context.cpp
   src/rclcpp/contexts/default_context.cpp
@@ -97,6 +98,7 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/serialization.cpp
   src/rclcpp/serialized_message.cpp
   src/rclcpp/service.cpp
+  src/rclcpp/service_intra_process_base.cpp
   src/rclcpp/signal_handler.cpp
   src/rclcpp/subscription_base.cpp
   src/rclcpp/subscription_intra_process_base.cpp

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -35,6 +35,7 @@
 #include "rclcpp/function_traits.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/node_interfaces/node_graph_interface.hpp"
+#include "rclcpp/qos.hpp"
 #include "rclcpp/type_support_decl.hpp"
 #include "rclcpp/utilities.hpp"
 #include "rclcpp/expand_topic_or_service_name.hpp"
@@ -214,6 +215,38 @@ public:
   RCLCPP_PUBLIC
   bool
   exchange_in_use_by_wait_set_state(bool in_use_state);
+
+  /// Get the actual request publsher QoS settings, after the defaults have been determined.
+  /**
+   * The actual configuration applied when using RMW_QOS_POLICY_*_SYSTEM_DEFAULT
+   * can only be resolved after the creation of the client, and it
+   * depends on the underlying rmw implementation.
+   * If the underlying setting in use can't be represented in ROS terms,
+   * it will be set to RMW_QOS_POLICY_*_UNKNOWN.
+   * May throw runtime_error when an unexpected error occurs.
+   *
+   * \return The actual request publsher qos settings.
+   * \throws std::runtime_error if failed to get qos settings
+   */
+  RCLCPP_PUBLIC
+  rclcpp::QoS
+  get_request_publisher_actual_qos() const;
+
+  /// Get the actual response subscription QoS settings, after the defaults have been determined.
+  /**
+   * The actual configuration applied when using RMW_QOS_POLICY_*_SYSTEM_DEFAULT
+   * can only be resolved after the creation of the client, and it
+   * depends on the underlying rmw implementation.
+   * If the underlying setting in use can't be represented in ROS terms,
+   * it will be set to RMW_QOS_POLICY_*_UNKNOWN.
+   * May throw runtime_error when an unexpected error occurs.
+   *
+   * \return The actual response subscription qos settings.
+   * \throws std::runtime_error if failed to get qos settings
+   */
+  RCLCPP_PUBLIC
+  rclcpp::QoS
+  get_response_subscription_actual_qos() const;
 
 protected:
   RCLCPP_DISABLE_COPY(ClientBase)

--- a/rclcpp/include/rclcpp/create_client.hpp
+++ b/rclcpp/include/rclcpp/create_client.hpp
@@ -35,7 +35,8 @@ create_client(
   std::shared_ptr<node_interfaces::NodeServicesInterface> node_services,
   const std::string & service_name,
   const rmw_qos_profile_t & qos_profile,
-  rclcpp::CallbackGroup::SharedPtr group)
+  rclcpp::CallbackGroup::SharedPtr group,
+  rclcpp::IntraProcessSetting ipc_setting)
 {
   rcl_client_options_t options = rcl_client_get_default_options();
   options.qos = qos_profile;
@@ -44,7 +45,8 @@ create_client(
     node_base.get(),
     node_graph,
     service_name,
-    options);
+    options,
+    ipc_setting);
 
   auto cli_base_ptr = std::dynamic_pointer_cast<rclcpp::ClientBase>(cli);
   node_services->add_client(cli_base_ptr, group);

--- a/rclcpp/include/rclcpp/create_service.hpp
+++ b/rclcpp/include/rclcpp/create_service.hpp
@@ -37,7 +37,8 @@ create_service(
   const std::string & service_name,
   CallbackT && callback,
   const rmw_qos_profile_t & qos_profile,
-  rclcpp::CallbackGroup::SharedPtr group)
+  rclcpp::CallbackGroup::SharedPtr group,
+  rclcpp::IntraProcessSetting ipc_setting)
 {
   rclcpp::AnyServiceCallback<ServiceT> any_service_callback;
   any_service_callback.set(std::forward<CallbackT>(callback));
@@ -46,8 +47,8 @@ create_service(
   service_options.qos = qos_profile;
 
   auto serv = Service<ServiceT>::make_shared(
-    node_base->get_shared_rcl_node_handle(),
-    service_name, any_service_callback, service_options);
+    node_base,
+    service_name, any_service_callback, service_options, ipc_setting);
   auto serv_base_ptr = std::dynamic_pointer_cast<ServiceBase>(serv);
   node_services->add_service(serv_base_ptr, group);
   return serv;

--- a/rclcpp/include/rclcpp/experimental/buffers/intra_process_buffer.hpp
+++ b/rclcpp/include/rclcpp/experimental/buffers/intra_process_buffer.hpp
@@ -233,6 +233,54 @@ private:
   }
 };
 
+template<typename BufferT>
+class ServiceIntraProcessBuffer : public IntraProcessBufferBase
+{
+public:
+  RCLCPP_SMART_PTR_ALIASES_ONLY(ServiceIntraProcessBuffer)
+
+  virtual ~ServiceIntraProcessBuffer() {}
+
+  explicit
+  ServiceIntraProcessBuffer(
+    std::unique_ptr<BufferImplementationBase<BufferT>> buffer_impl)
+  {
+    buffer_ = std::move(buffer_impl);
+  }
+
+  // Not to be used in this class. Todo: review base class to avoid this.
+  bool use_take_shared_method() const override
+  {
+    throw std::runtime_error(
+            "use_take_shared_method not intended to be used in this class");
+    return false;
+  }
+
+  bool has_data() const override
+  {
+    return buffer_->has_data();
+  }
+
+  void clear() override
+  {
+    buffer_->clear();
+  }
+
+  void add(BufferT && msg)
+  {
+    buffer_->enqueue(std::move(msg));
+  }
+
+  BufferT
+  consume()
+  {
+    return buffer_->dequeue();
+  }
+
+private:
+  std::unique_ptr<BufferImplementationBase<BufferT>> buffer_;
+};
+
 }  // namespace buffers
 }  // namespace experimental
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/experimental/client_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/client_intra_process.hpp
@@ -1,0 +1,141 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__EXPERIMENTAL__CLIENT_INTRA_PROCESS_HPP_
+#define RCLCPP__EXPERIMENTAL__CLIENT_INTRA_PROCESS_HPP_
+
+#include <functional>
+#include <future>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <variant>  // NOLINT, cpplint doesn't think this is a cpp std header
+
+#include "rcutils/logging_macros.h"
+#include "rclcpp/experimental/buffers/intra_process_buffer.hpp"
+#include "rclcpp/experimental/create_intra_process_buffer.hpp"
+#include "rclcpp/experimental/client_intra_process_base.hpp"
+
+namespace rclcpp
+{
+namespace experimental
+{
+
+template<typename ServiceT>
+class ClientIntraProcess : public ClientIntraProcessBase
+{
+public:
+  RCLCPP_SMART_PTR_DEFINITIONS(ClientIntraProcess)
+
+  using SharedRequest = typename ServiceT::Request::SharedPtr;
+  using SharedResponse = typename ServiceT::Response::SharedPtr;
+
+  using Promise = std::promise<SharedResponse>;
+  using PromiseWithRequest = std::promise<std::pair<SharedRequest, SharedResponse>>;
+
+  using SharedFuture = std::shared_future<SharedResponse>;
+  using SharedFutureWithRequest = std::shared_future<std::pair<SharedRequest, SharedResponse>>;
+
+  using CallbackType = std::function<void (SharedFuture)>;
+  using CallbackWithRequestType = std::function<void (SharedFutureWithRequest)>;
+
+  using CallbackTypeValueVariant = std::tuple<CallbackType, SharedFuture, Promise>;
+  using CallbackWithRequestTypeValueVariant = std::tuple<
+    CallbackWithRequestType, SharedRequest, SharedFutureWithRequest, PromiseWithRequest>;
+
+  using CallbackInfoVariant = std::variant<
+    std::promise<SharedResponse>,
+    CallbackTypeValueVariant,
+    CallbackWithRequestTypeValueVariant>;
+
+  using ClientResponse = std::pair<SharedResponse, CallbackInfoVariant>;
+
+  ClientIntraProcess(
+    rclcpp::Context::SharedPtr context,
+    const std::string & service_name,
+    const rclcpp::QoS & qos_profile)
+  : ClientIntraProcessBase(context, service_name, qos_profile)
+  {
+    // Create the intra-process buffer.
+    buffer_ = rclcpp::experimental::create_service_intra_process_buffer<
+      ClientResponse>(qos_profile);
+  }
+
+  virtual ~ClientIntraProcess() = default;
+
+  bool
+  is_ready(rcl_wait_set_t * wait_set)
+  {
+    (void) wait_set;
+    return buffer_->has_data();
+  }
+
+  void
+  store_intra_process_response(ClientResponse && response)
+  {
+    buffer_->add(std::move(response));
+    gc_.trigger();
+  }
+
+  std::shared_ptr<void>
+  take_data() override
+  {
+    auto data = std::make_shared<ClientResponse>(std::move(buffer_->consume()));
+    return std::static_pointer_cast<void>(data);
+  }
+
+  void execute(std::shared_ptr<void> & data)
+  {
+    if (!data) {
+      throw std::runtime_error("'data' is empty");
+    }
+
+    auto data_ptr = std::static_pointer_cast<ClientResponse>(data);
+    auto & typed_response = data_ptr->first;
+    auto & value = data_ptr->second;
+
+    if (std::holds_alternative<Promise>(value)) {
+      auto & promise = std::get<Promise>(value);
+      promise.set_value(std::move(typed_response));
+    } else if (std::holds_alternative<CallbackTypeValueVariant>(value)) {
+      auto & inner = std::get<CallbackTypeValueVariant>(value);
+      const auto & callback = std::get<CallbackType>(inner);
+      auto & promise = std::get<Promise>(inner);
+      auto & future = std::get<SharedFuture>(inner);
+      promise.set_value(std::move(typed_response));
+      callback(std::move(future));
+    } else if (std::holds_alternative<CallbackWithRequestTypeValueVariant>(value)) {
+      auto & inner = std::get<CallbackWithRequestTypeValueVariant>(value);
+      const auto & callback = std::get<CallbackWithRequestType>(inner);
+      auto & promise = std::get<PromiseWithRequest>(inner);
+      auto & future = std::get<SharedFutureWithRequest>(inner);
+      auto & request = std::get<SharedRequest>(inner);
+      promise.set_value(std::make_pair(std::move(request), std::move(typed_response)));
+      callback(std::move(future));
+    }
+  }
+
+protected:
+  using BufferUniquePtr =
+    typename rclcpp::experimental::buffers::ServiceIntraProcessBuffer<
+    ClientResponse>::UniquePtr;
+
+  BufferUniquePtr buffer_;
+};
+
+}  // namespace experimental
+}  // namespace rclcpp
+
+#endif  // RCLCPP__EXPERIMENTAL__CLIENT_INTRA_PROCESS_HPP_

--- a/rclcpp/include/rclcpp/experimental/client_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/client_intra_process_base.hpp
@@ -1,0 +1,86 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__EXPERIMENTAL__CLIENT_INTRA_PROCESS_BASE_HPP_
+#define RCLCPP__EXPERIMENTAL__CLIENT_INTRA_PROCESS_BASE_HPP_
+
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "rclcpp/context.hpp"
+#include "rclcpp/guard_condition.hpp"
+#include "rclcpp/qos.hpp"
+#include "rclcpp/type_support_decl.hpp"
+#include "rclcpp/waitable.hpp"
+
+namespace rclcpp
+{
+namespace experimental
+{
+
+class ClientIntraProcessBase : public rclcpp::Waitable
+{
+public:
+  RCLCPP_SMART_PTR_ALIASES_ONLY(ClientIntraProcessBase)
+
+  RCLCPP_PUBLIC
+  ClientIntraProcessBase(
+    rclcpp::Context::SharedPtr context,
+    const std::string & service_name,
+    const rclcpp::QoS & qos_profile)
+  : gc_(context), service_name_(service_name), qos_profile_(qos_profile)
+  {}
+
+  virtual ~ClientIntraProcessBase() = default;
+
+  RCLCPP_PUBLIC
+  size_t
+  get_number_of_ready_guard_conditions() {return 1;}
+
+  RCLCPP_PUBLIC
+  void
+  add_to_wait_set(rcl_wait_set_t * wait_set);
+
+  virtual bool
+  is_ready(rcl_wait_set_t * wait_set) = 0;
+
+  virtual
+  std::shared_ptr<void>
+  take_data() = 0;
+
+  virtual void
+  execute(std::shared_ptr<void> & data) = 0;
+
+  RCLCPP_PUBLIC
+  const char *
+  get_service_name() const;
+
+  RCLCPP_PUBLIC
+  QoS
+  get_actual_qos() const;
+
+protected:
+  std::recursive_mutex reentrant_mutex_;
+  rclcpp::GuardCondition gc_;
+
+private:
+  std::string service_name_;
+  QoS qos_profile_;
+};
+
+}  // namespace experimental
+}  // namespace rclcpp
+
+#endif  // RCLCPP__EXPERIMENTAL__CLIENT_INTRA_PROCESS_BASE_HPP_

--- a/rclcpp/include/rclcpp/experimental/create_intra_process_buffer.hpp
+++ b/rclcpp/include/rclcpp/experimental/create_intra_process_buffer.hpp
@@ -94,6 +94,26 @@ create_intra_process_buffer(
   return buffer;
 }
 
+template<typename BufferT>
+typename rclcpp::experimental::buffers::ServiceIntraProcessBuffer<BufferT>::UniquePtr
+create_service_intra_process_buffer(const rclcpp::QoS & qos)
+{
+  using rclcpp::experimental::buffers::RingBufferImplementation;
+
+  size_t buffer_size = qos.depth();
+  auto buffer_impl = std::make_unique<RingBufferImplementation<BufferT>>(buffer_size);
+
+  using rclcpp::experimental::buffers::ServiceIntraProcessBuffer;
+  typename ServiceIntraProcessBuffer<BufferT>::UniquePtr buffer;
+
+  // Construct the intra_process_buffer
+  buffer =
+    std::make_unique<ServiceIntraProcessBuffer<BufferT>>(
+    std::move(buffer_impl));
+
+  return buffer;
+}
+
 }  // namespace experimental
 }  // namespace rclcpp
 

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -31,6 +31,10 @@
 #include <vector>
 
 #include "rclcpp/allocator/allocator_deleter.hpp"
+#include "rclcpp/experimental/client_intra_process_base.hpp"
+#include "rclcpp/experimental/client_intra_process.hpp"
+#include "rclcpp/experimental/service_intra_process_base.hpp"
+#include "rclcpp/experimental/service_intra_process.hpp"
 #include "rclcpp/experimental/subscription_intra_process.hpp"
 #include "rclcpp/experimental/subscription_intra_process_base.hpp"
 #include "rclcpp/experimental/subscription_intra_process_buffer.hpp"
@@ -98,10 +102,10 @@ public:
   RCLCPP_SMART_PTR_DEFINITIONS(IntraProcessManager)
 
   RCLCPP_PUBLIC
-  IntraProcessManager();
+  IntraProcessManager() = default;
 
   RCLCPP_PUBLIC
-  virtual ~IntraProcessManager();
+  virtual ~IntraProcessManager() = default;
 
   /// Register a subscription with the manager, returns subscriptions unique id.
   /**
@@ -117,6 +121,24 @@ public:
   uint64_t
   add_subscription(rclcpp::experimental::SubscriptionIntraProcessBase::SharedPtr subscription);
 
+  /// Register an intra-process client with the manager, returns the client unique id.
+  /**
+   * \param client the ClientIntraProcessBase to register.
+   * \return an unsigned 64-bit integer which is the client's unique id.
+   */
+  RCLCPP_PUBLIC
+  uint64_t
+  add_intra_process_client(rclcpp::experimental::ClientIntraProcessBase::SharedPtr client);
+
+  /// Register an intra-process service with the manager, returns the service unique id.
+  /**
+   * \param service the Service IntraProcessBase to register.
+   * \return an unsigned 64-bit integer which is the service's unique id.
+   */
+  RCLCPP_PUBLIC
+  uint64_t
+  add_intra_process_service(rclcpp::experimental::ServiceIntraProcessBase::SharedPtr service);
+
   /// Unregister a subscription using the subscription's unique id.
   /**
    * This method does not allocate memory.
@@ -126,6 +148,22 @@ public:
   RCLCPP_PUBLIC
   void
   remove_subscription(uint64_t intra_process_subscription_id);
+
+  /// Unregister a client using the client's unique id.
+  /**
+   * \param intra_process_client_id id of the client to remove.
+   */
+  RCLCPP_PUBLIC
+  void
+  remove_client(uint64_t intra_process_client_id);
+
+  /// Unregister a service using the service's unique id.
+  /**
+   * \param intra_process_service_id id of the service to remove.
+   */
+  RCLCPP_PUBLIC
+  void
+  remove_service(uint64_t intra_process_service_id);
 
   /// Register a publisher with the manager, returns the publisher unique id.
   /**
@@ -236,6 +274,49 @@ public:
     }
   }
 
+  /// Send an intra-process client request
+  /**
+   * Using the intra-process client id, a matching intra-process service is retrieved
+   * which will store the request to process it asynchronously.
+   *
+   * \param intra_process_client_id_ the id of the client sending the request
+   * \param request the client's request plus callbacks if any.
+   */
+  template<typename ServiceT, typename RequestT>
+  void
+  send_intra_process_client_request(
+    uint64_t intra_process_client_id_,
+    RequestT request)
+  {
+    std::unique_lock<std::shared_timed_mutex> lock(mutex_);
+
+    auto client_it = clients_to_services_.find(intra_process_client_id_);
+
+    if (client_it == clients_to_services_.end()) {
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "Calling send_intra_process_client_request for invalid or no "
+        "longer existing client id");
+      return;
+    }
+    uint64_t service_id = client_it->second;
+
+    auto service_it = services_.find(service_id);
+    if (service_it == services_.end()) {
+      throw std::runtime_error(
+              "There are no services to send the intra-process request. Do Inter process.");
+    }
+    auto service_intra_process_base = service_it->second.lock();
+    if (service_intra_process_base) {
+      auto service = std::dynamic_pointer_cast<
+        rclcpp::experimental::ServiceIntraProcess<ServiceT>>(service_intra_process_base);
+      service->store_intra_process_request(
+        intra_process_client_id_, std::move(request));
+    } else {
+      services_.erase(service_it);
+    }
+  }
+
   template<
     typename MessageT,
     typename Alloc = std::allocator<void>,
@@ -304,6 +385,18 @@ public:
   rclcpp::experimental::SubscriptionIntraProcessBase::SharedPtr
   get_subscription_intra_process(uint64_t intra_process_subscription_id);
 
+  RCLCPP_PUBLIC
+  rclcpp::experimental::ClientIntraProcessBase::SharedPtr
+  get_client_intra_process(uint64_t intra_process_client_id);
+
+  RCLCPP_PUBLIC
+  rclcpp::experimental::ServiceIntraProcessBase::SharedPtr
+  get_service_intra_process(uint64_t intra_process_service_id);
+
+  RCLCPP_PUBLIC
+  bool
+  service_is_available(uint64_t intra_process_client_id);
+
 private:
   struct SplittedSubscriptions
   {
@@ -320,6 +413,15 @@ private:
   using PublisherToSubscriptionIdsMap =
     std::unordered_map<uint64_t, SplittedSubscriptions>;
 
+  using ClientMap =
+    std::unordered_map<uint64_t, rclcpp::experimental::ClientIntraProcessBase::WeakPtr>;
+
+  using ServiceMap =
+    std::unordered_map<uint64_t, rclcpp::experimental::ServiceIntraProcessBase::WeakPtr>;
+
+  using ClientToServiceIdsMap =
+    std::unordered_map<uint64_t, uint64_t>;
+
   RCLCPP_PUBLIC
   static
   uint64_t
@@ -334,6 +436,12 @@ private:
   can_communicate(
     rclcpp::PublisherBase::SharedPtr pub,
     rclcpp::experimental::SubscriptionIntraProcessBase::SharedPtr sub) const;
+
+  RCLCPP_PUBLIC
+  bool
+  can_communicate(
+    rclcpp::experimental::ClientIntraProcessBase::SharedPtr client,
+    rclcpp::experimental::ServiceIntraProcessBase::SharedPtr service) const;
 
   template<
     typename MessageT,
@@ -422,6 +530,9 @@ private:
   PublisherToSubscriptionIdsMap pub_to_subs_;
   SubscriptionMap subscriptions_;
   PublisherMap publishers_;
+  ClientToServiceIdsMap clients_to_services_;
+  ClientMap clients_;
+  ServiceMap services_;
 
   mutable std::shared_timed_mutex mutex_;
 };

--- a/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/service_intra_process.hpp
@@ -1,0 +1,159 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__EXPERIMENTAL__SERVICE_INTRA_PROCESS_HPP_
+#define RCLCPP__EXPERIMENTAL__SERVICE_INTRA_PROCESS_HPP_
+
+#include <functional>
+#include <future>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+
+#include "rcl/error_handling.h"
+#include "rcutils/logging_macros.h"
+
+#include "rclcpp/any_service_callback.hpp"
+#include "rclcpp/experimental/buffers/intra_process_buffer.hpp"
+#include "rclcpp/experimental/client_intra_process.hpp"
+#include "rclcpp/experimental/create_intra_process_buffer.hpp"
+#include "rclcpp/experimental/service_intra_process_base.hpp"
+#include "rclcpp/logging.hpp"
+#include "rclcpp/qos.hpp"
+#include "rclcpp/type_support_decl.hpp"
+
+namespace rclcpp
+{
+namespace experimental
+{
+
+template<typename ServiceT>
+class ServiceIntraProcess : public ServiceIntraProcessBase
+{
+public:
+  RCLCPP_SMART_PTR_DEFINITIONS(ServiceIntraProcess)
+
+  using SharedRequest = typename ServiceT::Request::SharedPtr;
+  using SharedResponse = typename ServiceT::Response::SharedPtr;
+
+  using Promise = std::promise<SharedResponse>;
+  using PromiseWithRequest = std::promise<std::pair<SharedRequest, SharedResponse>>;
+
+  using SharedFuture = std::shared_future<SharedResponse>;
+  using SharedFutureWithRequest = std::shared_future<std::pair<SharedRequest, SharedResponse>>;
+
+  using CallbackType = std::function<void (SharedFuture)>;
+  using CallbackWithRequestType = std::function<void (SharedFutureWithRequest)>;
+
+  using CallbackTypeValueVariant = std::tuple<CallbackType, SharedFuture, Promise>;
+  using CallbackWithRequestTypeValueVariant = std::tuple<
+    CallbackWithRequestType, SharedRequest, SharedFutureWithRequest, PromiseWithRequest>;
+
+  using CallbackInfoVariant = std::variant<
+    std::promise<SharedResponse>,
+    CallbackTypeValueVariant,
+    CallbackWithRequestTypeValueVariant>;
+
+  using RequestCallbackPair = std::pair<SharedRequest, CallbackInfoVariant>;
+  using ClientIDtoRequest = std::pair<uint64_t, RequestCallbackPair>;
+
+  ServiceIntraProcess(
+    AnyServiceCallback<ServiceT> callback,
+    rclcpp::Context::SharedPtr context,
+    const std::string & service_name,
+    const rclcpp::QoS & qos_profile)
+  : ServiceIntraProcessBase(context, service_name, qos_profile), any_callback_(callback)
+  {
+    // Create the intra-process buffer.
+    buffer_ = rclcpp::experimental::create_service_intra_process_buffer<
+      ClientIDtoRequest>(qos_profile);
+  }
+
+  virtual ~ServiceIntraProcess() = default;
+
+  bool
+  is_ready(rcl_wait_set_t * wait_set)
+  {
+    (void) wait_set;
+    return buffer_->has_data();
+  }
+
+  void
+  store_intra_process_request(
+    uint64_t intra_process_client_id,
+    RequestCallbackPair request)
+  {
+    buffer_->add(std::make_pair(intra_process_client_id, std::move(request)));
+    gc_.trigger();
+  }
+
+  std::shared_ptr<void>
+  take_data()
+  {
+    auto data = std::make_shared<ClientIDtoRequest>(std::move(buffer_->consume()));
+    return std::static_pointer_cast<void>(data);
+  }
+
+  void execute(std::shared_ptr<void> & data)
+  {
+    auto ptr = std::static_pointer_cast<ClientIDtoRequest>(data);
+
+    uint64_t intra_process_client_id = ptr->first;
+    SharedRequest & typed_request = ptr->second.first;
+    CallbackInfoVariant & value = ptr->second.second;
+
+    SharedResponse response = any_callback_.dispatch(nullptr, nullptr, std::move(typed_request));
+
+    if (response) {
+      std::unique_lock<std::recursive_mutex> lock(reentrant_mutex_);
+
+      auto client_it = clients_.find(intra_process_client_id);
+
+      if (client_it == clients_.end()) {
+        RCLCPP_WARN(
+          rclcpp::get_logger("rclcpp"),
+          "Calling intra_process_service_send_response for invalid or no "
+          "longer existing client id");
+        return;
+      }
+
+      auto client_intra_process_base = client_it->second.lock();
+
+      if (client_intra_process_base) {
+        auto client = std::dynamic_pointer_cast<
+          rclcpp::experimental::ClientIntraProcess<ServiceT>>(
+          client_intra_process_base);
+        client->store_intra_process_response(
+          std::make_pair(std::move(response), std::move(value)));
+      } else {
+        clients_.erase(client_it);
+      }
+    }
+  }
+
+protected:
+  using BufferUniquePtr =
+    typename rclcpp::experimental::buffers::ServiceIntraProcessBuffer<
+    ClientIDtoRequest>::UniquePtr;
+
+  BufferUniquePtr buffer_;
+
+  AnyServiceCallback<ServiceT> any_callback_;
+};
+
+}  // namespace experimental
+}  // namespace rclcpp
+
+#endif  // RCLCPP__EXPERIMENTAL__SERVICE_INTRA_PROCESS_HPP_

--- a/rclcpp/include/rclcpp/experimental/service_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/service_intra_process_base.hpp
@@ -1,0 +1,102 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__EXPERIMENTAL__SERVICE_INTRA_PROCESS_BASE_HPP_
+#define RCLCPP__EXPERIMENTAL__SERVICE_INTRA_PROCESS_BASE_HPP_
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "rcl/error_handling.h"
+
+#include "rclcpp/context.hpp"
+#include "rclcpp/experimental/client_intra_process_base.hpp"
+#include "rclcpp/guard_condition.hpp"
+#include "rclcpp/qos.hpp"
+#include "rclcpp/type_support_decl.hpp"
+#include "rclcpp/waitable.hpp"
+
+namespace rclcpp
+{
+namespace experimental
+{
+
+class ServiceIntraProcessBase : public rclcpp::Waitable
+{
+public:
+  RCLCPP_SMART_PTR_ALIASES_ONLY(ServiceIntraProcessBase)
+
+  RCLCPP_PUBLIC
+  ServiceIntraProcessBase(
+    rclcpp::Context::SharedPtr context,
+    const std::string & service_name,
+    const rclcpp::QoS & qos_profile)
+  : gc_(context), service_name_(service_name), qos_profile_(qos_profile)
+  {}
+
+  virtual ~ServiceIntraProcessBase() = default;
+
+  RCLCPP_PUBLIC
+  size_t
+  get_number_of_ready_guard_conditions() {return 1;}
+
+  RCLCPP_PUBLIC
+  void
+  add_to_wait_set(rcl_wait_set_t * wait_set);
+
+  virtual bool
+  is_ready(rcl_wait_set_t * wait_set) = 0;
+
+  virtual
+  std::shared_ptr<void>
+  take_data() = 0;
+
+  virtual void
+  execute(std::shared_ptr<void> & data) = 0;
+
+  RCLCPP_PUBLIC
+  const char *
+  get_service_name() const;
+
+  RCLCPP_PUBLIC
+  QoS
+  get_actual_qos() const;
+
+  RCLCPP_PUBLIC
+  void
+  add_intra_process_client(
+    rclcpp::experimental::ClientIntraProcessBase::SharedPtr client,
+    uint64_t client_id);
+
+protected:
+  std::recursive_mutex reentrant_mutex_;
+  rclcpp::GuardCondition gc_;
+
+  using ClientMap =
+    std::unordered_map<uint64_t, rclcpp::experimental::ClientIntraProcessBase::WeakPtr>;
+
+  ClientMap clients_;
+
+private:
+  std::string service_name_;
+  QoS qos_profile_;
+};
+
+}  // namespace experimental
+}  // namespace rclcpp
+
+#endif  // RCLCPP__EXPERIMENTAL__SERVICE_INTRA_PROCESS_BASE_HPP_

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -245,6 +245,7 @@ public:
    * \param[in] service_name The topic to service on.
    * \param[in] qos_profile rmw_qos_profile_t Quality of service profile for client.
    * \param[in] group Callback group to call the service.
+   * \param[in] ipc_setting Intra-process communication setting for the client.
    * \return Shared pointer to the created client.
    */
   template<typename ServiceT>
@@ -252,7 +253,8 @@ public:
   create_client(
     const std::string & service_name,
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_services_default,
-    rclcpp::CallbackGroup::SharedPtr group = nullptr);
+    rclcpp::CallbackGroup::SharedPtr group = nullptr,
+    rclcpp::IntraProcessSetting ipc_setting = rclcpp::IntraProcessSetting::Disable);
 
   /// Create and return a Service.
   /**
@@ -260,6 +262,7 @@ public:
    * \param[in] callback User-defined callback function.
    * \param[in] qos_profile rmw_qos_profile_t Quality of service profile for client.
    * \param[in] group Callback group to call the service.
+   * \param[in] ipc_setting Intra-process communication setting for the service.
    * \return Shared pointer to the created service.
    */
   template<typename ServiceT, typename CallbackT>
@@ -268,7 +271,8 @@ public:
     const std::string & service_name,
     CallbackT && callback,
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_services_default,
-    rclcpp::CallbackGroup::SharedPtr group = nullptr);
+    rclcpp::CallbackGroup::SharedPtr group = nullptr,
+    rclcpp::IntraProcessSetting ipc_setting = rclcpp::IntraProcessSetting::Disable);
 
   /// Create and return a GenericPublisher.
   /**

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -125,7 +125,8 @@ typename Client<ServiceT>::SharedPtr
 Node::create_client(
   const std::string & service_name,
   const rmw_qos_profile_t & qos_profile,
-  rclcpp::CallbackGroup::SharedPtr group)
+  rclcpp::CallbackGroup::SharedPtr group,
+  rclcpp::IntraProcessSetting ipc_setting)
 {
   return rclcpp::create_client<ServiceT>(
     node_base_,
@@ -133,7 +134,8 @@ Node::create_client(
     node_services_,
     extend_name_with_sub_namespace(service_name, this->get_sub_namespace()),
     qos_profile,
-    group);
+    group,
+    ipc_setting);
 }
 
 template<typename ServiceT, typename CallbackT>
@@ -142,7 +144,8 @@ Node::create_service(
   const std::string & service_name,
   CallbackT && callback,
   const rmw_qos_profile_t & qos_profile,
-  rclcpp::CallbackGroup::SharedPtr group)
+  rclcpp::CallbackGroup::SharedPtr group,
+  rclcpp::IntraProcessSetting ipc_setting)
 {
   return rclcpp::create_service<ServiceT, CallbackT>(
     node_base_,
@@ -150,7 +153,8 @@ Node::create_service(
     extend_name_with_sub_namespace(service_name, this->get_sub_namespace()),
     std::forward<CallbackT>(callback),
     qos_profile,
-    group);
+    group,
+    ipc_setting);
 }
 
 template<typename AllocatorT>

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -28,6 +28,7 @@
 #include "rclcpp/any_service_callback.hpp"
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/macros.hpp"
+#include "rclcpp/qos.hpp"
 #include "rclcpp/type_support_decl.hpp"
 #include "rclcpp/expand_topic_or_service_name.hpp"
 #include "rclcpp/visibility_control.hpp"
@@ -120,6 +121,38 @@ public:
   RCLCPP_PUBLIC
   bool
   exchange_in_use_by_wait_set_state(bool in_use_state);
+
+  /// Get the actual response publisher QoS settings, after the defaults have been determined.
+  /**
+   * The actual configuration applied when using RMW_QOS_POLICY_*_SYSTEM_DEFAULT
+   * can only be resolved after the creation of the service, and it
+   * depends on the underlying rmw implementation.
+   * If the underlying setting in use can't be represented in ROS terms,
+   * it will be set to RMW_QOS_POLICY_*_UNKNOWN.
+   * May throw runtime_error when an unexpected error occurs.
+   *
+   * \return The actual response publisher qos settings.
+   * \throws std::runtime_error if failed to get qos settings
+   */
+  RCLCPP_PUBLIC
+  rclcpp::QoS
+  get_response_publisher_actual_qos() const;
+
+  /// Get the actual request subscription QoS settings, after the defaults have been determined.
+  /**
+   * The actual configuration applied when using RMW_QOS_POLICY_*_SYSTEM_DEFAULT
+   * can only be resolved after the creation of the service, and it
+   * depends on the underlying rmw implementation.
+   * If the underlying setting in use can't be represented in ROS terms,
+   * it will be set to RMW_QOS_POLICY_*_UNKNOWN.
+   * May throw runtime_error when an unexpected error occurs.
+   *
+   * \return The actual request subscription qos settings.
+   * \throws std::runtime_error if failed to get qos settings
+   */
+  RCLCPP_PUBLIC
+  rclcpp::QoS
+  get_request_subscription_actual_qos() const;
 
 protected:
   RCLCPP_DISABLE_COPY(ServiceBase)

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -241,7 +241,7 @@ public:
   using IntraProcessManagerWeakPtr =
     std::weak_ptr<rclcpp::experimental::IntraProcessManager>;
 
-  /// Implemenation detail.
+  /// Implementation detail.
   RCLCPP_PUBLIC
   void
   setup_intra_process(

--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -198,3 +198,41 @@ ClientBase::exchange_in_use_by_wait_set_state(bool in_use_state)
 {
   return in_use_by_wait_set_.exchange(in_use_state);
 }
+
+rclcpp::QoS
+ClientBase::get_request_publisher_actual_qos() const
+{
+  const rmw_qos_profile_t * qos =
+    rcl_client_request_publisher_get_actual_qos(client_handle_.get());
+  if (!qos) {
+    auto msg =
+      std::string("failed to get client's request publisher qos settings: ") +
+      rcl_get_error_string().str;
+    rcl_reset_error();
+    throw std::runtime_error(msg);
+  }
+
+  rclcpp::QoS request_publisher_qos =
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(*qos), *qos);
+
+  return request_publisher_qos;
+}
+
+rclcpp::QoS
+ClientBase::get_response_subscription_actual_qos() const
+{
+  const rmw_qos_profile_t * qos =
+    rcl_client_response_subscription_get_actual_qos(client_handle_.get());
+  if (!qos) {
+    auto msg =
+      std::string("failed to get client's response subscription qos settings: ") +
+      rcl_get_error_string().str;
+    rcl_reset_error();
+    throw std::runtime_error(msg);
+  }
+
+  rclcpp::QoS response_subscription_qos =
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(*qos), *qos);
+
+  return response_subscription_qos;
+}

--- a/rclcpp/src/rclcpp/client.cpp
+++ b/rclcpp/src/rclcpp/client.cpp
@@ -236,3 +236,32 @@ ClientBase::get_response_subscription_actual_qos() const
 
   return response_subscription_qos;
 }
+
+void
+ClientBase::setup_intra_process(
+  uint64_t intra_process_client_id,
+  IntraProcessManagerWeakPtr weak_ipm)
+{
+  weak_ipm_ = weak_ipm;
+  use_intra_process_ = true;
+  intra_process_client_id_ = intra_process_client_id;
+}
+
+rclcpp::Waitable::SharedPtr
+ClientBase::get_intra_process_waitable() const
+{
+  // If not using intra process, shortcut to nullptr.
+  if (!use_intra_process_) {
+    return nullptr;
+  }
+  // Get the intra process manager.
+  auto ipm = weak_ipm_.lock();
+  if (!ipm) {
+    throw std::runtime_error(
+            "ClientBase::get_intra_process_waitable() called "
+            "after destruction of intra process manager");
+  }
+
+  // Use the id to retrieve the intra-process client from the intra-process manager.
+  return ipm->get_client_intra_process(intra_process_client_id_);
+}

--- a/rclcpp/src/rclcpp/client_intra_process_base.cpp
+++ b/rclcpp/src/rclcpp/client_intra_process_base.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Open Source Robotics Foundation, Inc.
+// Copyright 2021 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,23 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RCLCPP__INTRA_PROCESS_SETTING_HPP_
-#define RCLCPP__INTRA_PROCESS_SETTING_HPP_
+#include "rclcpp/detail/add_guard_condition_to_rcl_wait_set.hpp"
+#include "rclcpp/experimental/client_intra_process_base.hpp"
 
-namespace rclcpp
+using rclcpp::experimental::ClientIntraProcessBase;
+
+void
+ClientIntraProcessBase::add_to_wait_set(rcl_wait_set_t * wait_set)
 {
+  detail::add_guard_condition_to_rcl_wait_set(*wait_set, gc_);
+}
 
-/// Used as argument when creating publishers, subscriptions, clients and services.
-enum class IntraProcessSetting
+const char *
+ClientIntraProcessBase::get_service_name() const
 {
-  /// Explicitly enable intraprocess comm.
-  Enable,
-  /// Explicitly disable intraprocess comm.
-  Disable,
-  /// Take intraprocess configuration from the node.
-  NodeDefault
-};
+  return service_name_.c_str();
+}
 
-}  // namespace rclcpp
-
-#endif  // RCLCPP__INTRA_PROCESS_SETTING_HPP_
+rclcpp::QoS
+ClientIntraProcessBase::get_actual_qos() const
+{
+  return qos_profile_;
+}

--- a/rclcpp/src/rclcpp/intra_process_manager.cpp
+++ b/rclcpp/src/rclcpp/intra_process_manager.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "rclcpp/experimental/intra_process_manager.hpp"
-
 #include <atomic>
 #include <memory>
 #include <mutex>
+
+#include "rclcpp/experimental/intra_process_manager.hpp"
 
 namespace rclcpp
 {
@@ -24,12 +24,6 @@ namespace experimental
 {
 
 static std::atomic<uint64_t> _next_unique_id {1};
-
-IntraProcessManager::IntraProcessManager()
-{}
-
-IntraProcessManager::~IntraProcessManager()
-{}
 
 uint64_t
 IntraProcessManager::add_publisher(rclcpp::PublisherBase::SharedPtr publisher)
@@ -80,6 +74,73 @@ IntraProcessManager::add_subscription(SubscriptionIntraProcessBase::SharedPtr su
   }
 
   return sub_id;
+}
+
+uint64_t
+IntraProcessManager::add_intra_process_client(ClientIntraProcessBase::SharedPtr client)
+{
+  std::unique_lock<std::shared_timed_mutex> lock(mutex_);
+
+  uint64_t client_id = IntraProcessManager::get_next_unique_id();
+  clients_[client_id] = client;
+
+  // adds the client to the matchable service
+  for (auto & pair : services_) {
+    auto intra_process_service = pair.second.lock();
+    if (!intra_process_service) {
+      continue;
+    }
+    if (can_communicate(client, intra_process_service)) {
+      uint64_t service_id = pair.first;
+      clients_to_services_.emplace(client_id, service_id);
+      intra_process_service->add_intra_process_client(client, client_id);
+      break;
+    }
+  }
+
+  return client_id;
+}
+
+uint64_t
+IntraProcessManager::add_intra_process_service(ServiceIntraProcessBase::SharedPtr service)
+{
+  std::unique_lock<std::shared_timed_mutex> lock(mutex_);
+
+  // First check if we have already a service registered with same service name
+  // Todo: Open issue about this not being enforced with normal services
+  auto it = services_.begin();
+
+  while (it != services_.end()) {
+    auto srv = it->second.lock();
+    if (srv) {
+      if (srv->get_service_name() == service->get_service_name()) {
+        throw std::runtime_error(
+                "Can't have multiple services with same service name.");
+      }
+      it++;
+    } else {
+      it = services_.erase(it);
+    }
+  }
+
+  uint64_t service_id = IntraProcessManager::get_next_unique_id();
+  services_[service_id] = service;
+
+  // adds the service to the matchable clients
+  for (auto & pair : clients_) {
+    auto client = pair.second.lock();
+    if (!client) {
+      continue;
+    }
+    if (can_communicate(client, service)) {
+      uint64_t client_id = pair.first;
+      clients_to_services_.emplace(client_id, service_id);
+
+      service->add_intra_process_client(client, client_id);
+    }
+  }
+
+  return service_id;
 }
 
 void
@@ -172,6 +233,58 @@ IntraProcessManager::get_subscription_intra_process(uint64_t intra_process_subsc
   }
 }
 
+ServiceIntraProcessBase::SharedPtr
+IntraProcessManager::get_service_intra_process(uint64_t intra_process_service_id)
+{
+  std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+
+  auto service_it = services_.find(intra_process_service_id);
+  if (service_it == services_.end()) {
+    return nullptr;
+  } else {
+    auto service = service_it->second.lock();
+    if (service) {
+      return service;
+    } else {
+      services_.erase(service_it);
+      return nullptr;
+    }
+  }
+}
+
+bool
+IntraProcessManager::service_is_available(uint64_t intra_process_client_id)
+{
+  std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+
+  auto service_it = clients_to_services_.find(intra_process_client_id);
+
+  if (service_it != clients_to_services_.end()) {
+    // A server matching the client has been found
+    return true;
+  }
+  return false;
+}
+
+ClientIntraProcessBase::SharedPtr
+IntraProcessManager::get_client_intra_process(uint64_t intra_process_client_id)
+{
+  std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+
+  auto client_it = clients_.find(intra_process_client_id);
+  if (client_it == clients_.end()) {
+    return nullptr;
+  } else {
+    auto client = client_it->second.lock();
+    if (client) {
+      return client;
+    } else {
+      clients_.erase(client_it);
+      return nullptr;
+    }
+  }
+}
+
 uint64_t
 IntraProcessManager::get_next_unique_id()
 {
@@ -218,6 +331,26 @@ IntraProcessManager::can_communicate(
   }
 
   auto check_result = rclcpp::qos_check_compatible(pub->get_actual_qos(), sub->get_actual_qos());
+  if (check_result.compatibility == rclcpp::QoSCompatibility::Error) {
+    return false;
+  }
+
+  return true;
+}
+
+bool
+IntraProcessManager::can_communicate(
+  ClientIntraProcessBase::SharedPtr client,
+  ServiceIntraProcessBase::SharedPtr service) const
+{
+  // client and service must be under the same name
+  if (strcmp(client->get_service_name(), service->get_service_name()) != 0) {
+    return false;
+  }
+
+  auto check_result = rclcpp::qos_check_compatible(
+    client->get_actual_qos(), service->get_actual_qos());
+
   if (check_result.compatibility == rclcpp::QoSCompatibility::Error) {
     return false;
   }

--- a/rclcpp/src/rclcpp/node_interfaces/node_services.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_services.cpp
@@ -40,6 +40,12 @@ NodeServices::add_service(
     node_base_->get_default_callback_group()->add_service(service_base_ptr);
   }
 
+  auto service_intra_process_waitable = service_base_ptr->get_intra_process_waitable();
+  if (nullptr != service_intra_process_waitable) {
+    // Add to the callback group to be notified about intra-process msgs.
+    node_base_->get_default_callback_group()->add_waitable(service_intra_process_waitable);
+  }
+
   // Notify the executor that a new service was created using the parent Node.
   auto & node_gc = node_base_->get_notify_guard_condition();
   try {
@@ -63,6 +69,12 @@ NodeServices::add_client(
     group->add_client(client_base_ptr);
   } else {
     node_base_->get_default_callback_group()->add_client(client_base_ptr);
+  }
+
+  auto client_intra_process_waitable = client_base_ptr->get_intra_process_waitable();
+  if (nullptr != client_intra_process_waitable) {
+    // Add to the callback group to be notified about intra-process msgs.
+    node_base_->get_default_callback_group()->add_waitable(client_intra_process_waitable);
   }
 
   // Notify the executor that a new client was created using the parent Node.

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -48,6 +48,13 @@ AsyncParametersClient::AsyncParametersClient(
   rcl_client_options_t options = rcl_client_get_default_options();
   options.qos = qos_profile;
 
+  rclcpp::IntraProcessSetting ipc_setting;
+  if (node_base_interface->get_use_intra_process_default()) {
+    ipc_setting = rclcpp::IntraProcessSetting::Enable;
+  } else {
+    ipc_setting = rclcpp::IntraProcessSetting::Disable;
+  }
+
   using rclcpp::Client;
   using rclcpp::ClientBase;
 
@@ -55,7 +62,8 @@ AsyncParametersClient::AsyncParametersClient(
     node_base_interface.get(),
     node_graph_interface,
     remote_node_name_ + "/" + parameter_service_names::get_parameters,
-    options);
+    options,
+    ipc_setting);
   auto get_parameters_base = std::dynamic_pointer_cast<ClientBase>(get_parameters_client_);
   node_services_interface->add_client(get_parameters_base, group);
 
@@ -63,7 +71,8 @@ AsyncParametersClient::AsyncParametersClient(
     node_base_interface.get(),
     node_graph_interface,
     remote_node_name_ + "/" + parameter_service_names::get_parameter_types,
-    options);
+    options,
+    ipc_setting);
   auto get_parameter_types_base =
     std::dynamic_pointer_cast<ClientBase>(get_parameter_types_client_);
   node_services_interface->add_client(get_parameter_types_base, group);
@@ -72,7 +81,8 @@ AsyncParametersClient::AsyncParametersClient(
     node_base_interface.get(),
     node_graph_interface,
     remote_node_name_ + "/" + parameter_service_names::set_parameters,
-    options);
+    options,
+    ipc_setting);
   auto set_parameters_base = std::dynamic_pointer_cast<ClientBase>(set_parameters_client_);
   node_services_interface->add_client(set_parameters_base, group);
 
@@ -81,7 +91,8 @@ AsyncParametersClient::AsyncParametersClient(
     node_base_interface.get(),
     node_graph_interface,
     remote_node_name_ + "/" + parameter_service_names::set_parameters_atomically,
-    options);
+    options,
+    ipc_setting);
   auto set_parameters_atomically_base = std::dynamic_pointer_cast<ClientBase>(
     set_parameters_atomically_client_);
   node_services_interface->add_client(set_parameters_atomically_base, group);
@@ -90,7 +101,8 @@ AsyncParametersClient::AsyncParametersClient(
     node_base_interface.get(),
     node_graph_interface,
     remote_node_name_ + "/" + parameter_service_names::list_parameters,
-    options);
+    options,
+    ipc_setting);
   auto list_parameters_base = std::dynamic_pointer_cast<ClientBase>(list_parameters_client_);
   node_services_interface->add_client(list_parameters_base, group);
 
@@ -98,7 +110,8 @@ AsyncParametersClient::AsyncParametersClient(
     node_base_interface.get(),
     node_graph_interface,
     remote_node_name_ + "/" + parameter_service_names::describe_parameters,
-    options);
+    options,
+    ipc_setting);
   auto describe_parameters_base =
     std::dynamic_pointer_cast<ClientBase>(describe_parameters_client_);
   node_services_interface->add_client(describe_parameters_base, group);

--- a/rclcpp/src/rclcpp/parameter_service.cpp
+++ b/rclcpp/src/rclcpp/parameter_service.cpp
@@ -33,6 +33,13 @@ ParameterService::ParameterService(
 {
   const std::string node_name = node_base->get_name();
 
+  rclcpp::IntraProcessSetting ipc_setting;
+  if (node_base->get_use_intra_process_default()) {
+    ipc_setting = rclcpp::IntraProcessSetting::Enable;
+  } else {
+    ipc_setting = rclcpp::IntraProcessSetting::Disable;
+  }
+
   get_parameters_service_ = create_service<rcl_interfaces::srv::GetParameters>(
     node_base, node_services,
     node_name + "/" + parameter_service_names::get_parameters,
@@ -50,7 +57,7 @@ ParameterService::ParameterService(
         RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "Failed to get parameters: %s", ex.what());
       }
     },
-    qos_profile, nullptr);
+    qos_profile, nullptr, ipc_setting);
 
   get_parameter_types_service_ = create_service<rcl_interfaces::srv::GetParameterTypes>(
     node_base, node_services,
@@ -71,7 +78,7 @@ ParameterService::ParameterService(
         RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "Failed to get parameter types: %s", ex.what());
       }
     },
-    qos_profile, nullptr);
+    qos_profile, nullptr, ipc_setting);
 
   set_parameters_service_ = create_service<rcl_interfaces::srv::SetParameters>(
     node_base, node_services,
@@ -96,7 +103,7 @@ ParameterService::ParameterService(
         response->results.push_back(result);
       }
     },
-    qos_profile, nullptr);
+    qos_profile, nullptr, ipc_setting);
 
   set_parameters_atomically_service_ = create_service<rcl_interfaces::srv::SetParametersAtomically>(
     node_base, node_services,
@@ -123,7 +130,7 @@ ParameterService::ParameterService(
         response->result.reason = "One or more parameters were not declared before setting";
       }
     },
-    qos_profile, nullptr);
+    qos_profile, nullptr, ipc_setting);
 
   describe_parameters_service_ = create_service<rcl_interfaces::srv::DescribeParameters>(
     node_base, node_services,
@@ -140,7 +147,7 @@ ParameterService::ParameterService(
         RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "Failed to describe parameters: %s", ex.what());
       }
     },
-    qos_profile, nullptr);
+    qos_profile, nullptr, ipc_setting);
 
   list_parameters_service_ = create_service<rcl_interfaces::srv::ListParameters>(
     node_base, node_services,
@@ -153,5 +160,5 @@ ParameterService::ParameterService(
       auto result = node_params->list_parameters(request->prefixes, request->depth);
       response->result = result;
     },
-    qos_profile, nullptr);
+    qos_profile, nullptr, ipc_setting);
 }

--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -84,3 +84,41 @@ ServiceBase::exchange_in_use_by_wait_set_state(bool in_use_state)
 {
   return in_use_by_wait_set_.exchange(in_use_state);
 }
+
+rclcpp::QoS
+ServiceBase::get_response_publisher_actual_qos() const
+{
+  const rmw_qos_profile_t * qos =
+    rcl_service_response_publisher_get_actual_qos(service_handle_.get());
+  if (!qos) {
+    auto msg =
+      std::string("failed to get service's response publisher qos settings: ") +
+      rcl_get_error_string().str;
+    rcl_reset_error();
+    throw std::runtime_error(msg);
+  }
+
+  rclcpp::QoS response_publisher_qos =
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(*qos), *qos);
+
+  return response_publisher_qos;
+}
+
+rclcpp::QoS
+ServiceBase::get_request_subscription_actual_qos() const
+{
+  const rmw_qos_profile_t * qos =
+    rcl_service_request_subscription_get_actual_qos(service_handle_.get());
+  if (!qos) {
+    auto msg =
+      std::string("failed to get service's request subscription qos settings: ") +
+      rcl_get_error_string().str;
+    rcl_reset_error();
+    throw std::runtime_error(msg);
+  }
+
+  rclcpp::QoS request_subscription_qos =
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(*qos), *qos);
+
+  return request_subscription_qos;
+}

--- a/rclcpp/src/rclcpp/service_intra_process_base.cpp
+++ b/rclcpp/src/rclcpp/service_intra_process_base.cpp
@@ -1,0 +1,45 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/detail/add_guard_condition_to_rcl_wait_set.hpp"
+#include "rclcpp/experimental/service_intra_process_base.hpp"
+
+using rclcpp::experimental::ServiceIntraProcessBase;
+
+void
+ServiceIntraProcessBase::add_to_wait_set(rcl_wait_set_t * wait_set)
+{
+  detail::add_guard_condition_to_rcl_wait_set(*wait_set, gc_);
+}
+
+const char *
+ServiceIntraProcessBase::get_service_name() const
+{
+  return service_name_.c_str();
+}
+
+rclcpp::QoS
+ServiceIntraProcessBase::get_actual_qos() const
+{
+  return qos_profile_;
+}
+
+void
+ServiceIntraProcessBase::add_intra_process_client(
+  rclcpp::experimental::ClientIntraProcessBase::SharedPtr client,
+  uint64_t client_id)
+{
+  std::unique_lock<std::recursive_mutex> lock(reentrant_mutex_);
+  clients_[client_id] = client;
+}

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_services.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_services.cpp
@@ -30,7 +30,7 @@ class TestService : public rclcpp::ServiceBase
 {
 public:
   explicit TestService(rclcpp::Node * node)
-  : rclcpp::ServiceBase(node->get_node_base_interface()->get_shared_rcl_node_handle()) {}
+  : rclcpp::ServiceBase(node->get_node_base_interface()) {}
 
   std::shared_ptr<void> create_request() override {return nullptr;}
   std::shared_ptr<rmw_request_id_t> create_request_header() override {return nullptr;}
@@ -41,7 +41,8 @@ class TestClient : public rclcpp::ClientBase
 {
 public:
   explicit TestClient(rclcpp::Node * node)
-  : rclcpp::ClientBase(node->get_node_base_interface().get(), node->get_node_graph_interface()) {}
+  : rclcpp::ClientBase(node->get_node_base_interface().get(), node->get_node_graph_interface())
+  {}
 
   std::shared_ptr<void> create_response() override {return nullptr;}
   std::shared_ptr<rmw_request_id_t> create_request_header() override {return nullptr;}

--- a/rclcpp/test/rclcpp/test_client.cpp
+++ b/rclcpp/test/rclcpp/test_client.cpp
@@ -24,6 +24,7 @@
 #include "rcl_interfaces/srv/list_parameters.hpp"
 
 #include "../mocking_utils/patch.hpp"
+#include "../utils/rclcpp_gtest_macros.hpp"
 
 #include "test_msgs/srv/empty.hpp"
 
@@ -339,4 +340,106 @@ TEST_F(TestClientWithServer, take_response) {
       client->take_response(response, *request_header.get()),
       rclcpp::exceptions::RCLError);
   }
+}
+
+TEST_F(TestClient, rcl_client_request_publisher_get_actual_qos_error) {
+  auto mock = mocking_utils::patch_and_return(
+    "lib:rclcpp", rcl_client_request_publisher_get_actual_qos, nullptr);
+  auto client = node->create_client<test_msgs::srv::Empty>("service");
+  RCLCPP_EXPECT_THROW_EQ(
+    client->get_request_publisher_actual_qos(),
+    std::runtime_error("failed to get client's request publisher qos settings: error not set"));
+}
+
+TEST_F(TestClient, rcl_client_response_subscription_get_actual_qos_error) {
+  auto mock = mocking_utils::patch_and_return(
+    "lib:rclcpp", rcl_client_response_subscription_get_actual_qos, nullptr);
+  auto client = node->create_client<test_msgs::srv::Empty>("service");
+  RCLCPP_EXPECT_THROW_EQ(
+    client->get_response_subscription_actual_qos(),
+    std::runtime_error("failed to get client's response subscription qos settings: error not set"));
+}
+
+TEST_F(TestClient, client_qos) {
+  rmw_qos_profile_t qos_profile = rmw_qos_profile_services_default;
+  qos_profile.liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
+  uint64_t duration = 1;
+  qos_profile.deadline = {duration, duration};
+  qos_profile.lifespan = {duration, duration};
+  qos_profile.liveliness_lease_duration = {duration, duration};
+
+  auto client =
+    node->create_client<test_msgs::srv::Empty>("client", qos_profile);
+
+  auto init_qos =
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile), qos_profile);
+  auto rp_qos = client->get_request_publisher_actual_qos();
+  auto rs_qos = client->get_response_subscription_actual_qos();
+
+  EXPECT_EQ(init_qos, rp_qos);
+  // Lifespan has no meaning for subscription/readers
+  rs_qos.lifespan(qos_profile.lifespan);
+  EXPECT_EQ(init_qos, rs_qos);
+}
+
+TEST_F(TestClient, client_qos_depth) {
+  using namespace std::literals::chrono_literals;
+
+  rmw_qos_profile_t client_qos_profile = rmw_qos_profile_default;
+  client_qos_profile.depth = 2;
+
+  auto client = node->create_client<test_msgs::srv::Empty>("test_qos_depth", client_qos_profile);
+
+  uint64_t server_cb_count_ = 0;
+  auto server_callback = [&](
+    const test_msgs::srv::Empty::Request::SharedPtr,
+    test_msgs::srv::Empty::Response::SharedPtr) {server_cb_count_++;};
+
+  auto server_node = std::make_shared<rclcpp::Node>("server_node", "/ns");
+
+  rmw_qos_profile_t server_qos_profile = rmw_qos_profile_default;
+
+  auto server = server_node->create_service<test_msgs::srv::Empty>(
+    "test_qos_depth", std::move(server_callback), server_qos_profile);
+
+  auto request = std::make_shared<test_msgs::srv::Empty::Request>();
+  ::testing::AssertionResult request_result = ::testing::AssertionSuccess();
+
+  using SharedFuture = rclcpp::Client<test_msgs::srv::Empty>::SharedFuture;
+  uint64_t client_cb_count_ = 0;
+  auto client_callback = [&client_cb_count_, &request_result](SharedFuture future_response) {
+      if (nullptr == future_response.get()) {
+        request_result = ::testing::AssertionFailure() << "Future response was null";
+      }
+      client_cb_count_++;
+    };
+
+  uint64_t client_requests = 5;
+  for (uint64_t i = 0; i < client_requests; i++) {
+    client->async_send_request(request, client_callback);
+    std::this_thread::sleep_for(10ms);
+  }
+
+  auto start = std::chrono::steady_clock::now();
+  while ((server_cb_count_ < client_requests) &&
+    (std::chrono::steady_clock::now() - start) < 2s)
+  {
+    rclcpp::spin_some(server_node);
+    std::this_thread::sleep_for(2ms);
+  }
+
+  EXPECT_GT(server_cb_count_, client_qos_profile.depth);
+
+  start = std::chrono::steady_clock::now();
+  while ((client_cb_count_ < client_qos_profile.depth) &&
+    (std::chrono::steady_clock::now() - start) < 1s)
+  {
+    rclcpp::spin_some(node);
+  }
+
+  // Spin an extra time to check if client QoS depth has been ignored,
+  // so more client callbacks might be called than expected.
+  rclcpp::spin_some(node);
+
+  EXPECT_EQ(client_cb_count_, client_qos_profile.depth);
 }

--- a/rclcpp/test/rclcpp/test_client.cpp
+++ b/rclcpp/test/rclcpp/test_client.cpp
@@ -107,7 +107,8 @@ TEST_F(TestClient, construction_with_free_function) {
       node->get_node_services_interface(),
       "service",
       rmw_qos_profile_services_default,
-      nullptr);
+      nullptr,
+      rclcpp::IntraProcessSetting::Disable);
   }
   {
     ASSERT_THROW(
@@ -118,7 +119,8 @@ TEST_F(TestClient, construction_with_free_function) {
         node->get_node_services_interface(),
         "invalid_?service",
         rmw_qos_profile_services_default,
-        nullptr);
+        nullptr,
+        rclcpp::IntraProcessSetting::Disable);
     }, rclcpp::exceptions::InvalidServiceNameError);
   }
 }

--- a/rclcpp/test/rclcpp/test_externally_defined_services.cpp
+++ b/rclcpp/test/rclcpp/test_externally_defined_services.cpp
@@ -66,7 +66,7 @@ TEST_F(TestExternallyDefinedServices, extern_defined_uninitialized) {
   // expect fail
   try {
     rclcpp::Service<test_msgs::srv::Empty>(
-      node_handle->get_node_base_interface()->get_shared_rcl_node_handle(),
+      node_handle->get_node_base_interface(),
       &service_handle, cb);
   } catch (const std::runtime_error &) {
     SUCCEED();
@@ -97,7 +97,7 @@ TEST_F(TestExternallyDefinedServices, extern_defined_initialized) {
 
   try {
     rclcpp::Service<test_msgs::srv::Empty>(
-      node_handle->get_node_base_interface()->get_shared_rcl_node_handle(),
+      node_handle->get_node_base_interface(),
       &service_handle, cb);
   } catch (const std::runtime_error &) {
     FAIL();
@@ -137,7 +137,7 @@ TEST_F(TestExternallyDefinedServices, extern_defined_destructor) {
   {
     // Call constructor
     rclcpp::Service<test_msgs::srv::Empty> srv_cpp(
-      node_handle->get_node_base_interface()->get_shared_rcl_node_handle(),
+      node_handle->get_node_base_interface(),
       &service_handle, cb);
     // Call destructor
   }

--- a/rclcpp/test/rclcpp/test_intra_process_manager.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager.cpp
@@ -15,9 +15,12 @@
 #include <gmock/gmock.h>
 
 #include <cstdint>
+#include <future>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <utility>
+#include <variant> // NOLINT
 #include <vector>
 
 #define RCLCPP_BUILDING_LIBRARY 1
@@ -284,6 +287,98 @@ public:
   }
 };
 
+class ClientIntraProcessBase
+{
+public:
+  RCLCPP_SMART_PTR_ALIASES_ONLY(ClientIntraProcessBase)
+
+  const char *
+  get_service_name() const
+  {
+    return nullptr;
+  }
+
+  QoS get_actual_qos() const
+  {
+    QoS qos(0);
+    return qos;
+  }
+};
+
+template<typename ServiceT>
+class ClientIntraProcess : public ClientIntraProcessBase
+{
+public:
+  RCLCPP_SMART_PTR_ALIASES_ONLY(ClientIntraProcess)
+};
+
+class ServiceIntraProcessBase
+{
+public:
+  RCLCPP_SMART_PTR_ALIASES_ONLY(ServiceIntraProcessBase)
+
+  void
+  add_intra_process_client(
+    rclcpp::experimental::mock::ClientIntraProcessBase::SharedPtr client,
+    uint64_t client_id)
+  {
+    (void)client;
+    (void)client_id;
+  }
+
+  const char *
+  get_service_name() const
+  {
+    return nullptr;
+  }
+
+  QoS get_actual_qos() const
+  {
+    QoS qos(0);
+    return qos;
+  }
+};
+
+template<typename ServiceT>
+class ServiceIntraProcess : public ServiceIntraProcessBase
+{
+public:
+  RCLCPP_SMART_PTR_ALIASES_ONLY(ServiceIntraProcess)
+
+  using SharedRequest = typename ServiceT::Request::SharedPtr;
+  using SharedResponse = typename ServiceT::Response::SharedPtr;
+
+  using Promise = std::promise<SharedResponse>;
+  using PromiseWithRequest = std::promise<std::pair<SharedRequest, SharedResponse>>;
+
+  using SharedFuture = std::shared_future<SharedResponse>;
+  using SharedFutureWithRequest = std::shared_future<std::pair<SharedRequest, SharedResponse>>;
+
+  using CallbackType = std::function<void (SharedFuture)>;
+  using CallbackWithRequestType = std::function<void (SharedFutureWithRequest)>;
+
+  using CallbackTypeValueVariant = std::tuple<CallbackType, SharedFuture, Promise>;
+  using CallbackWithRequestTypeValueVariant = std::tuple<
+    CallbackWithRequestType, SharedRequest, SharedFutureWithRequest, PromiseWithRequest>;
+
+  using CallbackInfoVariant = std::variant<
+    std::promise<SharedResponse>,
+    CallbackTypeValueVariant,
+    CallbackWithRequestTypeValueVariant>;
+
+  using RequestCallbackPair = std::pair<SharedRequest, CallbackInfoVariant>;
+  using ClientIDtoRequest = std::pair<uint64_t, RequestCallbackPair>;
+
+  void
+  store_intra_process_request(
+    uint64_t intra_process_client_id,
+    RequestCallbackPair request)
+  {
+    (void)intra_process_client_id;
+    (void)request;
+  }
+};
+
 }  // namespace mock
 }  // namespace experimental
 }  // namespace rclcpp
@@ -294,6 +389,10 @@ public:
 #define RCLCPP__EXPERIMENTAL__SUBSCRIPTION_INTRA_PROCESS_HPP_
 #define RCLCPP__EXPERIMENTAL__SUBSCRIPTION_INTRA_PROCESS_BUFFER_HPP_
 #define RCLCPP__EXPERIMENTAL__SUBSCRIPTION_INTRA_PROCESS_BASE_HPP_
+#define RCLCPP__EXPERIMENTAL__SERVICE_INTRA_PROCESS_HPP_
+#define RCLCPP__EXPERIMENTAL__SERVICE_INTRA_PROCESS_BASE_HPP_
+#define RCLCPP__EXPERIMENTAL__CLIENT_INTRA_PROCESS_HPP_
+#define RCLCPP__EXPERIMENTAL__CLIENT_INTRA_PROCESS_BASE_HPP_
 // Force ipm to use our mock publisher class.
 #define Publisher mock::Publisher
 #define PublisherBase mock::PublisherBase
@@ -301,12 +400,20 @@ public:
 #define SubscriptionIntraProcessBase mock::SubscriptionIntraProcessBase
 #define SubscriptionIntraProcessBuffer mock::SubscriptionIntraProcessBuffer
 #define SubscriptionIntraProcess mock::SubscriptionIntraProcess
+#define ServiceIntraProcessBase mock::ServiceIntraProcessBase
+#define ServiceIntraProcess mock::ServiceIntraProcess
+#define ClientIntraProcessBase mock::ClientIntraProcessBase
+#define ClientIntraProcess mock::ClientIntraProcess
 #include "../src/rclcpp/intra_process_manager.cpp"
 #undef Publisher
 #undef PublisherBase
 #undef IntraProcessBuffer
 #undef SubscriptionIntraProcessBase
 #undef SubscriptionIntraProcess
+#undef ServiceIntraProcessBase
+#undef ServiceIntraProcess
+#undef ClientIntraProcessBase
+#undef ClientIntraProcess
 
 using ::testing::_;
 using ::testing::UnorderedElementsAre;

--- a/rclcpp/test/rclcpp/test_service.cpp
+++ b/rclcpp/test/rclcpp/test_service.cpp
@@ -22,6 +22,7 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include "../mocking_utils/patch.hpp"
+#include "../utils/rclcpp_gtest_macros.hpp"
 
 #include "rcl_interfaces/srv/list_parameters.hpp"
 #include "test_msgs/srv/empty.hpp"
@@ -234,4 +235,104 @@ TEST_F(TestService, send_response) {
       server->send_response(*request_id.get(), response),
       rclcpp::exceptions::RCLError);
   }
+}
+
+TEST_F(TestService, rcl_service_response_publisher_get_actual_qos_error) {
+  auto mock = mocking_utils::patch_and_return(
+    "lib:rclcpp", rcl_service_response_publisher_get_actual_qos, nullptr);
+  auto callback =
+    [](const test_msgs::srv::Empty::Request::SharedPtr,
+      test_msgs::srv::Empty::Response::SharedPtr) {};
+  auto server = node->create_service<test_msgs::srv::Empty>("service", callback);
+  RCLCPP_EXPECT_THROW_EQ(
+    server->get_response_publisher_actual_qos(),
+    std::runtime_error("failed to get service's response publisher qos settings: error not set"));
+}
+
+TEST_F(TestService, rcl_service_request_subscription_get_actual_qos_error) {
+  auto mock = mocking_utils::patch_and_return(
+    "lib:rclcpp", rcl_service_request_subscription_get_actual_qos, nullptr);
+  auto callback =
+    [](const test_msgs::srv::Empty::Request::SharedPtr,
+      test_msgs::srv::Empty::Response::SharedPtr) {};
+  auto server = node->create_service<test_msgs::srv::Empty>("service", callback);
+  RCLCPP_EXPECT_THROW_EQ(
+    server->get_request_subscription_actual_qos(),
+    std::runtime_error("failed to get service's request subscription qos settings: error not set"));
+}
+
+
+TEST_F(TestService, server_qos) {
+  rmw_qos_profile_t qos_profile = rmw_qos_profile_services_default;
+  qos_profile.liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
+  uint64_t duration = 1;
+  qos_profile.deadline = {duration, duration};
+  qos_profile.lifespan = {duration, duration};
+  qos_profile.liveliness_lease_duration = {duration, duration};
+
+  auto callback = [](const test_msgs::srv::Empty::Request::SharedPtr,
+      test_msgs::srv::Empty::Response::SharedPtr) {};
+
+  auto server = node->create_service<test_msgs::srv::Empty>(
+    "service", callback,
+    qos_profile);
+  auto init_qos =
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile), qos_profile);
+  auto rs_qos = server->get_request_subscription_actual_qos();
+  auto rp_qos = server->get_response_publisher_actual_qos();
+
+  EXPECT_EQ(init_qos, rp_qos);
+  // Lifespan has no meaning for subscription/readers
+  rs_qos.lifespan(qos_profile.lifespan);
+  EXPECT_EQ(init_qos, rs_qos);
+}
+
+TEST_F(TestService, server_qos_depth) {
+  using namespace std::literals::chrono_literals;
+
+  uint64_t server_cb_count_ = 0;
+  auto server_callback = [&](
+    const test_msgs::srv::Empty::Request::SharedPtr,
+    test_msgs::srv::Empty::Response::SharedPtr) {server_cb_count_++;};
+
+  auto server_node = std::make_shared<rclcpp::Node>("server_node", "/ns");
+
+  rmw_qos_profile_t server_qos_profile = rmw_qos_profile_default;
+  server_qos_profile.depth = 2;
+
+  auto server = server_node->create_service<test_msgs::srv::Empty>(
+    "test_qos_depth", std::move(server_callback), server_qos_profile);
+
+  rmw_qos_profile_t client_qos_profile = rmw_qos_profile_default;
+  auto client = node->create_client<test_msgs::srv::Empty>("test_qos_depth", client_qos_profile);
+
+  ::testing::AssertionResult request_result = ::testing::AssertionSuccess();
+  auto request = std::make_shared<test_msgs::srv::Empty::Request>();
+
+  using SharedFuture = rclcpp::Client<test_msgs::srv::Empty>::SharedFuture;
+  auto client_callback = [&request_result](SharedFuture future_response) {
+      if (nullptr == future_response.get()) {
+        request_result = ::testing::AssertionFailure() << "Future response was null";
+      }
+    };
+
+  uint64_t client_requests = 5;
+  for (uint64_t i = 0; i < client_requests; i++) {
+    client->async_send_request(request, client_callback);
+    std::this_thread::sleep_for(10ms);
+  }
+
+  auto start = std::chrono::steady_clock::now();
+  while ((server_cb_count_ < server_qos_profile.depth) &&
+    (std::chrono::steady_clock::now() - start) < 1s)
+  {
+    rclcpp::spin_some(server_node);
+    std::this_thread::sleep_for(1ms);
+  }
+
+  // Spin an extra time to check if server QoS depth has been ignored,
+  // so more server responses might be processed than expected.
+  rclcpp::spin_some(server_node);
+
+  EXPECT_EQ(server_cb_count_, server_qos_profile.depth);
 }

--- a/rclcpp/test/rclcpp/test_service.cpp
+++ b/rclcpp/test/rclcpp/test_service.cpp
@@ -173,7 +173,7 @@ TEST_F(TestService, basic_public_getters) {
     }
     rclcpp::AnyServiceCallback<test_msgs::srv::Empty> cb;
     const rclcpp::Service<test_msgs::srv::Empty> base(
-      node_handle_int->get_node_base_interface()->get_shared_rcl_node_handle(),
+      node_handle_int->get_node_base_interface(),
       &service_handle, cb);
     // Use get_service_handle specific to const service
     std::shared_ptr<const rcl_service_t> const_service_handle = base.get_service_handle();


### PR DESCRIPTION
These changes extend the intra-process capabilities to support intra-process client/services communication, so no need to go through the DDS when sending client requests / services responses, when they belong to the same process.

The first commit already exists in a currently open PR, which hopefully should be merged soon: https://github.com/ros2/rclcpp/pull/1784
The interesting part is the second commit: 89fbc9463ae3f0f5eea09fd60daf190b87e57ca1
Missing: Add unit tests.

@clalancette 
@alsora 

