### PR TITLE
Cleanup the TypeAdapt tests

### DIFF
--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -377,17 +377,8 @@ ament_add_gtest(test_subscription_with_type_adapter test_subscription_with_type_
   APPEND_LIBRARY_DIRS "${append_library_dirs}"
 )
 if(TARGET test_subscription_with_type_adapter)
-  ament_target_dependencies(test_subscription_with_type_adapter
-    "rcutils"
-    "rcl_interfaces"
-    "rmw"
-    "rosidl_runtime_cpp"
-    "rosidl_typesupport_cpp"
-    "test_msgs"
-  )
   target_link_libraries(test_subscription_with_type_adapter
     ${PROJECT_NAME}
-    mimick
     ${cpp_typesupport_target})
 endif()
 

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -368,17 +368,8 @@ ament_add_gtest(test_publisher_with_type_adapter test_publisher_with_type_adapte
   APPEND_LIBRARY_DIRS "${append_library_dirs}"
 )
 if(TARGET test_publisher_with_type_adapter)
-  ament_target_dependencies(test_publisher_with_type_adapter
-    "rcutils"
-    "rcl_interfaces"
-    "rmw"
-    "rosidl_runtime_cpp"
-    "rosidl_typesupport_cpp"
-    "test_msgs"
-  )
   target_link_libraries(test_publisher_with_type_adapter
     ${PROJECT_NAME}
-    mimick
     ${cpp_typesupport_target})
 endif()
 

--- a/rclcpp/test/rclcpp/test_publisher_with_type_adapter.cpp
+++ b/rclcpp/test/rclcpp/test_publisher_with_type_adapter.cpp
@@ -16,30 +16,16 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
-#include <functional>
 #include <memory>
 #include <string>
 #include <thread>
 #include <utility>
-#include <vector>
 
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/loaned_message.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-#include "../mocking_utils/patch.hpp"
-#include "../utils/rclcpp_gtest_macros.hpp"
-
-#include "test_msgs/msg/empty.hpp"
 #include "rclcpp/msg/string.hpp"
-
-
-#ifdef RMW_IMPLEMENTATION
-# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
-# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
-#else
-# define CLASSNAME(NAME, SUFFIX) NAME
-#endif
 
 
 using namespace std::chrono_literals;
@@ -56,28 +42,6 @@ public:
     if (!rclcpp::ok()) {
       rclcpp::init(0, nullptr);
     }
