### PR TITLE
Fix a bunch more rosdoc2 issues in rclcpp.

### DIFF
--- a/rclcpp/Doxyfile
+++ b/rclcpp/Doxyfile
@@ -33,10 +33,10 @@ PREDEFINED             += RCPPUTILS_TSA_REQUIRES(x)=
 DOT_GRAPH_MAX_NODES    = 101
 
 # Tag files that do not exist will produce a warning and cross-project linking will not work.
-TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
+#TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
 # Consider changing "latest" to the version you want to reference (e.g. beta1 or 1.0.0)
-TAGFILES += "../../../../doxygen_tag_files/rcl.tag=http://docs.ros2.org/latest/api/rcl/"
-TAGFILES += "../../../../doxygen_tag_files/rmw.tag=http://docs.ros2.org/latest/api/rmw/"
-TAGFILES += "../../../../doxygen_tag_files/rcutils.tag=http://docs.ros2.org/latest/api/rcutils/"
+#TAGFILES += "../../../../doxygen_tag_files/rcl.tag=http://docs.ros2.org/latest/api/rcl/"
+#TAGFILES += "../../../../doxygen_tag_files/rmw.tag=http://docs.ros2.org/latest/api/rmw/"
+#TAGFILES += "../../../../doxygen_tag_files/rcutils.tag=http://docs.ros2.org/latest/api/rcutils/"
 # Uncomment to generate tag files for cross-project linking.
 #GENERATE_TAGFILE = "../../../../doxygen_tag_files/rclcpp.tag"

--- a/rclcpp/include/rclcpp/detail/cpp_callback_trampoline.hpp
+++ b/rclcpp/include/rclcpp/detail/cpp_callback_trampoline.hpp
@@ -46,6 +46,7 @@ namespace detail
  * \tparam Args the arguments being passed to the callback
  * \tparam ReturnT the return type of this function and the callback, default void
  * \param user_data the function pointer, possibly type erased
+ * \param args the arguments to be forwarded to the callback
  * \returns whatever the callback returns, if anything
  */
 template<

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -307,7 +307,7 @@ public:
    *
    * \param[in] max_duration The maximum amount of time to spend executing work, must be >= 0.
    *   `0` is potentially block forever until no more work is available.
-   * \throw throw std::invalid_argument if max_duration is less than 0.
+   * \throw std::invalid_argument if max_duration is less than 0.
    * Note that spin_all() may take longer than this time as it only returns once max_duration has
    * been exceeded.
    */

