### PR TITLE
Fix documentation of `RCLCPP_[INFO,WARN,...]`

### DIFF
--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -114,7 +114,6 @@ def get_rclcpp_suffix_from_features(features):
 @[ end for]@
 @[ if 'stream' not in feature_combination]@
  * \param ... The format string, followed by the variable arguments for the format string.
- * It also accepts a single argument of type std::string.
 @[ end if]@
  */
 @{params = rclcpp_feature_combinations[feature_combination].params.keys()}@


### PR DESCRIPTION
In the pull request https://github.com/ros2/rclcpp/pull/1442 the ability
to use `std::string` as the first argument to the logging functions was
(rightfully) removed.

This commit just corrects the documentation of the macro, since it
confused me a bit ;)