### PR TITLE
Fix the GoalUUID to_string representation

### DIFF
--- a/rclcpp_action/include/rclcpp_action/types.hpp
+++ b/rclcpp_action/include/rclcpp_action/types.hpp
@@ -34,7 +34,7 @@ using GoalUUID = std::array<uint8_t, UUID_SIZE>;
 using GoalStatus = action_msgs::msg::GoalStatus;
 using GoalInfo = action_msgs::msg::GoalInfo;
 
-/// Convert a goal id to a human readable string.
+/// Convert a goal id to a human readable RFC-4122 compliant string.
 RCLCPP_ACTION_PUBLIC
 std::string
 to_string(const GoalUUID & goal_id);

--- a/rclcpp_action/src/types.cpp
+++ b/rclcpp_action/src/types.cpp
@@ -15,7 +15,6 @@
 #include "rclcpp_action/types.hpp"
 
 #include <string>
-#include <sstream>
 
 namespace rclcpp_action
 {
@@ -24,22 +23,25 @@ to_string(const GoalUUID & goal_id)
 {
   constexpr char HEX[] = "0123456789abcdef";
   std::string result;
-  result.reserve(36);
-  for (const auto byte : goal_id) {
-    result.push_back(HEX[byte >> 4]);
-    result.push_back(HEX[byte & 0x0f]);
+  result.resize(36);
+  size_t i = 0;
+  for (uint8_t byte : goal_id) {
+    result[i++] = HEX[byte >> 4];
+    result[i++] = HEX[byte & 0x0f];
+    // A RFC-4122 compliant UUID looks like:
+    // 00000000-0000-0000-0000-000000000000
+    // That means that there is a '-' at offset 8, 13, 18, and 23
+    if (i == 8 || i == 13 || i == 18 || i == 23) {
+      result[i++] = '-';
+    }
   }
-  result.insert(result.begin() + 20, '-');
-  result.insert(result.begin() + 16, '-');
-  result.insert(result.begin() + 12, '-');
-  result.insert(result.begin() + 8, '-');
   return result;
 }
 
 void
 convert(const GoalUUID & goal_id, rcl_action_goal_info_t * info)
 {
-  for (size_t i = 0; i < 16; ++i) {
+  for (size_t i = 0; i < UUID_SIZE; ++i) {
     info->goal_id.uuid[i] = goal_id[i];
   }
 }
@@ -47,7 +49,7 @@ convert(const GoalUUID & goal_id, rcl_action_goal_info_t * info)
 void
 convert(const rcl_action_goal_info_t & info, GoalUUID * goal_id)
 {
-  for (size_t i = 0; i < 16; ++i) {
+  for (size_t i = 0; i < UUID_SIZE; ++i) {
     (*goal_id)[i] = info.goal_id.uuid[i];
   }
 }

--- a/rclcpp_action/src/types.cpp
+++ b/rclcpp_action/src/types.cpp
@@ -22,12 +22,18 @@ namespace rclcpp_action
 std::string
 to_string(const GoalUUID & goal_id)
 {
-  std::stringstream stream;
-  stream << std::hex;
-  for (const auto & element : goal_id) {
-    stream << static_cast<int>(element);
+  constexpr char HEX[] = "0123456789abcdef";
+  std::string result;
+  result.reserve(36);
+  for (const auto byte : goal_id) {
+    result.push_back(HEX[byte >> 4]);
+    result.push_back(HEX[byte & 0x0f]);
   }
-  return stream.str();
+  result.insert(result.begin() + 20, '-');
+  result.insert(result.begin() + 16, '-');
+  result.insert(result.begin() + 12, '-');
+  result.insert(result.begin() + 8, '-');
+  return result;
 }
 
 void

--- a/rclcpp_action/test/test_types.cpp
+++ b/rclcpp_action/test/test_types.cpp
@@ -54,7 +54,7 @@ TEST(TestActionTypes, rcl_action_goal_info_to_goal_uuid) {
   }
 
   rclcpp_action::GoalUUID goal_id;
-  rclcpp_action::convert(goal_id, &goal_info);
+  rclcpp_action::convert(goal_info, &goal_id);
   for (uint8_t i = 0; i < UUID_SIZE; ++i) {
     EXPECT_EQ(goal_info.goal_id.uuid[i], goal_id[i]);
   }

--- a/rclcpp_action/test/test_types.cpp
+++ b/rclcpp_action/test/test_types.cpp
@@ -22,17 +22,17 @@ TEST(TestActionTypes, goal_uuid_to_string) {
   for (uint8_t i = 0; i < UUID_SIZE; ++i) {
     goal_id[i] = i;
   }
-  EXPECT_STREQ("0123456789abcdef", rclcpp_action::to_string(goal_id).c_str());
+  EXPECT_STREQ("00010203-0405-0607-0809-0a0b0c0d0e0f", rclcpp_action::to_string(goal_id).c_str());
 
   for (uint8_t i = 0; i < UUID_SIZE; ++i) {
     goal_id[i] = static_cast<uint8_t>(16u + i);
   }
-  EXPECT_STREQ("101112131415161718191a1b1c1d1e1f", rclcpp_action::to_string(goal_id).c_str());
+  EXPECT_STREQ("10111213-1415-1617-1819-1a1b1c1d1e1f", rclcpp_action::to_string(goal_id).c_str());
 
   for (uint8_t i = 0; i < UUID_SIZE; ++i) {
     goal_id[i] = static_cast<uint8_t>(std::numeric_limits<uint8_t>::max() - i);
   }
-  EXPECT_STREQ("fffefdfcfbfaf9f8f7f6f5f4f3f2f1f0", rclcpp_action::to_string(goal_id).c_str());
+  EXPECT_STREQ("fffefdfc-fbfa-f9f8-f7f6-f5f4f3f2f1f0", rclcpp_action::to_string(goal_id).c_str());
 }
 
 TEST(TestActionTypes, goal_uuid_to_rcl_action_goal_info) {


### PR DESCRIPTION
Changes the string representation of `rclcpp_action::GoalUUID`s to match the canonical format described in [RFC 4122](https://www.rfc-editor.org/rfc/rfc4122.html#section-3). (The current representation doesn't contain hyphens and omits the leading zero in the hex of a byte.)