### PR TITLE
Cleanup the lifecycle implementation

### DIFF
--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(rosidl_typesupport_cpp REQUIRED)
 ### CPP High level library
 add_library(rclcpp_lifecycle
   src/lifecycle_node.cpp
+  src/lifecycle_node_interface_impl.cpp
   src/managed_entity.cpp
   src/node_interfaces/lifecycle_node_interface.cpp
   src/state.cpp

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -847,7 +847,7 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   std::vector<State>
-  get_available_states();
+  get_available_states() const;
 
   /// Return a list with the current available transitions.
   /**
@@ -855,7 +855,7 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   std::vector<Transition>
-  get_available_transitions();
+  get_available_transitions() const;
 
   /// Return a list with all the transitions.
   /**
@@ -863,7 +863,7 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   std::vector<Transition>
-  get_transition_graph();
+  get_transition_graph() const;
 
   /// Trigger the specified transition.
   /*

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
@@ -61,7 +61,7 @@ public:
 
   /// Callback function for cleanup transition
   /*
-   * \return true by default
+   * \return SUCCESS by default
    */
   RCLCPP_LIFECYCLE_PUBLIC
   virtual CallbackReturn
@@ -69,7 +69,7 @@ public:
 
   /// Callback function for shutdown transition
   /*
-   * \return true by default
+   * \return SUCCESS by default
    */
   RCLCPP_LIFECYCLE_PUBLIC
   virtual CallbackReturn
@@ -77,7 +77,7 @@ public:
 
   /// Callback function for activate transition
   /*
-   * \return true by default
+   * \return SUCCESS by default
    */
   RCLCPP_LIFECYCLE_PUBLIC
   virtual CallbackReturn
@@ -85,7 +85,7 @@ public:
 
   /// Callback function for deactivate transition
   /*
-   * \return true by default
+   * \return SUCCESS by default
    */
   RCLCPP_LIFECYCLE_PUBLIC
   virtual CallbackReturn
@@ -93,7 +93,7 @@ public:
 
   /// Callback function for errorneous transition
   /*
-   * \return false by default
+   * \return SUCCESS by default
    */
   RCLCPP_LIFECYCLE_PUBLIC
   virtual CallbackReturn

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -541,19 +541,19 @@ LifecycleNode::get_current_state()
 }
 
 std::vector<State>
-LifecycleNode::get_available_states()
+LifecycleNode::get_available_states() const
 {
   return impl_->get_available_states();
 }
 
 std::vector<Transition>
-LifecycleNode::get_available_transitions()
+LifecycleNode::get_available_transitions() const
 {
   return impl_->get_available_transitions();
 }
 
 std::vector<Transition>
