### PR TITLE
Make create_service accept rclcpp::QoS

### DIFF
--- a/rclcpp/include/rclcpp/create_service.hpp
+++ b/rclcpp/include/rclcpp/create_service.hpp
@@ -26,6 +26,32 @@
 
 namespace rclcpp
 {
+/// Create a service with a given type.
+/**
+ * \param[in] node_base NodeBaseInterface implementation of the node on which
+ *  to create the service.
+ * \param[in] node_services NodeServicesInterface implementation of the node on
+ *  which to create the service.
+ * \param[in] service_name The name on which the service is accessible.
+ * \param[in] callback The callback to call when the service gets a request.
+ * \param[in] qos Quality of service profile for the service.
+ * \param[in] group Callback group to handle the reply to service calls.
+ * \return Shared pointer to the created service.
+ */
+template<typename ServiceT, typename CallbackT>
+typename rclcpp::Service<ServiceT>::SharedPtr
+create_service(
+  std::shared_ptr<node_interfaces::NodeBaseInterface> node_base,
+  std::shared_ptr<node_interfaces::NodeServicesInterface> node_services,
+  const std::string & service_name,
+  CallbackT && callback,
+  const rclcpp::QoS & qos,
+  rclcpp::CallbackGroup::SharedPtr group)
+{
+  return create_service<ServiceT, CallbackT>(
+    node_base, node_services, service_name,
+    std::forward<CallbackT>(callback), qos.get_rmw_qos_profile(), group);
+}
 
 /// Create a service with a given type.
 /// \internal

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -277,13 +277,31 @@ public:
    * \param[in] qos_profile rmw_qos_profile_t Quality of service profile for client.
    * \param[in] group Callback group to call the service.
    * \return Shared pointer to the created service.
+   * \deprecated use rclcpp::QoS instead of rmw_qos_profile_t
+   */
+  template<typename ServiceT, typename CallbackT>
+  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
+  typename rclcpp::Service<ServiceT>::SharedPtr
+  create_service(
+    const std::string & service_name,
+    CallbackT && callback,
+    const rmw_qos_profile_t & qos_profile,
+    rclcpp::CallbackGroup::SharedPtr group = nullptr);
+
+  /// Create and return a Service.
+  /**
+   * \param[in] service_name The topic to service on.
+   * \param[in] callback User-defined callback function.
+   * \param[in] qos Quality of service profile for the service.
+   * \param[in] group Callback group to call the service.
+   * \return Shared pointer to the created service.
    */
   template<typename ServiceT, typename CallbackT>
   typename rclcpp::Service<ServiceT>::SharedPtr
   create_service(
     const std::string & service_name,
     CallbackT && callback,
-    const rmw_qos_profile_t & qos_profile = rmw_qos_profile_services_default,
+    const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
     rclcpp::CallbackGroup::SharedPtr group = nullptr);
 
   /// Create and return a GenericPublisher.

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -157,6 +157,23 @@ typename rclcpp::Service<ServiceT>::SharedPtr
 Node::create_service(
   const std::string & service_name,
   CallbackT && callback,
+  const rclcpp::QoS & qos,
+  rclcpp::CallbackGroup::SharedPtr group)
+{
+  return rclcpp::create_service<ServiceT, CallbackT>(
+    node_base_,
+    node_services_,
+    extend_name_with_sub_namespace(service_name, this->get_sub_namespace()),
+    std::forward<CallbackT>(callback),
+    qos,
+    group);
+}
+
+template<typename ServiceT, typename CallbackT>
+typename rclcpp::Service<ServiceT>::SharedPtr
+Node::create_service(
+  const std::string & service_name,
+  CallbackT && callback,
   const rmw_qos_profile_t & qos_profile,
   rclcpp::CallbackGroup::SharedPtr group)
 {

--- a/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
@@ -162,7 +162,7 @@ protected:
 
     services_.push_back(
       node_with_service->create_service<test_msgs::srv::Empty>(
-        "service", std::move(service_callback), rmw_qos_profile_services_default, callback_group));
+        "service", std::move(service_callback), rclcpp::ServicesQoS(), callback_group));
     return node_with_service;
   }
 