--- a/rclcpp/include/rclcpp/logger.hpp
+++ b/rclcpp/include/rclcpp/logger.hpp
@@ -79,7 +79,7 @@ get_node_logger(const rcl_node_t * node);
 /// Get the current logging directory.
 /**
  * For more details of how the logging directory is determined,
- * see \ref rcl_logging_get_logging_directory.
+ * see rcl_logging_get_logging_directory().
  *
  * \returns the logging directory being used.
  * \throws rclcpp::exceptions::RCLError if an unexpected error occurs.

--- a/rclcpp/include/rclcpp/parameter.hpp
+++ b/rclcpp/include/rclcpp/parameter.hpp
@@ -264,6 +264,7 @@ get_value_helper<rclcpp::Parameter>(const rclcpp::Parameter * parameter)
 
 }  // namespace detail
 
+/// \cond
 template<typename T>
 decltype(auto)
 Parameter::get_value() const
@@ -275,6 +276,7 @@ Parameter::get_value() const
     throw exceptions::InvalidParameterTypeException(this->name_, ex.what());
   }
 }
+/// \endcond
 
 }  // namespace rclcpp
 

--- a/rclcpp/include/rclcpp/wait_set_policies/detail/write_preferring_read_write_lock.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/detail/write_preferring_read_write_lock.hpp
@@ -191,7 +191,7 @@ protected:
 
     WritePreferringReadWriteLock & parent_lock_;
 
-    friend WritePreferringReadWriteLock;
+    friend class WritePreferringReadWriteLock;
   };
 
   /// Write mutex for the WritePreferringReadWriteLock.
@@ -212,7 +212,7 @@ protected:
 
     WritePreferringReadWriteLock & parent_lock_;
 
-    friend WritePreferringReadWriteLock;
+    friend class WritePreferringReadWriteLock;
   };
 
   /// Return read mutex which can be used with standard constructs like std::lock_guard.

--- a/rclcpp_action/Doxyfile
+++ b/rclcpp_action/Doxyfile
@@ -21,15 +21,15 @@ GENERATE_LATEX         = NO
 ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
-PREDEFINED             = RCLCPP_PUBLIC=
+PREDEFINED             = RCLCPP_ACTION_PUBLIC=
 
 # Tag files that do not exist will produce a warning and cross-project linking will not work.
-TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
+#TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
 # Consider changing "latest" to the version you want to reference (e.g. beta1 or 1.0.0)
-TAGFILES += "../../../../doxygen_tag_files/rclcpp.tag=http://docs.ros2.org/latest/api/rclcpp/"
-TAGFILES += "../../../../doxygen_tag_files/rcl_action.tag=http://docs.ros2.org/latest/api/rcl_action/"
-TAGFILES += "../../../../doxygen_tag_files/rcl.tag=http://docs.ros2.org/latest/api/rcl/"
-TAGFILES += "../../../../doxygen_tag_files/rmw.tag=http://docs.ros2.org/latest/api/rmw/"
-TAGFILES += "../../../../doxygen_tag_files/rcutils.tag=http://docs.ros2.org/latest/api/rcutils/"
+#TAGFILES += "../../../../doxygen_tag_files/rclcpp.tag=http://docs.ros2.org/latest/api/rclcpp/"
+#TAGFILES += "../../../../doxygen_tag_files/rcl_action.tag=http://docs.ros2.org/latest/api/rcl_action/"
+#TAGFILES += "../../../../doxygen_tag_files/rcl.tag=http://docs.ros2.org/latest/api/rcl/"
+#TAGFILES += "../../../../doxygen_tag_files/rmw.tag=http://docs.ros2.org/latest/api/rmw/"
+#TAGFILES += "../../../../doxygen_tag_files/rcutils.tag=http://docs.ros2.org/latest/api/rcutils/"
 # Uncomment to generate tag files for cross-project linking.
 # GENERATE_TAGFILE = "../../../../doxygen_tag_files/rclcpp_action.tag"

--- a/rclcpp_action/include/rclcpp_action/client_goal_handle.hpp
+++ b/rclcpp_action/include/rclcpp_action/client_goal_handle.hpp
@@ -62,7 +62,7 @@ public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(ClientGoalHandle)
 
   // A wrapper that defines the result of an action
-  typedef struct WrappedResult
+  struct WrappedResult
   {
     /// The unique identifier of the goal
     GoalUUID goal_id;
@@ -70,7 +70,7 @@ public:
     ResultCode code;
     /// User defined fields sent back with an action
     typename ActionT::Result::SharedPtr result;
-  } WrappedResult;
+  };
 
   using Feedback = typename ActionT::Feedback;
   using Result = typename ActionT::Result;
@@ -104,7 +104,7 @@ public:
 
 private:
   // The templated Client creates goal handles
-  friend Client<ActionT>;
+  friend class Client<ActionT>;
 
   ClientGoalHandle(
     const GoalInfo & info,

--- a/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
+++ b/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
@@ -273,7 +273,7 @@ protected:
   /// A unique id for the goal request.
   const GoalUUID uuid_;
 
-  friend Server<ActionT>;
+  friend class Server<ActionT>;
 
   std::function<void(const GoalUUID &, std::shared_ptr<void>)> on_terminal_state_;
   std::function<void(const GoalUUID &)> on_executing_;

--- a/rclcpp_action/include/rclcpp_action/types.hpp
+++ b/rclcpp_action/include/rclcpp_action/types.hpp
@@ -17,6 +17,7 @@
 
 #include <array>
 #include <climits>
+#include <functional>
 #include <string>
 
 #include "rcl_action/types.h"

--- a/rclcpp_action/include/rclcpp_action/types.hpp
+++ b/rclcpp_action/include/rclcpp_action/types.hpp
@@ -15,8 +15,8 @@
 #ifndef RCLCPP_ACTION__TYPES_HPP_
 #define RCLCPP_ACTION__TYPES_HPP_
 
+#include <array>
 #include <climits>
-#include <functional>
 #include <string>
 
 #include "rcl_action/types.h"

--- a/rclcpp_components/Doxyfile
+++ b/rclcpp_components/Doxyfile
@@ -22,12 +22,12 @@ EXPAND_ONLY_PREDEF     = YES
 PREDEFINED             = RCLCPP_COMPONENTS_PUBLIC=
 
 # Tag files that do not exist will produce a warning and cross-project linking will not work.
-TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
+#TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
 # Consider changing "latest" to the version you want to reference (e.g. beta1 or 1.0.0)
-TAGFILES += "../../../../doxygen_tag_files/class_loader.tag=http://docs.ros2.org/latest/api/class_loader/"
-TAGFILES += "../../../../doxygen_tag_files/rclcpp.tag=http://docs.ros2.org/latest/api/rclcpp/"
-TAGFILES += "../../../../doxygen_tag_files/rcl.tag=http://docs.ros2.org/latest/api/rcl/"
-TAGFILES += "../../../../doxygen_tag_files/rcutils.tag=http://docs.ros2.org/latest/api/rcutils/"
-TAGFILES += "../../../../doxygen_tag_files/rmw.tag=http://docs.ros2.org/latest/api/rmw/"
+#TAGFILES += "../../../../doxygen_tag_files/class_loader.tag=http://docs.ros2.org/latest/api/class_loader/"
+#TAGFILES += "../../../../doxygen_tag_files/rclcpp.tag=http://docs.ros2.org/latest/api/rclcpp/"
+#TAGFILES += "../../../../doxygen_tag_files/rcl.tag=http://docs.ros2.org/latest/api/rcl/"
+#TAGFILES += "../../../../doxygen_tag_files/rcutils.tag=http://docs.ros2.org/latest/api/rcutils/"
+#TAGFILES += "../../../../doxygen_tag_files/rmw.tag=http://docs.ros2.org/latest/api/rmw/"
 # Uncomment to generate tag files for cross-project linking.
 GENERATE_TAGFILE = "../../../../doxygen_tag_files/rclcpp_components.tag"

--- a/rclcpp_lifecycle/Doxyfile
+++ b/rclcpp_lifecycle/Doxyfile
@@ -22,12 +22,13 @@ ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
 PREDEFINED             = RCLCPP_LIFECYCLE_PUBLIC=
+PREDEFINED             += RCUTILS_WARN_UNUSED
 
 # Tag files that do not exist will produce a warning and cross-project linking will not work.
-TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
+#TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
 # Consider changing "latest" to the version you want to reference (e.g. beta1 or 1.0.0)
-TAGFILES += "../../../../doxygen_tag_files/rclcpp.tag=http://docs.ros2.org/latest/api/rclcpp/"
-TAGFILES += "../../../../doxygen_tag_files/rcl_lifecycle.tag=http://docs.ros2.org/latest/api/rcl_lifecycle/"
-TAGFILES += "../../../../doxygen_tag_files/rmw.tag=http://docs.ros2.org/latest/api/rmw/"
+#TAGFILES += "../../../../doxygen_tag_files/rclcpp.tag=http://docs.ros2.org/latest/api/rclcpp/"
+#TAGFILES += "../../../../doxygen_tag_files/rcl_lifecycle.tag=http://docs.ros2.org/latest/api/rcl_lifecycle/"
+#TAGFILES += "../../../../doxygen_tag_files/rmw.tag=http://docs.ros2.org/latest/api/rmw/"
 # Uncomment to generate tag files for cross-project linking.
 GENERATE_TAGFILE = "../../../../doxygen_tag_files/rclcpp_lifecycle.tag"


### PR DESCRIPTION
There are a smattering of problems in here:

1.  We weren't properly using PREDEFINE for all of our macros.
2.  The Doxyfiles were referencing tag files that may not exist
(this will be handled by rosdoc2 automatically).
3.  The C++ parser in doxygen can't handle "friend classname",
but can handle "friend class classname"; it shouldn't matter
one way or the other to the compiler.
4.  There were a couple of parameters that were not documented.
5.  The doxygen C++ parser can't handle decltype in all situations.
6.  There was a structure using a C-style declaration.

This patch fixes all of the above issues.  We still aren't totally
clean on a rosdoc2 build, but we are a lot closer.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>