### PR TITLE
Avoid priority inversions in rclcpp

### DIFF
--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -16,9 +16,7 @@
 #define RCLCPP__CALLBACK_GROUP_HPP_
 
 #include <atomic>
-#include <functional>
-#include <memory>
-#include <mutex>
+#include <string>
 #include <vector>
 
 #include "rclcpp/client.hpp"
@@ -30,6 +28,7 @@
 #include "rclcpp/timer.hpp"
 #include "rclcpp/visibility_control.hpp"
 #include "rclcpp/waitable.hpp"
+#include "rcpputils/mutex.hpp"
 
 namespace rclcpp
 {
@@ -221,7 +220,7 @@ protected:
 
   CallbackGroupType type_;
   // Mutex to protect the subsequent vectors of pointers.
-  mutable std::mutex mutex_;
+  mutable rcpputils::PIMutex mutex_;
   std::atomic_bool associated_with_executor_;
   std::vector<rclcpp::SubscriptionBase::WeakPtr> subscription_ptrs_;
   std::vector<rclcpp::TimerBase::WeakPtr> timer_ptrs_;

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -19,7 +19,6 @@
 #include <future>
 #include <unordered_map>
 #include <memory>
-#include <mutex>
 #include <optional>  // NOLINT, cpplint doesn't think this is a cpp std header
 #include <sstream>
 #include <string>
@@ -44,6 +43,8 @@
 #include "rclcpp/type_support_decl.hpp"
 #include "rclcpp/utilities.hpp"
 #include "rclcpp/visibility_control.hpp"
+
+#include "rcpputils/mutex.hpp"
 
 #include "rmw/error_handling.h"
 #include "rmw/impl/cpp/demangle.hpp"
@@ -364,7 +365,7 @@ protected:
 
   std::atomic<bool> in_use_by_wait_set_{false};
 
-  std::recursive_mutex callback_mutex_;
+  rcpputils::RecursivePIMutex callback_mutex_;
   std::function<void(size_t)> on_new_response_callback_{nullptr};
 };
 
@@ -830,7 +831,7 @@ protected:
       std::chrono::time_point<std::chrono::system_clock>,
       CallbackInfoVariant>>
   pending_requests_;
-  std::mutex pending_requests_mutex_;
+  rcpputils::PIMutex pending_requests_mutex_;
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -17,7 +17,6 @@
 
 #include <functional>
 #include <memory>
-#include <mutex>
 
 #include "rclcpp/contexts/default_context.hpp"
 #include "rclcpp/macros.hpp"
@@ -27,6 +26,7 @@
 #include "rcl/time.h"
 #include "rcutils/time.h"
 #include "rcutils/types/rcutils_ret.h"
