### PR TITLE
[galactic backport] Remove use of std::allocator<>::rebind

### DIFF
--- a/rclcpp/include/rclcpp/allocator/allocator_deleter.hpp
+++ b/rclcpp/include/rclcpp/allocator/allocator_deleter.hpp
@@ -95,7 +95,7 @@ void set_allocator_for_deleter(AllocatorDeleter<T> * deleter, Alloc * alloc)
 template<typename Alloc, typename T>
 using Deleter = typename std::conditional<
   std::is_same<typename std::allocator_traits<Alloc>::template rebind_alloc<T>,
-  typename std::allocator<void>::template rebind<T>::other>::value,
+  std::allocator<T>>::value,
   std::default_delete<T>,
   AllocatorDeleter<Alloc>
   >::type;


### PR DESCRIPTION
rebind is deprecated in c++17 and removed in c++20

backporting https://github.com/ros2/rclcpp/pull/1678 to galactic so it can build with c++20