### PR TITLE
use reinterpret_cast for function pointer conversion.

### DIFF
--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -189,10 +189,10 @@ public:
     TRACEPOINT(
       rclcpp_timer_callback_added,
       static_cast<const void *>(get_timer_handle().get()),
-      static_cast<const void *>(&callback_));
+      reinterpret_cast<const void *>(&callback_));
     TRACEPOINT(
       rclcpp_callback_register,
-      static_cast<const void *>(&callback_),
+      reinterpret_cast<const void *>(&callback_),
       tracetools::get_symbol(callback_));
   }
 
@@ -226,9 +226,9 @@ public:
   void
   execute_callback() override
   {
-    TRACEPOINT(callback_start, static_cast<const void *>(&callback_), false);
+    TRACEPOINT(callback_start, reinterpret_cast<const void *>(&callback_), false);
     execute_callback_delegate<>();
-    TRACEPOINT(callback_end, static_cast<const void *>(&callback_));
+    TRACEPOINT(callback_end, reinterpret_cast<const void *>(&callback_));
   }
 
   // void specialization

--- a/rclcpp/test/rclcpp/test_create_timer.cpp
+++ b/rclcpp/test/rclcpp/test_create_timer.cpp
@@ -116,3 +116,20 @@ TEST(TestCreateTimer, call_wall_timer_with_bad_arguments)
     std::invalid_argument);
   rclcpp::shutdown();
 }
+
+static void test_timer_callback(void) {}
+
+TEST(TestCreateTimer, timer_function_pointer)
+{
+  rclcpp::init(0, nullptr);
+  auto node = std::make_shared<rclcpp::Node>("timer_function_pointer_node");
+
+  // make sure build succeeds with function pointer instead of lambda
+  auto some_timer = rclcpp::create_timer(
+    node,
+    node->get_clock(),
+    rclcpp::Duration(0ms),
+    test_timer_callback);
+
+  rclcpp::shutdown();
+}


### PR DESCRIPTION
address https://github.com/ros2/rclcpp/issues/1915

Signed-off-by: Tomoya Fujita <Tomoya.Fujita@sony.com>