-LifecycleNode::get_transition_graph()
+LifecycleNode::get_transition_graph() const
 {
   return impl_->get_transition_graph();
 }

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.cpp
@@ -1,0 +1,540 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "lifecycle_msgs/msg/transition_description.hpp"
+#include "lifecycle_msgs/msg/transition_event.h"  // for getting the c-typesupport
+#include "lifecycle_msgs/msg/transition_event.hpp"
+#include "lifecycle_msgs/srv/change_state.hpp"
+#include "lifecycle_msgs/srv/get_state.hpp"
+#include "lifecycle_msgs/srv/get_available_states.hpp"
+#include "lifecycle_msgs/srv/get_available_transitions.hpp"
+
+#include "rclcpp/node_interfaces/node_base_interface.hpp"
+#include "rclcpp/node_interfaces/node_services_interface.hpp"
+
+#include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+
+#include "rcl/error_handling.h"
+#include "rcl/node.h"
+
+#include "rcl_lifecycle/rcl_lifecycle.h"
+#include "rcl_lifecycle/transition_map.h"
+
+#include "rcutils/logging_macros.h"
+
+#include "rmw/types.h"
+
+#include "lifecycle_node_interface_impl.hpp"
+
+namespace rclcpp_lifecycle
+{
+
+LifecycleNode::LifecycleNodeInterfaceImpl::LifecycleNodeInterfaceImpl(
+  std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> node_base_interface,
+  std::shared_ptr<rclcpp::node_interfaces::NodeServicesInterface> node_services_interface)
+: node_base_interface_(node_base_interface),
+  node_services_interface_(node_services_interface)
+{
+}
+
+LifecycleNode::LifecycleNodeInterfaceImpl::~LifecycleNodeInterfaceImpl()
+{
+  rcl_node_t * node_handle = node_base_interface_->get_rcl_node_handle();
+  auto ret = rcl_lifecycle_state_machine_fini(&state_machine_, node_handle);
+  if (ret != RCL_RET_OK) {
+    RCUTILS_LOG_FATAL_NAMED(
+      "rclcpp_lifecycle",
+      "failed to destroy rcl_state_machine");
+  }
+}
+
+void
+LifecycleNode::LifecycleNodeInterfaceImpl::init(bool enable_communication_interface)
+{
+  rcl_node_t * node_handle = node_base_interface_->get_rcl_node_handle();
+  const rcl_node_options_t * node_options =
+    rcl_node_get_options(node_base_interface_->get_rcl_node_handle());
+  state_machine_ = rcl_lifecycle_get_zero_initialized_state_machine();
+  auto state_machine_options = rcl_lifecycle_get_default_state_machine_options();
+  state_machine_options.enable_com_interface = enable_communication_interface;
+  state_machine_options.allocator = node_options->allocator;
+
+  // The call to initialize the state machine takes
+  // currently five different typesupports for all publishers/services
+  // created within the RCL_LIFECYCLE structure.
+  // The publisher takes a C-Typesupport since the publishing (i.e. creating
+  // the message) is done fully in RCL.
+  // Services are handled in C++, so that it needs a C++ typesupport structure.
+  rcl_ret_t ret = rcl_lifecycle_state_machine_init(
+    &state_machine_,
+    node_handle,
+    ROSIDL_GET_MSG_TYPE_SUPPORT(lifecycle_msgs, msg, TransitionEvent),
+    rosidl_typesupport_cpp::get_service_type_support_handle<ChangeStateSrv>(),
+    rosidl_typesupport_cpp::get_service_type_support_handle<GetStateSrv>(),
+    rosidl_typesupport_cpp::get_service_type_support_handle<GetAvailableStatesSrv>(),
+    rosidl_typesupport_cpp::get_service_type_support_handle<GetAvailableTransitionsSrv>(),
+    rosidl_typesupport_cpp::get_service_type_support_handle<GetAvailableTransitionsSrv>(),
+    &state_machine_options);
+  if (ret != RCL_RET_OK) {
+    throw std::runtime_error(
+            std::string("Couldn't initialize state machine for node ") +
+            node_base_interface_->get_name());
+  }
+
+  if (enable_communication_interface) {
+    { // change_state
+      auto cb = std::bind(
+        &LifecycleNode::LifecycleNodeInterfaceImpl::on_change_state, this,
+        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+      rclcpp::AnyServiceCallback<ChangeStateSrv> any_cb;
+      any_cb.set(std::move(cb));
+
+      srv_change_state_ = std::make_shared<rclcpp::Service<ChangeStateSrv>>(
+        node_base_interface_->get_shared_rcl_node_handle(),
+        &state_machine_.com_interface.srv_change_state,
+        any_cb);
+      node_services_interface_->add_service(
+        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_change_state_),
+        nullptr);
+    }
+
+    { // get_state
+      auto cb = std::bind(
+        &LifecycleNode::LifecycleNodeInterfaceImpl::on_get_state, this,
+        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+      rclcpp::AnyServiceCallback<GetStateSrv> any_cb;
+      any_cb.set(std::move(cb));
+
+      srv_get_state_ = std::make_shared<rclcpp::Service<GetStateSrv>>(
+        node_base_interface_->get_shared_rcl_node_handle(),
+        &state_machine_.com_interface.srv_get_state,
+        any_cb);
+      node_services_interface_->add_service(
+        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_state_),
+        nullptr);
+    }
+
+    { // get_available_states
+      auto cb = std::bind(
+        &LifecycleNode::LifecycleNodeInterfaceImpl::on_get_available_states, this,
+        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+      rclcpp::AnyServiceCallback<GetAvailableStatesSrv> any_cb;
+      any_cb.set(std::move(cb));
+
+      srv_get_available_states_ = std::make_shared<rclcpp::Service<GetAvailableStatesSrv>>(
+        node_base_interface_->get_shared_rcl_node_handle(),
+        &state_machine_.com_interface.srv_get_available_states,
+        any_cb);
+      node_services_interface_->add_service(
+        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_available_states_),
+        nullptr);
+    }
+
+    { // get_available_transitions
+      auto cb = std::bind(
+        &LifecycleNode::LifecycleNodeInterfaceImpl::on_get_available_transitions, this,
+        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+      rclcpp::AnyServiceCallback<GetAvailableTransitionsSrv> any_cb;
+      any_cb.set(std::move(cb));
+
+      srv_get_available_transitions_ =
+        std::make_shared<rclcpp::Service<GetAvailableTransitionsSrv>>(
+        node_base_interface_->get_shared_rcl_node_handle(),
+        &state_machine_.com_interface.srv_get_available_transitions,
+        any_cb);
+      node_services_interface_->add_service(
+        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_available_transitions_),
+        nullptr);
+    }
+
+    { // get_transition_graph
+      auto cb = std::bind(
+        &LifecycleNode::LifecycleNodeInterfaceImpl::on_get_transition_graph, this,
+        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+      rclcpp::AnyServiceCallback<GetAvailableTransitionsSrv> any_cb;
+      any_cb.set(std::move(cb));
+
+      srv_get_transition_graph_ =
+        std::make_shared<rclcpp::Service<GetAvailableTransitionsSrv>>(
+        node_base_interface_->get_shared_rcl_node_handle(),
+        &state_machine_.com_interface.srv_get_transition_graph,
+        any_cb);
+      node_services_interface_->add_service(
+        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_transition_graph_),
+        nullptr);
+    }
+  }
+}
+
+bool
+LifecycleNode::LifecycleNodeInterfaceImpl::register_callback(
+  std::uint8_t lifecycle_transition,
+  std::function<node_interfaces::LifecycleNodeInterface::CallbackReturn(const State &)> & cb)
+{
+  cb_map_[lifecycle_transition] = cb;
+  return true;
+}
+
+void
+LifecycleNode::LifecycleNodeInterfaceImpl::on_change_state(
+  const std::shared_ptr<rmw_request_id_t> header,
+  const std::shared_ptr<ChangeStateSrv::Request> req,
+  std::shared_ptr<ChangeStateSrv::Response> resp)
+{
+  (void)header;
+  if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
+    throw std::runtime_error(
+            "Can't get state. State machine is not initialized.");
+  }
+
+  auto transition_id = req->transition.id;
+  // if there's a label attached to the request,
+  // we check the transition attached to this label.
+  // we further can't compare the id of the looked up transition
+  // because ros2 service call defaults all intergers to zero.
+  // that means if we call ros2 service call ... {transition: {label: shutdown}}
+  // the id of the request is 0 (zero) whereas the id from the lookup up transition
+  // can be different.
+  // the result of this is that the label takes presedence of the id.
+  if (req->transition.label.size() != 0) {
+    auto rcl_transition = rcl_lifecycle_get_transition_by_label(
+      state_machine_.current_state, req->transition.label.c_str());
+    if (rcl_transition == nullptr) {
+      resp->success = false;
+      return;
+    }
+    transition_id = static_cast<std::uint8_t>(rcl_transition->id);
+  }
+
+  node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code;
+  auto ret = change_state(transition_id, cb_return_code);
+  (void) ret;
+  // TODO(karsten1987): Lifecycle msgs have to be extended to keep both returns
+  // 1. return is the actual transition
+  // 2. return is whether an error occurred or not
+  resp->success =
+    (cb_return_code == node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
+}
+
+void
+LifecycleNode::LifecycleNodeInterfaceImpl::on_get_state(
+  const std::shared_ptr<rmw_request_id_t> header,
+  const std::shared_ptr<GetStateSrv::Request> req,
+  std::shared_ptr<GetStateSrv::Response> resp)
+{
+  (void)header;
+  (void)req;
+  if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
+    throw std::runtime_error(
+            "Can't get state. State machine is not initialized.");
+  }
+  resp->current_state.id = static_cast<uint8_t>(state_machine_.current_state->id);
+  resp->current_state.label = state_machine_.current_state->label;
+}
+
+void
+LifecycleNode::LifecycleNodeInterfaceImpl::on_get_available_states(
+  const std::shared_ptr<rmw_request_id_t> header,
+  const std::shared_ptr<GetAvailableStatesSrv::Request> req,
+  std::shared_ptr<GetAvailableStatesSrv::Response> resp)
+{
+  (void)header;
+  (void)req;
+  if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
+    throw std::runtime_error(
+            "Can't get available states. State machine is not initialized.");
+  }
+
+  resp->available_states.resize(state_machine_.transition_map.states_size);
+  for (unsigned int i = 0; i < state_machine_.transition_map.states_size; ++i) {
+    resp->available_states[i].id =
+      static_cast<uint8_t>(state_machine_.transition_map.states[i].id);
+    resp->available_states[i].label =
+      static_cast<std::string>(state_machine_.transition_map.states[i].label);
+  }
+}
+
+void
+LifecycleNode::LifecycleNodeInterfaceImpl::on_get_available_transitions(
+  const std::shared_ptr<rmw_request_id_t> header,
+  const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
+  std::shared_ptr<GetAvailableTransitionsSrv::Response> resp)
+{
+  (void)header;
+  (void)req;
+  if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
+    throw std::runtime_error(
+            "Can't get available transitions. State machine is not initialized.");
+  }
+
+  resp->available_transitions.resize(state_machine_.current_state->valid_transition_size);
+  for (unsigned int i = 0; i < state_machine_.current_state->valid_transition_size; ++i) {
+    lifecycle_msgs::msg::TransitionDescription & trans_desc = resp->available_transitions[i];
+
+    auto rcl_transition = state_machine_.current_state->valid_transitions[i];
+    trans_desc.transition.id = static_cast<uint8_t>(rcl_transition.id);
+    trans_desc.transition.label = rcl_transition.label;
+    trans_desc.start_state.id = static_cast<uint8_t>(rcl_transition.start->id);
+    trans_desc.start_state.label = rcl_transition.start->label;
+    trans_desc.goal_state.id = static_cast<uint8_t>(rcl_transition.goal->id);
+    trans_desc.goal_state.label = rcl_transition.goal->label;
+  }
+}
+
+void
+LifecycleNode::LifecycleNodeInterfaceImpl::on_get_transition_graph(
+  const std::shared_ptr<rmw_request_id_t> header,
+  const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
+  std::shared_ptr<GetAvailableTransitionsSrv::Response> resp)
+{
+  (void)header;
+  (void)req;
+  if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
+    throw std::runtime_error(
+            "Can't get available transitions. State machine is not initialized.");
+  }
+
+  resp->available_transitions.resize(state_machine_.transition_map.transitions_size);
+  for (unsigned int i = 0; i < state_machine_.transition_map.transitions_size; ++i) {
+    lifecycle_msgs::msg::TransitionDescription & trans_desc = resp->available_transitions[i];
+
+    auto rcl_transition = state_machine_.transition_map.transitions[i];
+    trans_desc.transition.id = static_cast<uint8_t>(rcl_transition.id);
+    trans_desc.transition.label = rcl_transition.label;
+    trans_desc.start_state.id = static_cast<uint8_t>(rcl_transition.start->id);
+    trans_desc.start_state.label = rcl_transition.start->label;
+    trans_desc.goal_state.id = static_cast<uint8_t>(rcl_transition.goal->id);
+    trans_desc.goal_state.label = rcl_transition.goal->label;
+  }
+}
+
+const State &
+LifecycleNode::LifecycleNodeInterfaceImpl::get_current_state()
+{
+  current_state_ = State(state_machine_.current_state);
+  return current_state_;
+}
+
+std::vector<State>
+LifecycleNode::LifecycleNodeInterfaceImpl::get_available_states()
+{
+  std::vector<State> states;
+  states.reserve(state_machine_.transition_map.states_size);
+
+  for (unsigned int i = 0; i < state_machine_.transition_map.states_size; ++i) {
+    states.emplace_back(&state_machine_.transition_map.states[i]);
+  }
+  return states;
+}
+
+std::vector<Transition>
+LifecycleNode::LifecycleNodeInterfaceImpl::get_available_transitions()
+{
+  std::vector<Transition> transitions;
+  transitions.reserve(state_machine_.current_state->valid_transition_size);
+
+  for (unsigned int i = 0; i < state_machine_.current_state->valid_transition_size; ++i) {
+    transitions.emplace_back(&state_machine_.current_state->valid_transitions[i]);
+  }
+  return transitions;
+}
+
+std::vector<Transition>
+LifecycleNode::LifecycleNodeInterfaceImpl::get_transition_graph()
+{
+  std::vector<Transition> transitions;
+  transitions.reserve(state_machine_.transition_map.transitions_size);
+
+  for (unsigned int i = 0; i < state_machine_.transition_map.transitions_size; ++i) {
+    transitions.emplace_back(&state_machine_.transition_map.transitions[i]);
+  }
+  return transitions;
+}
+
+rcl_ret_t
+LifecycleNode::LifecycleNodeInterfaceImpl::change_state(
+  std::uint8_t transition_id,
+  node_interfaces::LifecycleNodeInterface::CallbackReturn & cb_return_code)
+{
+  if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
+    RCUTILS_LOG_ERROR(
+      "Unable to change state for state machine for %s: %s",
+      node_base_interface_->get_name(), rcl_get_error_string().str);
+    return RCL_RET_ERROR;
+  }
+
+  constexpr bool publish_update = true;
+  // keep the initial state to pass to a transition callback
+  State initial_state(state_machine_.current_state);
+
+  if (
+    rcl_lifecycle_trigger_transition_by_id(
+      &state_machine_, transition_id, publish_update) != RCL_RET_OK)
+  {
+    RCUTILS_LOG_ERROR(
+      "Unable to start transition %u from current state %s: %s",
+      transition_id, state_machine_.current_state->label, rcl_get_error_string().str);
+    rcutils_reset_error();
+    return RCL_RET_ERROR;
+  }
+
+  auto get_label_for_return_code =
+    [](node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code) -> const char *{
+      auto cb_id = static_cast<uint8_t>(cb_return_code);
+      if (cb_id == lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS) {
+        return rcl_lifecycle_transition_success_label;
+      } else if (cb_id == lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE) {
+        return rcl_lifecycle_transition_failure_label;
+      }
+      return rcl_lifecycle_transition_error_label;
+    };
+
+  cb_return_code = execute_callback(state_machine_.current_state->id, initial_state);
+  auto transition_label = get_label_for_return_code(cb_return_code);
+
+  if (
+    rcl_lifecycle_trigger_transition_by_label(
+      &state_machine_, transition_label, publish_update) != RCL_RET_OK)
+  {
+    RCUTILS_LOG_ERROR(
+      "Failed to finish transition %u. Current state is now: %s (%s)",
+      transition_id, state_machine_.current_state->label, rcl_get_error_string().str);
+    rcutils_reset_error();
+    return RCL_RET_ERROR;
+  }
+
+  // error handling ?!
+  // TODO(karsten1987): iterate over possible ret value
+  if (cb_return_code == node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR) {
+    RCUTILS_LOG_WARN("Error occurred while doing error handling.");
+
+    auto error_cb_code = execute_callback(state_machine_.current_state->id, initial_state);
+    auto error_cb_label = get_label_for_return_code(error_cb_code);
+    if (
+      rcl_lifecycle_trigger_transition_by_label(
+        &state_machine_, error_cb_label, publish_update) != RCL_RET_OK)
+    {
+      RCUTILS_LOG_ERROR("Failed to call cleanup on error state: %s", rcl_get_error_string().str);
+      rcutils_reset_error();
+      return RCL_RET_ERROR;
+    }
+  }
+  // This true holds in both cases where the actual callback
+  // was successful or not, since at this point we have a valid transistion
+  // to either a new primary state or error state
+  return RCL_RET_OK;
+}
+
+node_interfaces::LifecycleNodeInterface::CallbackReturn
+LifecycleNode::LifecycleNodeInterfaceImpl::execute_callback(
+  unsigned int cb_id, const State & previous_state)
+{
+  // in case no callback was attached, we forward directly
+  auto cb_success = node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+
+  auto it = cb_map_.find(static_cast<uint8_t>(cb_id));
+  if (it != cb_map_.end()) {
+    auto callback = it->second;
+    try {
+      cb_success = callback(State(previous_state));
+    } catch (const std::exception & e) {
+      RCUTILS_LOG_ERROR("Caught exception in callback for transition %d", it->first);
+      RCUTILS_LOG_ERROR("Original error: %s", e.what());
+      cb_success = node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
+    }
+  }
+  return cb_success;
+}
+
+const State & LifecycleNode::LifecycleNodeInterfaceImpl::trigger_transition(
+  const char * transition_label)
+{
+  node_interfaces::LifecycleNodeInterface::CallbackReturn error;
+  return trigger_transition(transition_label, error);
+}
+
+const State & LifecycleNode::LifecycleNodeInterfaceImpl::trigger_transition(
+  const char * transition_label,
+  node_interfaces::LifecycleNodeInterface::CallbackReturn & cb_return_code)
+{
+  auto transition =
+    rcl_lifecycle_get_transition_by_label(state_machine_.current_state, transition_label);
+  if (transition) {
+    change_state(static_cast<uint8_t>(transition->id), cb_return_code);
+  }
+  return get_current_state();
+}
+
+const State &
+LifecycleNode::LifecycleNodeInterfaceImpl::trigger_transition(uint8_t transition_id)
+{
+  node_interfaces::LifecycleNodeInterface::CallbackReturn error;
+  change_state(transition_id, error);
+  (void) error;
+  return get_current_state();
+}
+
+const State &
+LifecycleNode::LifecycleNodeInterfaceImpl::trigger_transition(
+  uint8_t transition_id,
+  node_interfaces::LifecycleNodeInterface::CallbackReturn & cb_return_code)
+{
+  change_state(transition_id, cb_return_code);
+  return get_current_state();
+}
+
+void
+LifecycleNode::LifecycleNodeInterfaceImpl::add_managed_entity(
+  std::weak_ptr<rclcpp_lifecycle::ManagedEntityInterface> managed_entity)
+{
+  weak_managed_entities_.push_back(managed_entity);
+}
+
+void
+LifecycleNode::LifecycleNodeInterfaceImpl::add_timer_handle(
+  std::shared_ptr<rclcpp::TimerBase> timer)
+{
+  weak_timers_.push_back(timer);
+}
+
+void
+LifecycleNode::LifecycleNodeInterfaceImpl::on_activate()
+{
+  for (const auto & weak_entity : weak_managed_entities_) {
+    auto entity = weak_entity.lock();
+    if (entity) {
+      entity->on_activate();
+    }
+  }
+}
+
+void
+LifecycleNode::LifecycleNodeInterfaceImpl::on_deactivate()
+{
+  for (const auto & weak_entity : weak_managed_entities_) {
+    auto entity = weak_entity.lock();
+    if (entity) {
+      entity->on_deactivate();
+    }
+  }
+}
+
+}  // namespace rclcpp_lifecycle

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.cpp
@@ -238,7 +238,7 @@ void
 LifecycleNode::LifecycleNodeInterfaceImpl::on_get_state(
   const std::shared_ptr<rmw_request_id_t> header,
   const std::shared_ptr<GetStateSrv::Request> req,
-  std::shared_ptr<GetStateSrv::Response> resp)
+  std::shared_ptr<GetStateSrv::Response> resp) const
 {
   (void)header;
   (void)req;
@@ -254,7 +254,7 @@ void
 LifecycleNode::LifecycleNodeInterfaceImpl::on_get_available_states(
   const std::shared_ptr<rmw_request_id_t> header,
   const std::shared_ptr<GetAvailableStatesSrv::Request> req,
-  std::shared_ptr<GetAvailableStatesSrv::Response> resp)
+  std::shared_ptr<GetAvailableStatesSrv::Response> resp) const
 {
   (void)header;
   (void)req;
@@ -276,7 +276,7 @@ void
 LifecycleNode::LifecycleNodeInterfaceImpl::on_get_available_transitions(
   const std::shared_ptr<rmw_request_id_t> header,
   const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
-  std::shared_ptr<GetAvailableTransitionsSrv::Response> resp)
+  std::shared_ptr<GetAvailableTransitionsSrv::Response> resp) const
 {
   (void)header;
   (void)req;
@@ -303,7 +303,7 @@ void
 LifecycleNode::LifecycleNodeInterfaceImpl::on_get_transition_graph(
   const std::shared_ptr<rmw_request_id_t> header,
   const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
-  std::shared_ptr<GetAvailableTransitionsSrv::Response> resp)
+  std::shared_ptr<GetAvailableTransitionsSrv::Response> resp) const
 {
   (void)header;
   (void)req;
@@ -334,7 +334,7 @@ LifecycleNode::LifecycleNodeInterfaceImpl::get_current_state()
 }
 
 std::vector<State>
