### PR TITLE
Add tracing instrumentation for intra-process

### DIFF
--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -512,6 +512,10 @@ protected:
     if (!msg) {
       throw std::runtime_error("cannot publish msg which is a null pointer");
     }
+    TRACEPOINT(
+      rclcpp_intra_publish,
+      static_cast<const void *>(publisher_handle_.get()),
+      msg.get());
 
     ipm->template do_intra_process_publish<PublishedType, ROSMessageType, AllocatorT>(
       intra_process_publisher_id_,
@@ -530,6 +534,10 @@ protected:
     if (!msg) {
       throw std::runtime_error("cannot publish msg which is a null pointer");
     }
+    TRACEPOINT(
+      rclcpp_intra_publish,
+      static_cast<const void *>(publisher_handle_.get()),
+      msg.get());
 
     ipm->template do_intra_process_publish<ROSMessageType, ROSMessageType, AllocatorT>(
       intra_process_publisher_id_,
@@ -549,6 +557,10 @@ protected:
     if (!msg) {
       throw std::runtime_error("cannot publish msg which is a null pointer");
     }
+    TRACEPOINT(
+      rclcpp_intra_publish,
+      static_cast<const void *>(publisher_handle_.get()),
+      msg.get());
 
     return ipm->template do_intra_process_publish_and_return_shared<ROSMessageType, ROSMessageType,
              AllocatorT>(


### PR DESCRIPTION
## Overview
Hi, I'm a member of [CARET](https://github.com/tier4/caret) development team. We would like to officially support some tracepoints added by caret in the rclcpp fork and LD_PRELOAD.
The current tracetools do not support intra-process communication. This Pull Request adds tracing instrumentation to calculate the processing time from `publish` to `subscription callback`. These trace points are important in performance analysis. Processing that may become a bottleneck, such as strict time constraints or handling large data, often uses intra-process communication.