### PR TITLE
Select executor in node registration

### DIFF
--- a/rclcpp_components/cmake/rclcpp_components_register_node.cmake
+++ b/rclcpp_components/cmake/rclcpp_components_register_node.cmake
@@ -49,7 +49,7 @@ macro(rclcpp_components_register_node target)
   # default to executor if not specified otherwise
   set(executor "SingleThreadedExecutor")
   if(NOT "${ARGS_EXECUTOR}" STREQUAL "")
-      set(executor ${ARGS_EXECUTOR})
+    set(executor ${ARGS_EXECUTOR})
     message(STATUS "Setting executor non-default value ${executor}")
   endif()
 

--- a/rclcpp_components/cmake/rclcpp_components_register_node.cmake
+++ b/rclcpp_components/cmake/rclcpp_components_register_node.cmake
@@ -28,7 +28,7 @@
 # :type RESOURCE_INDEX: string
 #
 macro(rclcpp_components_register_node target)
-  cmake_parse_arguments(ARGS "" "PLUGIN;EXECUTABLE;RESOURCE_INDEX" "" ${ARGN})
+  cmake_parse_arguments(ARGS "" "PLUGIN;EXECUTABLE;EXECUTOR;RESOURCE_INDEX" "" ${ARGN})
   if(ARGS_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "rclcpp_components_register_node() called with unused "
       "arguments: ${ARGS_UNPARSED_ARGUMENTS}")
@@ -44,6 +44,13 @@ macro(rclcpp_components_register_node target)
   if(NOT "${ARGS_RESOURCE_INDEX}" STREQUAL "")
     set(resource_index ${ARGS_RESOURCE_INDEX})
     message(STATUS "Setting component resource index to non-default value ${resource_index}")
+  endif()
+
+  # default to executor if not specified otherwise
+  set(executor "SingleThreadedExecutor")
+  if(NOT "${ARGS_EXECUTOR}" STREQUAL "")
+      set(executor ${ARGS_EXECUTOR})
+    message(STATUS "Setting executor non-default value ${executor}")
   endif()
 
   set(component ${ARGS_PLUGIN})

--- a/rclcpp_components/src/node_main.cpp.in
+++ b/rclcpp_components/src/node_main.cpp.in
@@ -27,7 +27,7 @@ int main(int argc, char * argv[])
 {
   auto args = rclcpp::init_and_remove_ros_arguments(argc, argv);
   rclcpp::Logger logger = rclcpp::get_logger(NODE_MAIN_LOGGER_NAME);
-  rclcpp::executors::SingleThreadedExecutor exec;
+  rclcpp::executors::@executor@ exec;
   rclcpp::NodeOptions options;
   options.arguments(args);
   std::vector<class_loader::ClassLoader * > loaders;


### PR DESCRIPTION
This PR enables selection of executor type in `rclcpp_components_register_node` in `CMakeLists.txt`. 
So far, `SingleThreadedExecutor` is hard-coded.

FYI, I need this option to use of `MultiThereadedExecutor` because my node contains nested callback. 