### PR TITLE
Deal with rosidl_runtime_cpp::Vector in C++ messages.

### DIFF
--- a/rclcpp/include/rclcpp/parameter.hpp
+++ b/rclcpp/include/rclcpp/parameter.hpp
@@ -164,12 +164,12 @@ public:
   const std::vector<uint8_t> &
   as_byte_array() const;
 
-  /// Get value of parameter as bool array (vector<bool>).
+  /// Get value of parameter as bool array (rosidl_runtime_cpp::Vector<bool>).
   /**
    * \throws rclcpp::ParameterTypeException if the type doesn't match
    */
   RCLCPP_PUBLIC
-  const std::vector<bool> &
+  const rosidl_runtime_cpp::Vector<bool> &
   as_bool_array() const;
 
   /// Get value of parameter as integer array (vector<int64_t>).

--- a/rclcpp/include/rclcpp/parameter_value.hpp
+++ b/rclcpp/include/rclcpp/parameter_value.hpp
@@ -201,7 +201,7 @@ public:
   template<ParameterType type>
   constexpr
   typename std::enable_if<
-    type == ParameterType::PARAMETER_BOOL_ARRAY, const std::vector<bool> &>::type
+    type == ParameterType::PARAMETER_BOOL_ARRAY, const rosidl_runtime_cpp::Vector<bool> &>::type
   get() const
   {
     if (value_.type != rcl_interfaces::msg::ParameterType::PARAMETER_BOOL_ARRAY) {
@@ -295,7 +295,7 @@ public:
   constexpr
   typename std::enable_if<
     std::is_convertible<
-      type, const std::vector<bool> &>::value, const std::vector<bool> &>::type
+      type, std::vector<bool>>::value, const rosidl_runtime_cpp::Vector<bool> &>::type
   get() const
   {
     return get<ParameterType::PARAMETER_BOOL_ARRAY>();

--- a/rclcpp/src/rclcpp/parameter.cpp
+++ b/rclcpp/src/rclcpp/parameter.cpp
@@ -117,7 +117,7 @@ Parameter::as_byte_array() const
   return get_value<ParameterType::PARAMETER_BYTE_ARRAY>();
 }
 
-const std::vector<bool> &
+const rosidl_runtime_cpp::Vector<bool> &
 Parameter::as_bool_array() const
 {
   return get_value<ParameterType::PARAMETER_BOOL_ARRAY>();


### PR DESCRIPTION
Precisely what the title says. Connected to https://github.com/ros2/rosidl/pull/647. 

Interoperability with `std::vector<bool>` is kept in all cases but when an explicit `std::vector<bool>` reference is requested e.g. `const std::vector<bool> & param = rclcpp::ParameterValue{...}.get<std::vector<bool>>();` will no longer compile. 