### PR TITLE
Add force set parameter functionality

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -562,13 +562,14 @@ public:
    * deleted.
    *
    * \param[in] parameter The parameter to be set.
+   * \param[in] force Whether to ignore immutable parameter constraints.
    * \return The result of the set action.
    * \throws rclcpp::exceptions::ParameterNotDeclaredException if the parameter
    *   has not been declared and undeclared parameters are not allowed.
    */
   RCLCPP_PUBLIC
   rcl_interfaces::msg::SetParametersResult
-  set_parameter(const rclcpp::Parameter & parameter);
+  set_parameter(const rclcpp::Parameter & parameter, bool force = false);
 
   /// Set one or more parameters, one at a time.
   /**
@@ -600,13 +601,14 @@ public:
    * with the type rclcpp::PARAMETER_NOT_SET.
    *
    * \param[in] parameters The vector of parameters to be set.
+   * \param[in] force Whether to ignore immutable parameter constraints.
    * \return The results for each set action as a vector.
    * \throws rclcpp::exceptions::ParameterNotDeclaredException if any parameter
    *   has not been declared and undeclared parameters are not allowed.
    */
   RCLCPP_PUBLIC
   std::vector<rcl_interfaces::msg::SetParametersResult>
-  set_parameters(const std::vector<rclcpp::Parameter> & parameters);
+  set_parameters(const std::vector<rclcpp::Parameter> & parameters, bool force = false);
 
   /// Set one or more parameters, all at once.
   /**
@@ -634,13 +636,16 @@ public:
    * with the type rclcpp::PARAMETER_NOT_SET.
    *
    * \param[in] parameters The vector of parameters to be set.
+   * \param[in] force Whether to ignore immutable parameter constraints.
    * \return The aggregate result of setting all the parameters atomically.
    * \throws rclcpp::exceptions::ParameterNotDeclaredException if any parameter
    *   has not been declared and undeclared parameters are not allowed.
    */
   RCLCPP_PUBLIC
   rcl_interfaces::msg::SetParametersResult
