### PR TITLE
Allow != and == of Time objects with different sources

### DIFF
--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -100,9 +100,6 @@ public:
   Time &
   operator=(const builtin_interfaces::msg::Time & time_msg);
 
-  /**
-   * \throws std::runtime_error if the time sources are different
-   */
   RCLCPP_PUBLIC
   bool
   operator==(const rclcpp::Time & rhs) const;

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -116,11 +116,8 @@ Time::operator=(const builtin_interfaces::msg::Time & time_msg)
 bool
 Time::operator==(const rclcpp::Time & rhs) const
 {
-  if (rcl_time_.clock_type != rhs.rcl_time_.clock_type) {
-    throw std::runtime_error("can't compare times with different time sources");
-  }
-
-  return rcl_time_.nanoseconds == rhs.rcl_time_.nanoseconds;
+  return rcl_time_.clock_type == rhs.rcl_time_.clock_type &&
+         rcl_time_.nanoseconds == rhs.rcl_time_.nanoseconds;
 }
 
 bool

--- a/rclcpp/test/rclcpp/test_time.cpp
+++ b/rclcpp/test/rclcpp/test_time.cpp
@@ -234,8 +234,8 @@ TEST_F(TestTime, operators) {
   rclcpp::Time system_time(0, 0, RCL_SYSTEM_TIME);
   rclcpp::Time steady_time(0, 0, RCL_STEADY_TIME);
 
-  EXPECT_ANY_THROW((void)(system_time == steady_time));
-  EXPECT_ANY_THROW((void)(system_time != steady_time));
+  EXPECT_FALSE(system_time == steady_time);
+  EXPECT_TRUE(system_time != steady_time);
   EXPECT_ANY_THROW((void)(system_time <= steady_time));
   EXPECT_ANY_THROW((void)(system_time >= steady_time));
   EXPECT_ANY_THROW((void)(system_time < steady_time));
@@ -248,8 +248,8 @@ TEST_F(TestTime, operators) {
   rclcpp::Time now = system_clock.now();
   rclcpp::Time later = steady_clock.now();
 
-  EXPECT_ANY_THROW((void)(now == later));
-  EXPECT_ANY_THROW((void)(now != later));
+  EXPECT_FALSE(now == later);
+  EXPECT_TRUE(now != later);
   EXPECT_ANY_THROW((void)(now <= later));
   EXPECT_ANY_THROW((void)(now >= later));
   EXPECT_ANY_THROW((void)(now < later));


### PR DESCRIPTION
`rclcpp::Time` forbids comparisons between objects with different clock types. It raises an exception when that happens. This makes sense for `<`, `<=`, etc, but I think `==` and `!=` could be defined by saying `Time` objects with different clock types are never equal to each other.

I think this might simplify some of the logic for handling `Time` with different time sources here: https://github.com/locusrobotics/fuse/pull/307

@ros2/team thoughts?