### PR TITLE
Set explicitly callback type

### DIFF
--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -286,7 +286,7 @@ public:
               "is not callable.");
     }
 
-    auto new_callback =
+    std::function<void(size_t)> new_callback =
       [callback, this](size_t number_of_responses) {
         try {
           callback(number_of_responses);

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -312,7 +312,7 @@ public:
     // This two-step setting, prevents a gap where the old std::function has
     // been replaced but the middleware hasn't been told about the new one yet.
     set_on_new_response_callback(
-      rclcpp::detail::cpp_callback_trampoline<const void *, size_t>,
+      rclcpp::detail::cpp_callback_trampoline<decltype(new_callback), const void *, size_t>,
       static_cast<const void *>(&new_callback));
 
     // Store the std::function to keep it in scope, also overwrites the existing one.
@@ -320,7 +320,8 @@ public:
 
     // Set it again, now using the permanent storage.
     set_on_new_response_callback(
-      rclcpp::detail::cpp_callback_trampoline<const void *, size_t>,
+      rclcpp::detail::cpp_callback_trampoline<
+        decltype(on_new_response_callback_), const void *, size_t>,
       static_cast<const void *>(&on_new_response_callback_));
   }
 

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -286,7 +286,7 @@ public:
               "is not callable.");
     }
 
