### PR TITLE
[docs] add note about callback lifetime for {on, post}_set_parameter_callback

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -1039,6 +1039,9 @@ public:
    * rcl_interfaces::msg::SetParametersResult to indicate whether or not the
    * parameter should be set or not, and if not why.
    *
+   * The back returns a shared pointer to the callback handle.
+   * The callback is valid as long as the smart pointer is alive.
+   *
    * For an example callback:
    *
    * ```cpp
@@ -1106,6 +1109,9 @@ public:
   /**
    * The callback is called when any of the `set_parameter*` or `declare_parameter*`
    * methods are successful.
+   *
+   * The back returns a shared pointer to the callback handle.
+   * The callback is valid as long as the smart pointer is alive.
    *
    * The callback takes a reference to a const vector of parameters that have been
    * set successfully.

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -991,6 +991,9 @@ public:
    * One of the use case of "pre set callback" can be updating additional parameters
    * conditioned on changes to a parameter.
    *
+   * Users should retain a copy of the returned shared pointer, as the callbak
+   * is valid only as long as the smart pointer is alive.
+   *
    * For an example callback:
    *
    *```cpp
@@ -1039,8 +1042,8 @@ public:
    * rcl_interfaces::msg::SetParametersResult to indicate whether or not the
    * parameter should be set or not, and if not why.
    *
-   * The back returns a shared pointer to the callback handle.
-   * The callback is valid as long as the smart pointer is alive.
+   * Users should retain a copy of the returned shared pointer, as the callbak
+   * is valid only as long as the smart pointer is alive.
    *
    * For an example callback:
    *
@@ -1110,8 +1113,8 @@ public:
    * The callback is called when any of the `set_parameter*` or `declare_parameter*`
    * methods are successful.
    *
-   * The back returns a shared pointer to the callback handle.
-   * The callback is valid as long as the smart pointer is alive.
+   * Users should retain a copy of the returned shared pointer, 
+   * the callback is valid only as long as the smart pointer is alive.
    *
    * The callback takes a reference to a const vector of parameters that have been
    * set successfully.

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -991,7 +991,7 @@ public:
    * One of the use case of "pre set callback" can be updating additional parameters
    * conditioned on changes to a parameter.
    *
-   * Users should retain a copy of the returned shared pointer, as the callbak
+   * Users should retain a copy of the returned shared pointer, as the callback
    * is valid only as long as the smart pointer is alive.
    *
    * For an example callback:
@@ -1042,7 +1042,7 @@ public:
    * rcl_interfaces::msg::SetParametersResult to indicate whether or not the
    * parameter should be set or not, and if not why.
    *
-   * Users should retain a copy of the returned shared pointer, as the callbak
+   * Users should retain a copy of the returned shared pointer, as the callback
    * is valid only as long as the smart pointer is alive.
    *
    * For an example callback:
@@ -1113,8 +1113,8 @@ public:
    * The callback is called when any of the `set_parameter*` or `declare_parameter*`
    * methods are successful.
    *
-   * Users should retain a copy of the returned shared pointer, 
-   * the callback is valid only as long as the smart pointer is alive.
+   * Users should retain a copy of the returned shared pointer, as the callback
+   * is valid only as long as the smart pointer is alive.
    *
    * The callback takes a reference to a const vector of parameters that have been
    * set successfully.


### PR DESCRIPTION
I've been burned by ignoring the return value and so has a few others -- adding a note about the lifetime of the registered callback being tied to the returned callback handle further up the documentation should help others avoid making the same mistake.

Signed-off-by: Brian Chen <brian.chen@openrobotics.org>