### PR TITLE
fixes for rmw callbacks in qos_event class

### DIFF
--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -214,10 +214,11 @@ protected:
   void
   set_on_new_event_callback(rcl_event_callback_t callback, const void * user_data);
 
-  rcl_event_t event_handle_;
-  size_t wait_set_event_index_;
   std::recursive_mutex callback_mutex_;
   std::function<void(size_t)> on_new_event_callback_{nullptr};
+
+  rcl_event_t event_handle_;
+  size_t wait_set_event_index_;
 };
 
 template<typename EventCallbackT, typename ParentHandleT>

--- a/rclcpp/src/rclcpp/qos_event.cpp
+++ b/rclcpp/src/rclcpp/qos_event.cpp
@@ -40,9 +40,7 @@ QOSEventHandlerBase::~QOSEventHandlerBase()
   // This clearing is not needed for other rclcpp entities like pub/subs, since
   // they do own the underlying rmw entities, which are destroyed
   // on their rclcpp destructors, thus no risk of dangling pointers.
-  if (on_new_event_callback_) {
-    clear_on_ready_callback();
-  }
+  clear_on_ready_callback();
 
   if (rcl_event_fini(&event_handle_) != RCL_RET_OK) {
     RCUTILS_LOG_ERROR_NAMED(


### PR DESCRIPTION
This PR contains a couple of small fixes:
 - reorder members declaration in `qos_event.hpp`. this follows the same logic applied in https://github.com/ros2/rclcpp/pull/2024
 - remove an unprotected read to `on_new_event_callback_`. the `clear_on_ready_callback` already checks if a callback exists and it does that under a mutex.


Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>