-LifecycleNode::LifecycleNodeInterfaceImpl::get_available_states()
+LifecycleNode::LifecycleNodeInterfaceImpl::get_available_states() const
 {
   std::vector<State> states;
   states.reserve(state_machine_.transition_map.states_size);
@@ -346,7 +346,7 @@ LifecycleNode::LifecycleNodeInterfaceImpl::get_available_states()
 }
 
 std::vector<Transition>
-LifecycleNode::LifecycleNodeInterfaceImpl::get_available_transitions()
+LifecycleNode::LifecycleNodeInterfaceImpl::get_available_transitions() const
 {
   std::vector<Transition> transitions;
   transitions.reserve(state_machine_.current_state->valid_transition_size);
@@ -358,7 +358,7 @@ LifecycleNode::LifecycleNodeInterfaceImpl::get_available_transitions()
 }
 
 std::vector<Transition>
-LifecycleNode::LifecycleNodeInterfaceImpl::get_transition_graph()
+LifecycleNode::LifecycleNodeInterfaceImpl::get_transition_graph() const
 {
   std::vector<Transition> transitions;
   transitions.reserve(state_machine_.transition_map.transitions_size);
@@ -445,7 +445,7 @@ LifecycleNode::LifecycleNodeInterfaceImpl::change_state(
 
 node_interfaces::LifecycleNodeInterface::CallbackReturn
 LifecycleNode::LifecycleNodeInterfaceImpl::execute_callback(
-  unsigned int cb_id, const State & previous_state)
+  unsigned int cb_id, const State & previous_state) const
 {
   // in case no callback was attached, we forward directly
   auto cb_success = node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
@@ -516,7 +516,7 @@ LifecycleNode::LifecycleNodeInterfaceImpl::add_timer_handle(
 }
 
 void
-LifecycleNode::LifecycleNodeInterfaceImpl::on_activate()
+LifecycleNode::LifecycleNodeInterfaceImpl::on_activate() const
 {
   for (const auto & weak_entity : weak_managed_entities_) {
     auto entity = weak_entity.lock();
@@ -527,7 +527,7 @@ LifecycleNode::LifecycleNodeInterfaceImpl::on_activate()
 }
 
 void
-LifecycleNode::LifecycleNodeInterfaceImpl::on_deactivate()
+LifecycleNode::LifecycleNodeInterfaceImpl::on_deactivate() const
 {
   for (const auto & weak_entity : weak_managed_entities_) {
     auto entity = weak_entity.lock();

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -63,6 +63,45 @@ public:
     std::uint8_t lifecycle_transition,
     std::function<node_interfaces::LifecycleNodeInterface::CallbackReturn(const State &)> & cb);
 
+  const State &
+  get_current_state();
+
+  std::vector<State>
+  get_available_states() const;
+
+  std::vector<Transition>
+  get_available_transitions() const;
+
+  std::vector<Transition>
+  get_transition_graph() const;
+
+  const State &
+  trigger_transition(uint8_t transition_id);
+
+  const State &
+  trigger_transition(
+    uint8_t transition_id,
+    node_interfaces::LifecycleNodeInterface::CallbackReturn & cb_return_code);
+
+  const State & trigger_transition(const char * transition_label);
+
+  const State & trigger_transition(
+    const char * transition_label,
+    node_interfaces::LifecycleNodeInterface::CallbackReturn & cb_return_code);
+
+  void
+  on_activate() const;
+
+  void
+  on_deactivate() const;
+
+  void
+  add_managed_entity(std::weak_ptr<rclcpp_lifecycle::ManagedEntityInterface> managed_entity);
+
+  void
+  add_timer_handle(std::shared_ptr<rclcpp::TimerBase> timer);
+
+private:
   void
   on_change_state(
     const std::shared_ptr<rmw_request_id_t> header,
@@ -93,18 +132,6 @@ public:
     const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
     std::shared_ptr<GetAvailableTransitionsSrv::Response> resp) const;
 
-  const State &
-  get_current_state();
-
-  std::vector<State>
-  get_available_states() const;
-
-  std::vector<Transition>
-  get_available_transitions() const;
-
-  std::vector<Transition>
-  get_transition_graph() const;
-
   rcl_ret_t
   change_state(
     std::uint8_t transition_id,
@@ -112,32 +139,6 @@ public:
 
   node_interfaces::LifecycleNodeInterface::CallbackReturn
   execute_callback(unsigned int cb_id, const State & previous_state) const;
-
-  const State & trigger_transition(const char * transition_label);
-
-  const State & trigger_transition(
-    const char * transition_label,
-    node_interfaces::LifecycleNodeInterface::CallbackReturn & cb_return_code);
-
-  const State &
-  trigger_transition(uint8_t transition_id);
-
-  const State &
-  trigger_transition(
-    uint8_t transition_id,
-    node_interfaces::LifecycleNodeInterface::CallbackReturn & cb_return_code);
-
-  void
-  add_managed_entity(std::weak_ptr<rclcpp_lifecycle::ManagedEntityInterface> managed_entity);
-
-  void
-  add_timer_handle(std::shared_ptr<rclcpp::TimerBase> timer);
-
-  void
-  on_activate() const;
-
-  void
-  on_deactivate() const;
 
   rcl_lifecycle_state_machine_t state_machine_;
   State current_state_;

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -40,7 +40,7 @@
 namespace rclcpp_lifecycle
 {
 
-class LifecycleNode::LifecycleNodeInterfaceImpl
+class LifecycleNode::LifecycleNodeInterfaceImpl final
 {
   using ChangeStateSrv = lifecycle_msgs::srv::ChangeState;
   using GetStateSrv = lifecycle_msgs::srv::GetState;

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -20,28 +20,20 @@
 #include <functional>
 #include <map>
 #include <memory>
-#include <stdexcept>
-#include <string>
-#include <utility>
 #include <vector>
 
-#include "lifecycle_msgs/msg/transition_description.hpp"
-#include "lifecycle_msgs/msg/transition_event.h"  // for getting the c-typesupport
 #include "lifecycle_msgs/msg/transition_event.hpp"
 #include "lifecycle_msgs/srv/change_state.hpp"
 #include "lifecycle_msgs/srv/get_state.hpp"
 #include "lifecycle_msgs/srv/get_available_states.hpp"
 #include "lifecycle_msgs/srv/get_available_transitions.hpp"
 
-#include "rcl/error_handling.h"
-
 #include "rcl_lifecycle/rcl_lifecycle.h"
-#include "rcl_lifecycle/transition_map.h"
 
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/node_interfaces/node_services_interface.hpp"
 
-#include "rcutils/logging_macros.h"
+#include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 
 #include "rmw/types.h"
 
@@ -59,489 +51,99 @@ class LifecycleNode::LifecycleNodeInterfaceImpl
 public:
   LifecycleNodeInterfaceImpl(
     std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> node_base_interface,
-    std::shared_ptr<rclcpp::node_interfaces::NodeServicesInterface> node_services_interface)
-  : node_base_interface_(node_base_interface),
-    node_services_interface_(node_services_interface)
-  {}
+    std::shared_ptr<rclcpp::node_interfaces::NodeServicesInterface> node_services_interface);
 
-  ~LifecycleNodeInterfaceImpl()
-  {
-    rcl_node_t * node_handle = node_base_interface_->get_rcl_node_handle();
-    auto ret = rcl_lifecycle_state_machine_fini(&state_machine_, node_handle);
-    if (ret != RCL_RET_OK) {
-      RCUTILS_LOG_FATAL_NAMED(
-        "rclcpp_lifecycle",
-        "failed to destroy rcl_state_machine");
-    }
-  }
+  ~LifecycleNodeInterfaceImpl();
 
   void
-  init(bool enable_communication_interface = true)
-  {
-    rcl_node_t * node_handle = node_base_interface_->get_rcl_node_handle();
-    const rcl_node_options_t * node_options =
-      rcl_node_get_options(node_base_interface_->get_rcl_node_handle());
-    state_machine_ = rcl_lifecycle_get_zero_initialized_state_machine();
-    auto state_machine_options = rcl_lifecycle_get_default_state_machine_options();
-    state_machine_options.enable_com_interface = enable_communication_interface;
-    state_machine_options.allocator = node_options->allocator;
-
-    // The call to initialize the state machine takes
-    // currently five different typesupports for all publishers/services
-    // created within the RCL_LIFECYCLE structure.
-    // The publisher takes a C-Typesupport since the publishing (i.e. creating
-    // the message) is done fully in RCL.
-    // Services are handled in C++, so that it needs a C++ typesupport structure.
-    rcl_ret_t ret = rcl_lifecycle_state_machine_init(
-      &state_machine_,
-      node_handle,
-      ROSIDL_GET_MSG_TYPE_SUPPORT(lifecycle_msgs, msg, TransitionEvent),
-      rosidl_typesupport_cpp::get_service_type_support_handle<ChangeStateSrv>(),
-      rosidl_typesupport_cpp::get_service_type_support_handle<GetStateSrv>(),
-      rosidl_typesupport_cpp::get_service_type_support_handle<GetAvailableStatesSrv>(),
-      rosidl_typesupport_cpp::get_service_type_support_handle<GetAvailableTransitionsSrv>(),
-      rosidl_typesupport_cpp::get_service_type_support_handle<GetAvailableTransitionsSrv>(),
-      &state_machine_options);
-    if (ret != RCL_RET_OK) {
-      throw std::runtime_error(
-              std::string("Couldn't initialize state machine for node ") +
-              node_base_interface_->get_name());
-    }
-
-    if (enable_communication_interface) {
-      { // change_state
-        auto cb = std::bind(
-          &LifecycleNodeInterfaceImpl::on_change_state, this,
-          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-        rclcpp::AnyServiceCallback<ChangeStateSrv> any_cb;
-        any_cb.set(std::move(cb));
-
-        srv_change_state_ = std::make_shared<rclcpp::Service<ChangeStateSrv>>(
-          node_base_interface_->get_shared_rcl_node_handle(),
-          &state_machine_.com_interface.srv_change_state,
-          any_cb);
-        node_services_interface_->add_service(
-          std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_change_state_),
-          nullptr);
-      }
-
-      { // get_state
-        auto cb = std::bind(
-          &LifecycleNodeInterfaceImpl::on_get_state, this,
-          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-        rclcpp::AnyServiceCallback<GetStateSrv> any_cb;
-        any_cb.set(std::move(cb));
-
-        srv_get_state_ = std::make_shared<rclcpp::Service<GetStateSrv>>(
-          node_base_interface_->get_shared_rcl_node_handle(),
-          &state_machine_.com_interface.srv_get_state,
-          any_cb);
-        node_services_interface_->add_service(
-          std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_state_),
-          nullptr);
-      }
-
-      { // get_available_states
-        auto cb = std::bind(
-          &LifecycleNodeInterfaceImpl::on_get_available_states, this,
-          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-        rclcpp::AnyServiceCallback<GetAvailableStatesSrv> any_cb;
-        any_cb.set(std::move(cb));
-
-        srv_get_available_states_ = std::make_shared<rclcpp::Service<GetAvailableStatesSrv>>(
-          node_base_interface_->get_shared_rcl_node_handle(),
-          &state_machine_.com_interface.srv_get_available_states,
-          any_cb);
-        node_services_interface_->add_service(
-          std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_available_states_),
-          nullptr);
-      }
-
-      { // get_available_transitions
-        auto cb = std::bind(
-          &LifecycleNodeInterfaceImpl::on_get_available_transitions, this,
-          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-        rclcpp::AnyServiceCallback<GetAvailableTransitionsSrv> any_cb;
-        any_cb.set(std::move(cb));
-
-        srv_get_available_transitions_ =
-          std::make_shared<rclcpp::Service<GetAvailableTransitionsSrv>>(
-          node_base_interface_->get_shared_rcl_node_handle(),
-          &state_machine_.com_interface.srv_get_available_transitions,
-          any_cb);
-        node_services_interface_->add_service(
-          std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_available_transitions_),
-          nullptr);
-      }
-
-      { // get_transition_graph
-        auto cb = std::bind(
-          &LifecycleNodeInterfaceImpl::on_get_transition_graph, this,
-          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-        rclcpp::AnyServiceCallback<GetAvailableTransitionsSrv> any_cb;
-        any_cb.set(std::move(cb));
-
-        srv_get_transition_graph_ =
-          std::make_shared<rclcpp::Service<GetAvailableTransitionsSrv>>(
-          node_base_interface_->get_shared_rcl_node_handle(),
-          &state_machine_.com_interface.srv_get_transition_graph,
-          any_cb);
-        node_services_interface_->add_service(
-          std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_transition_graph_),
-          nullptr);
-      }
-    }
-  }
+  init(bool enable_communication_interface = true);
 
   bool
   register_callback(
     std::uint8_t lifecycle_transition,
-    std::function<node_interfaces::LifecycleNodeInterface::CallbackReturn(const State &)> & cb)
-  {
-    cb_map_[lifecycle_transition] = cb;
-    return true;
-  }
+    std::function<node_interfaces::LifecycleNodeInterface::CallbackReturn(const State &)> & cb);
 
   void
   on_change_state(
     const std::shared_ptr<rmw_request_id_t> header,
     const std::shared_ptr<ChangeStateSrv::Request> req,
-    std::shared_ptr<ChangeStateSrv::Response> resp)
-  {
-    (void)header;
-    if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
-      throw std::runtime_error(
-              "Can't get state. State machine is not initialized.");
-    }
-
-    auto transition_id = req->transition.id;
-    // if there's a label attached to the request,
-    // we check the transition attached to this label.
-    // we further can't compare the id of the looked up transition
-    // because ros2 service call defaults all intergers to zero.
-    // that means if we call ros2 service call ... {transition: {label: shutdown}}
-    // the id of the request is 0 (zero) whereas the id from the lookup up transition
-    // can be different.
-    // the result of this is that the label takes presedence of the id.
-    if (req->transition.label.size() != 0) {
-      auto rcl_transition = rcl_lifecycle_get_transition_by_label(
-        state_machine_.current_state, req->transition.label.c_str());
-      if (rcl_transition == nullptr) {
-        resp->success = false;
-        return;
-      }
-      transition_id = static_cast<std::uint8_t>(rcl_transition->id);
-    }
-
-    node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code;
-    auto ret = change_state(transition_id, cb_return_code);
-    (void) ret;
-    // TODO(karsten1987): Lifecycle msgs have to be extended to keep both returns
-    // 1. return is the actual transition
-    // 2. return is whether an error occurred or not
-    resp->success =
-      (cb_return_code == node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
-  }
+    std::shared_ptr<ChangeStateSrv::Response> resp);
 
   void
   on_get_state(
     const std::shared_ptr<rmw_request_id_t> header,
     const std::shared_ptr<GetStateSrv::Request> req,
-    std::shared_ptr<GetStateSrv::Response> resp)
-  {
-    (void)header;
-    (void)req;
-    if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
-      throw std::runtime_error(
-              "Can't get state. State machine is not initialized.");
-    }
-    resp->current_state.id = static_cast<uint8_t>(state_machine_.current_state->id);
-    resp->current_state.label = state_machine_.current_state->label;
-  }
+    std::shared_ptr<GetStateSrv::Response> resp);
 
   void
   on_get_available_states(
     const std::shared_ptr<rmw_request_id_t> header,
     const std::shared_ptr<GetAvailableStatesSrv::Request> req,
-    std::shared_ptr<GetAvailableStatesSrv::Response> resp)
-  {
-    (void)header;
-    (void)req;
-    if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
-      throw std::runtime_error(
-              "Can't get available states. State machine is not initialized.");
-    }
-
-    resp->available_states.resize(state_machine_.transition_map.states_size);
-    for (unsigned int i = 0; i < state_machine_.transition_map.states_size; ++i) {
-      resp->available_states[i].id =
-        static_cast<uint8_t>(state_machine_.transition_map.states[i].id);
-      resp->available_states[i].label =
-        static_cast<std::string>(state_machine_.transition_map.states[i].label);
-    }
-  }
+    std::shared_ptr<GetAvailableStatesSrv::Response> resp);
 
   void
   on_get_available_transitions(
     const std::shared_ptr<rmw_request_id_t> header,
     const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
-    std::shared_ptr<GetAvailableTransitionsSrv::Response> resp)
-  {
-    (void)header;
-    (void)req;
-    if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
-      throw std::runtime_error(
-              "Can't get available transitions. State machine is not initialized.");
-    }
-
-    resp->available_transitions.resize(state_machine_.current_state->valid_transition_size);
-    for (unsigned int i = 0; i < state_machine_.current_state->valid_transition_size; ++i) {
-      lifecycle_msgs::msg::TransitionDescription & trans_desc = resp->available_transitions[i];
-
-      auto rcl_transition = state_machine_.current_state->valid_transitions[i];
-      trans_desc.transition.id = static_cast<uint8_t>(rcl_transition.id);
-      trans_desc.transition.label = rcl_transition.label;
-      trans_desc.start_state.id = static_cast<uint8_t>(rcl_transition.start->id);
-      trans_desc.start_state.label = rcl_transition.start->label;
-      trans_desc.goal_state.id = static_cast<uint8_t>(rcl_transition.goal->id);
-      trans_desc.goal_state.label = rcl_transition.goal->label;
-    }
-  }
+    std::shared_ptr<GetAvailableTransitionsSrv::Response> resp);
 
   void
   on_get_transition_graph(
     const std::shared_ptr<rmw_request_id_t> header,
     const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
-    std::shared_ptr<GetAvailableTransitionsSrv::Response> resp)
-  {
-    (void)header;
-    (void)req;
-    if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
-      throw std::runtime_error(
-              "Can't get available transitions. State machine is not initialized.");
-    }
-
-    resp->available_transitions.resize(state_machine_.transition_map.transitions_size);
-    for (unsigned int i = 0; i < state_machine_.transition_map.transitions_size; ++i) {
-      lifecycle_msgs::msg::TransitionDescription & trans_desc = resp->available_transitions[i];
-
-      auto rcl_transition = state_machine_.transition_map.transitions[i];
-      trans_desc.transition.id = static_cast<uint8_t>(rcl_transition.id);
-      trans_desc.transition.label = rcl_transition.label;
-      trans_desc.start_state.id = static_cast<uint8_t>(rcl_transition.start->id);
-      trans_desc.start_state.label = rcl_transition.start->label;
-      trans_desc.goal_state.id = static_cast<uint8_t>(rcl_transition.goal->id);
-      trans_desc.goal_state.label = rcl_transition.goal->label;
-    }
-  }
+    std::shared_ptr<GetAvailableTransitionsSrv::Response> resp);
 
   const State &
