### PR TITLE
Make loaned messages const on the subscription side

### DIFF
--- a/rclcpp/include/rclcpp/generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/generic_subscription.hpp
@@ -146,7 +146,7 @@ public:
   /// This function is currently not implemented.
   RCLCPP_PUBLIC
   void handle_loaned_message(
-    void * loaned_message, const rclcpp::MessageInfo & message_info) override;
+    const void * loaned_message, const rclcpp::MessageInfo & message_info) override;
 
   // Same as return_serialized_message() as the subscription is to serialized_messages only
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -360,7 +360,7 @@ public:
 
   void
   handle_loaned_message(
-    void * loaned_message,
+    const void * loaned_message,
     const rclcpp::MessageInfo & message_info) override
   {
     if (matches_any_intra_process_publishers(&message_info.get_rmw_message_info().publisher_gid)) {
@@ -369,10 +369,10 @@ public:
       return;
     }
 
-    auto typed_message = static_cast<ROSMessageType *>(loaned_message);
+    const auto typed_message = static_cast<const ROSMessageType *>(loaned_message);
     // message is loaned, so we have to make sure that the deleter does not deallocate the message
-    auto sptr = std::shared_ptr<ROSMessageType>(
-      typed_message, [](ROSMessageType * msg) {(void) msg;});
+    auto sptr = std::shared_ptr<const ROSMessageType>(
+      typed_message, [](const ROSMessageType * msg) {(void) msg;});
 
     std::chrono::time_point<std::chrono::system_clock> now;
     if (subscription_topic_statistics_) {

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -199,7 +199,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   void
-  handle_loaned_message(void * loaned_message, const rclcpp::MessageInfo & message_info) = 0;
+  handle_loaned_message(const void * loaned_message, const rclcpp::MessageInfo & message_info) = 0;
 
   /// Return the message borrowed in create_message.
   /** \param[in] message Shared pointer to the returned message. */

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -598,7 +598,7 @@ Executor::execute_subscription(rclcpp::SubscriptionBase::SharedPtr subscription)
     // This is the case where a loaned message is taken from the middleware via
     // inter-process communication, given to the user for their callback,
     // and then returned.
-    void * loaned_msg = nullptr;
+    const void * loaned_msg = nullptr;
     // TODO(wjwwood): refactor this into methods on subscription when LoanedMessage
     //   is extened to support subscriptions as well.
     take_and_do_error_handling(

--- a/rclcpp/src/rclcpp/generic_subscription.cpp
+++ b/rclcpp/src/rclcpp/generic_subscription.cpp
@@ -52,7 +52,7 @@ GenericSubscription::handle_serialized_message(
 }
 
 void GenericSubscription::handle_loaned_message(
-  void * message, const rclcpp::MessageInfo & message_info)
+  const void * message, const rclcpp::MessageInfo & message_info)
 {
   (void) message;
   (void) message_info;

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_topics.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_topics.cpp
@@ -70,7 +70,7 @@ public:
   create_serialized_message() override {return nullptr;}
 
   void handle_message(std::shared_ptr<void> &, const rclcpp::MessageInfo &) override {}
-  void handle_loaned_message(void *, const rclcpp::MessageInfo &) override {}
+  void handle_loaned_message(const void *, const rclcpp::MessageInfo &) override {}
   void handle_serialized_message(
     const std::shared_ptr<rclcpp::SerializedMessage> &, const rclcpp::MessageInfo &) override {}
   void return_message(std::shared_ptr<void> &) override {}


### PR DESCRIPTION
Related to https://github.com/ros2/rcl/pull/992.

To make callback dispatching work, I generalized `dispatch()` to work with both const and non-const messages. Maybe there is a better way.