-    std::function<void(size_t)> new_callback =
+    auto new_callback =
       [callback, this](size_t number_of_responses) {
         try {
           callback(number_of_responses);

--- a/rclcpp/include/rclcpp/detail/cpp_callback_trampoline.hpp
+++ b/rclcpp/include/rclcpp/detail/cpp_callback_trampoline.hpp
@@ -41,6 +41,7 @@ namespace detail
  * so no exceptions should be thrown at this point, and doing so results in
  * undefined behavior.
  *
+ * \tparam UserDataRealT Declared type of the passed function
  * \tparam UserDataT Deduced type based on what is passed for user data,
  *   usually this type is either `void *` or `const void *`.
  * \tparam Args the arguments being passed to the callback
@@ -50,6 +51,7 @@ namespace detail
  * \returns whatever the callback returns, if anything
  */
 template<
+  typename UserDataRealT,
   typename UserDataT,
   typename ... Args,
   typename ReturnT = void
@@ -57,7 +59,7 @@ template<
 ReturnT
 cpp_callback_trampoline(UserDataT user_data, Args ... args) noexcept
 {
-  auto & actual_callback = *reinterpret_cast<const std::function<ReturnT(Args...)> *>(user_data);
+  auto & actual_callback = *static_cast<const UserDataRealT *>(user_data);
   return actual_callback(args ...);
 }
 

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -128,7 +128,7 @@ public:
     }
 
     // Note: we bind the int identifier argument to this waitable's entity types
-    std::function<void(size_t)> new_callback =
+    auto new_callback =
       [callback, this](size_t number_of_events) {
         try {
           callback(number_of_events, static_cast<int>(EntityType::Subscription));

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -128,7 +128,7 @@ public:
     }
 
     // Note: we bind the int identifier argument to this waitable's entity types
-    auto new_callback =
+    std::function<void(size_t)> new_callback =
       [callback, this](size_t number_of_events) {
         try {
           callback(number_of_events, static_cast<int>(EntityType::Subscription));

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -185,7 +185,7 @@ public:
     // This two-step setting, prevents a gap where the old std::function has
     // been replaced but the middleware hasn't been told about the new one yet.
     set_on_new_event_callback(
-      rclcpp::detail::cpp_callback_trampoline<const void *, size_t>,
+      rclcpp::detail::cpp_callback_trampoline<decltype(new_callback), const void *, size_t>,
       static_cast<const void *>(&new_callback));
 
     // Store the std::function to keep it in scope, also overwrites the existing one.
@@ -193,7 +193,8 @@ public:
 
     // Set it again, now using the permanent storage.
     set_on_new_event_callback(
-      rclcpp::detail::cpp_callback_trampoline<const void *, size_t>,
+      rclcpp::detail::cpp_callback_trampoline<
+        decltype(on_new_event_callback_), const void *, size_t>,
       static_cast<const void *>(&on_new_event_callback_));
   }
 

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -158,7 +158,7 @@ public:
     }
 
     // Note: we bind the int identifier argument to this waitable's entity types
-    std::function<void(size_t)> new_callback =
+    auto new_callback =
       [callback, this](size_t number_of_events) {
         try {
           callback(number_of_events, static_cast<int>(EntityType::Event));

--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -158,7 +158,7 @@ public:
     }
 
     // Note: we bind the int identifier argument to this waitable's entity types
-    auto new_callback =
+    std::function<void(size_t)> new_callback =
       [callback, this](size_t number_of_events) {
         try {
           callback(number_of_events, static_cast<int>(EntityType::Event));

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -222,7 +222,7 @@ public:
     // This two-step setting, prevents a gap where the old std::function has
     // been replaced but the middleware hasn't been told about the new one yet.
     set_on_new_request_callback(
-      rclcpp::detail::cpp_callback_trampoline<const void *, size_t>,
+      rclcpp::detail::cpp_callback_trampoline<decltype(new_callback), const void *, size_t>,
       static_cast<const void *>(&new_callback));
 
     // Store the std::function to keep it in scope, also overwrites the existing one.
@@ -230,7 +230,8 @@ public:
 
     // Set it again, now using the permanent storage.
     set_on_new_request_callback(
-      rclcpp::detail::cpp_callback_trampoline<const void *, size_t>,
+      rclcpp::detail::cpp_callback_trampoline<
+        decltype(on_new_request_callback_), const void *, size_t>,
       static_cast<const void *>(&on_new_request_callback_));
   }
 

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -196,7 +196,7 @@ public:
               "is not callable.");
     }
 
-    std::function<void(size_t)> new_callback =
+    auto new_callback =
       [callback, this](size_t number_of_requests) {
         try {
           callback(number_of_requests);

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -196,7 +196,7 @@ public:
               "is not callable.");
     }
 
-    auto new_callback =
+    std::function<void(size_t)> new_callback =
       [callback, this](size_t number_of_requests) {
         try {
           callback(number_of_requests);

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -322,7 +322,7 @@ public:
               "is not callable.");
     }
 
-    std::function<void(size_t)> new_callback =
+    auto new_callback =
       [callback, this](size_t number_of_messages) {
         try {
           callback(number_of_messages);

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -348,7 +348,7 @@ public:
     // This two-step setting, prevents a gap where the old std::function has
     // been replaced but the middleware hasn't been told about the new one yet.
     set_on_new_message_callback(
-      rclcpp::detail::cpp_callback_trampoline<const void *, size_t>,
+      rclcpp::detail::cpp_callback_trampoline<decltype(new_callback), const void *, size_t>,
       static_cast<const void *>(&new_callback));
 
     // Store the std::function to keep it in scope, also overwrites the existing one.
@@ -356,7 +356,8 @@ public:
 
     // Set it again, now using the permanent storage.
     set_on_new_message_callback(
-      rclcpp::detail::cpp_callback_trampoline<const void *, size_t>,
+      rclcpp::detail::cpp_callback_trampoline<
+        decltype(on_new_message_callback_), const void *, size_t>,
       static_cast<const void *>(&on_new_message_callback_));
   }
 

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -322,7 +322,7 @@ public:
               "is not callable.");
     }
 
-    auto new_callback =
+    std::function<void(size_t)> new_callback =
       [callback, this](size_t number_of_messages) {
         try {
           callback(number_of_messages);

--- a/rclcpp_action/src/client.cpp
+++ b/rclcpp_action/src/client.cpp
@@ -433,7 +433,7 @@ ClientBase::set_callback_to_entity(
   // been replaced but the middleware hasn't been told about the new one yet.
   set_on_ready_callback(
     entity_type,
-    rclcpp::detail::cpp_callback_trampoline<const void *, size_t>,
+    rclcpp::detail::cpp_callback_trampoline<decltype(new_callback), const void *, size_t>,
     static_cast<const void *>(&new_callback));
 
   std::lock_guard<std::recursive_mutex> lock(listener_mutex_);
@@ -453,7 +453,7 @@ ClientBase::set_callback_to_entity(
     auto & cb = it->second;
     set_on_ready_callback(
       entity_type,
-      rclcpp::detail::cpp_callback_trampoline<const void *, size_t>,
+      rclcpp::detail::cpp_callback_trampoline<decltype(it->second), const void *, size_t>,
       static_cast<const void *>(&cb));
   }
 

--- a/rclcpp_action/src/client.cpp
+++ b/rclcpp_action/src/client.cpp
@@ -407,7 +407,7 @@ ClientBase::set_callback_to_entity(
   std::function<void(size_t, int)> callback)
 {
   // Note: we bind the int identifier argument to this waitable's entity types
-  std::function<void(size_t)> new_callback =
+  auto new_callback =
     [callback, entity_type, this](size_t number_of_events) {
       try {
         callback(number_of_events, static_cast<int>(entity_type));

--- a/rclcpp_action/src/client.cpp
+++ b/rclcpp_action/src/client.cpp
@@ -407,7 +407,7 @@ ClientBase::set_callback_to_entity(
   std::function<void(size_t, int)> callback)
 {
   // Note: we bind the int identifier argument to this waitable's entity types
-  auto new_callback =
+  std::function<void(size_t)> new_callback =
     [callback, entity_type, this](size_t number_of_events) {
       try {
         callback(number_of_events, static_cast<int>(entity_type));

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -745,7 +745,7 @@ ServerBase::set_callback_to_entity(
   // been replaced but the middleware hasn't been told about the new one yet.
   set_on_ready_callback(
     entity_type,
-    rclcpp::detail::cpp_callback_trampoline<const void *, size_t>,
+    rclcpp::detail::cpp_callback_trampoline<decltype(new_callback), const void *, size_t>,
     static_cast<const void *>(&new_callback));
 
   std::lock_guard<std::recursive_mutex> lock(listener_mutex_);
@@ -765,7 +765,7 @@ ServerBase::set_callback_to_entity(
     auto & cb = it->second;
     set_on_ready_callback(
       entity_type,
-      rclcpp::detail::cpp_callback_trampoline<const void *, size_t>,
+      rclcpp::detail::cpp_callback_trampoline<decltype(it->second), const void *, size_t>,
       static_cast<const void *>(&cb));
   }
 

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -719,7 +719,7 @@ ServerBase::set_callback_to_entity(
   std::function<void(size_t, int)> callback)
 {
   // Note: we bind the int identifier argument to this waitable's entity types
-  auto new_callback =
+  std::function<void(size_t)> new_callback =
     [callback, entity_type, this](size_t number_of_events) {
       try {
         callback(number_of_events, static_cast<int>(entity_type));

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -719,7 +719,7 @@ ServerBase::set_callback_to_entity(
   std::function<void(size_t, int)> callback)
 {
   // Note: we bind the int identifier argument to this waitable's entity types
-  std::function<void(size_t)> new_callback =
+  auto new_callback =
     [callback, entity_type, this](size_t number_of_events) {
       try {
         callback(number_of_events, static_cast<int>(entity_type));


### PR DESCRIPTION
This is to fix seg-faults happening when compiling with `-O2` or `-O3` optimizations.
They happened because we did:

https://github.com/ros2/rclcpp/blob/338eed0c060ab58608fc6e44c6936bde2c4e061e/rclcpp/include/rclcpp/client.hpp#L289

assuming that `auto` was deduced to be a `std::function<void(size_t)>`. 

And then, to the trampoline, we say we were passing a function returning `void*` and with an arg of type `size_t`
https://github.com/ros2/rclcpp/blob/338eed0c060ab58608fc6e44c6936bde2c4e061e/rclcpp/include/rclcpp/client.hpp#L314-L316
But when compiling with optimizations, the `auto new_callback = ...` signature seems to change to other type. So then the `trampoline` function failed when did the cast back:
https://github.com/ros2/rclcpp/blob/338eed0c060ab58608fc6e44c6936bde2c4e061e/rclcpp/include/rclcpp/detail/cpp_callback_trampoline.hpp#L60


