### PR TITLE
Mark rclcpp::Clock::now() as const

### DIFF
--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -77,7 +77,7 @@ public:
    */
   RCLCPP_PUBLIC
   Time
-  now();
+  now() const;
 
   /**
    * Sleep until a specified Time, according to clock type.

--- a/rclcpp/src/rclcpp/clock.cpp
+++ b/rclcpp/src/rclcpp/clock.cpp
@@ -67,7 +67,7 @@ Clock::Clock(rcl_clock_type_t clock_type)
 Clock::~Clock() {}
 
 Time
-Clock::now()
+Clock::now() const
 {
   Time now(0, 0, impl_->rcl_clock_.type);
 


### PR DESCRIPTION
I think `now()` can be marked as `const`. All it does is [call rcl_clock_get_now()](https://github.com/ros2/rclcpp/blob/91bc312190e61c8915b0152e5c927c987fc22d6c/rclcpp/src/rclcpp/clock.cpp#L71-L80) which [doesn't look like it modifies the clock to me](https://github.com/ros2/rcl/blob/e4f7e1367dfda83d3e309397f9201642ebe38618/rcl/src/rcl/time.c#L268-L280).

* When `get_now` is `rcl_get_ros_time`: https://github.com/ros2/rcl/blob/e4f7e1367dfda83d3e309397f9201642ebe38618/rcl/src/rcl/time.c#L65-L73
* When `get_now` is `rcl_get_system_time`: https://github.com/ros2/rcl/blob/e4f7e1367dfda83d3e309397f9201642ebe38618/rcl/src/rcl/time.c#L44-L48
* When `get_now` is `rcl_get_steady_time`: https://github.com/ros2/rcl/blob/e4f7e1367dfda83d3e309397f9201642ebe38618/rcl/src/rcl/time.c#L36-L40