### PR TITLE
Add alias libs for rclcpp all following form of rclcpp::X

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -179,6 +179,7 @@ foreach(interface_file ${interface_files})
 endforeach()
 
 add_library(${PROJECT_NAME} ${${PROJECT_NAME}_SRCS})
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 # TODO(wjwwood): address all deprecation warnings and then remove this
 if(WIN32)

--- a/rclcpp_components/CMakeLists.txt
+++ b/rclcpp_components/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(rcpputils REQUIRED)
 
 # Add an interface library that can be dependend upon by libraries who register components
 add_library(component INTERFACE)
+add_library(rclcpp::component ALIAS component)
 target_include_directories(component INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
@@ -34,6 +35,7 @@ add_library(
   SHARED
   src/component_manager.cpp
 )
+add_library(rclcpp::component_manager ALIAS component_manager)
 target_include_directories(component_manager PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
@@ -96,6 +98,7 @@ if(BUILD_TESTING)
 
   set(components "")
   add_library(test_component SHARED test/components/test_component.cpp)
+  add_library(rclcpp::test_component ALIAS test_component)
   target_link_libraries(test_component PRIVATE component)
   #rclcpp_components_register_nodes(test_component "test_rclcpp_components::TestComponent")
   set(components "${components}test_rclcpp_components::TestComponentFoo;$<TARGET_FILE:test_component>\n")

--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(rclcpp_lifecycle
   src/state.cpp
   src/transition.cpp
 )
+add_library(rclcpp::rclcpp_lifecycle ALIAS ${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME}
   PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"


### PR DESCRIPTION
Due to some requests in gscam2's upgrades to modern CMake, it would like to consume alias library targets for all its dependencies. This PR is to add them to rclcpp. 

Signed-off-by: Ryan Friedman <ryan_friedman@trimble.com>