@@ -793,7 +793,7 @@ TEST_F(TestAllocatorMemoryStrategy, get_next_service_out_of_scope) {
       [](const test_msgs::srv::Empty::Request::SharedPtr,
         test_msgs::srv::Empty::Response::SharedPtr) {};
     auto service = node->create_service<test_msgs::srv::Empty>(
-      "service", std::move(service_callback), rmw_qos_profile_services_default, callback_group);
+      "service", std::move(service_callback), rclcpp::ServicesQoS(), callback_group);
 
     node->for_each_callback_group(
       [node, &weak_groups_to_nodes](rclcpp::CallbackGroup::SharedPtr group_ptr)

--- a/rclcpp/test/rclcpp/test_client.cpp
+++ b/rclcpp/test/rclcpp/test_client.cpp
@@ -404,7 +404,7 @@ TEST_F(TestClient, on_new_response_callback) {
     const test_msgs::srv::Empty::Request::SharedPtr,
     test_msgs::srv::Empty::Response::SharedPtr) {server_requests_count++;};
   auto server = server_node->create_service<test_msgs::srv::Empty>(
-    "test_service", server_callback, client_qos.get_rmw_qos_profile());
+    "test_service", server_callback, client_qos);
   auto request = std::make_shared<test_msgs::srv::Empty::Request>();
 
   std::atomic<size_t> c1 {0};
