### PR TITLE
Fix ambiguous auto variable on gcc 7.5

### DIFF
--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -816,7 +816,7 @@ protected:
         "Received invalid sequence number. Ignoring...");
       return std::nullopt;
     }
-    auto value = std::move(it->second.second);
+    std::optional<CallbackInfoVariant> value = std::optional<CallbackInfoVariant>{std::move(it->second.second)};
     this->pending_requests_.erase(request_number);
     return value;
   }


### PR DESCRIPTION
I'm running humble on an older version of embedded linux thats stuck with gcc 7.5. For some reason it didn't like this auto declaration. Could we get this pushed into rolling and humble branches?

This should resolve https://github.com/ros2/rclcpp/issues/1963