-  get_current_state()
-  {
-    current_state_ = State(state_machine_.current_state);
-    return current_state_;
-  }
+  get_current_state();
 
   std::vector<State>
-  get_available_states()
-  {
-    std::vector<State> states;
-    states.reserve(state_machine_.transition_map.states_size);
-
-    for (unsigned int i = 0; i < state_machine_.transition_map.states_size; ++i) {
-      states.emplace_back(&state_machine_.transition_map.states[i]);
-    }
-    return states;
-  }
+  get_available_states();
 
   std::vector<Transition>
-  get_available_transitions()
-  {
-    std::vector<Transition> transitions;
-    transitions.reserve(state_machine_.current_state->valid_transition_size);
-
-    for (unsigned int i = 0; i < state_machine_.current_state->valid_transition_size; ++i) {
-      transitions.emplace_back(&state_machine_.current_state->valid_transitions[i]);
-    }
-    return transitions;
-  }
+  get_available_transitions();
 
   std::vector<Transition>
-  get_transition_graph()
-  {
-    std::vector<Transition> transitions;
-    transitions.reserve(state_machine_.transition_map.transitions_size);
-
-    for (unsigned int i = 0; i < state_machine_.transition_map.transitions_size; ++i) {
-      transitions.emplace_back(&state_machine_.transition_map.transitions[i]);
-    }
-    return transitions;
-  }
+  get_transition_graph();
 
   rcl_ret_t
