### PR TITLE
Revert "Fix memory leak in tracetools::get_symbol()"

### DIFF
--- a/rclcpp/include/rclcpp/any_service_callback.hpp
+++ b/rclcpp/include/rclcpp/any_service_callback.hpp
@@ -191,14 +191,10 @@ public:
 #ifndef TRACETOOLS_DISABLED
     std::visit(
       [this](auto && arg) {
-        if (TRACEPOINT_ENABLED(rclcpp_callback_register)) {
-          char * symbol = tracetools::get_symbol(arg);
-          DO_TRACEPOINT(
-            rclcpp_callback_register,
-            static_cast<const void *>(this),
-            symbol);
-          std::free(symbol);
-        }
+        TRACEPOINT(
+          rclcpp_callback_register,
+          static_cast<const void *>(this),
+          tracetools::get_symbol(arg));
       }, callback_);
 #endif  // TRACETOOLS_DISABLED
   }

--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -965,14 +965,10 @@ public:
 #ifndef TRACETOOLS_DISABLED
     std::visit(
       [this](auto && callback) {
-        if (TRACEPOINT_ENABLED(rclcpp_callback_register)) {
-          char * symbol = tracetools::get_symbol(callback);
-          DO_TRACEPOINT(
-            rclcpp_callback_register,
-            static_cast<const void *>(this),
-            symbol);
-          std::free(symbol);
-        }
+        TRACEPOINT(
+          rclcpp_callback_register,
+          static_cast<const void *>(this),
+          tracetools::get_symbol(callback));
       }, callback_variant_);
 #endif  // TRACETOOLS_DISABLED
   }

--- a/rclcpp/include/rclcpp/timer.hpp
+++ b/rclcpp/include/rclcpp/timer.hpp
@@ -227,16 +227,10 @@ public:
       rclcpp_timer_callback_added,
       static_cast<const void *>(get_timer_handle().get()),
       reinterpret_cast<const void *>(&callback_));
-#ifndef TRACETOOLS_DISABLED
-    if (TRACEPOINT_ENABLED(rclcpp_callback_register)) {
-      char * symbol = tracetools::get_symbol(callback_);
-      DO_TRACEPOINT(
-        rclcpp_callback_register,
-        reinterpret_cast<const void *>(&callback_),
-        symbol);
-      std::free(symbol);
-    }
-#endif
+    TRACEPOINT(
+      rclcpp_callback_register,
+      reinterpret_cast<const void *>(&callback_),
+      tracetools::get_symbol(callback_));
   }
 
   /// Default destructor.


### PR DESCRIPTION
Reverts ros2/rclcpp#2104