### PR TITLE
Make create_client accept rclcpp::QoS

### DIFF
--- a/rclcpp/include/rclcpp/create_client.hpp
+++ b/rclcpp/include/rclcpp/create_client.hpp
@@ -20,10 +20,40 @@
 
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/node_interfaces/node_services_interface.hpp"
+#include "rclcpp/qos.hpp"
 #include "rmw/rmw.h"
 
 namespace rclcpp
 {
+/// Create a service client with a given type.
+/**
+ * \param[in] node_base NodeBaseInterface implementation of the node on which
+ *  to create the client.
+ * \param[in] node_graph NodeGraphInterface implementation of the node on which
+ *  to create the client.
+ * \param[in] node_services NodeServicesInterface implementation of the node on
+ *  which to create the client.
+ * \param[in] service_name The name on which the service is accessible.
+ * \param[in] qos Quality of service profile for client.
+ * \param[in] group Callback group to handle the reply to service calls.
+ * \return Shared pointer to the created client.
+ */
+template<typename ServiceT>
+typename rclcpp::Client<ServiceT>::SharedPtr
+create_client(
+  std::shared_ptr<node_interfaces::NodeBaseInterface> node_base,
+  std::shared_ptr<node_interfaces::NodeGraphInterface> node_graph,
+  std::shared_ptr<node_interfaces::NodeServicesInterface> node_services,
+  const std::string & service_name,
+  const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
+  rclcpp::CallbackGroup::SharedPtr group = nullptr)
+{
+  return create_client<ServiceT>(
+    node_base, node_graph, node_services,
+    service_name,
+    qos.get_rmw_qos_profile(),
+    group);
+}
 
 /// Create a service client with a given type.
 /// \internal

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -251,7 +251,21 @@ public:
   typename rclcpp::Client<ServiceT>::SharedPtr
   create_client(
     const std::string & service_name,
-    const rmw_qos_profile_t & qos_profile = rmw_qos_profile_services_default,
+    const rmw_qos_profile_t & qos_profile,
+    rclcpp::CallbackGroup::SharedPtr group = nullptr);
+
+  /// Create and return a Client.
+  /**
+   * \param[in] service_name The name on which the service is accessible.
+   * \param[in] qos Quality of service profile for client.
+   * \param[in] group Callback group to handle the reply to service calls.
+   * \return Shared pointer to the created client.
+   */
+  template<typename ServiceT>
+  typename rclcpp::Client<ServiceT>::SharedPtr
+  create_client(
+    const std::string & service_name,
+    const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
     rclcpp::CallbackGroup::SharedPtr group = nullptr);
 
   /// Create and return a Service.

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -246,8 +246,10 @@ public:
    * \param[in] qos_profile rmw_qos_profile_t Quality of service profile for client.
    * \param[in] group Callback group to call the service.
    * \return Shared pointer to the created client.
+   * \deprecated use rclcpp::QoS instead of rmw_qos_profile_t
    */
   template<typename ServiceT>
+  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
   typename rclcpp::Client<ServiceT>::SharedPtr
   create_client(
     const std::string & service_name,

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -124,6 +124,22 @@ template<typename ServiceT>
 typename Client<ServiceT>::SharedPtr
 Node::create_client(
   const std::string & service_name,
+  const rclcpp::QoS & qos,
+  rclcpp::CallbackGroup::SharedPtr group)
+{
+  return rclcpp::create_client<ServiceT>(
+    node_base_,
+    node_graph_,
+    node_services_,
+    extend_name_with_sub_namespace(service_name, this->get_sub_namespace()),
+    qos,
+    group);
+}
+
+template<typename ServiceT>
+typename Client<ServiceT>::SharedPtr
+Node::create_client(
+  const std::string & service_name,
   const rmw_qos_profile_t & qos_profile,
   rclcpp::CallbackGroup::SharedPtr group)
 {

--- a/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
@@ -177,7 +177,7 @@ protected:
 
     clients_.push_back(
       node_with_client->create_client<test_msgs::srv::Empty>(
-        "service", rmw_qos_profile_services_default, callback_group));
+        "service", rclcpp::ServicesQoS(), callback_group));
     return node_with_client;
   }
 
