### PR TITLE
Add rclcpp_components::component target

### DIFF
--- a/rclcpp_components/CMakeLists.txt
+++ b/rclcpp_components/CMakeLists.txt
@@ -20,6 +20,15 @@ find_package(composition_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcpputils REQUIRED)
 
+# Add an interface library that can be dependend upon by libraries who register components
+add_library(component INTERFACE)
+target_include_directories(component INTERFACE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>")
+target_link_libraries(component INTERFACE
+  class_loader::class_loader
+  rclcpp::rclcpp)
+
 add_library(
   component_manager
   SHARED
@@ -87,10 +96,7 @@ if(BUILD_TESTING)
 
   set(components "")
   add_library(test_component SHARED test/components/test_component.cpp)
-  target_include_directories(test_component PUBLIC include)
-  ament_target_dependencies(test_component
-    "class_loader"
-    "rclcpp")
+  target_link_libraries(test_component PRIVATE component)
   #rclcpp_components_register_nodes(test_component "test_rclcpp_components::TestComponent")
   set(components "${components}test_rclcpp_components::TestComponentFoo;$<TARGET_FILE:test_component>\n")
   set(components "${components}test_rclcpp_components::TestComponentBar;$<TARGET_FILE:test_component>\n")
@@ -138,7 +144,7 @@ if(BUILD_TESTING)
 endif()
 
 install(
-  TARGETS component_manager EXPORT component_manager
+  TARGETS component component_manager EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -165,7 +171,7 @@ install(
 # specific order: dependents before dependencies
 ament_export_include_directories(include)
 ament_export_libraries(component_manager)
-ament_export_targets(component_manager)
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(ament_index_cpp)
 ament_export_dependencies(class_loader)
 ament_export_dependencies(composition_interfaces)


### PR DESCRIPTION
Currently any rclcpp component is forced to depend on and link against the component manager. Plugins actually just need access to `rclcpp_component`'s headers which themselves use `rclcpp` and `class_loader`. This adds and exports a new CMake interface library `rclcpp_components::component` that can be depended upon by components.

Part of ament/ament_cmake#365