### PR TITLE
small improvements to node_main.cpp.in

### DIFF
--- a/rclcpp_components/src/node_main.cpp.in
+++ b/rclcpp_components/src/node_main.cpp.in
@@ -39,9 +39,9 @@ int main(int argc, char * argv[])
   RCLCPP_DEBUG(logger, "Load library %s", library_name.c_str());
   auto loader = new class_loader::ClassLoader(library_name);
   auto classes = loader->getAvailableClasses<rclcpp_components::NodeFactory>();
-  for (auto clazz : classes) {
+  for (const auto & clazz : classes) {
     std::string name = clazz.c_str();
-    if (!(name.compare(class_name))) {
+    if (name.compare(class_name) == 0) {
       RCLCPP_DEBUG(logger, "Instantiate class %s", clazz.c_str());
       auto node_factory = loader->createInstance<rclcpp_components::NodeFactory>(clazz);
       auto wrapper = node_factory->create_node_instance(options);


### PR DESCRIPTION
Small improvements identified by clang tidy for the `node_main.cpp.in` file.

```
warning: loop variable is copied but only used as const reference; consider making it a const reference [performance-for-range-copy]
1:   for (auto clazz : classes) {
```
and

```
warning: implicit conversion 'int' -> bool [readability-implicit-bool-conversion]
1:     if (!(name.compare(class_name))) {
```

Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>