### PR TITLE
MultiThreadExecutor number of threads is at least 2+ in default.

### DIFF
--- a/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
@@ -47,7 +47,7 @@ public:
    *
    * \param options common options for all executors
    * \param number_of_threads number of threads to have in the thread pool,
-   *   the default 0 will use the number of cpu cores found instead
+   *   the default 0 will use the number of cpu cores found (minimum of 2)
    * \param yield_before_execute if true std::this_thread::yield() is called
    * \param timeout maximum time to wait
    */


### PR DESCRIPTION
minor comment follow-up for https://github.com/ros2/rclcpp/pull/2030

Signed-off-by: Tomoya Fujita <Tomoya.Fujita@sony.com>