### PR TITLE
Cleanup the rclcpp_lifecycle dependencies.

### DIFF
--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -11,10 +11,13 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake_ros REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rcl_lifecycle REQUIRED)
-find_package(rosidl_typesupport_cpp REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
+find_package(rcl REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rcl_interfaces REQUIRED)
+find_package(rcl_lifecycle REQUIRED)
+find_package(rcutils REQUIRED)
+find_package(rosidl_typesupport_cpp REQUIRED)
 
 ### CPP High level library
 add_library(rclcpp_lifecycle
@@ -28,12 +31,14 @@ target_include_directories(${PROJECT_NAME}
   PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
-# specific order: dependents before dependencies
-ament_target_dependencies(rclcpp_lifecycle
-  "rclcpp"
-  "rcl_lifecycle"
-  "lifecycle_msgs"
-  "rosidl_typesupport_cpp"
+target_link_libraries(${PROJECT_NAME}
+  ${lifecycle_msgs_TARGETS}
+  rcl::rcl
+  rclcpp::rclcpp
+  ${rcl_interfaces_TARGETS}
+  rcl_lifecycle::rcl_lifecycle
+  rcutils::rcutils
+  rosidl_typesupport_cpp::rosidl_typesupport_cpp
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,
@@ -45,6 +50,9 @@ install(TARGETS
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
+
+install(DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -58,15 +66,13 @@ if(BUILD_TESTING)
     benchmark_lifecycle_client
     test/benchmark/benchmark_lifecycle_client.cpp)
   if(TARGET benchmark_lifecycle_client)
-    target_link_libraries(benchmark_lifecycle_client ${PROJECT_NAME})
-    ament_target_dependencies(benchmark_lifecycle_client rclcpp)
+    target_link_libraries(benchmark_lifecycle_client ${PROJECT_NAME} rclcpp::rclcpp)
   endif()
   add_performance_test(
     benchmark_lifecycle_node
     test/benchmark/benchmark_lifecycle_node.cpp)
   if(TARGET benchmark_lifecycle_node)
-    target_link_libraries(benchmark_lifecycle_node ${PROJECT_NAME})
-    ament_target_dependencies(benchmark_lifecycle_node rclcpp)
+    target_link_libraries(benchmark_lifecycle_node ${PROJECT_NAME} rclcpp::rclcpp)
   endif()
   add_performance_test(
     benchmark_state
@@ -83,31 +89,21 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_lifecycle_node test/test_lifecycle_node.cpp TIMEOUT 120)
   if(TARGET test_lifecycle_node)
-    ament_target_dependencies(test_lifecycle_node
-      "rcl_lifecycle"
-      "rclcpp"
-      "rcutils"
-    )
-    target_link_libraries(test_lifecycle_node ${PROJECT_NAME} mimick)
+    target_link_libraries(test_lifecycle_node ${PROJECT_NAME} mimick rcl_lifecycle::rcl_lifecycle rclcpp::rclcpp rcutils::rcutils)
   endif()
   ament_add_gtest(test_lifecycle_publisher test/test_lifecycle_publisher.cpp)
   if(TARGET test_lifecycle_publisher)
-    ament_target_dependencies(test_lifecycle_publisher
-      "rcl_lifecycle"
-      "rclcpp"
-      "test_msgs"
-    )
-    target_link_libraries(test_lifecycle_publisher ${PROJECT_NAME})
+    target_link_libraries(test_lifecycle_publisher ${PROJECT_NAME} rcl_lifecycle::rcl_lifecycle rclcpp::rclcpp ${test_msgs_TARGETS})
   endif()
   ament_add_gtest(test_lifecycle_service_client test/test_lifecycle_service_client.cpp TIMEOUT 120)
   if(TARGET test_lifecycle_service_client)
-    ament_target_dependencies(test_lifecycle_service_client
-      "rcl_lifecycle"
-      "rclcpp"
-      "rcpputils"
-      "rcutils"
-    )
-    target_link_libraries(test_lifecycle_service_client ${PROJECT_NAME} mimick)
+    target_link_libraries(test_lifecycle_service_client
+      ${PROJECT_NAME}
+      mimick
+      rcl_lifecycle::rcl_lifecycle
+      rclcpp::rclcpp
+      rcpputils::rcpputils
+      rcutils::rcutils)
   endif()
   ament_add_gtest(test_client test/test_client.cpp TIMEOUT 120)
   if(TARGET test_client)
@@ -127,44 +123,23 @@ if(BUILD_TESTING)
   endif()
   ament_add_gtest(test_state_machine_info test/test_state_machine_info.cpp)
   if(TARGET test_state_machine_info)
-    ament_target_dependencies(test_state_machine_info
-      "rcl_lifecycle"
-      "rclcpp"
-    )
-    target_link_libraries(test_state_machine_info ${PROJECT_NAME})
+    target_link_libraries(test_state_machine_info ${PROJECT_NAME} rcl_lifecycle::rcl_lifecycle rclcpp::rclcpp)
   endif()
   ament_add_gtest(test_register_custom_callbacks test/test_register_custom_callbacks.cpp)
   if(TARGET test_register_custom_callbacks)
-    ament_target_dependencies(test_register_custom_callbacks
-      "rcl_lifecycle"
-      "rclcpp"
-    )
-    target_link_libraries(test_register_custom_callbacks ${PROJECT_NAME})
+    target_link_libraries(test_register_custom_callbacks ${PROJECT_NAME} rcl_lifecycle::rcl_lifecycle rclcpp::rclcpp)
   endif()
   ament_add_gtest(test_callback_exceptions test/test_callback_exceptions.cpp)
   if(TARGET test_callback_exceptions)
-    ament_target_dependencies(test_callback_exceptions
-      "rcl_lifecycle"
-      "rclcpp"
-    )
-    target_link_libraries(test_callback_exceptions ${PROJECT_NAME})
+    target_link_libraries(test_callback_exceptions ${PROJECT_NAME} rcl_lifecycle::rcl_lifecycle rclcpp::rclcpp)
   endif()
   ament_add_gtest(test_state_wrapper test/test_state_wrapper.cpp)
   if(TARGET test_state_wrapper)
-    ament_target_dependencies(test_state_wrapper
-      "rcl_lifecycle"
-      "rclcpp"
-    )
-    target_link_libraries(test_state_wrapper ${PROJECT_NAME})
+    target_link_libraries(test_state_wrapper ${PROJECT_NAME} rcl_lifecycle::rcl_lifecycle rclcpp::rclcpp)
   endif()
   ament_add_gtest(test_transition_wrapper test/test_transition_wrapper.cpp)
   if(TARGET test_transition_wrapper)
-    ament_target_dependencies(test_transition_wrapper
-      "rcl_lifecycle"
-      "rclcpp"
-      "rcutils"
-    )
-    target_link_libraries(test_transition_wrapper ${PROJECT_NAME} mimick)
+    target_link_libraries(test_transition_wrapper ${PROJECT_NAME} mimick rcl_lifecycle::rcl_lifecycle rclcpp::rclcpp rcutils::rcutils)
     target_compile_definitions(test_transition_wrapper
       PUBLIC RCUTILS_ENABLE_FAULT_INJECTION
     )
@@ -178,11 +153,7 @@ ament_export_libraries(${PROJECT_NAME})
 # Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
 
-# specific order: dependents before dependencies
-ament_export_dependencies(rclcpp)
-ament_export_dependencies(rcl_lifecycle)
-ament_export_dependencies(lifecycle_msgs)
-ament_package()
+# Export dependencies
+ament_export_dependencies(lifecycle_msgs rcl rclcpp rcl_interfaces rcl_lifecycle rcutils rosidl_typesupport_cpp)
 
-install(DIRECTORY include/
-  DESTINATION include/${PROJECT_NAME})
+ament_package()

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -36,6 +36,8 @@
 #ifndef RCLCPP_LIFECYCLE__LIFECYCLE_NODE_HPP_
 #define RCLCPP_LIFECYCLE__LIFECYCLE_NODE_HPP_
 
+#include <chrono>
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>
@@ -49,13 +51,11 @@
 
 #include "rcl_interfaces/msg/list_parameters_result.hpp"
 #include "rcl_interfaces/msg/parameter_descriptor.hpp"
-#include "rcl_interfaces/msg/parameter_event.hpp"
 #include "rcl_interfaces/msg/set_parameters_result.hpp"
 
 #include "rclcpp/callback_group.hpp"
 #include "rclcpp/client.hpp"
 #include "rclcpp/clock.hpp"
-#include "rclcpp/context.hpp"
 #include "rclcpp/event.hpp"
 #include "rclcpp/generic_publisher.hpp"
 #include "rclcpp/generic_subscription.hpp"
@@ -82,6 +82,8 @@
 #include "rclcpp/subscription_options.hpp"
 #include "rclcpp/time.hpp"
 #include "rclcpp/timer.hpp"
+
+#include "rmw/types.h"
 
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "rclcpp_lifecycle/lifecycle_publisher.hpp"
@@ -137,7 +139,7 @@ public:
     const rclcpp::NodeOptions & options = rclcpp::NodeOptions(),
     bool enable_communication_interface = true);
 
-  /// Create a node based on the node name and a rclcpp::Context.
+  /// Create a node based on the node name
   /**
    * \param[in] node_name Name of the node.
    * \param[in] namespace_ Namespace of the node.

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
@@ -15,29 +15,35 @@
 #ifndef RCLCPP_LIFECYCLE__LIFECYCLE_NODE_IMPL_HPP_
 #define RCLCPP_LIFECYCLE__LIFECYCLE_NODE_IMPL_HPP_
 
+#include <algorithm>
+#include <chrono>
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "rclcpp/contexts/default_context.hpp"
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
+
+#include "rclcpp/callback_group.hpp"
 #include "rclcpp/create_client.hpp"
 #include "rclcpp/create_generic_publisher.hpp"
 #include "rclcpp/create_generic_subscription.hpp"
 #include "rclcpp/create_publisher.hpp"
 #include "rclcpp/create_service.hpp"
 #include "rclcpp/create_subscription.hpp"
-#include "rclcpp/event.hpp"
-#include "rclcpp/experimental/intra_process_manager.hpp"
 #include "rclcpp/parameter.hpp"
+#include "rclcpp/publisher_options.hpp"
+#include "rclcpp/qos.hpp"
 #include "rclcpp/subscription_options.hpp"
 #include "rclcpp/type_support_decl.hpp"
 
-#include "lifecycle_publisher.hpp"
-#include "rclcpp_lifecycle/visibility_control.h"
+#include "rmw/types.h"
 
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
+#include "rclcpp_lifecycle/visibility_control.h"
 
 namespace rclcpp_lifecycle
 {

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_publisher.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_publisher.hpp
@@ -20,7 +20,10 @@
 #include <utility>
 
 #include "rclcpp/logging.hpp"
+#include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/publisher.hpp"
+#include "rclcpp/publisher_options.hpp"
+#include "rclcpp/qos.hpp"
 
 #include "rclcpp_lifecycle/managed_entity.hpp"
 

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
@@ -17,8 +17,6 @@
 
 #include "lifecycle_msgs/msg/transition.hpp"
 
-#include "rcl_lifecycle/rcl_lifecycle.h"
-
 #include "rclcpp_lifecycle/state.hpp"
 #include "rclcpp_lifecycle/visibility_control.h"
 

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/state.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/state.hpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "rcl_lifecycle/data_types.h"
+
 #include "rclcpp_lifecycle/visibility_control.h"
 
 #include "rcutils/allocator.h"

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/transition.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/transition.hpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "rcl_lifecycle/data_types.h"
+
 #include "rclcpp_lifecycle/state.hpp"
 #include "rclcpp_lifecycle/visibility_control.h"
 

--- a/rclcpp_lifecycle/package.xml
+++ b/rclcpp_lifecycle/package.xml
@@ -13,16 +13,22 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <build_depend>lifecycle_msgs</build_depend>
+  <build_depend>rcl</build_depend>
   <build_depend>rclcpp</build_depend>
+  <build_depend>rcl_interfaces</build_depend>
   <build_depend>rcl_lifecycle</build_depend>
+  <build_depend>rcutils</build_depend>
+  <build_depend>rmw</build_depend>
   <build_depend>rosidl_typesupport_cpp</build_depend>
 
   <exec_depend>lifecycle_msgs</exec_depend>
+  <exec_depend>rcl</exec_depend>
   <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rcl_interfaces</exec_depend>
   <exec_depend>rcl_lifecycle</exec_depend>
+  <exec_depend>rcutils</exec_depend>
+  <exec_depend>rmw</exec_depend>
   <exec_depend>rosidl_typesupport_cpp</exec_depend>
-
-  <depend>rmw</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
@@ -30,7 +36,6 @@
   <test_depend>mimick_vendor</test_depend>
   <test_depend>performance_test_fixture</test_depend>
   <test_depend>rcpputils</test_depend>
-  <test_depend>rcutils</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -14,14 +14,21 @@
 
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
-#include <string>
+#include <chrono>
+#include <functional>
 #include <map>
 #include <memory>
-#include <vector>
+#include <stdexcept>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "lifecycle_msgs/msg/state.hpp"
 #include "lifecycle_msgs/msg/transition.hpp"
+
+#include "rcl_interfaces/msg/list_parameters_result.hpp"
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
+#include "rcl_interfaces/msg/set_parameters_result.hpp"
 
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/graph_listener.hpp"

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -20,9 +20,10 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <stdexcept>
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "lifecycle_msgs/msg/transition_description.hpp"
 #include "lifecycle_msgs/msg/transition_event.h"  // for getting the c-typesupport
@@ -41,6 +42,8 @@
 #include "rclcpp/node_interfaces/node_services_interface.hpp"
 
 #include "rcutils/logging_macros.h"
+
+#include "rmw/types.h"
 
 namespace rclcpp_lifecycle
 {

--- a/rclcpp_lifecycle/src/node_interfaces/lifecycle_node_interface.cpp
+++ b/rclcpp_lifecycle/src/node_interfaces/lifecycle_node_interface.cpp
@@ -14,7 +14,7 @@
 
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 
-#include "rcl_lifecycle/rcl_lifecycle.h"
+#include "rclcpp_lifecycle/state.hpp"
 
 namespace rclcpp_lifecycle
 {

--- a/rclcpp_lifecycle/src/state.cpp
+++ b/rclcpp_lifecycle/src/state.cpp
@@ -14,6 +14,7 @@
 
 #include "rclcpp_lifecycle/state.hpp"
 
+#include <stdexcept>
 #include <string>
 
 #include "lifecycle_msgs/msg/state.hpp"

--- a/rclcpp_lifecycle/src/transition.cpp
+++ b/rclcpp_lifecycle/src/transition.cpp
@@ -14,6 +14,7 @@
 
 #include "rclcpp_lifecycle/transition.hpp"
 
+#include <stdexcept>
 #include <string>
 
 #include "lifecycle_msgs/msg/transition.hpp"

--- a/rclcpp_lifecycle/test/test_client.cpp
+++ b/rclcpp_lifecycle/test/test_client.cpp
@@ -24,6 +24,7 @@
 
 #include "rcl_interfaces/srv/list_parameters.hpp"
 
+#include "rmw/qos_profiles.h"
 
 class TestClient : public ::testing::Test
 {

--- a/rclcpp_lifecycle/test/test_lifecycle_service_client.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_service_client.cpp
@@ -33,6 +33,8 @@
 #include "lifecycle_msgs/srv/get_available_transitions.hpp"
 #include "lifecycle_msgs/srv/get_state.hpp"
 
+#include "rcl_lifecycle/rcl_lifecycle.h"
+
 #include "rclcpp/node_interfaces/node_graph.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"

--- a/rclcpp_lifecycle/test/test_service.cpp
+++ b/rclcpp_lifecycle/test/test_service.cpp
@@ -22,6 +22,8 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
+#include "rmw/qos_profiles.h"
+
 #include "test_msgs/srv/empty.hpp"
 
 using namespace std::chrono_literals;

--- a/rclcpp_lifecycle/test/test_transition_wrapper.cpp
+++ b/rclcpp_lifecycle/test/test_transition_wrapper.cpp
@@ -18,9 +18,11 @@
 #include <utility>
 #include <vector>
 
-#include "rcutils/testing/fault_injection.h"
+#include "rcl_lifecycle/rcl_lifecycle.h"
 
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+#include "rcutils/testing/fault_injection.h"
 
 #include "./mocking_utils/patch.hpp"
 


### PR DESCRIPTION
That is, make sure they are all listed in package.xml, found in the CMakeLists.txt, and properly included where they are used.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

There should be no functional change from this PR; I just noticed all of this while reviewing other PRs touching the lifecycle stuff.