### PR TITLE
Fix the documentation for rclcpp::ok to be accurate.

### DIFF
--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -169,7 +169,7 @@ remove_ros_arguments(int argc, char const * const * argv);
  * the context initialized by rclcpp::init().
  *
  * \param[in] context Optional check for shutdown of this Context.
- * \return true if shutdown has been called, false otherwise
+ * \return false if shutdown has been called, true otherwise
  */
 RCLCPP_PUBLIC
 bool


### PR DESCRIPTION
That is, it returns false if shutdown has been called, and
true in all other circumstances.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

As pointed out by @jasonbeach in https://github.com/ros2/rclcpp/issues/3#issuecomment-1159486639