### PR TITLE
Add 'best available' QoS enum values and methods

### DIFF
--- a/rclcpp/include/rclcpp/qos.hpp
+++ b/rclcpp/include/rclcpp/qos.hpp
@@ -44,6 +44,7 @@ enum class ReliabilityPolicy
   BestEffort = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT,
   Reliable = RMW_QOS_POLICY_RELIABILITY_RELIABLE,
   SystemDefault = RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT,
+  BestAvailable = RMW_QOS_POLICY_RELIABILITY_BEST_AVAILABLE,
   Unknown = RMW_QOS_POLICY_RELIABILITY_UNKNOWN,
 };
 
@@ -52,6 +53,7 @@ enum class DurabilityPolicy
   Volatile = RMW_QOS_POLICY_DURABILITY_VOLATILE,
   TransientLocal = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
   SystemDefault = RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT,
+  BestAvailable = RMW_QOS_POLICY_DURABILITY_BEST_AVAILABLE,
   Unknown = RMW_QOS_POLICY_DURABILITY_UNKNOWN,
 };
 
@@ -60,6 +62,7 @@ enum class LivelinessPolicy
   Automatic = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC,
   ManualByTopic = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC,
   SystemDefault = RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT,
+  BestAvailable = RMW_QOS_POLICY_LIVELINESS_BEST_AVAILABLE,
   Unknown = RMW_QOS_POLICY_LIVELINESS_UNKNOWN,
 };
 
@@ -180,6 +183,10 @@ public:
   QoS &
   best_effort();
 
+  /// Set the reliability setting to best available.
+  QoS &
+  reliability_best_available();
+
   /// Set the durability setting.
   QoS &
   durability(rmw_qos_durability_policy_t durability);
@@ -198,6 +205,10 @@ public:
   /// Set the durability setting to transient local.
   QoS &
   transient_local();
+
+  /// Set the durability setting to best available.
+  QoS &
+  durability_best_available();
 
   /// Set the deadline setting.
   QoS &
@@ -485,6 +496,36 @@ public:
   SystemDefaultsQoS(
     const QoSInitialization & qos_initialization = (
       QoSInitialization::from_rmw(rmw_qos_profile_system_default)
+  ));
+};
+
+/**
+ * Best available QoS class
+ *
+ * Match majority of endpoints currently available while maintaining the highest level of service.
+ * Policies are chosen at the time of creating a subscription or publisher.
+ * The middleware is not expected to update policies after creating a subscription or publisher,
+ * even if one or more policies are incompatible with newly discovered endpoints.
+ * Therefore, this profile should be used with care since non-deterministic behavior can occur due
+ * to races with discovery.
+ *
+ *    - History: Keep last,
+ *    - Depth: 10,
+ *    - Reliability: Best available,
+ *    - Durability: Best available,
+ *    - Deadline: Best available,
+ *    - Lifespan: Default,
+ *    - Liveliness: Best available,
+ *    - Liveliness lease duration: Best available,
+ *    - avoid ros namespace conventions: false
+ */
+class RCLCPP_PUBLIC BestAvailableQoS : public QoS
+{
+public:
+  explicit
+  BestAvailableQoS(
+    const QoSInitialization & qos_initialization = (
+      QoSInitialization::from_rmw(rmw_qos_profile_best_available)
   ));
 };
 

--- a/rclcpp/src/rclcpp/qos.cpp
+++ b/rclcpp/src/rclcpp/qos.cpp
@@ -151,6 +151,12 @@ QoS::best_effort()
 }
 
 QoS &
+QoS::reliability_best_available()
+{
+  return this->reliability(RMW_QOS_POLICY_RELIABILITY_BEST_AVAILABLE);
+}
+
+QoS &
 QoS::durability(rmw_qos_durability_policy_t durability)
 {
   rmw_qos_profile_.durability = durability;
@@ -174,6 +180,12 @@ QoS &
 QoS::transient_local()
 {
   return this->durability(RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
+}
+
+QoS &
+QoS::durability_best_available()
+{
+  return this->durability(RMW_QOS_POLICY_DURABILITY_BEST_AVAILABLE);
 }
 
 QoS &
@@ -378,6 +390,10 @@ RosoutQoS::RosoutQoS(const QoSInitialization & rosout_initialization)
 
 SystemDefaultsQoS::SystemDefaultsQoS(const QoSInitialization & qos_initialization)
 : QoS(qos_initialization, rmw_qos_profile_system_default)
+{}
+
+BestAvailableQoS::BestAvailableQoS(const QoSInitialization & qos_initialization)
+: QoS(qos_initialization, rmw_qos_profile_best_available)
 {}
 
 }  // namespace rclcpp

--- a/rclcpp/test/rclcpp/test_qos.cpp
+++ b/rclcpp/test/rclcpp/test_qos.cpp
@@ -93,6 +93,9 @@ TEST(TestQoS, setters_and_getters) {
   qos.reliable();
   EXPECT_EQ(rclcpp::ReliabilityPolicy::Reliable, qos.reliability());
 
+  qos.reliability_best_available();
+  EXPECT_EQ(rclcpp::ReliabilityPolicy::BestAvailable, qos.reliability());
+
   qos.reliability(rclcpp::ReliabilityPolicy::BestEffort);
   EXPECT_EQ(rclcpp::ReliabilityPolicy::BestEffort, qos.reliability());
 
@@ -101,6 +104,9 @@ TEST(TestQoS, setters_and_getters) {
 
   qos.transient_local();
   EXPECT_EQ(rclcpp::DurabilityPolicy::TransientLocal, qos.durability());
+
+  qos.durability_best_available();
+  EXPECT_EQ(rclcpp::DurabilityPolicy::BestAvailable, qos.durability());
 
   qos.durability(rclcpp::DurabilityPolicy::Volatile);
   EXPECT_EQ(rclcpp::DurabilityPolicy::Volatile, qos.durability());
@@ -183,6 +189,9 @@ TEST(TestQoS, DerivedTypes) {
   const rclcpp::KeepLast expected_initialization(RMW_QOS_POLICY_DEPTH_SYSTEM_DEFAULT);
   const rclcpp::QoS expected_default(expected_initialization);
   EXPECT_EQ(expected_default.get_rmw_qos_profile(), system_default_qos.get_rmw_qos_profile());
+
+  rclcpp::BestAvailableQoS best_available_qos;
+  EXPECT_EQ(rmw_qos_profile_best_available, best_available_qos.get_rmw_qos_profile());
 }
 
 TEST(TestQoS, policy_name_from_kind) {


### PR DESCRIPTION
If users set a policy as 'best available', then the middleware will pick a policy
that is most compatible with the current set of discovered endpoints while maintaining
the highest level of service possible.

For details about the expected behavior, see connected changes:

- https://github.com/ros2/rmw/pull/320
- https://github.com/ros2/rmw_dds_common/pull/60