### PR TITLE
[NodeParameters] Set name in param info pre-check

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -298,6 +298,11 @@ __set_parameters_atomically_common(
   const OnParametersSetCallbackType & callback,
   bool allow_undeclared = false)
 {
+  // Set the parameter name before checks, for more desciprtive error messages
+  for (size_t i = 0; i < parameters.size(); ++i) {
+    const std::string & name = parameters[i].get_name();
+    parameter_infos[name].descriptor.name = parameters[i].get_name();
+  }
   // Check if the value being set complies with the descriptor.
   rcl_interfaces::msg::SetParametersResult result = __check_parameters(
     parameter_infos, parameters, allow_undeclared);
@@ -314,7 +319,6 @@ __set_parameters_atomically_common(
   if (result.successful) {
     for (size_t i = 0; i < parameters.size(); ++i) {
       const std::string & name = parameters[i].get_name();
-      parameter_infos[name].descriptor.name = parameters[i].get_name();
       parameter_infos[name].descriptor.type = parameters[i].get_type();
       parameter_infos[name].value = parameters[i].get_parameter_value();
     }

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -236,7 +236,9 @@ __check_parameters(
     } else {
       descriptor = parameter_infos[name].descriptor;
     }
-    descriptor.name = name;
+    if (descriptor.name.empty()) {
+      descriptor.name = name;
+    }
     const auto new_type = parameter.get_type();
     const auto specified_type = static_cast<rclcpp::ParameterType>(descriptor.type);
     result.successful = descriptor.dynamic_typing || specified_type == new_type;

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -236,6 +236,7 @@ __check_parameters(
     } else {
       descriptor = parameter_infos[name].descriptor;
     }
+    descriptor.name = name;
     const auto new_type = parameter.get_type();
     const auto specified_type = static_cast<rclcpp::ParameterType>(descriptor.type);
     result.successful = descriptor.dynamic_typing || specified_type == new_type;
@@ -298,11 +299,6 @@ __set_parameters_atomically_common(
   const OnParametersSetCallbackType & callback,
   bool allow_undeclared = false)
 {
-  // Set the parameter name before checks, for more desciprtive error messages
-  for (size_t i = 0; i < parameters.size(); ++i) {
-    const std::string & name = parameters[i].get_name();
-    parameter_infos[name].descriptor.name = parameters[i].get_name();
-  }
   // Check if the value being set complies with the descriptor.
   rcl_interfaces::msg::SetParametersResult result = __check_parameters(
     parameter_infos, parameters, allow_undeclared);
@@ -319,6 +315,7 @@ __set_parameters_atomically_common(
   if (result.successful) {
     for (size_t i = 0; i < parameters.size(); ++i) {
       const std::string & name = parameters[i].get_name();
+      parameter_infos[name].descriptor.name = parameters[i].get_name();
       parameter_infos[name].descriptor.type = parameters[i].get_type();
       parameter_infos[name].value = parameters[i].get_parameter_value();
     }


### PR DESCRIPTION
In `__check_parameters`, there are function-scoped parameter
descriptor structures generated by searching the `ParameterInfo`
map provided from other declaratory functions. This PR populates
this temporary structure with the parameter name information.
This way, the change does not show in other data structures, but the
name field is also not empty when used to generate error messages in
`__check_parameter_value_in_range`.

See this [demo node](https://github.com/aprotyas/ros2_playground/tree/master/rclcpp_1906) for testing purposes.

Fixes #1906.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>