### PR TITLE
Add clock type to node_options

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/node_clock.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_clock.hpp
@@ -15,6 +15,7 @@
 #ifndef RCLCPP__NODE_INTERFACES__NODE_CLOCK_HPP_
 #define RCLCPP__NODE_INTERFACES__NODE_CLOCK_HPP_
 
+#include "rcl/time.h"
 #include "rclcpp/clock.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
@@ -42,7 +43,8 @@ public:
     rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
     rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph,
     rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services,
-    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging);
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
+    rcl_clock_type_t clock_type);
 
   RCLCPP_PUBLIC
   virtual

--- a/rclcpp/include/rclcpp/node_interfaces/node_clock.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_clock.hpp
@@ -69,7 +69,7 @@ private:
   rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_;
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_;
 
-  rclcpp::Clock::SharedPtr ros_clock_;
+  rclcpp::Clock::SharedPtr clock_;
 };
 
 }  // namespace node_interfaces

--- a/rclcpp/include/rclcpp/node_options.hpp
+++ b/rclcpp/include/rclcpp/node_options.hpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "rcl/time.h"
 #include "rcl/node_options.h"
 #include "rclcpp/context.hpp"
 #include "rclcpp/contexts/default_context.hpp"
@@ -46,6 +47,7 @@ public:
    *   - enable_topic_statistics = false
    *   - start_parameter_services = true
    *   - start_parameter_event_publisher = true
+   *   - clock_type = RCL_ROS_TIME
    *   - clock_qos = rclcpp::ClockQoS()
    *   - use_clock_thread = true
    *   - rosout_qos = rclcpp::RosoutQoS()
@@ -246,6 +248,19 @@ public:
   NodeOptions &
   start_parameter_event_publisher(bool start_parameter_event_publisher);
 
+  /// Return a reference to the clock type.
+  RCLCPP_PUBLIC
+  const rcl_clock_type_t &
+  clock_type() const;
+
+  /// Set the clock type.
+  /**
+   * The clock type to be used by the node.
+   */
+  RCLCPP_PUBLIC
+  NodeOptions &
+  clock_type(const rcl_clock_type_t & clock_type);
+
   /// Return a reference to the clock QoS.
   RCLCPP_PUBLIC
   const rclcpp::QoS &
@@ -399,6 +414,8 @@ private:
   bool start_parameter_services_ {true};
 
   bool start_parameter_event_publisher_ {true};