-  change_state(std::uint8_t transition_id, LifecycleNodeInterface::CallbackReturn & cb_return_code)
-  {
-    if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
-      RCUTILS_LOG_ERROR(
-        "Unable to change state for state machine for %s: %s",
-        node_base_interface_->get_name(), rcl_get_error_string().str);
-      return RCL_RET_ERROR;
-    }
+  change_state(
+    std::uint8_t transition_id,
+    node_interfaces::LifecycleNodeInterface::CallbackReturn & cb_return_code);
 
-    constexpr bool publish_update = true;
-    // keep the initial state to pass to a transition callback
-    State initial_state(state_machine_.current_state);
+  node_interfaces::LifecycleNodeInterface::CallbackReturn
+  execute_callback(unsigned int cb_id, const State & previous_state);
 
-    if (
-      rcl_lifecycle_trigger_transition_by_id(
-        &state_machine_, transition_id, publish_update) != RCL_RET_OK)
-    {
-      RCUTILS_LOG_ERROR(
-        "Unable to start transition %u from current state %s: %s",
-        transition_id, state_machine_.current_state->label, rcl_get_error_string().str);
-      rcutils_reset_error();
-      return RCL_RET_ERROR;
-    }
-
-    auto get_label_for_return_code =
-      [](node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code) -> const char *{
-        auto cb_id = static_cast<uint8_t>(cb_return_code);
-        if (cb_id == lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS) {
-          return rcl_lifecycle_transition_success_label;
-        } else if (cb_id == lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE) {
-          return rcl_lifecycle_transition_failure_label;
-        }
-        return rcl_lifecycle_transition_error_label;
-      };
-
-    cb_return_code = execute_callback(state_machine_.current_state->id, initial_state);
-    auto transition_label = get_label_for_return_code(cb_return_code);
-
-    if (
-      rcl_lifecycle_trigger_transition_by_label(
-        &state_machine_, transition_label, publish_update) != RCL_RET_OK)
-    {
-      RCUTILS_LOG_ERROR(
-        "Failed to finish transition %u. Current state is now: %s (%s)",
-        transition_id, state_machine_.current_state->label, rcl_get_error_string().str);
-      rcutils_reset_error();
-      return RCL_RET_ERROR;
-    }
-
-    // error handling ?!
-    // TODO(karsten1987): iterate over possible ret value
-    if (cb_return_code == node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR) {
-      RCUTILS_LOG_WARN("Error occurred while doing error handling.");
-
-      auto error_cb_code = execute_callback(state_machine_.current_state->id, initial_state);
-      auto error_cb_label = get_label_for_return_code(error_cb_code);
-      if (
-        rcl_lifecycle_trigger_transition_by_label(
-          &state_machine_, error_cb_label, publish_update) != RCL_RET_OK)
-      {
-        RCUTILS_LOG_ERROR("Failed to call cleanup on error state: %s", rcl_get_error_string().str);
-        rcutils_reset_error();
-        return RCL_RET_ERROR;
-      }
-    }
-    // This true holds in both cases where the actual callback
-    // was successful or not, since at this point we have a valid transistion
-    // to either a new primary state or error state
-    return RCL_RET_OK;
-  }
-
-  LifecycleNodeInterface::CallbackReturn
-  execute_callback(unsigned int cb_id, const State & previous_state)
-  {
-    // in case no callback was attached, we forward directly
-    auto cb_success = node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-
-    auto it = cb_map_.find(static_cast<uint8_t>(cb_id));
-    if (it != cb_map_.end()) {
-      auto callback = it->second;
-      try {
-        cb_success = callback(State(previous_state));
-      } catch (const std::exception & e) {
-        RCUTILS_LOG_ERROR("Caught exception in callback for transition %d", it->first);
-        RCUTILS_LOG_ERROR("Original error: %s", e.what());
-        cb_success = node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
-      }
-    }
-    return cb_success;
-  }
-
-  const State & trigger_transition(const char * transition_label)
-  {
-    LifecycleNodeInterface::CallbackReturn error;
-    return trigger_transition(transition_label, error);
-  }
+  const State & trigger_transition(const char * transition_label);
 
   const State & trigger_transition(
-    const char * transition_label, LifecycleNodeInterface::CallbackReturn & cb_return_code)
-  {
-    auto transition =
-      rcl_lifecycle_get_transition_by_label(state_machine_.current_state, transition_label);
-    if (transition) {
-      change_state(static_cast<uint8_t>(transition->id), cb_return_code);
-    }
-    return get_current_state();
-  }
+    const char * transition_label,
+    node_interfaces::LifecycleNodeInterface::CallbackReturn & cb_return_code);
 
   const State &
