### PR TITLE
time_until_trigger returns max time if timer is cancelled

### DIFF
--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -113,7 +113,8 @@ public:
 
   /// Check how long the timer has until its next scheduled callback.
   /**
-   * \return A std::chrono::duration representing the relative time until the next callback.
+   * \return A std::chrono::duration representing the relative time until the next callback
+   * or std::chrono::nanoseconds::max() if the timer is canceled.
    * \throws std::runtime_error if the rcl_timer_get_time_until_next_call returns a failure
    */
   RCLCPP_PUBLIC

--- a/rclcpp/src/rclcpp/timer.cpp
+++ b/rclcpp/src/rclcpp/timer.cpp
@@ -119,7 +119,9 @@ TimerBase::time_until_trigger()
   int64_t time_until_next_call = 0;
   rcl_ret_t ret = rcl_timer_get_time_until_next_call(
     timer_handle_.get(), &time_until_next_call);
-  if (ret != RCL_RET_OK) {
+  if (ret == RCL_RET_TIMER_CANCELED) {
+    return std::chrono::nanoseconds::max();
+  } else if (ret != RCL_RET_OK) {
     rclcpp::exceptions::throw_from_rcl_error(ret, "Timer could not get time until next call");
   }
   return std::chrono::nanoseconds(time_until_next_call);

--- a/rclcpp/test/rclcpp/test_timer.cpp
+++ b/rclcpp/test/rclcpp/test_timer.cpp
@@ -111,11 +111,13 @@ TEST_F(TestTimer, test_is_canceled_reset)
 
   // reset shouldn't affect state (not canceled yet)
   timer->reset();
+  EXPECT_LE(timer->time_until_trigger().count(), std::chrono::nanoseconds::max().count());
   EXPECT_FALSE(timer->is_canceled());
 
   // cancel after reset
   timer->cancel();
   EXPECT_TRUE(timer->is_canceled());
+  EXPECT_EQ(timer->time_until_trigger().count(), std::chrono::nanoseconds::max().count());
 
   // reset and cancel
   timer->reset();


### PR DESCRIPTION
This PR changes `rclcpp::TimerBase::time_until_trigger` to return `std::chrono::nanoseconds::max()` if the timer is canceled, since is does not seem correct to return the `rcl_timer_get_time_until_next_call` if the timer won't be called at that time.

Signed-off-by: Mauro Passerino <mpasserino@irobot.com>