### PR TITLE
Add in a warning for a KeepLast depth of 0.

### DIFF
--- a/rclcpp/src/rclcpp/qos.cpp
+++ b/rclcpp/src/rclcpp/qos.cpp
@@ -84,6 +84,15 @@ QoS::QoS(
   const rmw_qos_profile_t & initial_profile)
 : rmw_qos_profile_(initial_profile)
 {
+  if (qos_initialization.history_policy == RMW_QOS_POLICY_HISTORY_KEEP_LAST &&
+    qos_initialization.depth == 0)
+  {
+    RCLCPP_WARN_ONCE(
+      rclcpp::get_logger(
+        "rclcpp"),
+      "A zero depth with KEEP_LAST doesn't make sense; no data could be stored."
+      "This will be interpreted as SYSTEM_DEFAULT");
+  }
   rmw_qos_profile_.history = qos_initialization.history_policy;
   rmw_qos_profile_.depth = qos_initialization.depth;
 }
@@ -121,6 +130,14 @@ QoS::history(HistoryPolicy history)
 QoS &
 QoS::keep_last(size_t depth)
 {
+  if (depth == 0) {
+    RCLCPP_WARN_ONCE(
+      rclcpp::get_logger(
+        "rclcpp"),
+      "A zero depth with KEEP_LAST doesn't make sense; no data could be stored."
+      "This will be interpreted as SYSTEM_DEFAULT");
+  }
+
   rmw_qos_profile_.history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
   rmw_qos_profile_.depth = depth;
   return *this;

--- a/rclcpp/src/rclcpp/qos.cpp
+++ b/rclcpp/src/rclcpp/qos.cpp
@@ -16,6 +16,8 @@
 
 #include <string>
 
+#include "rclcpp/logging.hpp"
+
 #include "rmw/error_handling.h"
 #include "rmw/types.h"
 #include "rmw/qos_profiles.h"
@@ -67,7 +69,15 @@ KeepAll::KeepAll()
 
 KeepLast::KeepLast(size_t depth)
 : QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, depth)
-{}
+{
+  if (depth == 0) {
+    RCLCPP_WARN_ONCE(
+      rclcpp::get_logger(
+        "rclcpp"),
+      "A zero depth with KEEP_LAST doesn't make sense; no data could be stored."
+      "This will be interpreted as SYSTEM_DEFAULT");
+  }
+}
 
 QoS::QoS(
   const QoSInitialization & qos_initialization,

--- a/rclcpp/test/rclcpp/test_qos_parameters.cpp
+++ b/rclcpp/test/rclcpp/test_qos_parameters.cpp
@@ -255,3 +255,9 @@ TEST(TestQosParameters, internal_functions_failure_modes) {
       nullptr, rclcpp::QosPolicyKind::Reliability),
     std::invalid_argument);
 }
+
+TEST(TestQosParameters, keep_last_zero) {
+  rclcpp::KeepLast keep_last(0);
+
+  EXPECT_EQ(keep_last.depth, RMW_QOS_POLICY_DEPTH_SYSTEM_DEFAULT);
+}


### PR DESCRIPTION
It really doesn't make much sense to have a KeepLast depth of 0; no data could possibly be stored.  Indeed, the underlying DDS implementations don't actually support this.  It currently "works" because a KeepLast depth of 0 is assumed to be system default, so the RMW layer typically chooses "1" instead.  But this isn't something we should be encouraging users to do, so add a warning.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

I'll note that I could easily be convinced to make this throw an exception instead.  That would be a much stronger warning to users not to do this, but it does break existing practice so has some risk of downstream breakage.  Happy to discuss it.