-  trigger_transition(uint8_t transition_id)
-  {
-    LifecycleNodeInterface::CallbackReturn error;
-    change_state(transition_id, error);
-    (void) error;
-    return get_current_state();
-  }
+  trigger_transition(uint8_t transition_id);
 
   const State &
-  trigger_transition(uint8_t transition_id, LifecycleNodeInterface::CallbackReturn & cb_return_code)
-  {
-    change_state(transition_id, cb_return_code);
-    return get_current_state();
-  }
+  trigger_transition(
+    uint8_t transition_id,
+    node_interfaces::LifecycleNodeInterface::CallbackReturn & cb_return_code);
 
   void
-  add_managed_entity(std::weak_ptr<rclcpp_lifecycle::ManagedEntityInterface> managed_entity)
-  {
-    weak_managed_entities_.push_back(managed_entity);
-  }
+  add_managed_entity(std::weak_ptr<rclcpp_lifecycle::ManagedEntityInterface> managed_entity);
 
   void
-  add_timer_handle(std::shared_ptr<rclcpp::TimerBase> timer)
-  {
-    weak_timers_.push_back(timer);
-  }
+  add_timer_handle(std::shared_ptr<rclcpp::TimerBase> timer);
 
   void
-  on_activate()
-  {
-    for (const auto & weak_entity : weak_managed_entities_) {
-      auto entity = weak_entity.lock();
-      if (entity) {
-        entity->on_activate();
-      }
-    }
-  }
+  on_activate();
 
   void
