### PR TITLE
Fix logging macros to build with msvc and cpp20

### DIFF
--- a/rclcpp/resource/logging.hpp.em
+++ b/rclcpp/resource/logging.hpp.em
@@ -124,7 +124,7 @@ def get_rclcpp_suffix_from_features(features):
 ) \
   do { \
     static_assert( \
-      ::std::is_same<typename std::remove_cv<typename std::remove_reference<decltype(logger)>::type>::type, \
+      ::std::is_same<typename std::remove_cv_t<typename std::remove_reference_t<decltype(logger)>>, \
       typename ::rclcpp::Logger>::value, \
       "First argument to logging macros must be an rclcpp::Logger"); \
 @[ if 'throttle' in feature_combination]@ \


### PR DESCRIPTION
When I was building my project (CMAKE_CXX_STANDARD 20) with rclcpp on Windows, it failed with the same error as described in https://github.com/ros2/rclcpp/issues/1973 (c++17 + [permissive flag](https://learn.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-170) added to MSVC). The same flag is set implicitly with C++20 because is required for C++20 Modules support.

I was trying to investigate why the template in logging macro is not passing standards conformance, but I was not able to find it out. It seems to be an MSVC issue. A similar problem was reported in [Microsoft Developer Community](https://developercommunity.visualstudio.com/t/the-c2039-type-is-not-a-member-of-std-error-in-def/1562967) more than a year ago and has not been resolved yet.

I used helper type aliases from `type_traits` instead of member types. This change makes rclcpp build successfully with MSVC and C++20.