### PR TITLE
Remove templating on to_rcl_subscription_options

### DIFF
--- a/rclcpp/include/rclcpp/generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/generic_subscription.hpp
@@ -81,7 +81,7 @@ public:
       node_base,
       *rclcpp::get_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *ts_lib),
       topic_name,
-      options.template to_rcl_subscription_options<rclcpp::SerializedMessage>(qos),
+      options.to_rcl_subscription_options(qos),
       true),
     callback_(callback),
     ts_lib_(ts_lib)

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -140,7 +140,7 @@ public:
       node_base,
       type_support_handle,
       topic_name,
-      options.template to_rcl_subscription_options<ROSMessageType>(qos),
+      options.to_rcl_subscription_options(qos),
       callback.is_serialized_message_callback()),
     any_callback_(callback),
     options_(options),

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -110,7 +110,6 @@ struct SubscriptionOptionsWithAllocator : public SubscriptionOptionsBase
    * \param qos QoS profile for subcription.
    * \return rcl_subscription_options_t structure based on the rclcpp::QoS
    */
-  template<typename MessageT>
   rcl_subscription_options_t
   to_rcl_subscription_options(const rclcpp::QoS & qos) const
   {

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_topics.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_topics.cpp
@@ -44,8 +44,8 @@ const rcl_publisher_options_t PublisherOptions()
 
 const rcl_subscription_options_t SubscriptionOptions()
 {
-  return rclcpp::SubscriptionOptionsWithAllocator<std::allocator<void>>().template
-         to_rcl_subscription_options<test_msgs::msg::Empty>(rclcpp::QoS(10));
+  return rclcpp::SubscriptionOptionsWithAllocator<std::allocator<void>>()
+         .to_rcl_subscription_options(rclcpp::QoS(10));
 }
 
 }  // namespace


### PR DESCRIPTION
`to_rcl_subscription_options` no longer needs a template parameter, so I'm just removing it to trim bloat.