### PR TITLE
Add rclcpp::RosTime

### DIFF
--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -210,7 +210,7 @@ public:
   rcl_clock_type_t
   get_clock_type() const;
 
-private:
+protected:
   rcl_time_point_t rcl_time_;
   friend Clock;  // Allow clock to manipulate internal data
 };
@@ -221,6 +221,56 @@ private:
 RCLCPP_PUBLIC
 Time
 operator+(const rclcpp::Duration & lhs, const rclcpp::Time & rhs);
+
+/// Time class that always uses ROS time
+class RosTime : public Time
+{
+  public:
+  /// Time constructor
+  /**
+   * Initializes the time values for seconds and nanoseconds individually.
+   * Large values for nanoseconds are wrapped automatically with the remainder added to seconds.
+   * Both inputs must be integers.
+   *
+   * \param seconds part of the time in seconds since time epoch
+   * \param nanoseconds part of the time in nanoseconds since time epoch
+   * \throws std::runtime_error if seconds are negative
+   */
+  RCLCPP_PUBLIC
+  explicit RosTime(int32_t seconds, uint32_t nanoseconds = 0) : Time(seconds, nanoseconds, RCL_ROS_TIME) {}
+
+  /// Construct from non-ros time
+  RCLCPP_PUBLIC
+  explicit RosTime(const Time & rhs);
+
+  /// RosTime constructor
+  /**
+   * \param time_msg builtin_interfaces time message to copy
+   * \throws std::runtime_error if seconds are negative
+   */
+  RCLCPP_PUBLIC
+  RosTime(const builtin_interfaces::msg::Time & time_msg) : Time(time_msg, RCL_ROS_TIME) {}
+
+  /// Time constructor
+  /**
+   * \param time_point rcl_time_point_t structure to copy
+   * \throws std::runtime_error if clock type 
+   */
+  RCLCPP_PUBLIC
+  explicit RosTime(const rcl_time_point_t & time_point);
+
+  /// Destructor
+  RCLCPP_PUBLIC
+  virtual ~RosTime();
+
+  /**
+   * \throws std::runtime_error if seconds are negative
+   * \throws std::runtime_error if rhs clock type is not RCL_ROS_TIME
+   */
+  RCLCPP_PUBLIC
+  RosTime &
+  operator=(const Time & rhs);
+};
 
 }  // namespace rclcpp
 

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -226,7 +226,7 @@ operator+(const rclcpp::Duration & lhs, const rclcpp::Time & rhs);
 class RosTime : public Time
 {
 public:
-  /// Time constructor
+  /// RosTime constructor
   /**
    * Initializes the time values for seconds and nanoseconds individually.
    * Large values for nanoseconds are wrapped automatically with the remainder added to seconds.
@@ -253,7 +253,7 @@ public:
   explicit RosTime(const builtin_interfaces::msg::Time & time_msg)
   : Time(time_msg, RCL_ROS_TIME) {}
 
-  /// Time constructor
+  /// RosTime constructor
   /**
    * \param time_point rcl_time_point_t structure to copy
    * \throws std::runtime_error if clock type
@@ -261,7 +261,7 @@ public:
   RCLCPP_PUBLIC
   explicit RosTime(const rcl_time_point_t & time_point);
 
-  /// Destructor
+  /// RosTime Destructor
   RCLCPP_PUBLIC
   virtual ~RosTime();
 

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -225,7 +225,7 @@ operator+(const rclcpp::Duration & lhs, const rclcpp::Time & rhs);
 /// Time class that always uses ROS time
 class RosTime : public Time
 {
-  public:
+public:
   /// Time constructor
   /**
    * Initializes the time values for seconds and nanoseconds individually.
@@ -237,7 +237,8 @@ class RosTime : public Time
    * \throws std::runtime_error if seconds are negative
    */
   RCLCPP_PUBLIC
-  explicit RosTime(int32_t seconds, uint32_t nanoseconds = 0) : Time(seconds, nanoseconds, RCL_ROS_TIME) {}
+  explicit RosTime(int32_t seconds, uint32_t nanoseconds = 0)
+  : Time(seconds, nanoseconds, RCL_ROS_TIME) {}
 
   /// Construct from non-ros time
   RCLCPP_PUBLIC
@@ -249,12 +250,13 @@ class RosTime : public Time
    * \throws std::runtime_error if seconds are negative
    */
   RCLCPP_PUBLIC
-  RosTime(const builtin_interfaces::msg::Time & time_msg) : Time(time_msg, RCL_ROS_TIME) {}
+  explicit RosTime(const builtin_interfaces::msg::Time & time_msg)
+  : Time(time_msg, RCL_ROS_TIME) {}
 
   /// Time constructor
   /**
    * \param time_point rcl_time_point_t structure to copy
-   * \throws std::runtime_error if clock type 
+   * \throws std::runtime_error if clock type
    */
   RCLCPP_PUBLIC
   explicit RosTime(const rcl_time_point_t & time_point);

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -282,4 +282,35 @@ Time::max()
 }
 
 
+RosTime::RosTime(const rcl_time_point_t & time_point)
+{
+  if (RCL_ROS_TIME != time_point.clock_type) {
+    throw std::runtime_error("RosTime requires a clock type of RCL_ROS_TIME");
+  }
+  rcl_time_ = time_point;
+}
+
+RosTime::RosTime(const Time &other)
+{
+  if (RCL_ROS_TIME != other.get_clock_type()) {
+    throw std::runtime_error("RosTime requires a clock type of RCL_ROS_TIME");
+  }
+  rcl_time_.clock_type = RCL_ROS_TIME;
+  rcl_time_.nanoseconds = other.nanoseconds();
+}
+
+RosTime::~RosTime()
+{
+}
+
+RosTime &
+RosTime::operator=(const Time & rhs)
+{
+  if (RCL_ROS_TIME != rhs.get_clock_type()) {
+    throw std::runtime_error("RosTime requires a clock type of RCL_ROS_TIME");
+  }
+  rcl_time_.nanoseconds = rhs.nanoseconds();
+  return *this;
+}
+
 }  // namespace rclcpp

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -290,7 +290,7 @@ RosTime::RosTime(const rcl_time_point_t & time_point)
   rcl_time_ = time_point;
 }
 
-RosTime::RosTime(const Time &other)
+RosTime::RosTime(const Time & other)
 {
   if (RCL_ROS_TIME != other.get_clock_type()) {
     throw std::runtime_error("RosTime requires a clock type of RCL_ROS_TIME");


### PR DESCRIPTION
This adds a class `rclcpp::RosTime`, which inherits from `rclcpp::Time`. The value it adds is that the clock type can only be `RCL_ROS_TIME`. This prevents exceptions due to comparisons with default constructed objects. It can also be used to make it clear an API only accepts `RCL_ROS_TIME`.


For motivation see:
* https://github.com/locusrobotics/fuse/pull/307