-  on_deactivate()
-  {
-    for (const auto & weak_entity : weak_managed_entities_) {
-      auto entity = weak_entity.lock();
-      if (entity) {
-        entity->on_deactivate();
-      }
-    }
-  }
+  on_deactivate();
 
   rcl_lifecycle_state_machine_t state_machine_;
   State current_state_;
   std::map<
     std::uint8_t,
-    std::function<LifecycleNodeInterface::CallbackReturn(const State &)>> cb_map_;
+    std::function<node_interfaces::LifecycleNodeInterface::CallbackReturn(const State &)>> cb_map_;
 
   using NodeBasePtr = std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>;
   using NodeServicesPtr = std::shared_ptr<rclcpp::node_interfaces::NodeServicesInterface>;

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -73,37 +73,37 @@ public:
   on_get_state(
     const std::shared_ptr<rmw_request_id_t> header,
     const std::shared_ptr<GetStateSrv::Request> req,
-    std::shared_ptr<GetStateSrv::Response> resp);
+    std::shared_ptr<GetStateSrv::Response> resp) const;
 
   void
   on_get_available_states(
     const std::shared_ptr<rmw_request_id_t> header,
     const std::shared_ptr<GetAvailableStatesSrv::Request> req,
-    std::shared_ptr<GetAvailableStatesSrv::Response> resp);
+    std::shared_ptr<GetAvailableStatesSrv::Response> resp) const;
 
   void
   on_get_available_transitions(
     const std::shared_ptr<rmw_request_id_t> header,
     const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
-    std::shared_ptr<GetAvailableTransitionsSrv::Response> resp);
+    std::shared_ptr<GetAvailableTransitionsSrv::Response> resp) const;
 
   void
   on_get_transition_graph(
     const std::shared_ptr<rmw_request_id_t> header,
     const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
-    std::shared_ptr<GetAvailableTransitionsSrv::Response> resp);
+    std::shared_ptr<GetAvailableTransitionsSrv::Response> resp) const;
 
   const State &
   get_current_state();
 
   std::vector<State>