@@ -831,7 +831,7 @@ TEST_F(TestAllocatorMemoryStrategy, get_next_client_out_of_scope) {
       node->create_callback_group(
       rclcpp::CallbackGroupType::MutuallyExclusive);
     auto client = node->create_client<test_msgs::srv::Empty>(
-      "service", rmw_qos_profile_services_default, callback_group);
+      "service", rclcpp::ServicesQoS(), callback_group);
 
     weak_groups_to_nodes.insert(
       std::pair<rclcpp::CallbackGroup::WeakPtr,

--- a/rclcpp/test/rclcpp/test_client.cpp
+++ b/rclcpp/test/rclcpp/test_client.cpp
@@ -92,6 +92,14 @@ TEST_F(TestClient, construction_and_destruction) {
   {
     auto client = node->create_client<ListParameters>("service");
   }
+  {
+    auto client = node->create_client<ListParameters>(
+      "service", rmw_qos_profile_services_default);
+  }
+  {
+    auto client = node->create_client<ListParameters>(
+      "service", rclcpp::ServicesQoS());
+  }
 
   {
     ASSERT_THROW(
@@ -120,6 +128,27 @@ TEST_F(TestClient, construction_with_free_function) {
         node->get_node_services_interface(),
         "invalid_?service",
         rmw_qos_profile_services_default,
+        nullptr);
+    }, rclcpp::exceptions::InvalidServiceNameError);
+  }
+  {
+    auto client = rclcpp::create_client<rcl_interfaces::srv::ListParameters>(
+      node->get_node_base_interface(),
+      node->get_node_graph_interface(),
+      node->get_node_services_interface(),
+      "service",
+      rclcpp::ServicesQoS(),
+      nullptr);
+  }
+  {
+    ASSERT_THROW(
+    {
+      auto client = rclcpp::create_client<rcl_interfaces::srv::ListParameters>(
+        node->get_node_base_interface(),
+        node->get_node_graph_interface(),
+        node->get_node_services_interface(),
+        "invalid_?service",
+        rclcpp::ServicesQoS(),
         nullptr);
     }, rclcpp::exceptions::InvalidServiceNameError);
   }

--- a/rclcpp/test/rclcpp/test_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/test_memory_strategy.cpp
@@ -197,7 +197,7 @@ TEST_F(TestMemoryStrategy, get_client_by_handle) {
         node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
       {
         auto client = node->create_client<test_msgs::srv::Empty>(
-          "service", rmw_qos_profile_services_default, callback_group);
+          "service", rclcpp::ServicesQoS(), callback_group);
 
         client_handle = client->get_client_handle();
         weak_groups_to_nodes.insert(
@@ -435,7 +435,7 @@ TEST_F(TestMemoryStrategy, get_group_by_client) {
         node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
       client = node->create_client<test_msgs::srv::Empty>(
-        "service", rmw_qos_profile_services_default, callback_group);
+        "service", rclcpp::ServicesQoS(), callback_group);
       weak_groups_to_nodes.insert(
         std::pair<rclcpp::CallbackGroup::WeakPtr,
         rclcpp::node_interfaces::NodeBaseInterface::WeakPtr>(

--- a/rclcpp/test/rclcpp/test_service.cpp
+++ b/rclcpp/test/rclcpp/test_service.cpp
@@ -246,10 +246,10 @@ TEST_F(TestService, on_new_request_callback) {
   auto server_callback =
     [](const test_msgs::srv::Empty::Request::SharedPtr,
       test_msgs::srv::Empty::Response::SharedPtr) {FAIL();};
-  rmw_qos_profile_t service_qos = rmw_qos_profile_services_default;
-  service_qos.depth = 3;
+  rclcpp::ServicesQoS service_qos;
+  service_qos.keep_last(3);
   auto server = node->create_service<test_msgs::srv::Empty>(
-    "~/test_service", server_callback, service_qos);
+    "~/test_service", server_callback, service_qos.get_rmw_qos_profile());
 
   std::atomic<size_t> c1 {0};
   auto increase_c1_cb = [&c1](size_t count_msgs) {c1 += count_msgs;};
@@ -378,7 +378,7 @@ TEST_F(TestService, server_qos_depth) {
   auto server = server_node->create_service<test_msgs::srv::Empty>(
     "test_qos_depth", std::move(server_callback), server_qos_profile);
 
-  rmw_qos_profile_t client_qos_profile = rmw_qos_profile_default;
+  rclcpp::QoS client_qos_profile(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
   auto client = node->create_client<test_msgs::srv::Empty>("test_qos_depth", client_qos_profile);
 
   ::testing::AssertionResult request_result = ::testing::AssertionSuccess();

--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -109,6 +109,14 @@ if(BUILD_TESTING)
     )
     target_link_libraries(test_lifecycle_service_client ${PROJECT_NAME} mimick)
   endif()
+  ament_add_gtest(test_client test/test_client.cpp TIMEOUT 120)
+  if(TARGET test_client)
+    target_link_libraries(test_client
+      ${PROJECT_NAME}
+      mimick
+      ${rcl_interfaces_TARGETS}
+      rclcpp::rclcpp)
+  endif()
   ament_add_gtest(test_state_machine_info test/test_state_machine_info.cpp)
   if(TARGET test_state_machine_info)
     ament_target_dependencies(test_state_machine_info

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -258,8 +258,10 @@ public:
   /// Create and return a Client.
   /**
    * \sa rclcpp::Node::create_client
+   * \deprecated use rclcpp::QoS instead of rmw_qos_profile_t
    */
   template<typename ServiceT>
+  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
   typename rclcpp::Client<ServiceT>::SharedPtr
   create_client(
     const std::string & service_name,

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -263,7 +263,21 @@ public:
   typename rclcpp::Client<ServiceT>::SharedPtr
   create_client(
     const std::string & service_name,
-    const rmw_qos_profile_t & qos_profile = rmw_qos_profile_services_default,
+    const rmw_qos_profile_t & qos_profile,
+    rclcpp::CallbackGroup::SharedPtr group = nullptr);
+
+  /// Create and return a Client.
+  /**
+   * \param[in] service_name The name on which the service is accessible.
+   * \param[in] qos Quality of service profile for client.
+   * \param[in] group Callback group to handle the reply to service calls.
+   * \return Shared pointer to the created client.
+   */
+  template<typename ServiceT>
+  typename rclcpp::Client<ServiceT>::SharedPtr
+  create_client(
+    const std::string & service_name,
+    const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
     rclcpp::CallbackGroup::SharedPtr group = nullptr);
 
   /// Create and return a Service.

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "rclcpp/contexts/default_context.hpp"
+#include "rclcpp/create_client.hpp"
 #include "rclcpp/create_generic_publisher.hpp"
 #include "rclcpp/create_generic_subscription.hpp"
 #include "rclcpp/create_publisher.hpp"
@@ -103,21 +104,21 @@ LifecycleNode::create_client(
   const rmw_qos_profile_t & qos_profile,
   rclcpp::CallbackGroup::SharedPtr group)
 {
-  rcl_client_options_t options = rcl_client_get_default_options();
-  options.qos = qos_profile;
+  return rclcpp::create_client<ServiceT>(
+    node_base_, node_graph_, node_services_,
+    service_name, qos_profile, group);
+}
 
-  using rclcpp::Client;
-  using rclcpp::ClientBase;
-
-  auto cli = Client<ServiceT>::make_shared(
-    node_base_.get(),
-    node_graph_,
-    service_name,
-    options);
-
-  auto cli_base_ptr = std::dynamic_pointer_cast<ClientBase>(cli);
-  node_services_->add_client(cli_base_ptr, group);
-  return cli;
+template<typename ServiceT>
+typename rclcpp::Client<ServiceT>::SharedPtr
+LifecycleNode::create_client(
+  const std::string & service_name,
+  const rclcpp::QoS & qos,
+  rclcpp::CallbackGroup::SharedPtr group)
+{
+  return rclcpp::create_client<ServiceT>(
+    node_base_, node_graph_, node_services_,
+    service_name, qos, group);
 }
 
 template<typename ServiceT, typename CallbackT>

--- a/rclcpp_lifecycle/test/test_client.cpp
+++ b/rclcpp_lifecycle/test/test_client.cpp
@@ -61,9 +61,25 @@ TEST_F(TestClient, construction_and_destruction) {
     EXPECT_TRUE(client);
   }
   {
+    // suppress deprecated function warning
+    #if !defined(_WIN32)
+    # pragma GCC diagnostic push
+    # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #else  // !defined(_WIN32)
+    # pragma warning(push)
+    # pragma warning(disable: 4996)
+    #endif
+
     auto client = node_->create_client<ListParameters>(
       "service", rmw_qos_profile_services_default);
     EXPECT_TRUE(client);
+
+    // remove warning suppression
+    #if !defined(_WIN32)
+    # pragma GCC diagnostic pop
+    #else  // !defined(_WIN32)
+    # pragma warning(pop)
+    #endif
   }
   {
     auto client = node_->create_client<ListParameters>(

--- a/rclcpp_lifecycle/test/test_client.cpp
+++ b/rclcpp_lifecycle/test/test_client.cpp
@@ -1,0 +1,127 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+#include <utility>
+
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+#include "rcl_interfaces/srv/list_parameters.hpp"
+
+
+class TestClient : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
+
+  void SetUp()
+  {
+    node_ = std::make_shared<rclcpp_lifecycle::LifecycleNode>("my_lifecycle_node", "/ns");
+  }
+
+  void TearDown()
+  {
+    node_.reset();
+  }
+
+  rclcpp_lifecycle::LifecycleNode::SharedPtr node_;
+};
+
+/*
+   Testing client construction and destruction.
+ */
+TEST_F(TestClient, construction_and_destruction) {
+  using rcl_interfaces::srv::ListParameters;
+  {
+    auto client = node_->create_client<ListParameters>("service");
+    EXPECT_TRUE(client);
+  }
+  {
+    auto client = node_->create_client<ListParameters>(
+      "service", rmw_qos_profile_services_default);
+    EXPECT_TRUE(client);
+  }
+  {
+    auto client = node_->create_client<ListParameters>(
+      "service", rclcpp::ServicesQoS());
+    EXPECT_TRUE(client);
+  }
+
+  {
+    ASSERT_THROW(
+    {
+      auto client = node_->create_client<ListParameters>("invalid_service?");
+    }, rclcpp::exceptions::InvalidServiceNameError);
+  }
+}
+
+TEST_F(TestClient, construction_with_free_function) {
+  {
+    auto client = rclcpp::create_client<rcl_interfaces::srv::ListParameters>(
+      node_->get_node_base_interface(),
+      node_->get_node_graph_interface(),
+      node_->get_node_services_interface(),
+      "service",
+      rmw_qos_profile_services_default,
+      nullptr);
+    EXPECT_TRUE(client);
+  }
+  {
+    ASSERT_THROW(
+    {
+      auto client = rclcpp::create_client<rcl_interfaces::srv::ListParameters>(
+        node_->get_node_base_interface(),
+        node_->get_node_graph_interface(),
+        node_->get_node_services_interface(),
+        "invalid_?service",
+        rmw_qos_profile_services_default,
+        nullptr);
+    }, rclcpp::exceptions::InvalidServiceNameError);
+  }
+  {
+    auto client = rclcpp::create_client<rcl_interfaces::srv::ListParameters>(
+      node_->get_node_base_interface(),
+      node_->get_node_graph_interface(),
+      node_->get_node_services_interface(),
+      "service",
+      rclcpp::ServicesQoS(),
+      nullptr);
+    EXPECT_TRUE(client);
+  }
+  {
+    ASSERT_THROW(
+    {
+      auto client = rclcpp::create_client<rcl_interfaces::srv::ListParameters>(
+        node_->get_node_base_interface(),
+        node_->get_node_graph_interface(),
+        node_->get_node_services_interface(),
+        "invalid_?service",
+        rclcpp::ServicesQoS(),
+        nullptr);
+    }, rclcpp::exceptions::InvalidServiceNameError);
+  }
+}


### PR DESCRIPTION
This adds a version of `create_client` that accepts `rclcpp::QoS` instead of `rmw_qos_profile_t`. It's available via `rclcpp::create_client`, `rclcpp::Node::create_client`, and `rclcpp_lifecycle::LifecycleNode::create_client`.

While here I also made the implementation of `rclcpp_lifecycle::LifecycleNode::create_client` use the free function `rclcppp::create_client`.