### PR TITLE
Fix -Wmaybe-uninitialized warning

### DIFF
--- a/rclcpp/include/rclcpp/context.hpp
+++ b/rclcpp/include/rclcpp/context.hpp
@@ -398,20 +398,22 @@ private:
 
   using ShutdownCallback = ShutdownCallbackHandle::ShutdownCallbackType;
 
+  template<ShutdownType shutdown_type>
   RCLCPP_LOCAL
   ShutdownCallbackHandle
   add_shutdown_callback(
-    ShutdownType shutdown_type,
     ShutdownCallback callback);
 
+  template<ShutdownType shutdown_type>
   RCLCPP_LOCAL
   bool
   remove_shutdown_callback(
-    ShutdownType shutdown_type,
     const ShutdownCallbackHandle & callback_handle);
 
+  template<ShutdownType shutdown_type>
+  RCLCPP_LOCAL
   std::vector<rclcpp::Context::ShutdownCallback>
-  get_shutdown_callback(ShutdownType shutdown_type) const;
+  get_shutdown_callback() const;
 };
 
 /// Return a copy of the list of context shared pointers.

--- a/rclcpp/src/rclcpp/context.cpp
+++ b/rclcpp/src/rclcpp/context.cpp
@@ -365,49 +365,45 @@ Context::on_shutdown(OnShutdownCallback callback)
 rclcpp::OnShutdownCallbackHandle
 Context::add_on_shutdown_callback(OnShutdownCallback callback)
 {
-  return add_shutdown_callback(ShutdownType::on_shutdown, callback);
+  return add_shutdown_callback<ShutdownType::on_shutdown>(callback);
 }
 
 bool
 Context::remove_on_shutdown_callback(const OnShutdownCallbackHandle & callback_handle)
 {
-  return remove_shutdown_callback(ShutdownType::on_shutdown, callback_handle);
+  return remove_shutdown_callback<ShutdownType::on_shutdown>(callback_handle);
 }
 
 rclcpp::PreShutdownCallbackHandle
 Context::add_pre_shutdown_callback(PreShutdownCallback callback)
 {
-  return add_shutdown_callback(ShutdownType::pre_shutdown, callback);
+  return add_shutdown_callback<ShutdownType::pre_shutdown>(callback);
 }
 
 bool
 Context::remove_pre_shutdown_callback(
   const PreShutdownCallbackHandle & callback_handle)
 {
-  return remove_shutdown_callback(ShutdownType::pre_shutdown, callback_handle);
+  return remove_shutdown_callback<ShutdownType::pre_shutdown>(callback_handle);
 }
 
