### PR TITLE
Add default constructor to NodeInterfaces

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/detail/node_interfaces_helpers.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/detail/node_interfaces_helpers.hpp
@@ -44,7 +44,7 @@ struct NodeInterfacesStorage
   : interfaces_(init_tuple<decltype(node), InterfaceTs ...>(node))
   {}
 
-  NodeInterfacesStorage()  // NOLINT(runtime/explicit)
+  NodeInterfacesStorage()
   : interfaces_()
   {}
 

--- a/rclcpp/include/rclcpp/node_interfaces/detail/node_interfaces_helpers.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/detail/node_interfaces_helpers.hpp
@@ -44,6 +44,10 @@ struct NodeInterfacesStorage
   : interfaces_(init_tuple<decltype(node), InterfaceTs ...>(node))
   {}
 
+  NodeInterfacesStorage()  // NOLINT(runtime/explicit)
+  : interfaces_()
+  {}
+
   explicit NodeInterfacesStorage(std::shared_ptr<InterfaceTs>... args)
   : interfaces_(args ...)
   {}

--- a/rclcpp/include/rclcpp/node_interfaces/node_interfaces.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_interfaces.hpp
@@ -147,6 +147,11 @@ public:
   : NodeInterfacesSupportsT(node)
   {}
 
+  // Create a NodeInterfaces object with no bound interfaces
+  NodeInterfaces()
+  : NodeInterfacesSupportsT()
+  {}
+
   explicit NodeInterfaces(std::shared_ptr<InterfaceTs>... args)
   : NodeInterfacesSupportsT(args ...)
   {}

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_interfaces.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_interfaces.cpp
@@ -33,6 +33,15 @@ protected:
   }
 };
 
+TEST_F(TestNodeInterfaces, default_constructor) {
+  auto node = std::make_shared<rclcpp::Node>("my_node");
+  using rclcpp::node_interfaces::NodeInterfaces;
+  using rclcpp::node_interfaces::NodeBaseInterface;
+  using rclcpp::node_interfaces::NodeGraphInterface;
+  NodeInterfaces<NodeBaseInterface, NodeGraphInterface> interfaces;
+  interfaces = NodeInterfaces<NodeBaseInterface, NodeGraphInterface>(*node);
+}
+
 /*
    Testing NodeInterfaces construction from nodes.
  */


### PR DESCRIPTION
This adds a default constructor. This allows a class to have an `interfaces` member that get's populated by an argument to it's constructor.