### PR TITLE
Exception handling in user callbacks?

### DIFF
--- a/rclcpp/include/rclcpp/executors.hpp
+++ b/rclcpp/include/rclcpp/executors.hpp
@@ -74,10 +74,16 @@ spin_node_until_future_complete(
   const FutureT & future,
   std::chrono::duration<TimeRepT, TimeT> timeout = std::chrono::duration<TimeRepT, TimeT>(-1))
 {
+  rclcpp::FutureReturnCode retcode;
   // TODO(wjwwood): does not work recursively; can't call spin_node_until_future_complete
   // inside a callback executed by an executor.
   executor.add_node(node_ptr);
-  auto retcode = executor.spin_until_future_complete(future, timeout);
+  try {
+    retcode = executor.spin_until_future_complete(future, timeout);
+  } catch (...) {
+    executor.remove_node(node_ptr);
+    throw;
+  }
   executor.remove_node(node_ptr);
   return retcode;
 }

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -389,7 +389,12 @@ Executor::spin_node_once_nanoseconds(
 {
   this->add_node(node, false);
   // non-blocking = true
-  spin_once(timeout);
+  try {
+    spin_once(timeout);
+  } catch (...) {
+    this->remove_node(node, false);
+    throw;
+  }
   this->remove_node(node, false);
 }
 
@@ -397,7 +402,12 @@ void
 Executor::spin_node_some(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node)
 {
   this->add_node(node, false);
-  spin_some();
+  try {
+    spin_some();
+  } catch (...) {
+    this->remove_node(node, false);
+    throw;
+  }
   this->remove_node(node, false);
 }
 

--- a/rclcpp/src/rclcpp/executors.cpp
+++ b/rclcpp/src/rclcpp/executors.cpp
@@ -32,7 +32,12 @@ rclcpp::spin(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr)
 {
   rclcpp::executors::SingleThreadedExecutor exec;
   exec.add_node(node_ptr);
-  exec.spin();
+  try {
+    exec.spin();
+  } catch (...) {
+    exec.remove_node(node_ptr);
+    throw;
+  }
   exec.remove_node(node_ptr);
 }
 


### PR DESCRIPTION
This pull request is actually more meant as a question, rather than an actual request to merge or a bug report. But I am quite sure that something is fishy here, and that the proposed patch may at least help to mitigate the issue. So here it is:

### What is the expected behavior of rclcpp in case of an exception raised in a user callback?

I tried to find some information about this topic in the [documentation](https://docs.ros.org/en/rolling/Concepts/About-Executors.html), in the [code](https://github.com/ros2/rclcpp), on [GitHub](https://github.com/search?q=rclcpp+callback+exception&type=issues), on [Discourse](https://discourse.ros.org/search?q=rclcpp%20callback%20exception), on [ROS Answers](https://answers.ros.org/questions/), but failed to find something conclusive, or maybe used the wrong search terms. Only [this post](https://discourse.ros.org/t/my-ros2-minimal-examples-difficulties-coming-from-ros1/18705/13?u=johannesmeyer) and [this answer](https://answers.ros.org/question/356549/how-to-handle-exceptions-in-the-user-defined-callback-in-service-server-and-how-to-inform-service-client-about-the-failed-service-call-in-ros2-rclcpp/) seem to be related. For the special case of service callbacks I remember having seen a discussion/feature request to forward exceptions to the caller as a special response like in ROS 1, but did not find it anymore now.

1. _User callbacks must never throw?_

   They do. I triggered the case by using the [`ros1_bridge`](https://github.com/ros2/ros1_bridge) with a service server in ROS 1 and a client calling it from ROS 2: If the ROS 1 service is not available anymore, for example because the ROS 1 node died, the callback defined in [`ServiceFactory<ROS1_T, ROS2_T>::forward_2_to_1()`](https://github.com/ros2/ros1_bridge/blob/b9f1739fd84fc877a8ec6e5c416b65aa2d782f89/include/ros1_bridge/factory.hpp#L282-L293) throws a runtime error after the roscpp service call API returned false. Also any ROS 2 middleware can throw exceptions, I assume, when the user callback invokes a publisher or service client itself. Apparently it is even [recommended to handle errors by throwing exceptions](https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Migration-Guide.html#use-of-service-objects).

   So if the rule would be that user callbacks must handle exceptions internally, I guess `ros1_bridge` and numerous other node implementations would need to be fixed.

2. _Did I miss a place where this is already handled within rclcpp?_

   Even rclcpp code itself may throw exceptions in the `Executor` code path while spinning, for example [here](https://github.com/ros2/rclcpp/blob/6a8c61c0269187c9505632647f6a9f5698b523e8/rclcpp/src/rclcpp/executor.cpp#L536-L538).

   If that is not the case yet, maybe a per executor, per node or per context flag would be nice-to-have, that decides whether exceptions are unhandled like it seems to be the case now, or whether rclcpp catches and logs them internally. Or some mechanism to register a user callback that receives an [`std::exception_ptr`](https://en.cppreference.com/w/cpp/error/exception_ptr) and whose return value decides whether the executor continuous or aborts...

3. _Always catch exceptions when spinning?_

    As a last resort, I wanted to patch the [main loop of the `dynamic_bridge`](https://github.com/ros2/ros1_bridge/blob/b9f1739fd84fc877a8ec6e5c416b65aa2d782f89/src/dynamic_bridge.cpp#L795-L799) (and other nodes), such that exceptions get logged, but the node does not terminate and continues to forward other topics and service calls. But that is not possible without the patch proposed here:

   ```cpp
   // ROS 2 spinning loop
   rclcpp::executors::SingleThreadedExecutor executor;
   while (ros1_node.ok() && rclcpp::ok()) {
     try {
       executor.spin_node_once(ros2_node);
     } catch (std::exception& e) {
       // Log the exception and continue spinning...
     }
   }
   ```

   The problem is that it triggers the "Node has already been added to an executor" exception [here](https://github.com/ros2/rclcpp/blob/6a8c61c0269187c9505632647f6a9f5698b523e8/rclcpp/src/rclcpp/executor.cpp#L256-L258) in the next cycle after the exception, and hence keeps logging in a loop. So maybe the executor needs to be recreated to recover? Or I could call `executor.remove_node(ros2_node)` in the catch body as a workaround? That was the point where I started to investigate the problem and ended up here.

   The proposed patch would fix that, I think, by removing the node from the executor before the exception is rethrown to be handled in `main()` or whereever else `spin_once()` has been called from. I have not actually tested it yet by compiling rclcpp from source. I also may have missed other places where `add_node()` and `remove_node()` gets called in pairs. Maybe a better design would involve a [RAII-style class](https://en.cppreference.com/w/cpp/language/raii) that adds a node in its constructor and removes it again in its destructor? Seems like [`RCPPUTILS_SCOPE_EXIT()`](https://github.com/ros2/rcpputils/blob/358b62b672094470e61c2edf19ecda51845de8ec/include/rcpputils/scope_exit.hpp#L65-L66) is meant exactly for those use cases and should be applied instead of my try/catch block, but I only discovered it while writing this.

   The same pattern that involves a loop with `rclcpp::ok()` and `rclcpp::spin_once()` directly in `main()` can be found in many other places, too, e.g. [here](https://github.com/ros2/rclcpp/issues/3#issuecomment-369365541). I am not sure whether rclpy is also affected, but in [ROS2 Python examples](https://github.com/ros2/examples/tree/rolling/rclpy) the equivalent pattern is [even dominant](https://github.com/ros2/examples/search?q=spin_once).

   For the more simple `rclcpp::spin(node)` call an extra loop would need to be added to keep spinning after an exception.

I can almost not believe that there is no foreseen or documented way to prevent that any minor fault terminates the whole process, or that this behavior is "by design"? I am sorry in case there is something more obvious, and I just missed it.

It is easy to reproduce the crash with the [`minimal_service` example](https://github.com/ros2/examples/blob/0410665143fd89b33e98b4c7d90829b32a6158f7/rclcpp/services/minimal_service/main.cpp) in [ros2/examples](https://github.com/ros2/examples), by adding a throw statement in the callback:

```sh
$ ros2 run examples_rclcpp_minimal_service service_main &
[1] 353822
$ ros2 service call /add_two_ints example_interfaces/srv/AddTwoInts "{}"
requester: making request: example_interfaces.srv.AddTwoInts_Request(a=0, b=0)

[INFO] [1663789664.837616992] [minimal_service]: request: 0 + 0
terminate called after throwing an instance of 'std::runtime_error'
  what():  some error
^C[1]+  Exit 250                ros2 run examples_rclcpp_minimal_service service_main
$ 
```