### PR TITLE
Cleanup time source object lifetimes

### DIFF
--- a/rclcpp/include/rclcpp/time_source.hpp
+++ b/rclcpp/include/rclcpp/time_source.hpp
@@ -147,9 +147,6 @@ public:
   ~TimeSource();
 
 private:
-  class ClocksState;
-  std::shared_ptr<ClocksState> clocks_state_;
-
   class NodeState;
   std::shared_ptr<NodeState> node_state_;
 

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -281,8 +281,10 @@ public:
   // Detach the attached node
   void detachNode()
   {
-    clocks_state_.disable_ros_time();
+    // destroy_clock_sub() *must* be first here, to ensure that the executor
+    // can't possibly call any of the callbacks as we are cleaning up.
     destroy_clock_sub();
+    clocks_state_.disable_ros_time();
     parameter_subscription_.reset();
     node_base_.reset();
     node_topics_.reset();

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -327,9 +327,7 @@ private:
   rclcpp::QoS qos_;
 
   // The subscription for the clock callback
-  using MessageT = rosgraph_msgs::msg::Clock;
-  using Alloc = std::allocator<void>;
-  using SubscriptionT = rclcpp::Subscription<MessageT, Alloc>;
+  using SubscriptionT = rclcpp::Subscription<rosgraph_msgs::msg::Clock>;
   std::shared_ptr<SubscriptionT> clock_subscription_{nullptr};
   std::mutex clock_sub_lock_;
   rclcpp::CallbackGroup::SharedPtr clock_callback_group_;
@@ -422,8 +420,7 @@ private:
   }
 
   // Parameter Event subscription
-  using ParamMessageT = rcl_interfaces::msg::ParameterEvent;
-  using ParamSubscriptionT = rclcpp::Subscription<ParamMessageT, Alloc>;
+  using ParamSubscriptionT = rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>;
   std::shared_ptr<ParamSubscriptionT> parameter_subscription_;
 
   // Callback for parameter updates
@@ -457,7 +454,7 @@ private:
       {rclcpp::ParameterEventsFilter::EventType::DELETED});
     for (auto & it : deleted.get_events()) {
       (void) it;  // if there is a match it's already matched, don't bother reading it.
-      // If the parameter is deleted mark it as unset but dont' change state.
+      // If the parameter is deleted mark it as unset but don't change state.
       parameter_state_ = UNSET;
     }
   }

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -270,22 +270,6 @@ public:
         rclcpp::to_string(use_sim_time_param.get_type()).c_str());
       throw std::invalid_argument("Invalid type for parameter 'use_sim_time', should be 'bool'");
     }
-    sim_time_cb_handler_ = node_parameters_->add_on_set_parameters_callback(
-      [use_sim_time_name](const std::vector<rclcpp::Parameter> & parameters) {
-        rcl_interfaces::msg::SetParametersResult result;
-        result.successful = true;
-        for (const auto & parameter : parameters) {
-          if (
-            parameter.get_name() == use_sim_time_name &&
-            parameter.get_type() != rclcpp::PARAMETER_BOOL)
-          {
-            result.successful = false;
-            result.reason = "'" + use_sim_time_name + "' must be a bool";
-            break;
-          }
-        }
-        return result;
-      });
 
     // TODO(tfoote) use parameters interface not subscribe to events via topic ticketed #609
     parameter_subscription_ = rclcpp::AsyncParametersClient::on_parameter_event(
@@ -316,10 +300,6 @@ public:
     node_services_.reset();
     node_logging_.reset();
     node_clock_.reset();
-    if (sim_time_cb_handler_ && node_parameters_) {
-      node_parameters_->remove_on_set_parameters_callback(sim_time_cb_handler_.get());
-    }
-    sim_time_cb_handler_.reset();
     node_parameters_.reset();
   }
 
@@ -496,9 +476,6 @@ private:
   // An enum to hold the parameter state
   enum UseSimTimeParameterState {UNSET, SET_TRUE, SET_FALSE};
   UseSimTimeParameterState parameter_state_;
-
-  // A handler for the use_sim_time parameter callback.
-  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr sim_time_cb_handler_{nullptr};
 };
 
 TimeSource::TimeSource(

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -445,8 +445,8 @@ private:
         create_clock_sub();
       } else {
         parameter_state_ = SET_FALSE;
-        clocks_state_.disable_ros_time();
         destroy_clock_sub();
+        clocks_state_.disable_ros_time();
       }
     }
     // Handle the case that use_sim_time was deleted.
