### PR TITLE
Update data callback tests to account for all published samples.

### DIFF
--- a/rclcpp/test/rclcpp/test_client.cpp
+++ b/rclcpp/test/rclcpp/test_client.cpp
@@ -358,7 +358,7 @@ TEST_F(TestClient, on_new_response_callback) {
     const test_msgs::srv::Empty::Request::SharedPtr,
     test_msgs::srv::Empty::Response::SharedPtr) {server_requests_count++;};
   auto server = server_node->create_service<test_msgs::srv::Empty>(
-      "test_service", server_callback, client_qos);
+    "test_service", server_callback, client_qos);
   auto request = std::make_shared<test_msgs::srv::Empty::Request>();
 
   std::atomic<size_t> c1 {0};

--- a/rclcpp/test/rclcpp/test_client.cpp
+++ b/rclcpp/test/rclcpp/test_client.cpp
@@ -350,12 +350,15 @@ TEST_F(TestClient, on_new_response_callback) {
   auto client_node = std::make_shared<rclcpp::Node>("client_node", "ns");
   auto server_node = std::make_shared<rclcpp::Node>("server_node", "ns");
 
-  auto client = client_node->create_client<test_msgs::srv::Empty>("test_service");
+  rmw_qos_profile_t client_qos = rmw_qos_profile_services_default;
+  client_qos.depth = 3;
+  auto client = client_node->create_client<test_msgs::srv::Empty>("test_service", client_qos);
   std::atomic<size_t> server_requests_count {0};
   auto server_callback = [&server_requests_count](
     const test_msgs::srv::Empty::Request::SharedPtr,
     test_msgs::srv::Empty::Response::SharedPtr) {server_requests_count++;};
-  auto server = server_node->create_service<test_msgs::srv::Empty>("test_service", server_callback);
+  auto server = server_node->create_service<test_msgs::srv::Empty>(
+      "test_service", server_callback, client_qos);
   auto request = std::make_shared<test_msgs::srv::Empty::Request>();
 
   std::atomic<size_t> c1 {0};
@@ -422,7 +425,7 @@ TEST_F(TestClient, on_new_response_callback) {
   start = std::chrono::steady_clock::now();
   do {
     std::this_thread::sleep_for(100ms);
-  } while (c3 == 0 && std::chrono::steady_clock::now() - start < 10s);
+  } while (c3 < 3 && std::chrono::steady_clock::now() - start < 10s);
 
   EXPECT_EQ(c1.load(), 1u);
   EXPECT_EQ(c2.load(), 1u);

--- a/rclcpp/test/rclcpp/test_subscription.cpp
+++ b/rclcpp/test/rclcpp/test_subscription.cpp
@@ -454,7 +454,7 @@ TEST_F(TestSubscription, on_new_message_callback) {
   auto increase_c1_cb = [&c1](size_t count_msgs) {c1 += count_msgs;};
   sub->set_on_new_message_callback(increase_c1_cb);
 
-  auto pub = node->create_publisher<test_msgs::msg::Empty>("~/test_take", 1);
+  auto pub = node->create_publisher<test_msgs::msg::Empty>("~/test_take", 3);
   {
     test_msgs::msg::Empty msg;
     pub->publish(msg);
@@ -500,7 +500,7 @@ TEST_F(TestSubscription, on_new_message_callback) {
   start = std::chrono::steady_clock::now();
   do {
     std::this_thread::sleep_for(100ms);
-  } while (c3 == 0 && std::chrono::steady_clock::now() - start < 10s);
+  } while (c3 < 3 && std::chrono::steady_clock::now() - start < 10s);
 
   EXPECT_EQ(c1.load(), 1u);
   EXPECT_EQ(c2.load(), 1u);


### PR DESCRIPTION
This PR updates some unit tests related to the data callbacks for subscriptions, clients, and services, to make them more robust when run on different RMWs.

The changes were identified while investigating [some failures observed when running the tests with `rmw_connextdds`](https://github.com/ros2/rmw_connextdds/pull/76#issuecomment-1071783755) as part of ros2/rmw_connextdds#76.

In particular, all tests at one point try to publish 3 messages and subsequently expect all 3 samples to be notified via callback.
For this to happen reliably, the endpoints should all be using a History depth of at least 3. Moreover, the tests should wait for the counter variable to be increased up to 3 before making any further assertion.