+template<Context::ShutdownType shutdown_type>
 rclcpp::ShutdownCallbackHandle
 Context::add_shutdown_callback(
-  ShutdownType shutdown_type,
   ShutdownCallback callback)
 {
   auto callback_shared_ptr =
     std::make_shared<ShutdownCallbackHandle::ShutdownCallbackType>(callback);
 
-  switch (shutdown_type) {
-    case ShutdownType::pre_shutdown:
-      {
-        std::lock_guard<std::mutex> lock(pre_shutdown_callbacks_mutex_);
-        pre_shutdown_callbacks_.emplace(callback_shared_ptr);
-      }
-      break;
-    case ShutdownType::on_shutdown:
-      {
-        std::lock_guard<std::mutex> lock(on_shutdown_callbacks_mutex_);
-        on_shutdown_callbacks_.emplace(callback_shared_ptr);
-      }
-      break;
+  static_assert(
+    shutdown_type == ShutdownType::pre_shutdown || shutdown_type == ShutdownType::on_shutdown);
+
+  if constexpr (shutdown_type == ShutdownType::pre_shutdown) {
+    std::lock_guard<std::mutex> lock(pre_shutdown_callbacks_mutex_);
+    pre_shutdown_callbacks_.emplace(callback_shared_ptr);
+  } else {
+    std::lock_guard<std::mutex> lock(on_shutdown_callbacks_mutex_);
+    on_shutdown_callbacks_.emplace(callback_shared_ptr);
   }
 
   ShutdownCallbackHandle callback_handle;
@@ -415,73 +411,63 @@ Context::add_shutdown_callback(
   return callback_handle;
 }
 
+template<Context::ShutdownType shutdown_type>
 bool
 Context::remove_shutdown_callback(
-  ShutdownType shutdown_type,
   const ShutdownCallbackHandle & callback_handle)
 {
-  std::mutex * mutex_ptr = nullptr;
-  std::unordered_set<
-    std::shared_ptr<ShutdownCallbackHandle::ShutdownCallbackType>> * callback_list_ptr;
+  const auto remove_callback = [this, &callback_handle](auto & mutex, auto & callback_set) {
+      const std::lock_guard<std::mutex> lock(mutex);
+      const auto callback_shared_ptr = callback_handle.callback.lock();
+      if (callback_shared_ptr == nullptr) {
+        return false;
+      }
+      return callback_set.erase(callback_shared_ptr) == 1;
+    };
 
-  switch (shutdown_type) {
-    case ShutdownType::pre_shutdown:
-      mutex_ptr = &pre_shutdown_callbacks_mutex_;
-      callback_list_ptr = &pre_shutdown_callbacks_;
-      break;
-    case ShutdownType::on_shutdown:
-      mutex_ptr = &on_shutdown_callbacks_mutex_;
-      callback_list_ptr = &on_shutdown_callbacks_;
-      break;
-  }
+  static_assert(
+    shutdown_type == ShutdownType::pre_shutdown || shutdown_type == ShutdownType::on_shutdown);
 
-  std::lock_guard<std::mutex> lock(*mutex_ptr);
-  auto callback_shared_ptr = callback_handle.callback.lock();
-  if (callback_shared_ptr == nullptr) {
-    return false;
+  if constexpr (shutdown_type == ShutdownType::pre_shutdown) {
+    return remove_callback(pre_shutdown_callbacks_mutex_, pre_shutdown_callbacks_);
+  } else {
+    return remove_callback(on_shutdown_callbacks_mutex_, on_shutdown_callbacks_);
   }
-  return callback_list_ptr->erase(callback_shared_ptr) == 1;
 }
 
 std::vector<rclcpp::Context::OnShutdownCallback>
 Context::get_on_shutdown_callbacks() const
 {
-  return get_shutdown_callback(ShutdownType::on_shutdown);
+  return get_shutdown_callback<ShutdownType::on_shutdown>();
 }
 
 std::vector<rclcpp::Context::PreShutdownCallback>
 Context::get_pre_shutdown_callbacks() const
 {
-  return get_shutdown_callback(ShutdownType::pre_shutdown);
+  return get_shutdown_callback<ShutdownType::pre_shutdown>();
 }
 
+template<Context::ShutdownType shutdown_type>
 std::vector<rclcpp::Context::ShutdownCallback>
-Context::get_shutdown_callback(ShutdownType shutdown_type) const
+Context::get_shutdown_callback() const
 {
-  std::mutex * mutex_ptr = nullptr;
-  const std::unordered_set<
-    std::shared_ptr<ShutdownCallbackHandle::ShutdownCallbackType>> * callback_list_ptr;
+  const auto get_callback_vector = [this](auto & mutex, auto & callback_set) {
+      const std::lock_guard<std::mutex> lock(mutex);
+      std::vector<rclcpp::Context::ShutdownCallback> callbacks;
+      for (auto & callback : callback_set) {
+        callbacks.push_back(*callback);
+      }
+      return callbacks;
+    };
 
-  switch (shutdown_type) {
-    case ShutdownType::pre_shutdown:
-      mutex_ptr = &pre_shutdown_callbacks_mutex_;
-      callback_list_ptr = &pre_shutdown_callbacks_;
-      break;
-    case ShutdownType::on_shutdown:
-      mutex_ptr = &on_shutdown_callbacks_mutex_;
-      callback_list_ptr = &on_shutdown_callbacks_;
-      break;
+  static_assert(
+    shutdown_type == ShutdownType::pre_shutdown || shutdown_type == ShutdownType::on_shutdown);
+
+  if constexpr (shutdown_type == ShutdownType::pre_shutdown) {
+    return get_callback_vector(pre_shutdown_callbacks_mutex_, pre_shutdown_callbacks_);
+  } else {
+    return get_callback_vector(on_shutdown_callbacks_mutex_, on_shutdown_callbacks_);
   }
-
-  std::vector<rclcpp::Context::ShutdownCallback> callbacks;
-  {
-    std::lock_guard<std::mutex> lock(*mutex_ptr);
-    for (auto & iter : *callback_list_ptr) {
-      callbacks.emplace_back(*iter);
-    }
-  }
-
-  return callbacks;
 }
 
 std::shared_ptr<rcl_context_t>

--- a/rclcpp/src/rclcpp/context.cpp
+++ b/rclcpp/src/rclcpp/context.cpp
@@ -416,12 +416,13 @@ bool
 Context::remove_shutdown_callback(
   const ShutdownCallbackHandle & callback_handle)
 {
-  const auto remove_callback = [this, &callback_handle](auto & mutex, auto & callback_set) {
+  const auto callback_shared_ptr = callback_handle.callback.lock();
+  if (callback_shared_ptr == nullptr) {
+    return false;
+  }
+
+  const auto remove_callback = [this, &callback_shared_ptr](auto & mutex, auto & callback_set) {
       const std::lock_guard<std::mutex> lock(mutex);
-      const auto callback_shared_ptr = callback_handle.callback.lock();
-      if (callback_shared_ptr == nullptr) {
-        return false;
-      }
       return callback_set.erase(callback_shared_ptr) == 1;
     };
 


### PR DESCRIPTION
gcc 12 warns about this when compiling in release mode (i.e., with `-O2`):

```
In file included from /usr/include/c++/12/unordered_map:46,
                 from /usr/include/c++/12/functional:61,
                 from /home/ahans/src/ros2_rolling/src/ros2/rclcpp/rclcpp/include/rclcpp/context.hpp:19,
                 from /home/ahans/src/ros2_rolling/src/ros2/rclcpp/rclcpp/src/rclcpp/context.cpp:15:
In member function ‘std::_Hashtable<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::iterator std::_Hashtable<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::_M_erase(size_type, __node_base_ptr, __node_ptr) [with _Key = std::shared_ptr<std::function<void()> >; _Value = std::shared_ptr<std::function<void()> >; _Alloc = std::allocator<std::shared_ptr<std::function<void()> > >; _ExtractKey = std::__detail::_Identity; _Equal = std::equal_to<std::shared_ptr<std::function<void()> > >; _Hash = std::hash<std::shared_ptr<std::function<void()> > >; _RangeHash = std::__detail::_Mod_range_hashing; _Unused = std::__detail::_Default_ranged_hash; _RehashPolicy = std::__detail::_Prime_rehash_policy; _Traits = std::__detail::_Hashtable_traits<false, true, true>]’,
    inlined from ‘std::_Hashtable<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::size_type std::_Hashtable<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::_M_erase(std::true_type, const key_type&) [with _Key = std::shared_ptr<std::function<void()> >; _Value = std::shared_ptr<std::function<void()> >; _Alloc = std::allocator<std::shared_ptr<std::function<void()> > >; _ExtractKey = std::__detail::_Identity; _Equal = std::equal_to<std::shared_ptr<std::function<void()> > >; _Hash = std::hash<std::shared_ptr<std::function<void()> > >; _RangeHash = std::__detail::_Mod_range_hashing; _Unused = std::__detail::_Default_ranged_hash; _RehashPolicy = std::__detail::_Prime_rehash_policy; _Traits = std::__detail::_Hashtable_traits<false, true, true>]’ at /usr/include/c++/12/bits/hashtable.h:2372:15,
    inlined from ‘std::_Hashtable<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::size_type std::_Hashtable<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::erase(const key_type&) [with _Key = std::shared_ptr<std::function<void()> >; _Value = std::shared_ptr<std::function<void()> >; _Alloc = std::allocator<std::shared_ptr<std::function<void()> > >; _ExtractKey = std::__detail::_Identity; _Equal = std::equal_to<std::shared_ptr<std::function<void()> > >; _Hash = std::hash<std::shared_ptr<std::function<void()> > >; _RangeHash = std::__detail::_Mod_range_hashing; _Unused = std::__detail::_Default_ranged_hash; _RehashPolicy = std::__detail::_Prime_rehash_policy; _Traits = std::__detail::_Hashtable_traits<false, true, true>]’ at /usr/include/c++/12/bits/hashtable.h:973:24,
    inlined from ‘std::unordered_set<_Value, _Hash, _Pred, _Alloc>::size_type std::unordered_set<_Value, _Hash, _Pred, _Alloc>::erase(const key_type&) [with _Value = std::shared_ptr<std::function<void()> >; _Hash = std::hash<std::shared_ptr<std::function<void()> > >; _Pred = std::equal_to<std::shared_ptr<std::function<void()> > >; _Alloc = std::allocator<std::shared_ptr<std::function<void()> > >]’ at /usr/include/c++/12/bits/unordered_set.h:546:26,
    inlined from ‘bool rclcpp::Context::remove_shutdown_callback(ShutdownType, const rclcpp::ShutdownCallbackHandle&)’ at /home/ahans/src/ros2_rolling/src/ros2/rclcpp/rclcpp/src/rclcpp/context.cpp:443:34:
/usr/include/c++/12/bits/hashtable.h:2330:9: warning: ‘callback_list_ptr’ may be used uninitialized [-Wmaybe-uninitialized]
 2330 |       --_M_element_count;
      |         ^~~~~~~~~~~~~~~~
/home/ahans/src/ros2_rolling/src/ros2/rclcpp/rclcpp/src/rclcpp/context.cpp: In member function ‘bool rclcpp::Context::remove_shutdown_callback(ShutdownType, const rclcpp::ShutdownCallbackHandle&)’:
/home/ahans/src/ros2_rolling/src/ros2/rclcpp/rclcpp/src/rclcpp/context.cpp:425:70: note: ‘callback_list_ptr’ was declared here
  425 |     std::shared_ptr<ShutdownCallbackHandle::ShutdownCallbackType>> * callback_list_ptr;
      |                                                                      ^~~~~~~~~~~~~~~~~
In member function ‘std::_Hashtable<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::__node_ptr std::_Hashtable<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::_M_begin() const [with _Key = std::shared_ptr<std::function<void()> >; _Value = std::shared_ptr<std::function<void()> >; _Alloc = std::allocator<std::shared_ptr<std::function<void()> > >; _ExtractKey = std::__detail::_Identity; _Equal = std::equal_to<std::shared_ptr<std::function<void()> > >; _Hash = std::hash<std::shared_ptr<std::function<void()> > >; _RangeHash = std::__detail::_Mod_range_hashing; _Unused = std::__detail::_Default_ranged_hash; _RehashPolicy = std::__detail::_Prime_rehash_policy; _Traits = std::__detail::_Hashtable_traits<false, true, true>]’,
    inlined from ‘std::_Hashtable<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::const_iterator std::_Hashtable<_Key, _Value, _Alloc, _ExtractKey, _Equal, _Hash, _RangeHash, _Unused, _RehashPolicy, _Traits>::begin() const [with _Key = std::shared_ptr<std::function<void()> >; _Value = std::shared_ptr<std::function<void()> >; _Alloc = std::allocator<std::shared_ptr<std::function<void()> > >; _ExtractKey = std::__detail::_Identity; _Equal = std::equal_to<std::shared_ptr<std::function<void()> > >; _Hash = std::hash<std::shared_ptr<std::function<void()> > >; _RangeHash = std::__detail::_Mod_range_hashing; _Unused = std::__detail::_Default_ranged_hash; _RehashPolicy = std::__detail::_Prime_rehash_policy; _Traits = std::__detail::_Hashtable_traits<false, true, true>]’ at /usr/include/c++/12/bits/hashtable.h:629:16,
    inlined from ‘std::unordered_set<_Value, _Hash, _Pred, _Alloc>::const_iterator std::unordered_set<_Value, _Hash, _Pred, _Alloc>::begin() const [with _Value = std::shared_ptr<std::function<void()> >; _Hash = std::hash<std::shared_ptr<std::function<void()> > >; _Pred = std::equal_to<std::shared_ptr<std::function<void()> > >; _Alloc = std::allocator<std::shared_ptr<std::function<void()> > >]’ at /usr/include/c++/12/bits/unordered_set.h:325:26,
    inlined from ‘std::vector<std::function<void()> > rclcpp::Context::get_shutdown_callback(ShutdownType) const’ at /home/ahans/src/ros2_rolling/src/ros2/rclcpp/rclcpp/src/rclcpp/context.cpp:479:25:
/usr/include/c++/12/bits/hashtable.h:466:62: warning: ‘callback_list_ptr’ may be used uninitialized [-Wmaybe-uninitialized]
  466 |       { return static_cast<__node_ptr>(_M_before_begin._M_nxt); }
      |                                                              ^
/home/ahans/src/ros2_rolling/src/ros2/rclcpp/rclcpp/src/rclcpp/context.cpp: In member function ‘std::vector<std::function<void()> > rclcpp::Context::get_shutdown_callback(ShutdownType) const’:
/home/ahans/src/ros2_rolling/src/ros2/rclcpp/rclcpp/src/rclcpp/context.cpp:463:70: note: ‘callback_list_ptr’ was declared here
  463 |     std::shared_ptr<ShutdownCallbackHandle::ShutdownCallbackType>> * callback_list_ptr;
```