### PR TITLE
add get_fully_qualified_name to rclcpp_lifecycle

### DIFF
--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -172,6 +172,15 @@ public:
   const char *
   get_namespace() const;
 
+  /// Get the fully-qualified name of the node.
+  /**
+   * The fully-qualified name includes the local namespace and name of the node.
+   * \return fully-qualified name of the node.
+   */
+  RCLCPP_PUBLIC
+  const char *
+  get_fully_qualified_name() const;
+
   /// Get the logger of the node.
   /**
    * \return The logger of the node.

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -165,6 +165,12 @@ LifecycleNode::get_namespace() const
   return node_base_->get_namespace();
 }
 
+const char *
+LifecycleNode::get_fully_qualified_name() const
+{
+  return node_base_->get_fully_qualified_name();
+}
+
 rclcpp::Logger
 LifecycleNode::get_logger() const
 {

--- a/rclcpp_lifecycle/test/test_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_node.cpp
@@ -229,6 +229,7 @@ TEST_F(TestDefaultStateMachine, empty_initializer) {
   auto test_node = std::make_shared<EmptyLifecycleNode>("testnode");
   EXPECT_STREQ("testnode", test_node->get_name());
   EXPECT_STREQ("/", test_node->get_namespace());
+  EXPECT_STREQ("/testnode", test_node->get_fully_qualified_name());
   EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
 }
 


### PR DESCRIPTION
Self explanatory, directly lifted from the normal node to lifecycle