### PR TITLE
remove DEFINE_CONTENT_FILTER cmake option

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -2,10 +2,8 @@ cmake_minimum_required(VERSION 3.12)
 
 project(rclcpp)
 
-option(DEFINE_CONTENT_FILTER "Content filter feature support" ON)
-if(DEFINE_CONTENT_FILTER)
-  add_definitions(-DCONTENT_FILTER_ENABLE)
-endif()
+# A macro to control the content filter feature support
+add_definitions(-DCONTENT_FILTER_ENABLE)
 
 find_package(Threads REQUIRED)
 

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -734,22 +734,20 @@ if(TARGET test_graph_listener)
   target_link_libraries(test_graph_listener ${PROJECT_NAME} mimick)
 endif()
 
-if(DEFINE_CONTENT_FILTER)
-  function(test_subscription_content_filter_for_rmw_implementation)
-    set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
-    ament_add_gmock(test_subscription_content_filter${target_suffix}
-      test_subscription_content_filter.cpp
-      ENV ${rmw_implementation_env_var}
-      TIMEOUT 120
+function(test_subscription_content_filter_for_rmw_implementation)
+  set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
+  ament_add_gmock(test_subscription_content_filter${target_suffix}
+    test_subscription_content_filter.cpp
+    ENV ${rmw_implementation_env_var}
+    TIMEOUT 120
+  )
+  if(TARGET test_subscription_content_filter${target_suffix})
+    target_link_libraries(test_subscription_content_filter${target_suffix} ${PROJECT_NAME} mimick)
+    ament_target_dependencies(test_subscription_content_filter${target_suffix}
+      "rcpputils"
+      "rosidl_typesupport_cpp"
+      "test_msgs"
     )
-    if(TARGET test_subscription_content_filter${target_suffix})
-      target_link_libraries(test_subscription_content_filter${target_suffix} ${PROJECT_NAME} mimick)
-      ament_target_dependencies(test_subscription_content_filter${target_suffix}
-        "rcpputils"
-        "rosidl_typesupport_cpp"
-        "test_msgs"
-      )
-    endif()
-  endfunction()
-  call_for_each_rmw_implementation(test_subscription_content_filter_for_rmw_implementation)
-endif()
+  endif()
+endfunction()
+call_for_each_rmw_implementation(test_subscription_content_filter_for_rmw_implementation)


### PR DESCRIPTION
a follow-up PR to remove this option, which was metioned at https://github.com/ros2/rclcpp/pull/1561#discussion_r841933383

Signed-off-by: Chen Lihui <lihui.chen@sony.com>