### PR TITLE
Use ament_generate_version_header

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -255,4 +255,5 @@ if(TEST cppcheck)
   set_tests_properties(cppcheck PROPERTIES TIMEOUT 500)
 endif()
 
-ament_cmake_gen_version_h()
+ament_generate_version_header(${PROJECT_NAME}
+  INSTALL_PATH "include")


### PR DESCRIPTION
Part of https://github.com/ament/ament_cmake/pull/377 - this uses `ament_generate_version_header` instead of `ament_cmake_gen_version_h` to generate the version header. The installed header is identical.