### PR TITLE
check thread whether joinable before join

### DIFF
--- a/rclcpp/src/rclcpp/signal_handler.cpp
+++ b/rclcpp/src/rclcpp/signal_handler.cpp
@@ -191,7 +191,9 @@ SignalHandler::uninstall()
     signal_handlers_options_ = SignalHandlerOptions::None;
     RCLCPP_DEBUG(get_logger(), "SignalHandler::uninstall(): notifying deferred signal handler");
     notify_signal_handler();
-    signal_handler_thread_.join();
+    if (signal_handler_thread_.joinable()) {
+      signal_handler_thread_.join();
+    }
     teardown_wait_for_signal();
   } catch (...) {
     installed_.exchange(true);


### PR DESCRIPTION
If rclcpp is inited with rclcpp::SignalHandlerOptions::None,  signal_handler_thread will not be created.

Checking thread whether is joinable before join is a solution to this little bug.