### PR TITLE
LifecycleNode::on_deactivate deactivate all managed entities.

### DIFF
--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -529,7 +529,7 @@ public:
     for (const auto & weak_entity : weak_managed_entities_) {
       auto entity = weak_entity.lock();
       if (entity) {
-        entity->on_activate();
+        entity->on_deactivate();
       }
     }
   }


### PR DESCRIPTION
address https://github.com/ros2/rclcpp/issues/1884

Signed-off-by: Tomoya Fujita <Tomoya.Fujita@sony.com>