+#include "rcpputils/mutex.hpp"
 
 namespace rclcpp
 {
@@ -204,7 +204,7 @@ public:
 
   /// Get the clock's mutex
   RCLCPP_PUBLIC
-  std::mutex &
+  rcpputils::PIMutex &
   get_clock_mutex() noexcept;
 
   // Add a callback to invoke if the jump threshold is exceeded.

--- a/rclcpp/include/rclcpp/context.hpp
+++ b/rclcpp/include/rclcpp/context.hpp
@@ -18,7 +18,6 @@
 #include <condition_variable>
 #include <functional>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <typeindex>
 #include <typeinfo>
@@ -33,6 +32,7 @@
 #include "rclcpp/init_options.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/visibility_control.hpp"
+#include "rcpputils/mutex.hpp"
 
 namespace rclcpp
 {
@@ -377,15 +377,15 @@ private:
   std::recursive_mutex sub_contexts_mutex_;
 
   std::unordered_set<std::shared_ptr<OnShutdownCallback>> on_shutdown_callbacks_;
-  mutable std::mutex on_shutdown_callbacks_mutex_;
+  mutable rcpputils::PIMutex on_shutdown_callbacks_mutex_;
 
   std::unordered_set<std::shared_ptr<PreShutdownCallback>> pre_shutdown_callbacks_;
-  mutable std::mutex pre_shutdown_callbacks_mutex_;
+  mutable rcpputils::PIMutex pre_shutdown_callbacks_mutex_;
 
   /// Condition variable for timed sleep (see sleep_for).
   std::condition_variable interrupt_condition_variable_;
   /// Mutex for protecting the global condition variable.
-  std::mutex interrupt_mutex_;
+  rcpputils::PIMutex interrupt_mutex_;
 
   /// Keep shared ownership of global vector of weak contexts
   std::shared_ptr<WeakContextsWrapper> weak_contexts_;

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -23,13 +23,13 @@
 #include <list>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <vector>
 
 #include "rcl/guard_condition.h"
 #include "rcl/wait.h"
 #include "rcpputils/scope_exit.hpp"
+#include "rcpputils/mutex.hpp"
 
 #include "rclcpp/context.hpp"
 #include "rclcpp/contexts/default_context.hpp"
@@ -545,7 +545,7 @@ protected:
   rcl_wait_set_t wait_set_ = rcl_get_zero_initialized_wait_set();
 
   // Mutex to protect the subsequent memory_strategy_.
-  mutable std::mutex mutex_;
+  mutable rcpputils::PIMutex mutex_;
 
   /// The memory strategy: an interface for handling user-defined memory allocation strategies.
   memory_strategy::MemoryStrategy::SharedPtr

--- a/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
@@ -17,7 +17,6 @@
 
 #include <chrono>
 #include <memory>
-#include <mutex>
 #include <set>
 #include <thread>
 #include <unordered_map>
@@ -26,6 +25,8 @@
 #include "rclcpp/macros.hpp"
 #include "rclcpp/memory_strategies.hpp"
 #include "rclcpp/visibility_control.hpp"
+
+#include "rcpputils/mutex.hpp"
 
 namespace rclcpp
 {
@@ -81,7 +82,7 @@ protected:
 private:
   RCLCPP_DISABLE_COPY(MultiThreadedExecutor)
 
-  std::mutex wait_mutex_;
+  rcpputils::PIMutex wait_mutex_;
   size_t number_of_threads_;
   bool yield_before_execute_;
   std::chrono::nanoseconds next_exec_timeout_;

--- a/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
@@ -30,6 +30,8 @@
 #include "rclcpp/visibility_control.hpp"
 #include "rclcpp/waitable.hpp"
 
+#include "rcpputils/mutex.hpp"
+
 namespace rclcpp
 {
 namespace executors
@@ -338,7 +340,7 @@ private:
   std::list<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr> weak_nodes_;
 
   // Mutex to protect vector of new nodes.
-  std::mutex new_nodes_mutex_;
+  rcpputils::PIMutex new_nodes_mutex_;
   std::vector<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr> new_nodes_;
 
   /// Wait set for managing entities that the rmw layer waits on.

--- a/rclcpp/include/rclcpp/experimental/buffers/ring_buffer_implementation.hpp
+++ b/rclcpp/include/rclcpp/experimental/buffers/ring_buffer_implementation.hpp
@@ -15,7 +15,6 @@
 #ifndef RCLCPP__EXPERIMENTAL__BUFFERS__RING_BUFFER_IMPLEMENTATION_HPP_
 #define RCLCPP__EXPERIMENTAL__BUFFERS__RING_BUFFER_IMPLEMENTATION_HPP_
 
-#include <mutex>
 #include <stdexcept>
 #include <utility>
 #include <vector>
@@ -25,6 +24,8 @@
 #include "rclcpp/logging.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/visibility_control.hpp"
+
+#include "rcpputils/mutex.hpp"
 
 namespace rclcpp
 {
@@ -181,7 +182,7 @@ private:
   size_t read_index_;
   size_t size_;
 
-  mutable std::mutex mutex_;
+  mutable rcpputils::PIMutex mutex_;
 };
 
 }  // namespace buffers

--- a/rclcpp/include/rclcpp/graph_listener.hpp
+++ b/rclcpp/include/rclcpp/graph_listener.hpp
@@ -17,7 +17,6 @@
 
 #include <atomic>
 #include <memory>
-#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -28,6 +27,7 @@
 #include "rclcpp/macros.hpp"
 #include "rclcpp/node_interfaces/node_graph_interface.hpp"
 #include "rclcpp/visibility_control.hpp"
+#include "rcpputils/mutex.hpp"
 
 namespace rclcpp
 {
@@ -187,10 +187,10 @@ private:
   std::thread listener_thread_;
   bool is_started_;
   std::atomic_bool is_shutdown_;
-  mutable std::mutex shutdown_mutex_;
+  mutable rcpputils::PIMutex shutdown_mutex_;
 
-  mutable std::mutex node_graph_interfaces_barrier_mutex_;
-  mutable std::mutex node_graph_interfaces_mutex_;
+  mutable rcpputils::PIMutex node_graph_interfaces_barrier_mutex_;
+  mutable rcpputils::PIMutex node_graph_interfaces_mutex_;
   std::vector<rclcpp::node_interfaces::NodeGraphInterface *> node_graph_interfaces_;
 
   rclcpp::GuardCondition interrupt_guard_condition_;

--- a/rclcpp/include/rclcpp/init_options.hpp
+++ b/rclcpp/include/rclcpp/init_options.hpp
@@ -16,10 +16,10 @@
 #define RCLCPP__INIT_OPTIONS_HPP_
 
 #include <memory>
-#include <mutex>
 
 #include "rcl/init_options.h"
 #include "rclcpp/visibility_control.hpp"
+#include "rcpputils/mutex.hpp"
 
 namespace rclcpp
 {
@@ -104,7 +104,7 @@ private:
   void
   finalize_init_options_impl();
 
-  mutable std::mutex init_options_mutex_;
+  mutable rcpputils::PIMutex init_options_mutex_;
   std::unique_ptr<rcl_init_options_t> init_options_;
   bool initialize_logging_{true};
 };

--- a/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
@@ -17,7 +17,6 @@
 
 #include <atomic>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <vector>
 
@@ -27,6 +26,8 @@
 #include "rclcpp/macros.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/visibility_control.hpp"
+
+#include "rcpputils/mutex.hpp"
 
 namespace rclcpp
 {
@@ -146,13 +147,13 @@ private:
   std::shared_ptr<rcl_node_t> node_handle_;
 
   rclcpp::CallbackGroup::SharedPtr default_callback_group_;
-  std::mutex callback_groups_mutex_;
+  rcpputils::PIMutex callback_groups_mutex_;
   std::vector<rclcpp::CallbackGroup::WeakPtr> callback_groups_;
 
   std::atomic_bool associated_with_executor_;
 
   /// Guard condition for notifying the Executor of changes to this node.
-  mutable std::recursive_mutex notify_guard_condition_mutex_;
+  mutable rcpputils::RecursivePIMutex notify_guard_condition_mutex_;
   rclcpp::GuardCondition notify_guard_condition_;
   bool notify_guard_condition_is_valid_;
 };

--- a/rclcpp/include/rclcpp/node_interfaces/node_graph.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph.hpp
@@ -20,7 +20,6 @@
 #include <condition_variable>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -33,6 +32,9 @@
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/node_interfaces/node_graph_interface.hpp"
 #include "rclcpp/visibility_control.hpp"
+
+#include "rcpputils/mutex.hpp"
+
 #include "rmw/topic_endpoint_info_array.h"
 
 namespace rclcpp
@@ -163,7 +165,7 @@ private:
   std::atomic_bool should_add_to_graph_listener_;
 
   /// Mutex to guard the graph event related data structures.
-  mutable std::mutex graph_mutex_;
+  mutable rcpputils::PIMutex graph_mutex_;
   /// For notifying waiting threads (wait_for_graph_change()) on changes (notify_graph_change()).
   std::condition_variable graph_cv_;
   /// Weak references to graph events out on loan.

--- a/rclcpp/include/rclcpp/topic_statistics/subscription_topic_statistics.hpp
+++ b/rclcpp/include/rclcpp/topic_statistics/subscription_topic_statistics.hpp
@@ -33,6 +33,8 @@
 
 #include "statistics_msgs/msg/metrics_message.hpp"
 
+#include "rcpputils/mutex.hpp"
+
 namespace rclcpp
 {
 namespace topic_statistics
@@ -227,7 +229,7 @@ private:
   }
 
   /// Mutex to protect the subsequence vectors
-  mutable std::mutex mutex_;
+  mutable rcpputils::PIMutex mutex_;
   /// Collection of statistics collectors
   std::vector<std::unique_ptr<TopicStatsCollector>> subscriber_statistics_collectors_{};
   /// Node name used to generate topic statistics messages to be published

--- a/rclcpp/include/rclcpp/wait_set_policies/detail/write_preferring_read_write_lock.hpp
+++ b/rclcpp/include/rclcpp/wait_set_policies/detail/write_preferring_read_write_lock.hpp
@@ -17,9 +17,10 @@
 
 #include <condition_variable>
 #include <functional>
-#include <mutex>
 
 #include "rclcpp/visibility_control.hpp"
+
+#include "rcpputils/mutex.hpp"
 
 namespace rclcpp
 {
@@ -229,7 +230,7 @@ protected:
   bool reader_active_ = false;
   std::size_t number_of_writers_waiting_ = 0;
   bool writer_active_ = false;
-  std::mutex mutex_;
+  rcpputils::PIMutex mutex_;
   std::condition_variable condition_variable_;
   ReadMutex read_mutex_;
   WriteMutex write_mutex_;

--- a/rclcpp/src/rclcpp/context.cpp
+++ b/rclcpp/src/rclcpp/context.cpp
@@ -15,7 +15,6 @@
 #include "rclcpp/context.hpp"
 
 #include <memory>
-#include <mutex>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -31,6 +30,8 @@
 
 #include "rcutils/error_handling.h"
 #include "rcutils/macros.h"
+
+#include "rcpputils/mutex.hpp"
 
 #include "./logging_mutex.hpp"
 
@@ -91,7 +92,7 @@ public:
 
 private:
   std::vector<std::weak_ptr<rclcpp::Context>> weak_contexts_;
-  std::mutex mutex_;
+  rcpputils::PIMutex mutex_;
 };
 }  // namespace rclcpp
 

--- a/rclcpp/src/rclcpp/signal_handler.hpp
+++ b/rclcpp/src/rclcpp/signal_handler.hpp
@@ -17,11 +17,12 @@
 
 #include <atomic>
 #include <csignal>
-#include <mutex>
 #include <thread>
 
 #include "rclcpp/logging.hpp"
 #include "rclcpp/utilities.hpp"
+
+#include "rcpputils/mutex.hpp"
 
 // includes for semaphore notification code
 #if defined(_WIN32)
@@ -193,7 +194,7 @@ private:
   std::thread signal_handler_thread_;
 
   // A mutex used to synchronize the install() and uninstall() methods.
-  std::mutex install_mutex_;
+  rcpputils::PIMutex install_mutex_;
   // Whether or not the signal handler has been installed.
   std::atomic_bool installed_ = false;
 

--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -30,6 +30,8 @@
 #include "rclcpp/time.hpp"
 #include "rclcpp/time_source.hpp"
 
+#include "rcpputils/mutex.hpp"
+
 namespace rclcpp
 {
 
@@ -191,7 +193,7 @@ private:
   Logger logger_;
 
   // A lock to protect iterating the associated_clocks_ field.
-  std::mutex clock_list_lock_;
+  rcpputils::PIMutex clock_list_lock_;
   // A vector to store references to associated clocks.
   std::vector<rclcpp::Clock::SharedPtr> associated_clocks_;
 
@@ -358,7 +360,7 @@ private:
   // The subscription for the clock callback
   using SubscriptionT = rclcpp::Subscription<rosgraph_msgs::msg::Clock>;
   std::shared_ptr<SubscriptionT> clock_subscription_{nullptr};
-  std::mutex clock_sub_lock_;
+  rcpputils::PIMutex clock_sub_lock_;
   rclcpp::CallbackGroup::SharedPtr clock_callback_group_;
   rclcpp::executors::SingleThreadedExecutor::SharedPtr clock_executor_;
   std::promise<void> cancel_clock_executor_promise_;

--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -21,7 +21,6 @@
 #include <future>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -45,6 +44,7 @@
 #include "rclcpp_action/types.hpp"
 #include "rclcpp_action/visibility_control.hpp"
 
+#include "rcpputils/mutex.hpp"
 
 namespace rclcpp_action
 {
@@ -755,7 +755,7 @@ private:
   }
 
   std::map<GoalUUID, typename GoalHandle::WeakPtr> goal_handles_;
-  std::mutex goal_handles_mutex_;
+  rcpputils::PIMutex goal_handles_mutex_;
 };
 }  // namespace rclcpp_action
 

--- a/rclcpp_action/include/rclcpp_action/client_goal_handle.hpp
+++ b/rclcpp_action/include/rclcpp_action/client_goal_handle.hpp
@@ -18,7 +18,6 @@
 #include <functional>
 #include <future>
 #include <memory>
-#include <mutex>
 
 #include "rcl_action/action_client.h"
 
@@ -29,6 +28,8 @@
 #include "rclcpp_action/exceptions.hpp"
 #include "rclcpp_action/types.hpp"
 #include "rclcpp_action/visibility_control.hpp"
+
+#include "rcpputils/mutex.hpp"
 
 namespace rclcpp_action
 {
@@ -163,7 +164,7 @@ private:
   ResultCallback result_callback_{nullptr};
   int8_t status_{GoalStatus::STATUS_ACCEPTED};
 
-  std::mutex handle_mutex_;
+  rcpputils::PIMutex handle_mutex_;
 };
 }  // namespace rclcpp_action
 

--- a/rclcpp_action/include/rclcpp_action/server.hpp
+++ b/rclcpp_action/include/rclcpp_action/server.hpp
@@ -17,7 +17,6 @@
 
 #include <functional>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -30,6 +29,7 @@
 #include "rclcpp/node_interfaces/node_clock_interface.hpp"
 #include "rclcpp/node_interfaces/node_logging_interface.hpp"
 #include "rclcpp/waitable.hpp"
+#include "rcpputils/mutex.hpp"
 
 #include "rclcpp_action/visibility_control.hpp"
 #include "rclcpp_action/server_goal_handle.hpp"
@@ -564,7 +564,7 @@ private:
   /// A map of goal id to goal handle weak pointers.
   /// This is used to provide a goal handle to handle_cancel.
   std::unordered_map<GoalUUID, GoalHandleWeakPtr> goal_handles_;
-  std::mutex goal_handles_mutex_;
+  rcpputils::PIMutex goal_handles_mutex_;
 };
 }  // namespace rclcpp_action
 #endif  // RCLCPP_ACTION__SERVER_HPP_