@@ -529,7 +529,7 @@ void TimeSource::attachClock(std::shared_ptr<rclcpp::Clock> clock)
 
 void TimeSource::detachClock(std::shared_ptr<rclcpp::Clock> clock)
 {
-  node_state_->attachClock(std::move(clock));
+  node_state_->detachClock(std::move(clock));
 }
 
 bool TimeSource::get_use_clock_thread()

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -250,8 +250,7 @@ public:
     if (!node_parameters_->has_parameter(use_sim_time_name)) {
       use_sim_time_param = node_parameters_->declare_parameter(
         use_sim_time_name,
-        rclcpp::ParameterValue(false),
-        rcl_interfaces::msg::ParameterDescriptor());
+        rclcpp::ParameterValue(false));
     } else {
       use_sim_time_param = node_parameters_->get_parameter(use_sim_time_name).get_parameter_value();
     }
@@ -269,6 +268,7 @@ public:
       RCLCPP_ERROR(
         logger_, "Invalid type '%s' for parameter 'use_sim_time', should be 'bool'",
         rclcpp::to_string(use_sim_time_param.get_type()).c_str());
+      throw std::invalid_argument("Invalid type for parameter 'use_sim_time', should be 'bool'");
     }
     sim_time_cb_handler_ = node_parameters_->add_on_set_parameters_callback(
       [use_sim_time_name](const std::vector<rclcpp::Parameter> & parameters) {
@@ -505,11 +505,8 @@ TimeSource::TimeSource(
   std::shared_ptr<rclcpp::Node> node,
   const rclcpp::QoS & qos,
   bool use_clock_thread)
-: constructed_use_clock_thread_(use_clock_thread),
-  constructed_qos_(qos)
+: TimeSource(qos, use_clock_thread)
 {
-  clocks_state_ = std::make_shared<ClocksState>();
-  node_state_ = std::make_shared<NodeState>(clocks_state_->weak_from_this(), qos, use_clock_thread);
   attachNode(node);
 }
 

--- a/rclcpp/test/rclcpp/test_time_source.cpp
+++ b/rclcpp/test/rclcpp/test_time_source.cpp
@@ -27,6 +27,8 @@
 #include "rclcpp/time.hpp"
 #include "rclcpp/time_source.hpp"
 
+#include "../utils/rclcpp_gtest_macros.hpp"
+
 using namespace std::chrono_literals;
 
 class TestTimeSource : public ::testing::Test
@@ -246,9 +248,23 @@ TEST_F(TestTimeSource, ROS_time_valid_sim_time) {
 }
 
 TEST_F(TestTimeSource, ROS_invalid_sim_time) {
-  rclcpp::TimeSource ts;
-  ts.attachNode(node);
+  rclcpp::TimeSource ts(node);
   EXPECT_FALSE(node->set_parameter(rclcpp::Parameter("use_sim_time", "not boolean")).successful);
+}
+
+TEST(TimeSource, invalid_sim_time_parameter_override)
+{
+  rclcpp::init(0, nullptr);
+
+  rclcpp::NodeOptions options;
+  options.automatically_declare_parameters_from_overrides(true);
+  options.append_parameter_override("use_sim_time", "not boolean");
+
+  RCLCPP_EXPECT_THROW_EQ(
+    std::make_shared<rclcpp::Node>("my_node", options),
+    std::invalid_argument("Invalid type for parameter 'use_sim_time', should be 'bool'"));
+
+  rclcpp::shutdown();
 }
 
 TEST_F(TestTimeSource, clock) {
@@ -749,8 +765,7 @@ TEST_F(TestTimeSource, clock_sleep_until_with_ros_time_basic) {
 
   node->set_parameter({"use_sim_time", true});
   auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
-  rclcpp::TimeSource time_source;
-  time_source.attachNode(node);
+  rclcpp::TimeSource time_source(node);
   time_source.attachClock(clock);
 
   // Wait until time source has definitely received a first ROS time from the pub node

--- a/rclcpp/test/rclcpp/test_time_source.cpp
+++ b/rclcpp/test/rclcpp/test_time_source.cpp
@@ -261,7 +261,7 @@ TEST(TimeSource, invalid_sim_time_parameter_override)
   options.append_parameter_override("use_sim_time", "not boolean");
 
   RCLCPP_EXPECT_THROW_EQ(
-    std::make_shared<rclcpp::Node>("my_node", options),
+    rclcpp::Node("my_node", options),
     std::invalid_argument("Invalid type for parameter 'use_sim_time', should be 'bool'"));
 
   rclcpp::shutdown();


### PR DESCRIPTION
Previously, we were managing a bunch of internal objects with shared_ptr/weak_ptr.  But this was an unnecessary abstraction, and also lead to flaky tests as in #1861 .

Instead, simplify this quite a lot and just use normal C++ object lifetimes.  This is easier to understand, is less code, and also fixes the flaky test.

Supersedes #1865.

Fixes #1861 

@Barry-Xu-2018 @ralph-lange FYI.