### PR TITLE
Add in a fix for older compilers.

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/node_interfaces.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_interfaces.hpp
@@ -150,7 +150,7 @@ public:
   /// NodeT::SharedPtr Constructor
   template<typename NodeT>
   NodeInterfaces(std::shared_ptr<NodeT> node)  // NOLINT(runtime/explicit)
-  : NodeInterfaces(node ? *node : throw std::invalid_argument("given node pointer is nullptr"))
+  : NodeInterfaces(*node)
   {}
 
   explicit NodeInterfaces(std::shared_ptr<InterfaceTs>... args)

--- a/rclcpp/include/rclcpp/node_interfaces/node_interfaces.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_interfaces.hpp
@@ -147,12 +147,6 @@ public:
   : NodeInterfacesSupportsT(node)
   {}
 
-  /// NodeT::SharedPtr Constructor
-  template<typename NodeT>
-  NodeInterfaces(std::shared_ptr<NodeT> node)  // NOLINT(runtime/explicit)
-  : NodeInterfaces(*node)
-  {}
-
   explicit NodeInterfaces(std::shared_ptr<InterfaceTs>... args)
   : NodeInterfacesSupportsT(args ...)
   {}

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_interfaces.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_interfaces.cpp
@@ -44,7 +44,7 @@ TEST_F(TestNodeInterfaces, node_interfaces_nominal) {
     using rclcpp::node_interfaces::NodeInterfaces;
     using rclcpp::node_interfaces::NodeBaseInterface;
     using rclcpp::node_interfaces::NodeGraphInterface;
-    auto node_interfaces = NodeInterfaces<NodeBaseInterface, NodeGraphInterface>(node);
+    auto node_interfaces = NodeInterfaces<NodeBaseInterface, NodeGraphInterface>(*node);
   }
 
   // Implicit conversion of rclcpp::Node into function that uses NodeInterfaces of base.
@@ -55,7 +55,7 @@ TEST_F(TestNodeInterfaces, node_interfaces_nominal) {
         auto base_interface = ni.get<NodeBaseInterface>();
       };
 
-    some_func(node);
+    some_func(*node);
   }
 
   // Implicit narrowing of NodeInterfaces into a new interface NodeInterfaces with fewer interfaces.
@@ -67,7 +67,7 @@ TEST_F(TestNodeInterfaces, node_interfaces_nominal) {
         auto base_interface = ni_with_one.get<NodeBaseInterface>();
       };
 
-    NodeInterfaces<NodeBaseInterface, NodeGraphInterface> ni_with_two(node);
+    NodeInterfaces<NodeBaseInterface, NodeGraphInterface> ni_with_two(*node);
 
     some_func(ni_with_two);
   }
@@ -102,7 +102,7 @@ TEST_F(TestNodeInterfaces, node_interfaces_standard_interfaces) {
     rclcpp::node_interfaces::NodeWaitablesInterface,
     rclcpp::node_interfaces::NodeParametersInterface,
     rclcpp::node_interfaces::NodeTimeSourceInterface
-    >(node);
+    >(*node);
 }
 
 /*
@@ -134,7 +134,7 @@ TEST_F(TestNodeInterfaces, ni_init) {
     NodeWaitablesInterface,
     NodeParametersInterface,
     NodeTimeSourceInterface
-    >(node);
+    >(*node);
 
   {
     auto base = ni.get<NodeBaseInterface>();
@@ -198,7 +198,7 @@ TEST_F(TestNodeInterfaces, ni_all_init) {
   using rclcpp::node_interfaces::NodeParametersInterface;
   using rclcpp::node_interfaces::NodeTimeSourceInterface;
 
-  auto ni = rclcpp::node_interfaces::NodeInterfaces<ALL_RCLCPP_NODE_INTERFACES>(node);
+  auto ni = rclcpp::node_interfaces::NodeInterfaces<ALL_RCLCPP_NODE_INTERFACES>(*node);
 
   {
     auto base = ni.get<NodeBaseInterface>();


### PR DESCRIPTION
The addition of the NodeInterfaces class made it stop compiling with older compilers (such as gcc 9.4.0 on Ubuntu 20.04). The error has to do with calling the copy constructor on rclcpp::Node, which is deleted.  Work around this by just getting rid of the nullptr check; it isn't actually needed, I don't think.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

I'm honestly not sure that this is the best solution, but it definitely fixes the build on Ubuntu 20.04, and will likely fix the CI failures we are seeing in https://ci.ros2.org/view/nightly/job/nightly_linux-rhel_release/1370/ .  I could use further feedback from @methylDragon and @wjwwood .