--- a/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
+++ b/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
@@ -17,7 +17,6 @@
 
 #include <functional>
 #include <memory>
-#include <mutex>
 
 #include "rcl_action/types.h"
 #include "rcl_action/goal_handle.h"
@@ -26,6 +25,8 @@
 
 #include "rclcpp_action/visibility_control.hpp"
 #include "rclcpp_action/types.hpp"
+
+#include "rcpputils/mutex.hpp"
 
 namespace rclcpp_action
 {
@@ -113,7 +114,7 @@ protected:
 
 private:
   std::shared_ptr<rcl_action_goal_handle_t> rcl_handle_;
-  mutable std::mutex rcl_handle_mutex_;
+  mutable rcpputils::PIMutex rcl_handle_mutex_;
 };
 
 // Forward declare server

--- a/rclcpp_action/src/client.cpp
+++ b/rclcpp_action/src/client.cpp
@@ -22,11 +22,14 @@
 
 #include "rcl_action/action_client.h"
 #include "rcl_action/wait.h"
+
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/node_interfaces/node_logging_interface.hpp"
 
 #include "rclcpp_action/client.hpp"
 #include "rclcpp_action/exceptions.hpp"
+
+#include "rcpputils/mutex.hpp"
 
 namespace rclcpp_action
 {
@@ -110,13 +113,13 @@ public:
   using ResponseCallback = std::function<void (std::shared_ptr<void> response)>;
 
   std::map<int64_t, ResponseCallback> pending_goal_responses;
-  std::mutex goal_requests_mutex;
+  rcpputils::PIMutex goal_requests_mutex;
 
   std::map<int64_t, ResponseCallback> pending_result_responses;
-  std::mutex result_requests_mutex;
+  rcpputils::PIMutex result_requests_mutex;
 
   std::map<int64_t, ResponseCallback> pending_cancel_responses;
-  std::mutex cancel_requests_mutex;
+  rcpputils::PIMutex cancel_requests_mutex;
 
   std::independent_bits_engine<
     std::default_random_engine, 8, unsigned int> random_bytes_generator;


### PR DESCRIPTION
The content of this pull request ensures that rclcpp will not have priority inversions when using hard realtime scheduling, i.e. FIFO scheduling as defined in the POSIX standard. This is achieved by replacing std::mutex with rclcpp::PIMutex and std::recursive_mutex with rclcpp::RecursivePIMutex. To compile this pull request the following pull requests for rcutils and rcpputils are required:
https://github.com/ros2/rcpputils/pull/174
https://github.com/ros2/rcutils/pull/406

The code changes in this pull request should not effect the runtime behavior of existing ROS2 projects in a negative way. In case that a project uses ordinary fair/non-realtime thread scheduling it should behave as before.

In case this pull request gets accepted other ROS2 components can be made priority inversion safe in the manner which was demonstrated here. This will make ROS2 more suitable for hard realtime scenarios.
