### PR TITLE
Fix subscription instrumentation for ConstSharedPtr[WithInfo]Callback

### DIFF
--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -246,6 +246,16 @@ public:
         rclcpp_callback_register,
         (const void *)this,
         get_symbol(shared_ptr_with_info_callback_));
+    } else if (const_shared_ptr_callback_) {
+      TRACEPOINT(
+        rclcpp_callback_register,
+        (const void *)this,
+        get_symbol(const_shared_ptr_callback_));
+    } else if (const_shared_ptr_with_info_callback_) {
+      TRACEPOINT(
+        rclcpp_callback_register,
+        (const void *)this,
+        get_symbol(const_shared_ptr_with_info_callback_));
     } else if (unique_ptr_callback_) {
       TRACEPOINT(
         rclcpp_callback_register,


### PR DESCRIPTION
Subscription callbacks of types `ConstSharedPtrCallback` and `ConstSharedPtrWithInfoCallback` were not getting registered.

See: https://gitlab.com/ros-tracing/tracetools_analysis/-/issues/47#note_817008890

Switching to something like this (in `galactic`) would be better, but the change would be less minimal: https://github.com/ros2/rclcpp/blob/468cbab1aa9efb0f18b8d3f5cd410d2a9f21b3c6/rclcpp/include/rclcpp/any_subscription_callback.hpp#L372-L384

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>