### PR TITLE
Set the minimum number of threads of the Multithreaded executor to 2

### DIFF
--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -21,6 +21,7 @@
 
 #include "rcpputils/scope_exit.hpp"
 
+#include "rclcpp/logging.hpp"
 #include "rclcpp/utilities.hpp"
 
 using rclcpp::executors::MultiThreadedExecutor;
@@ -36,9 +37,11 @@ MultiThreadedExecutor::MultiThreadedExecutor(
 {
   number_of_threads_ = number_of_threads
                            ? number_of_threads
-                           : std::max(std::thread::hardware_concurrency(), 2);
-  if (number_of_threads_ == 0) {
-    number_of_threads_ = 2;
+                           : std::max(std::thread::hardware_concurrency(), 2U);
+  if (number_of_threads_ == 1) {
+    RCLCPP_WARN(rclcpp::get_logger("rclcpp"),
+                "MultiThreadedExecutor executor used with a single thread.\n"
+                "Use SingleThreadedExecutor instead.");
   }
 }
 

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -35,9 +35,10 @@ MultiThreadedExecutor::MultiThreadedExecutor(
   yield_before_execute_(yield_before_execute),
   next_exec_timeout_(next_exec_timeout)
 {
-  number_of_threads_ = number_of_threads ?
+  number_of_threads_ = number_of_threads > 0 ?
     number_of_threads :
     std::max(std::thread::hardware_concurrency(), 2U);
+
   if (number_of_threads_ == 1) {
     RCLCPP_WARN(
       rclcpp::get_logger("rclcpp"),

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -34,9 +34,11 @@ MultiThreadedExecutor::MultiThreadedExecutor(
   yield_before_execute_(yield_before_execute),
   next_exec_timeout_(next_exec_timeout)
 {
-  number_of_threads_ = number_of_threads ? number_of_threads : std::thread::hardware_concurrency();
+  number_of_threads_ = number_of_threads
+                           ? number_of_threads
+                           : std::max(std::thread::hardware_concurrency(), 2);
   if (number_of_threads_ == 0) {
-    number_of_threads_ = 1;
+    number_of_threads_ = 2;
   }
 }
 

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -40,8 +40,8 @@ MultiThreadedExecutor::MultiThreadedExecutor(
                            : std::max(std::thread::hardware_concurrency(), 2U);
   if (number_of_threads_ == 1) {
     RCLCPP_WARN(rclcpp::get_logger("rclcpp"),
-                "MultiThreadedExecutor executor used with a single thread.\n"
-                "Use SingleThreadedExecutor instead.");
+                "MultiThreadedExecutor is used with a single thread.\n"
+                "Use the SingleThreadedExecutor instead.");
   }
 }
 

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -35,13 +35,14 @@ MultiThreadedExecutor::MultiThreadedExecutor(
   yield_before_execute_(yield_before_execute),
   next_exec_timeout_(next_exec_timeout)
 {
-  number_of_threads_ = number_of_threads
-                           ? number_of_threads
-                           : std::max(std::thread::hardware_concurrency(), 2U);
+  number_of_threads_ = number_of_threads ?
+    number_of_threads :
+    std::max(std::thread::hardware_concurrency(), 2U);
   if (number_of_threads_ == 1) {
-    RCLCPP_WARN(rclcpp::get_logger("rclcpp"),
-                "MultiThreadedExecutor is used with a single thread.\n"
-                "Use the SingleThreadedExecutor instead.");
+    RCLCPP_WARN(
+      rclcpp::get_logger("rclcpp"),
+      "MultiThreadedExecutor is used with a single thread.\n"
+      "Use the SingleThreadedExecutor instead.");
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Alexis Paques <paa1ti@bosch.com>

Closes https://github.com/ros2/rclcpp/issues/2029

This ensures the number of threads of a **Multi-threaded executor** is at least 2 unless defined explicitly as 1 (why not use the SingleThreadedExecutor?)
Indeed, if we are calling a service from a callback and call the get function of the future directly, we effectively block until the service request resolves but it can't as the reply will not be processed, causing a deadlock. This is either solved by having a Multi-threaded executor and multiple callback groups for non time critical software (which has to wait for the result anyway).

The default number of threads is `std::thread::hardware_concurrency` which can be 1 for a VM or a small target. 
This means those targets (or VM) will **not** be able to receive the message of an otherwise correct node, while working on everybody else's machine.

The second motivation is to solve the misconception a Multithreaded executor _always_ has multiple thread, by making it have _always_ multiple treads by default. 