-  get_available_states();
+  get_available_states() const;
 
   std::vector<Transition>
-  get_available_transitions();
+  get_available_transitions() const;
 
   std::vector<Transition>
-  get_transition_graph();
+  get_transition_graph() const;
 
   rcl_ret_t
   change_state(
@@ -111,7 +111,7 @@ public:
     node_interfaces::LifecycleNodeInterface::CallbackReturn & cb_return_code);
 
   node_interfaces::LifecycleNodeInterface::CallbackReturn
-  execute_callback(unsigned int cb_id, const State & previous_state);
+  execute_callback(unsigned int cb_id, const State & previous_state) const;
 
   const State & trigger_transition(const char * transition_label);
 
@@ -134,10 +134,10 @@ public:
   add_timer_handle(std::shared_ptr<rclcpp::TimerBase> timer);
 
   void
-  on_activate();
+  on_activate() const;
 
   void
-  on_deactivate();
+  on_deactivate() const;
 
   rcl_lifecycle_state_machine_t state_machine_;
   State current_state_;

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -30,6 +30,7 @@
 
 #include "rcl_lifecycle/rcl_lifecycle.h"
 
+#include "rclcpp/macros.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/node_interfaces/node_services_interface.hpp"
 
@@ -102,6 +103,8 @@ public:
   add_timer_handle(std::shared_ptr<rclcpp::TimerBase> timer);
 
 private:
+  RCLCPP_DISABLE_COPY(LifecycleNodeInterfaceImpl)
+
   void
   on_change_state(
     const std::shared_ptr<rmw_request_id_t> header,


### PR DESCRIPTION
This series of patches cleans up the code that implements `LifecycleNodeInterfaceImpl`, the PIMPL interface for the `LifecycleNode` class.  In particular, it does the following things:

1.  Moves the implementation from completely in a header file into a split header file/source file.  This class is not templated, so there is no reason the implementation has to be in the header file.
2. Marks the `LifecycleNodeInterfaceImpl` class as `final` (nothing can possibly derive from it).
3. Updates some documentation.
4. Marks a number of methods inside of `LifecycleNodeInterfaceImpl` as `const`.
5. Makes quite a bit of the internals of `LifecycleNodeInterfaceImpl` private.
6. Disables copies of `LifecycleNodeInterfaceImpl`.
7. Marks some methods from `LifecycleNode` as const.

The main goal here is cleanup, but this should also make PRs like https://github.com/ros2/rclcpp/pull/1756 more clear.

@fujitatomoya please take a look when you get a chance.