-  }
-
-protected:
-  void initialize(const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions())
-  {
-    node = std::make_shared<rclcpp::Node>("my_node", "/ns", node_options);
-  }
-
-  void TearDown()
-  {
-    node.reset();
-  }
-
-  rclcpp::Node::SharedPtr node;
-};
-
-class CLASSNAME (test_intra_process_within_one_node, RMW_IMPLEMENTATION) : public ::testing::Test
-{
-public:
-  static void SetUpTestCase()
-  {
-    rclcpp::init(0, nullptr);
   }
 
   static void TearDownTestCase()
@@ -128,7 +92,7 @@ struct TypeAdapter<int, rclcpp::msg::String>
   {
     (void) source;
     (void) destination;
-    throw std::runtime_error("This should happen");
+    throw std::runtime_error("This should not happen");
   }
 
   static void
@@ -150,7 +114,7 @@ TEST_F(TestPublisher, various_creation_signatures) {
   for (auto is_intra_process : {true, false}) {
     rclcpp::NodeOptions options;
     options.use_intra_process_comms(is_intra_process);
-    initialize(options);
+    auto node = std::make_shared<rclcpp::Node>("my_node", "/ns", options);
     {
       using StringTypeAdapter = rclcpp::TypeAdapter<std::string, rclcpp::msg::String>;
       auto publisher = node->create_publisher<StringTypeAdapter>("topic", 42);
@@ -179,7 +143,7 @@ TEST_F(TestPublisher, conversion_exception_is_passed_up) {
         (void)msg;
       };
 
-    initialize(options);
+    auto node = std::make_shared<rclcpp::Node>("my_node", "/ns", options);
     auto pub = node->create_publisher<BadStringTypeAdapter>("topic_name", 1);
     // A subscription is created to ensure the existence of a buffer in the intra proccess
     // manager which will trigger the faulty conversion.
@@ -192,7 +156,7 @@ TEST_F(TestPublisher, conversion_exception_is_passed_up) {
  * Testing that publisher sends type adapted types and ROS message types with intra proccess communications.
  */
 TEST_F(
-  CLASSNAME(test_intra_process_within_one_node, RMW_IMPLEMENTATION),
+  TestPublisher,
   check_type_adapted_message_is_sent_and_received_intra_process) {
   using StringTypeAdapter = rclcpp::TypeAdapter<std::string, rclcpp::msg::String>;
   const std::string message_data = "Message Data";
@@ -281,7 +245,7 @@ TEST_F(
 TEST_F(TestPublisher, check_type_adapted_message_is_sent_and_received) {
   using StringTypeAdapter = rclcpp::TypeAdapter<std::string, rclcpp::msg::String>;
 
-  initialize();
+  auto node = std::make_shared<rclcpp::Node>("my_node", "/ns", rclcpp::NodeOptions());
 
   const std::string message_data = "Message Data";
   const std::string topic_name = "topic_name";

--- a/rclcpp/test/rclcpp/test_subscription_with_type_adapter.cpp
+++ b/rclcpp/test/rclcpp/test_subscription_with_type_adapter.cpp
@@ -16,30 +16,14 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
-#include <functional>
 #include <memory>
 #include <string>
 #include <thread>
-#include <utility>
-#include <vector>
 
 #include "rclcpp/exceptions.hpp"
-#include "rclcpp/loaned_message.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-#include "../mocking_utils/patch.hpp"
-#include "../utils/rclcpp_gtest_macros.hpp"
-
-#include "test_msgs/msg/empty.hpp"
 #include "rclcpp/msg/string.hpp"
-
-
-#ifdef RMW_IMPLEMENTATION
-# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
-# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
-#else
-# define CLASSNAME(NAME, SUFFIX) NAME
-#endif
 
 
 using namespace std::chrono_literals;
@@ -49,30 +33,6 @@ static const std::chrono::milliseconds g_sleep_per_loop(10);
 
 
 class TestSubscription : public ::testing::Test
-{
-public:
-  static void SetUpTestCase()
-  {
-    if (!rclcpp::ok()) {
-      rclcpp::init(0, nullptr);
-    }
-  }
-
-protected:
-  void initialize(const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions())
-  {
-    node = std::make_shared<rclcpp::Node>("my_node", "/ns", node_options);
-  }
-
-  void TearDown()
-  {
-    node.reset();
-  }
-
-  rclcpp::Node::SharedPtr node;
-};
-
-class CLASSNAME (test_intra_process_within_one_node, RMW_IMPLEMENTATION) : public ::testing::Test
 {
 public:
   static void SetUpTestCase()
@@ -148,7 +108,7 @@ bool wait_for_match(
  * Testing publisher creation signatures with a type adapter.
  */
 TEST_F(TestSubscription, various_creation_signatures) {
-  initialize();
+  auto node = std::make_shared<rclcpp::Node>("my_node", "/ns", rclcpp::NodeOptions());
   {
     using StringTypeAdapter = rclcpp::TypeAdapter<std::string, rclcpp::msg::String>;
     auto sub =
@@ -167,7 +127,7 @@ TEST_F(TestSubscription, various_creation_signatures) {
  * Testing that subscriber receives type adapted types and ROS message types with intra proccess communications.
  */
 TEST_F(
-  CLASSNAME(test_intra_process_within_one_node, RMW_IMPLEMENTATION),
+  TestSubscription,
   check_type_adapted_messages_are_received_by_intra_process_subscription) {
   using StringTypeAdapter = rclcpp::TypeAdapter<std::string, rclcpp::msg::String>;
   const std::string message_data = "Message Data";
@@ -386,7 +346,7 @@ TEST_F(
  * Testing that subscriber receives type adapted types and ROS message types with inter proccess communications.
  */
 TEST_F(
-  CLASSNAME(test_intra_process_within_one_node, RMW_IMPLEMENTATION),
+  TestSubscription,
   check_type_adapted_messages_are_received_by_inter_process_subscription) {
   using StringTypeAdapter = rclcpp::TypeAdapter<std::string, rclcpp::msg::String>;
   const std::string message_data = "Message Data";


### PR DESCRIPTION
They had a bunch of unnecessary infrastructure, so just simplify them to what they actually need.  This also makes them run with less warnings, which is a nice side benefit.