### PR TITLE
add is_spinning() method to executor base class

### DIFF
--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -401,6 +401,15 @@ public:
   void
   set_memory_strategy(memory_strategy::MemoryStrategy::SharedPtr memory_strategy);
 
+  /// Returns true if the executor is currently spinning.
+  /**
+   * This function can be called asynchronously from any thread.
+   * \return True if the executor is currently spinning.
+   */
+  RCLCPP_PUBLIC
+  bool
+  is_spinning();
+
 protected:
   RCLCPP_PUBLIC
   void

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -928,3 +928,9 @@ Executor::has_node(
       return other_ptr == node_ptr;
     }) != weak_groups_to_nodes.end();
 }
+
+bool
+Executor::is_spinning()
+{
+  return spinning;
+}

--- a/rclcpp/test/rclcpp/test_executor.cpp
+++ b/rclcpp/test/rclcpp/test_executor.cpp
@@ -556,3 +556,24 @@ TEST_F(TestExecutor, spin_until_future_complete_future_already_complete) {
     rclcpp::FutureReturnCode::SUCCESS,
     dummy.spin_until_future_complete(future, std::chrono::milliseconds(1)));
 }
+
+TEST_F(TestExecutor, is_spinning) {
+  DummyExecutor dummy;
+  ASSERT_FALSE(dummy.is_spinning());
+
+  auto node = std::make_shared<rclcpp::Node>("node", "ns");
+  bool timer_called = false;
+  auto timer =
+    node->create_wall_timer(
+    std::chrono::milliseconds(1), [&]() {
+      timer_called = true;
+      EXPECT_TRUE(dummy.is_spinning());
+    });
+
+  dummy.add_node(node);
+  // Wait for the wall timer to have expired.
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  dummy.spin_some(std::chrono::milliseconds(1));
+
+  ASSERT_TRUE(timer_called);
+}


### PR DESCRIPTION
This PR addresses a problem I recently noticed when you start an executor in a separate thread.
For example:

```
auto executor = std::make_shared<SingleThreadedExecutor>();
std::thread executor_thread([&](){
    executor->spin();
});

//// When I reach this line I don't have any way to know whether the executor is already spinning or not.
executor->cancel(); // This call may be uneffective as it may get executed before the executor starts to spin
/// Similarly, if I have to do an operation that requires the executor to be spinning
```

There are hacky solutions to this, for example I added a node with a one shot timer with period 0 to the executor such that I can guarantee that after that timer triggers the executor is definitely spinning.
However this looks very bad and it could be done in a much nicer way thanks to the addition of this new API.