### PR TITLE
Increase timeout for acknowledgments

### DIFF
--- a/rclcpp/test/rclcpp/test_publisher.cpp
+++ b/rclcpp/test/rclcpp/test_publisher.cpp
@@ -612,7 +612,7 @@ TEST_P(TestPublisherWaitForAllAcked, check_wait_for_all_acked_with_QosPolicy) {
   for (int i = 0; i < 20; i++) {
     ASSERT_NO_THROW(pub->publish(*msg));
   }
-  EXPECT_TRUE(pub->wait_for_all_acked(std::chrono::milliseconds(500)));
+  EXPECT_TRUE(pub->wait_for_all_acked(std::chrono::milliseconds(6000)));
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
This PR updates a unit test for the `wait_for_acknowledgments()` API by increasing the timeout from 500ms to 6s.

This change allows the test to successfully and reliably pass when run with `rmw_connextdds`. The reason for this change is that Connext DDS usese a 3s periodic heartbeat by default, so it may take quite longer than 500ms to detect and repair a missed sample. 6s guarantees that at least one heartbeat will be published while waiting for all samples to be acknowledged.

The failure of the test was identified while working on ros2/rmw_connextdds#76, after running the Linux CI with only `rmw_connextdds` enabled.