### PR TITLE
Timer that can be triggered a finite number of times.

### DIFF
--- a/rclcpp/include/rclcpp/create_timer.hpp
+++ b/rclcpp/include/rclcpp/create_timer.hpp
@@ -39,13 +39,15 @@ create_timer(
   rclcpp::Clock::SharedPtr clock,
   rclcpp::Duration period,
   CallbackT && callback,
-  rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  rclcpp::CallbackGroup::SharedPtr group = nullptr,
+  unsigned int amount_of_callbacks = 0)
 {
   auto timer = rclcpp::GenericTimer<CallbackT>::make_shared(
     clock,
     period.to_chrono<std::chrono::nanoseconds>(),
     std::forward<CallbackT>(callback),
-    node_base->get_context());
+    node_base->get_context(),
+    amount_of_callbacks);
 
   node_timers->add_timer(timer, group);
   return timer;
@@ -59,7 +61,8 @@ create_timer(
   rclcpp::Clock::SharedPtr clock,
   rclcpp::Duration period,
   CallbackT && callback,
-  rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  rclcpp::CallbackGroup::SharedPtr group = nullptr,
+  unsigned int amount_of_callbacks = 0)
 {
   return create_timer(
     rclcpp::node_interfaces::get_node_base_interface(node),
@@ -67,7 +70,8 @@ create_timer(
     clock,
     period,
     std::forward<CallbackT>(callback),
-    group);
+    group,
+    amount_of_callbacks);
 }
 
 /// Convenience method to create a timer with node resources.
@@ -81,6 +85,7 @@ create_timer(
  * \param group
  * \param node_base
  * \param node_timers
+ * \param amount_of_callbacks Quantity of times the callback will be triggered.
  * \return
  * \throws std::invalid argument if either node_base or node_timers
  * are null, or period is negative or too large
@@ -92,7 +97,8 @@ create_wall_timer(
   CallbackT callback,
   rclcpp::CallbackGroup::SharedPtr group,
   node_interfaces::NodeBaseInterface * node_base,
-  node_interfaces::NodeTimersInterface * node_timers)
+  node_interfaces::NodeTimersInterface * node_timers,
+  unsigned int amount_of_callbacks = 0)
 {
   if (node_base == nullptr) {
     throw std::invalid_argument{"input node_base cannot be null"};
@@ -133,7 +139,7 @@ create_wall_timer(
   }
 
   auto timer = rclcpp::WallTimer<CallbackT>::make_shared(
-    period_ns, std::move(callback), node_base->get_context());
+    period_ns, std::move(callback), node_base->get_context(), amount_of_callbacks);
   node_timers->add_timer(timer, group);
   return timer;
 }

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -232,13 +232,15 @@ public:
    * \param[in] period Time interval between triggers of the callback.
    * \param[in] callback User-defined callback function.
    * \param[in] group Callback group to execute this timer's callback in.
+   * \param[in] amount_of_callbacks Quantity of times the callback will be triggered.
    */
   template<typename DurationRepT = int64_t, typename DurationT = std::milli, typename CallbackT>
   typename rclcpp::WallTimer<CallbackT>::SharedPtr
   create_wall_timer(
     std::chrono::duration<DurationRepT, DurationT> period,
     CallbackT callback,
-    rclcpp::CallbackGroup::SharedPtr group = nullptr);
+    rclcpp::CallbackGroup::SharedPtr group = nullptr,
+    unsigned int amount_of_callbacks = 0);
 
   /// Create and return a Client.
   /**

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -110,14 +110,16 @@ typename rclcpp::WallTimer<CallbackT>::SharedPtr
 Node::create_wall_timer(
   std::chrono::duration<DurationRepT, DurationT> period,
   CallbackT callback,
-  rclcpp::CallbackGroup::SharedPtr group)
+  rclcpp::CallbackGroup::SharedPtr group,
+  unsigned int amount_of_callbacks)
 {
   return rclcpp::create_wall_timer(
     period,
     std::move(callback),
     group,
     this->node_base_.get(),
-    this->node_timers_.get());
+    this->node_timers_.get(),
+    amount_of_callbacks);
 }
 
 template<typename ServiceT>

--- a/rclcpp/test/rclcpp/test_create_timer.cpp
+++ b/rclcpp/test/rclcpp/test_create_timer.cpp
@@ -133,3 +133,32 @@ TEST(TestCreateTimer, timer_function_pointer)
 
   rclcpp::shutdown();
 }
+
+TEST(TestCreateTimer, timer_triggered_twice)
+{
+  rclcpp::init(0, nullptr);
+  auto node = std::make_shared<rclcpp::Node>("test_timer_triggered_twice");
+
+  std::atomic<int> callback_counter{0};
+
+  rclcpp::TimerBase::SharedPtr timer;
+  timer = rclcpp::create_timer(
+    node,
+    node->get_clock(),
+    rclcpp::Duration(0ms),
+    [&callback_counter]() {
+      callback_counter += 1;
+    }, nullptr, 2);
+
+  rclcpp::spin_some(node);
+  ASSERT_EQ(1, callback_counter);
+
+  rclcpp::spin_some(node);
+  ASSERT_EQ(2, callback_counter);
+
+  rclcpp::spin_some(node);
+  ASSERT_NE(callback_counter == 3);
+  ASSERT_TRUE(timer->is_canceled());
+
+  rclcpp::shutdown();
+}

--- a/rclcpp/test/rclcpp/test_timer.cpp
+++ b/rclcpp/test/rclcpp/test_timer.cpp
@@ -283,3 +283,21 @@ TEST_F(TestTimer, test_failures_with_exceptions)
       std::runtime_error("Timer could not get time until next call: error not set"));
   }
 }
+
+TEST_F(TestTimer, test_timer_triggered_twice) {
+  std::atomic<int> callback_counter{0};
+
+  rclcpp::TimerBase::SharedPtr timer_called_twice;
+  timer_called_twice = test_node->create_wall_timer(
+    0ms,
+    [&callback_counter]() {
+      callback_counter += 1;
+    }, nullptr, 1);
+
+  executor->spin();
+  ASSERT_EQ(1, callback_counter);
+
+  executor->spin();
+  ASSERT_NE(callback_counter == 2);
+  ASSERT_TRUE(timer_called_twice->is_canceled());
+}


### PR DESCRIPTION
This PR addresses the #1990. Basically it gives the timers API the possibility to select the number of times the timer will be triggered and be canceled after that using a variable. This variable (`amount_of_callbacks`) have the default value of `-1` which indicates that the timer will be triggered infinite times until it is 'manually' cancelled, i.e., the same behavior the times have at the moment. For example, initializing the timer with `amount_of_callbacks = 1`, would create a one shot timer, which would be triggered once and then would be canceled.