+
+  rcl_clock_type_t clock_type_ {RCL_ROS_TIME};
 
   rclcpp::QoS clock_qos_ = rclcpp::ClockQoS();
 

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -176,7 +176,8 @@ Node::Node(
       node_topics_,
       node_graph_,
       node_services_,
-      node_logging_
+      node_logging_,
+      options.clock_type()
     )),
   node_parameters_(new rclcpp::node_interfaces::NodeParameters(
       node_base_,

--- a/rclcpp/src/rclcpp/node_interfaces/node_clock.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_clock.cpp
@@ -31,7 +31,7 @@ NodeClock::NodeClock(
   node_graph_(node_graph),
   node_services_(node_services),
   node_logging_(node_logging),
-  ros_clock_(std::make_shared<rclcpp::Clock>(clock_type))
+  clock_(std::make_shared<rclcpp::Clock>(clock_type))
 {}
 
 NodeClock::~NodeClock()
@@ -40,11 +40,11 @@ NodeClock::~NodeClock()
 rclcpp::Clock::SharedPtr
 NodeClock::get_clock()
 {
-  return ros_clock_;
+  return clock_;
 }
 
 rclcpp::Clock::ConstSharedPtr
 NodeClock::get_clock() const
 {
-  return ros_clock_;
+  return clock_;
 }

--- a/rclcpp/src/rclcpp/node_interfaces/node_clock.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_clock.cpp
@@ -24,13 +24,14 @@ NodeClock::NodeClock(
   rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics,
   rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph,
   rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services,
-  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging)
+  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
+  rcl_clock_type_t clock_type)
 : node_base_(node_base),
   node_topics_(node_topics),
   node_graph_(node_graph),
   node_services_(node_services),
   node_logging_(node_logging),
-  ros_clock_(std::make_shared<rclcpp::Clock>(RCL_ROS_TIME))
+  ros_clock_(std::make_shared<rclcpp::Clock>(clock_type))
 {}
 
 NodeClock::~NodeClock()

--- a/rclcpp/src/rclcpp/node_options.cpp
+++ b/rclcpp/src/rclcpp/node_options.cpp
@@ -20,6 +20,7 @@
 #include <vector>
 #include <utility>
 
+#include "rcl/time.h"
 #include "rclcpp/detail/utilities.hpp"
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/logging.hpp"
@@ -77,6 +78,7 @@ NodeOptions::operator=(const NodeOptions & other)
     this->enable_topic_statistics_ = other.enable_topic_statistics_;
     this->start_parameter_services_ = other.start_parameter_services_;
     this->start_parameter_event_publisher_ = other.start_parameter_event_publisher_;
+    this->clock_type_ = other.clock_type_;
     this->clock_qos_ = other.clock_qos_;
     this->use_clock_thread_ = other.use_clock_thread_;
     this->parameter_event_qos_ = other.parameter_event_qos_;
@@ -257,6 +259,19 @@ NodeOptions &
 NodeOptions::start_parameter_event_publisher(bool start_parameter_event_publisher)
 {
   this->start_parameter_event_publisher_ = start_parameter_event_publisher;
+  return *this;
+}
+
+const rcl_clock_type_t &
+NodeOptions::clock_type() const
+{
+  return this->clock_type_;
+}
+
+NodeOptions &
+NodeOptions::clock_type(const rcl_clock_type_t & clock_type)
+{
+  this->clock_type_ = clock_type;
   return *this;
 }
 

--- a/rclcpp/src/rclcpp/node_options.cpp
+++ b/rclcpp/src/rclcpp/node_options.cpp
@@ -20,7 +20,6 @@
 #include <vector>
 #include <utility>
 
-#include "rcl/time.h"
 #include "rclcpp/detail/utilities.hpp"
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/logging.hpp"

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -93,7 +93,7 @@ public:
   {
     {
       std::lock_guard<std::mutex> clock_guard(clock->get_clock_mutex());
-      if (clock->get_clock_type() != RCL_ROS_TIME && ros_time_active_ == true) {
+      if (clock->get_clock_type() != RCL_ROS_TIME && ros_time_active_) {
         throw std::invalid_argument(
                 "ros_time_active_ can't be true while clock is not of RCL_ROS_TIME type");
       }
@@ -309,7 +309,7 @@ public:
     // can't possibly call any of the callbacks as we are cleaning up.
     destroy_clock_sub();
     clocks_state_.disable_ros_time();
-    if (on_set_parameters_callback_ && node_parameters_) {
+    if (on_set_parameters_callback_) {
       node_parameters_->remove_on_set_parameters_callback(on_set_parameters_callback_.get());
     }
     on_set_parameters_callback_.reset();

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -460,7 +460,6 @@ private:
   {
     rcl_interfaces::msg::SetParametersResult result;
     result.successful = true;
-    result.reason = "success";
     for (const auto & param : parameters) {
       if (param.get_name() == "use_sim_time" && param.get_type() == rclcpp::PARAMETER_BOOL) {
         if (param.as_bool() && !(clocks_state_.are_all_clocks_rcl_ros_time())) {

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -95,6 +95,74 @@ TEST_F(TestNode, construction_and_destruction) {
       (void)node;
     }, rclcpp::exceptions::InvalidNamespaceError);
   }
+
+  {
+    rclcpp::NodeOptions options;
+    ASSERT_NO_THROW(
+    {
+      const auto node = std::make_shared<rclcpp::Node>("my_node", "/ns", options);
+      EXPECT_EQ(RCL_ROS_TIME, node->get_clock()->get_clock_type());
+    });
+  }
+
+  {
+    rclcpp::NodeOptions options;
+    options.parameter_overrides(
+    {
+      {"use_sim_time", true},
+    });
+    ASSERT_NO_THROW(
+    {
+      const auto node = std::make_shared<rclcpp::Node>("my_node", "/ns", options);
+      EXPECT_EQ(RCL_ROS_TIME, node->get_clock()->get_clock_type());
+    });
+  }
+
+  {
+    rclcpp::NodeOptions options;
+    options.clock_type(RCL_SYSTEM_TIME);
+    ASSERT_NO_THROW(
+    {
+      const auto node = std::make_shared<rclcpp::Node>("my_node", "/ns", options);
+      EXPECT_EQ(RCL_SYSTEM_TIME, node->get_clock()->get_clock_type());
+    });
+  }
+
+  {
+    rclcpp::NodeOptions options;
+    options.parameter_overrides(
+    {
+      {"use_sim_time", true},
+    });
+    options.clock_type(RCL_SYSTEM_TIME);
+    ASSERT_THROW(
+      const auto node = std::make_shared<rclcpp::Node>(
+        "my_node", "/ns",
+        options), std::invalid_argument);
+  }
+
+  {
+    rclcpp::NodeOptions options;
+    options.clock_type(RCL_STEADY_TIME);
+    ASSERT_NO_THROW(
+    {
+      const auto node = std::make_shared<rclcpp::Node>("my_node", "/ns", options);
+      EXPECT_EQ(RCL_STEADY_TIME, node->get_clock()->get_clock_type());
+    });
+  }
+
+  {
+    rclcpp::NodeOptions options;
+    options.parameter_overrides(
+    {
+      {"use_sim_time", true},
+    });
+    options.clock_type(RCL_STEADY_TIME);
+    ASSERT_THROW(
+      const auto node = std::make_shared<rclcpp::Node>(
+        "my_node", "/ns",
+        options), std::invalid_argument);
+  }
 }
 
 /*

--- a/rclcpp/test/rclcpp/test_node_options.cpp
+++ b/rclcpp/test/rclcpp/test_node_options.cpp
@@ -316,3 +316,12 @@ TEST(TestNodeOptions, set_get_allocator) {
   // Check invalid allocator
   EXPECT_THROW(options.get_rcl_node_options(), std::bad_alloc);
 }
+
+TEST(TestNodeOptions, clock_type) {
+  rclcpp::NodeOptions options;
+  EXPECT_EQ(RCL_ROS_TIME, options.clock_type());
+  options.clock_type(RCL_SYSTEM_TIME);
+  EXPECT_EQ(RCL_SYSTEM_TIME, options.clock_type());
+  options.clock_type(RCL_STEADY_TIME);
+  EXPECT_EQ(RCL_STEADY_TIME, options.clock_type());
+}

--- a/rclcpp/test/rclcpp/test_time_source.cpp
+++ b/rclcpp/test/rclcpp/test_time_source.cpp
@@ -267,6 +267,35 @@ TEST(TimeSource, invalid_sim_time_parameter_override)
   rclcpp::shutdown();
 }
 
+TEST(TimeSource, valid_clock_type_for_sim_time)
+{
+  rclcpp::init(0, nullptr);
+
+  rclcpp::NodeOptions options;
+  auto node = std::make_shared<rclcpp::Node>("my_node", options);
+  EXPECT_TRUE(
+    node->set_parameter(
+      rclcpp::Parameter(
+        "use_sim_time", rclcpp::ParameterValue(
+          true))).successful);
+  rclcpp::shutdown();
+}
+
+TEST(TimeSource, invalid_clock_type_for_sim_time)
+{
+  rclcpp::init(0, nullptr);
+
+  rclcpp::NodeOptions options;
+  options.clock_type(RCL_STEADY_TIME);
+  auto node = std::make_shared<rclcpp::Node>("my_node", options);
+  EXPECT_FALSE(
+    node->set_parameter(
+      rclcpp::Parameter(
+        "use_sim_time", rclcpp::ParameterValue(
+          true))).successful);
+  rclcpp::shutdown();
+}
+
 TEST_F(TestTimeSource, clock) {
   rclcpp::TimeSource ts(node);
   auto ros_clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -85,7 +85,8 @@ LifecycleNode::LifecycleNode(
       node_topics_,
       node_graph_,
       node_services_,
-      node_logging_
+      node_logging_,
+      options.clock_type()
     )),
   node_parameters_(new rclcpp::node_interfaces::NodeParameters(
       node_base_,


### PR DESCRIPTION
Signed-off-by: Jeffery Hsu [jefferyyjhsu@gmail.com](mailto:jefferyyjhsu@gmail.com)
This PR adds the option for selecting clock source in Node/LifecycleNode thru NodeOptions.
A similar option is already present in rclcpp::Timer but it is currently missing in Nodes/LifecycleNode. There's currently no way to set Node::now() and all other time-related functions to use clock sources other than ROS_TIME.