### PR TITLE
API url info fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ rclcpp provides the standard C++ API for interacting with ROS 2.
 
 The link to the latest API documentation can be found on the rclcpp package info page, at the [ROS Index](https://index.ros.org/p/rclcpp/).
 
+
 ### Examples
 
 The ROS 2 tutorials [Writing a simple publisher and subscriber](https://docs.ros.org/en/rolling/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber.html).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ rclcpp provides the standard C++ API for interacting with ROS 2.
 
 `#include "rclcpp/rclcpp.hpp"` allows use of the most common elements of the ROS 2 system.
 
-Visit the [rclcpp API documentation](http://docs.ros2.org/latest/api/rclcpp/) for a complete list of its main components.
+The link to the latest API documentation can be found on the rclcpp package info page, at the [ROS Index](https://index.ros.org/p/rclcpp/).
 
 ### Examples
 


### PR DESCRIPTION
Change README to point at the ROS Index for API 
Cfr. PR https://github.com/ros2/rclcpp/pull/2058
@clalancette 