@@ -534,10 +534,10 @@ TEST_F(TestClient, client_qos_depth) {
 
   auto server_node = std::make_shared<rclcpp::Node>("server_node", "/ns");
 
-  rmw_qos_profile_t server_qos_profile = rmw_qos_profile_default;
+  rclcpp::QoS server_qos(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
 
   auto server = server_node->create_service<test_msgs::srv::Empty>(
-    "test_qos_depth", std::move(server_callback), server_qos_profile);
+    "test_qos_depth", std::move(server_callback), server_qos);
 
   auto request = std::make_shared<test_msgs::srv::Empty::Request>();
   ::testing::AssertionResult request_result = ::testing::AssertionSuccess();

--- a/rclcpp/test/rclcpp/test_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/test_memory_strategy.cpp
@@ -155,7 +155,7 @@ TEST_F(TestMemoryStrategy, get_service_by_handle) {
       {
         auto service = node->create_service<test_msgs::srv::Empty>(
           "service", std::move(service_callback),
-          rmw_qos_profile_services_default, callback_group);
+          rclcpp::ServicesQoS(), callback_group);
 
         service_handle = service->get_service_handle();
 
@@ -396,7 +396,7 @@ TEST_F(TestMemoryStrategy, get_group_by_service) {
 
       service = node->create_service<test_msgs::srv::Empty>(
         "service", std::move(service_callback),
-        rmw_qos_profile_services_default, callback_group);
+        rclcpp::ServicesQoS(), callback_group);
       weak_groups_to_nodes.insert(
         std::pair<rclcpp::CallbackGroup::WeakPtr,
         rclcpp::node_interfaces::NodeBaseInterface::WeakPtr>(

--- a/rclcpp/test/rclcpp/test_service.cpp
+++ b/rclcpp/test/rclcpp/test_service.cpp
@@ -249,7 +249,7 @@ TEST_F(TestService, on_new_request_callback) {
   rclcpp::ServicesQoS service_qos;
   service_qos.keep_last(3);
   auto server = node->create_service<test_msgs::srv::Empty>(
-    "~/test_service", server_callback, service_qos.get_rmw_qos_profile());
+    "~/test_service", server_callback, service_qos);
 
   std::atomic<size_t> c1 {0};
   auto increase_c1_cb = [&c1](size_t count_msgs) {c1 += count_msgs;};
@@ -338,28 +338,25 @@ TEST_F(TestService, rcl_service_request_subscription_get_actual_qos_error) {
 
 
 TEST_F(TestService, server_qos) {
-  rmw_qos_profile_t qos_profile = rmw_qos_profile_services_default;
-  qos_profile.liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
-  uint64_t duration = 1;
-  qos_profile.deadline = {duration, duration};
-  qos_profile.lifespan = {duration, duration};
-  qos_profile.liveliness_lease_duration = {duration, duration};
+  rclcpp::ServicesQoS qos_profile;
+  qos_profile.liveliness(rclcpp::LivelinessPolicy::Automatic);
+  rclcpp::Duration duration(std::chrono::nanoseconds(1));
+  qos_profile.deadline(duration);
+  qos_profile.lifespan(duration);
+  qos_profile.liveliness_lease_duration(duration);
 
   auto callback = [](const test_msgs::srv::Empty::Request::SharedPtr,
       test_msgs::srv::Empty::Response::SharedPtr) {};
 
   auto server = node->create_service<test_msgs::srv::Empty>(
-    "service", callback,
-    qos_profile);
-  auto init_qos =
-    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile), qos_profile);
+    "service", callback, qos_profile);
   auto rs_qos = server->get_request_subscription_actual_qos();
   auto rp_qos = server->get_response_publisher_actual_qos();
 
-  EXPECT_EQ(init_qos, rp_qos);
+  EXPECT_EQ(qos_profile, rp_qos);
   // Lifespan has no meaning for subscription/readers
-  rs_qos.lifespan(qos_profile.lifespan);
-  EXPECT_EQ(init_qos, rs_qos);
+  rs_qos.lifespan(qos_profile.lifespan());
+  EXPECT_EQ(qos_profile, rs_qos);
 }
 
 TEST_F(TestService, server_qos_depth) {
@@ -372,8 +369,7 @@ TEST_F(TestService, server_qos_depth) {
 
   auto server_node = std::make_shared<rclcpp::Node>("server_node", "/ns");
 
-  rmw_qos_profile_t server_qos_profile = rmw_qos_profile_default;
-  server_qos_profile.depth = 2;
+  rclcpp::QoS server_qos_profile(2);
 
   auto server = server_node->create_service<test_msgs::srv::Empty>(
     "test_qos_depth", std::move(server_callback), server_qos_profile);
@@ -398,7 +394,7 @@ TEST_F(TestService, server_qos_depth) {
   }
 
   auto start = std::chrono::steady_clock::now();
-  while ((server_cb_count_ < server_qos_profile.depth) &&
+  while ((server_cb_count_ < server_qos_profile.depth()) &&
     (std::chrono::steady_clock::now() - start) < 1s)
   {
     rclcpp::spin_some(server_node);
@@ -409,5 +405,5 @@ TEST_F(TestService, server_qos_depth) {
   // so more server responses might be processed than expected.
   rclcpp::spin_some(server_node);
 
-  EXPECT_EQ(server_cb_count_, server_qos_profile.depth);
+  EXPECT_EQ(server_cb_count_, server_qos_profile.depth());
 }

--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -117,6 +117,14 @@ if(BUILD_TESTING)
       ${rcl_interfaces_TARGETS}
       rclcpp::rclcpp)
   endif()
+  ament_add_gtest(test_service test/test_service.cpp TIMEOUT 120)
+  if(TARGET test_service)
+    target_link_libraries(test_service
+      ${PROJECT_NAME}
+      mimick
+      ${test_msgs_TARGETS}
+      rclcpp::rclcpp)
+  endif()
   ament_add_gtest(test_state_machine_info test/test_state_machine_info.cpp)
   if(TARGET test_state_machine_info)
     ament_target_dependencies(test_state_machine_info

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -285,13 +285,27 @@ public:
   /// Create and return a Service.
   /**
    * \sa rclcpp::Node::create_service
+   * \deprecated use rclcpp::QoS instead of rmw_qos_profile_t
+   */
+  template<typename ServiceT, typename CallbackT>
+  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
+  typename rclcpp::Service<ServiceT>::SharedPtr
+  create_service(
+    const std::string & service_name,
+    CallbackT && callback,
+    const rmw_qos_profile_t & qos_profile,
+    rclcpp::CallbackGroup::SharedPtr group = nullptr);
+
+  /// Create and return a Service.
+  /**
+   * \sa rclcpp::Node::create_service
    */
   template<typename ServiceT, typename CallbackT>
   typename rclcpp::Service<ServiceT>::SharedPtr
   create_service(
     const std::string & service_name,
     CallbackT && callback,
-    const rmw_qos_profile_t & qos_profile = rmw_qos_profile_services_default,
+    const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
     rclcpp::CallbackGroup::SharedPtr group = nullptr);
 
   /// Create and return a GenericPublisher.

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
@@ -134,6 +134,19 @@ LifecycleNode::create_service(
     service_name, std::forward<CallbackT>(callback), qos_profile, group);
 }
 
+template<typename ServiceT, typename CallbackT>
+typename rclcpp::Service<ServiceT>::SharedPtr
+LifecycleNode::create_service(
+  const std::string & service_name,
+  CallbackT && callback,
+  const rclcpp::QoS & qos,
+  rclcpp::CallbackGroup::SharedPtr group)
+{
+  return rclcpp::create_service<ServiceT, CallbackT>(
+    node_base_, node_services_,
+    service_name, std::forward<CallbackT>(callback), qos, group);
+}
+
 template<typename AllocatorT>
 std::shared_ptr<rclcpp::GenericPublisher>
 LifecycleNode::create_generic_publisher(

--- a/rclcpp_lifecycle/test/test_service.cpp
+++ b/rclcpp_lifecycle/test/test_service.cpp
@@ -1,0 +1,100 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+#include <utility>
+
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+#include "test_msgs/srv/empty.hpp"
+
+using namespace std::chrono_literals;
+
+class TestService : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
+
+  void SetUp()
+  {
+    node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("my_lifecycle_node", "/ns");
+  }
+
+  void TearDown()
+  {
+    node.reset();
+  }
+
+  rclcpp_lifecycle::LifecycleNode::SharedPtr node;
+};
+
+/*
+   Testing service construction and destruction.
+ */
+TEST_F(TestService, construction_and_destruction) {
+  using test_msgs::srv::Empty;
+  auto callback =
+    [](const Empty::Request::SharedPtr, Empty::Response::SharedPtr) {
+    };
+  {
+    auto service = node->create_service<Empty>("service", callback);
+    EXPECT_NE(nullptr, service->get_service_handle());
+    const rclcpp::ServiceBase * const_service_base = service.get();
+    EXPECT_NE(nullptr, const_service_base->get_service_handle());
+  }
+  {
+    // suppress deprecated function warning
+    #if !defined(_WIN32)
+    # pragma GCC diagnostic push
+    # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #else  // !defined(_WIN32)
+    # pragma warning(push)
+    # pragma warning(disable: 4996)
+    #endif
+
+    auto service = node->create_service<Empty>(
+      "service", callback, rmw_qos_profile_services_default);
+
+    // remove warning suppression
+    #if !defined(_WIN32)
+    # pragma GCC diagnostic pop
+    #else  // !defined(_WIN32)
+    # pragma warning(pop)
+    #endif
+
+    EXPECT_NE(nullptr, service->get_service_handle());
+    const rclcpp::ServiceBase * const_service_base = service.get();
+    EXPECT_NE(nullptr, const_service_base->get_service_handle());
+  }
+
+  {
+    ASSERT_THROW(
+    {
+      auto service = node->create_service<Empty>("invalid_service?", callback);
+    }, rclcpp::exceptions::InvalidServiceNameError);
+  }
+}


### PR DESCRIPTION
Follow up to #1964, this allows using `rclcpp::QoS` with `create_service` and deprecates the version taking `rmw_qos_profile_t`