-  set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters);
+  set_parameters_atomically(
+    const std::vector<rclcpp::Parameter> & parameters,
+    bool force = false);
 
   /// Return the parameter by the given name.
   /**

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
@@ -151,12 +151,14 @@ public:
   RCLCPP_PUBLIC
   std::vector<rcl_interfaces::msg::SetParametersResult>
   set_parameters(
-    const std::vector<rclcpp::Parameter> & parameters) override;
+    const std::vector<rclcpp::Parameter> & parameters,
+    bool force) override;
 
   RCLCPP_PUBLIC
   rcl_interfaces::msg::SetParametersResult
   set_parameters_atomically(
-    const std::vector<rclcpp::Parameter> & parameters) override;
+    const std::vector<rclcpp::Parameter> & parameters,
+    bool force) override;
 
   RCLCPP_PUBLIC
   std::vector<rclcpp::Parameter>

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -128,7 +128,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   std::vector<rcl_interfaces::msg::SetParametersResult>
-  set_parameters(const std::vector<rclcpp::Parameter> & parameters) = 0;
+  set_parameters(const std::vector<rclcpp::Parameter> & parameters, bool force) = 0;
 
   /// Set one or more parameters, all at once.
   /**
@@ -137,8 +137,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   rcl_interfaces::msg::SetParametersResult
-  set_parameters_atomically(
-    const std::vector<rclcpp::Parameter> & parameters) = 0;
+  set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters, bool force) = 0;
 
   /// Get descriptions of parameters given their names.
   /*

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -367,21 +367,21 @@ Node::has_parameter(const std::string & name) const
 }
 
 rcl_interfaces::msg::SetParametersResult
-Node::set_parameter(const rclcpp::Parameter & parameter)
+Node::set_parameter(const rclcpp::Parameter & parameter, bool force)
 {
-  return this->set_parameters_atomically({parameter});
+  return this->set_parameters_atomically({parameter}, force);
 }
 
 std::vector<rcl_interfaces::msg::SetParametersResult>
-Node::set_parameters(const std::vector<rclcpp::Parameter> & parameters)
+Node::set_parameters(const std::vector<rclcpp::Parameter> & parameters, bool force)
 {
-  return node_parameters_->set_parameters(parameters);
+  return node_parameters_->set_parameters(parameters, force);
 }
 
 rcl_interfaces::msg::SetParametersResult
-Node::set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters)
+Node::set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters, bool force)
 {
-  return node_parameters_->set_parameters_atomically(parameters);
+  return node_parameters_->set_parameters_atomically(parameters, force);
 }
 
 rclcpp::Parameter

--- a/rclcpp/src/rclcpp/parameter_service.cpp
+++ b/rclcpp/src/rclcpp/parameter_service.cpp
@@ -87,7 +87,8 @@ ParameterService::ParameterService(
       for (auto & p : request->parameters) {
         try {
           result = node_params->set_parameters_atomically(
-            {rclcpp::Parameter::from_parameter_msg(p)});
+            {rclcpp::Parameter::from_parameter_msg(p)},
+            false);
         } catch (const rclcpp::exceptions::ParameterNotDeclaredException & ex) {
           RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "Failed to set parameter: %s", ex.what());
           result.successful = false;
@@ -114,7 +115,7 @@ ParameterService::ParameterService(
           return rclcpp::Parameter::from_parameter_msg(p);
         });
       try {
-        auto result = node_params->set_parameters_atomically(pvariants);
+        auto result = node_params->set_parameters_atomically(pvariants, false);
         response->result = result;
       } catch (const rclcpp::exceptions::ParameterNotDeclaredException & ex) {
         RCLCPP_DEBUG(

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_parameters.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_parameters.cpp
@@ -153,7 +153,7 @@ TEST_F(TestNodeParameters, set_parameters) {
     rclcpp::Parameter("bool_parameter", true),
     rclcpp::Parameter("read_only_parameter", 42),
   };
-  auto result = node_parameters->set_parameters(parameters);
+  auto result = node_parameters->set_parameters(parameters, false);
   ASSERT_EQ(parameters.size(), result.size());
   EXPECT_TRUE(result[0].successful);
   EXPECT_FALSE(result[1].successful);
@@ -161,11 +161,18 @@ TEST_F(TestNodeParameters, set_parameters) {
     "parameter 'read_only_parameter' cannot be set because it is read-only",
     result[1].reason.c_str());
 
+  result = node_parameters->set_parameters({rclcpp::Parameter("read_only_parameter", 55)}, true);
+  ASSERT_EQ(1u, result.size());
+  EXPECT_TRUE(result[0].successful);
+
   RCLCPP_EXPECT_THROW_EQ(
-    node_parameters->set_parameters({rclcpp::Parameter("", true)}),
+    node_parameters->set_parameters({rclcpp::Parameter("", true)}, false),
     rclcpp::exceptions::InvalidParametersException("parameter name must not be empty"));
 
-  result = node_parameters->set_parameters({rclcpp::Parameter("undeclared_parameter", 3.14159)});
+  result = node_parameters->set_parameters(
+    {rclcpp::Parameter(
+        "undeclared_parameter",
+        3.14159)}, false);
   ASSERT_EQ(1u, result.size());
   EXPECT_TRUE(result[0].successful);
 }
@@ -188,7 +195,7 @@ TEST_F(TestNodeParameters, add_remove_parameters_callback) {
     };
 
   auto handle = node_parameters->add_on_set_parameters_callback(callback);
-  auto result = node_parameters->set_parameters(parameters);
+  auto result = node_parameters->set_parameters(parameters, false);
   ASSERT_EQ(1u, result.size());
   EXPECT_FALSE(result[0].successful);
   EXPECT_EQ(reason, result[0].reason);

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -419,7 +419,7 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   rcl_interfaces::msg::SetParametersResult
-  set_parameter(const rclcpp::Parameter & parameter);
+  set_parameter(const rclcpp::Parameter & parameter, bool force = false);
 
   /// Set one or more parameters, one at a time.
   /**
@@ -427,7 +427,7 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   std::vector<rcl_interfaces::msg::SetParametersResult>
-  set_parameters(const std::vector<rclcpp::Parameter> & parameters);
+  set_parameters(const std::vector<rclcpp::Parameter> & parameters, bool force = false);
 
   /// Set one or more parameters, all at once.
   /**
@@ -435,7 +435,9 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   rcl_interfaces::msg::SetParametersResult
-  set_parameters_atomically(const std::vector<rclcpp::Parameter> & parameters);
+  set_parameters_atomically(
+    const std::vector<rclcpp::Parameter> & parameters,
+    bool force = false);
 
   /// Return the parameter by the given name.
   /**

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -227,23 +227,25 @@ LifecycleNode::has_parameter(const std::string & name) const
 }
 
 rcl_interfaces::msg::SetParametersResult
-LifecycleNode::set_parameter(const rclcpp::Parameter & parameter)
+LifecycleNode::set_parameter(const rclcpp::Parameter & parameter, bool force)
 {
-  return this->set_parameters_atomically({parameter});
+  return this->set_parameters_atomically({parameter}, force);
 }
 
 std::vector<rcl_interfaces::msg::SetParametersResult>
 LifecycleNode::set_parameters(
-  const std::vector<rclcpp::Parameter> & parameters)
+  const std::vector<rclcpp::Parameter> & parameters,
+  bool force)
 {
-  return node_parameters_->set_parameters(parameters);
+  return node_parameters_->set_parameters(parameters, force);
 }
 
 rcl_interfaces::msg::SetParametersResult
 LifecycleNode::set_parameters_atomically(
-  const std::vector<rclcpp::Parameter> & parameters)
+  const std::vector<rclcpp::Parameter> & parameters,
+  bool force)
 {
-  return node_parameters_->set_parameters_atomically(parameters);
+  return node_parameters_->set_parameters_atomically(parameters, force);
 }
 
 std::vector<rclcpp::Parameter>


### PR DESCRIPTION
Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>


This PR contains the force-set-parameter functionality first introduced in https://github.com/ros2/rclcpp/pull/1824.

We can use this separate PR to discuss whether we want this API or not.

@wjwwood wrote

> I actually don't think we should have "set" functions that override the read_only flag. One of the reasons for introducing the read_only flag was so that the storage could be static (imagine a read_only sequence stored as a std::array). We're not taking advantage of this in rclcpp but I know of people using it in their own forks in that way. It was one of the purposes. Undeclaring it would just be removing it from the list of declared parameters or marking it as inaccessible, but changing the value, especially if you ignore the dynamic_typing flag and/or let the size of a sequence change would be a problem.

Can you elaborate on why this is a problem?
We all agree that a node should be always allowed to undeclare a parameter it already declared.
Nothing prevents the node from declaring this parameter again with a different size.

IMO this function is just a very convenient utility that allows to do in a single atomic operation what users would otherwise do in two separate operations (undeclare + declare different), thus reducing complexity in user code and saving them from having to handle concurrency issues.