### PR TITLE
Make Rate to select the clock to work with

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -107,6 +107,7 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/qos.cpp
   src/rclcpp/event_handler.cpp
   src/rclcpp/qos_overriding_options.cpp
+  src/rclcpp/rate.cpp
   src/rclcpp/serialization.cpp
   src/rclcpp/serialized_message.cpp
   src/rclcpp/service.cpp

--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -39,17 +39,19 @@ public:
 };
 
 template<class Clock = std::chrono::high_resolution_clock>
-class [[deprecated("use rclcpp::Rate class instead of GenericRate")]] GenericRate : public RateBase
+class [[deprecated("use rclcpp::Rate class instead of GenericRate")]] GenericRate
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(GenericRate)
 
   explicit GenericRate(double) {}
   explicit GenericRate(std::chrono::nanoseconds) {}
+  virtual ~GenericRate() {}
 
   virtual bool sleep() {return false;}
-  virtual rcl_clock_type_t get_type() const {return RCL_CLOCK_UNINITIALIZED;}
+  virtual bool is_steady() const {return false;}
   virtual void reset() {}
+  std::chrono::nanoseconds period() const {return std::chrono::seconds(1);}
 };
 
 class Rate : public RateBase

--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -33,10 +33,19 @@ class RateBase
 public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(RateBase)
 
+  RCLCPP_PUBLIC
   virtual ~RateBase() {}
+
+  RCLCPP_PUBLIC
   virtual bool sleep() = 0;
+
+  RCLCPP_PUBLIC
   [[deprecated("use get_type() instead")]] virtual bool is_steady() const = 0;
+
+  RCLCPP_PUBLIC
   virtual rcl_clock_type_t get_type() const = 0;
+
+  RCLCPP_PUBLIC
   virtual void reset() = 0;
 };
 
@@ -120,32 +129,39 @@ private:
   std::chrono::time_point<Clock, ClockDurationNano> last_interval_;
 };
 
-class RCLCPP_PUBLIC Rate : public RateBase
+class Rate : public RateBase
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(Rate)
 
+  RCLCPP_PUBLIC
   explicit Rate(
     const double rate,
     Clock::SharedPtr clock = std::make_shared<Clock>(RCL_SYSTEM_TIME));
 
+  RCLCPP_PUBLIC
   explicit Rate(
     const Duration & period,
     Clock::SharedPtr clock = std::make_shared<Clock>(RCL_SYSTEM_TIME));
 
+  RCLCPP_PUBLIC
   virtual bool
   sleep();
 
+  RCLCPP_PUBLIC
   [[deprecated("use get_type() instead")]]
   virtual bool
   is_steady() const;
 
+  RCLCPP_PUBLIC
   virtual rcl_clock_type_t
   get_type() const;
 
+  RCLCPP_PUBLIC
   virtual void
   reset();
 
+  RCLCPP_PUBLIC
   Duration
   period() const;
 
@@ -157,17 +173,23 @@ private:
   Time last_interval_;
 };
 
-class RCLCPP_PUBLIC WallRate : public Rate
+class WallRate : public Rate
 {
 public:
+  RCLCPP_PUBLIC
   explicit WallRate(const double rate);
+
+  RCLCPP_PUBLIC
   explicit WallRate(const Duration & period);
 };
 
-class RCLCPP_PUBLIC ROSRate : public Rate
+class ROSRate : public Rate
 {
 public:
+  RCLCPP_PUBLIC
   explicit ROSRate(const double rate);
+
+  RCLCPP_PUBLIC
   explicit ROSRate(const Duration & period);
 };
 

--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -131,7 +131,7 @@ public:
   : clock_(clock), period_(0, 0), last_interval_(clock_->now())
   {
     if (rate <= 0.0) {
-      throw std::invalid_argument{"rate must greater than 0"};
+      throw std::invalid_argument{"rate must be greater than 0"};
     }
     period_ = Duration::from_seconds(1.0 / rate);
   }
@@ -141,7 +141,7 @@ public:
   : clock_(clock), period_(period), last_interval_(clock_->now())
   {
     if (period <= Duration(0, 0)) {
-      throw std::invalid_argument{"period must greater than 0"};
+      throw std::invalid_argument{"period must be greater than 0"};
     }
   }
 

--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -39,8 +39,9 @@ public:
   RCLCPP_PUBLIC
   virtual bool sleep() = 0;
 
+  [[deprecated("use get_type() instead")]]
   RCLCPP_PUBLIC
-  [[deprecated("use get_type() instead")]] virtual bool is_steady() const = 0;
+  virtual bool is_steady() const = 0;
 
   RCLCPP_PUBLIC
   virtual rcl_clock_type_t get_type() const = 0;
@@ -148,8 +149,8 @@ public:
   virtual bool
   sleep();
 
-  RCLCPP_PUBLIC
   [[deprecated("use get_type() instead")]]
+  RCLCPP_PUBLIC
   virtual bool
   is_steady() const;
 

--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -127,23 +127,11 @@ public:
 
   explicit Rate(
     const double rate,
-    Clock::SharedPtr clock = std::make_shared<Clock>(RCL_SYSTEM_TIME))
-  : clock_(clock), period_(0, 0), last_interval_(clock_->now())
-  {
-    if (rate <= 0.0) {
-      throw std::invalid_argument{"rate must be greater than 0"};
-    }
-    period_ = Duration::from_seconds(1.0 / rate);
-  }
+    Clock::SharedPtr clock = std::make_shared<Clock>(RCL_SYSTEM_TIME));
+
   explicit Rate(
     const Duration & period,
-    Clock::SharedPtr clock = std::make_shared<Clock>(RCL_SYSTEM_TIME))
-  : clock_(clock), period_(period), last_interval_(clock_->now())
-  {
-    if (period <= Duration(0, 0)) {
-      throw std::invalid_argument{"period must be greater than 0"};
-    }
-  }
+    Clock::SharedPtr clock = std::make_shared<Clock>(RCL_SYSTEM_TIME));
 
   virtual bool
   sleep();
@@ -172,25 +160,15 @@ private:
 class WallRate : public Rate
 {
 public:
-  explicit WallRate(const double rate)
-  : Rate(rate, std::make_shared<Clock>(RCL_STEADY_TIME))
-  {}
-
-  explicit WallRate(const Duration & period)
-  : Rate(period, std::make_shared<Clock>(RCL_STEADY_TIME))
-  {}
+  explicit WallRate(const double rate);
+  explicit WallRate(const Duration & period);
 };
 
 class ROSRate : public Rate
 {
 public:
-  explicit ROSRate(const double rate)
-  : Rate(rate, std::make_shared<Clock>(RCL_ROS_TIME))
-  {}
-
-  explicit ROSRate(const Duration & period)
-  : Rate(period, std::make_shared<Clock>(RCL_ROS_TIME))
-  {}
+  explicit ROSRate(const double rate);
+  explicit ROSRate(const Duration & period);
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -35,7 +35,7 @@ public:
 
   virtual ~RateBase() {}
   virtual bool sleep() = 0;
-  virtual bool is_steady() const = 0;
+  [[deprecated("use get_type() instead")]] virtual bool is_steady() const = 0;
   virtual rcl_clock_type_t get_type() const = 0;
   virtual void reset() = 0;
 };
@@ -45,7 +45,7 @@ using std::chrono::duration_cast;
 using std::chrono::nanoseconds;
 
 template<class Clock = std::chrono::high_resolution_clock>
-class [[deprecated("use rclcpp::Rate class instead of GenericRate")]] GenericRate
+class [[deprecated("use rclcpp::Rate class instead of GenericRate")]] GenericRate : public RateBase
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(GenericRate)
@@ -56,8 +56,6 @@ public:
   explicit GenericRate(std::chrono::nanoseconds period)
   : period_(period), last_interval_(Clock::now())
   {}
-
-  virtual ~GenericRate() {}
 
   virtual bool
   sleep()
@@ -91,10 +89,16 @@ public:
     return true;
   }
 
+  [[deprecated("use get_type() instead")]]
   virtual bool
   is_steady() const
   {
     return Clock::is_steady;
+  }
+
+  virtual rcl_clock_type_t get_type() const
+  {
+    return Clock::is_steady ? RCL_STEADY_TIME : RCL_SYSTEM_TIME;
   }
 
   virtual void
@@ -164,6 +168,7 @@ public:
     return clock_->sleep_for(time_to_sleep);
   }
 
+  [[deprecated("use get_type() instead")]]
   virtual bool
   is_steady() const
   {

--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -157,7 +157,7 @@ private:
   Time last_interval_;
 };
 
-class WallRate : public Rate
+class RCLCPP_PUBLIC WallRate : public Rate
 {
 public:
   explicit WallRate(const double rate);

--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -164,7 +164,7 @@ public:
   explicit WallRate(const Duration & period);
 };
 
-class ROSRate : public Rate
+class RCLCPP_PUBLIC ROSRate : public Rate
 {
 public:
   explicit ROSRate(const double rate);

--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -128,14 +128,22 @@ public:
   explicit Rate(
     const double rate,
     Clock::SharedPtr clock = std::make_shared<Clock>(RCL_SYSTEM_TIME))
-  : Rate(
-      Duration::from_seconds(1.0 / rate), clock)
-  {}
+  : clock_(clock), period_(0, 0), last_interval_(clock_->now())
+  {
+    if (rate <= 0.0) {
+      throw std::invalid_argument{"rate must greater than 0"};
+    }
+    period_ = Duration::from_seconds(1.0 / rate);
+  }
   explicit Rate(
     const Duration & period,
     Clock::SharedPtr clock = std::make_shared<Clock>(RCL_SYSTEM_TIME))
   : clock_(clock), period_(period), last_interval_(clock_->now())
-  {}
+  {
+    if (period <= Duration(0, 0)) {
+      throw std::invalid_argument{"period must greater than 0"};
+    }
+  }
 
   virtual bool
   sleep();

--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -17,6 +17,7 @@
 
 #include <chrono>
 #include <memory>
+#include <thread>
 
 #include "rclcpp/clock.hpp"
 #include "rclcpp/duration.hpp"
@@ -34,9 +35,14 @@ public:
 
   virtual ~RateBase() {}
   virtual bool sleep() = 0;
+  virtual bool is_steady() const = 0;
   virtual rcl_clock_type_t get_type() const = 0;
   virtual void reset() = 0;
 };
+
+using std::chrono::duration;
+using std::chrono::duration_cast;
+using std::chrono::nanoseconds;
 
 template<class Clock = std::chrono::high_resolution_clock>
 class [[deprecated("use rclcpp::Rate class instead of GenericRate")]] GenericRate
@@ -44,14 +50,70 @@ class [[deprecated("use rclcpp::Rate class instead of GenericRate")]] GenericRat
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(GenericRate)
 
-  explicit GenericRate(double) {}
-  explicit GenericRate(std::chrono::nanoseconds) {}
+  explicit GenericRate(double rate)
+  : period_(duration_cast<nanoseconds>(duration<double>(1.0 / rate))), last_interval_(Clock::now())
+  {}
+  explicit GenericRate(std::chrono::nanoseconds period)
+  : period_(period), last_interval_(Clock::now())
+  {}
+
   virtual ~GenericRate() {}
 
-  virtual bool sleep() {return false;}
-  virtual bool is_steady() const {return false;}
-  virtual void reset() {}
-  std::chrono::nanoseconds period() const {return std::chrono::seconds(1);}
+  virtual bool
+  sleep()
+  {
+    // Time coming into sleep
+    auto now = Clock::now();
+    // Time of next interval
+    auto next_interval = last_interval_ + period_;
+    // Detect backwards time flow
+    if (now < last_interval_) {
+      // Best thing to do is to set the next_interval to now + period
+      next_interval = now + period_;
+    }
+    // Calculate the time to sleep
+    auto time_to_sleep = next_interval - now;
+    // Update the interval
+    last_interval_ += period_;
+    // If the time_to_sleep is negative or zero, don't sleep
+    if (time_to_sleep <= std::chrono::seconds(0)) {
+      // If an entire cycle was missed then reset next interval.
+      // This might happen if the loop took more than a cycle.
+      // Or if time jumps forward.
+      if (now > next_interval + period_) {
+        last_interval_ = now + period_;
+      }
+      // Either way do not sleep and return false
+      return false;
+    }
+    // Sleep (will get interrupted by ctrl-c, may not sleep full time)
+    rclcpp::sleep_for(time_to_sleep);
+    return true;
+  }
+
+  virtual bool
+  is_steady() const
+  {
+    return Clock::is_steady;
+  }
+
+  virtual void
+  reset()
+  {
+    last_interval_ = Clock::now();
+  }
+
+  std::chrono::nanoseconds period() const
+  {
+    return period_;
+  }
+
+private:
+  RCLCPP_DISABLE_COPY(GenericRate)
+
+  std::chrono::nanoseconds period_;
+  using ClockDurationNano = std::chrono::duration<typename Clock::rep, std::nano>;
+  std::chrono::time_point<Clock, ClockDurationNano> last_interval_;
 };
 
 class Rate : public RateBase
@@ -99,8 +161,13 @@ public:
     // Calculate the time to sleep
     auto time_to_sleep = next_interval - now;
     // Sleep (will get interrupted by ctrl-c, may not sleep full time)
-    clock_->sleep_for(time_to_sleep);
-    return true;
+    return clock_->sleep_for(time_to_sleep);
+  }
+
+  virtual bool
+  is_steady() const
+  {
+    return clock_->get_clock_type() == RCL_STEADY_TIME;
   }
 
   virtual rcl_clock_type_t

--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -138,59 +138,20 @@ public:
   {}
 
   virtual bool
-  sleep()
-  {
-    // Time coming into sleep
-    auto now = clock_->now();
-    // Time of next interval
-    auto next_interval = last_interval_ + period_;
-    // Detect backwards time flow
-    if (now < last_interval_) {
-      // Best thing to do is to set the next_interval to now + period
-      next_interval = now + period_;
-    }
-    // Update the interval
-    last_interval_ += period_;
-    // If the time_to_sleep is negative or zero, don't sleep
-    if (next_interval <= now) {
-      // If an entire cycle was missed then reset next interval.
-      // This might happen if the loop took more than a cycle.
-      // Or if time jumps forward.
-      if (now > next_interval + period_) {
-        last_interval_ = now + period_;
-      }
-      // Either way do not sleep and return false
-      return false;
-    }
-    // Calculate the time to sleep
-    auto time_to_sleep = next_interval - now;
-    // Sleep (will get interrupted by ctrl-c, may not sleep full time)
-    return clock_->sleep_for(time_to_sleep);
-  }
+  sleep();
 
   [[deprecated("use get_type() instead")]]
   virtual bool
-  is_steady() const
-  {
-    return clock_->get_clock_type() == RCL_STEADY_TIME;
-  }
+  is_steady() const;
 
   virtual rcl_clock_type_t
-  get_type() const
-  {
-    return clock_->get_clock_type();
-  }
+  get_type() const;
 
   virtual void
-  reset()
-  {
-    last_interval_ = clock_->now();
-  }
+  reset();
 
-  Duration period() const
-  {
-    return period_;
-  }
+  Duration
+  period() const;
 
 private:
   RCLCPP_DISABLE_COPY(Rate)

--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -15,6 +15,7 @@
 #ifndef RCLCPP__RATE_HPP_
 #define RCLCPP__RATE_HPP_
 
+#include <chrono>
 #include <memory>
 
 #include "rclcpp/clock.hpp"
@@ -35,6 +36,20 @@ public:
   virtual bool sleep() = 0;
   virtual rcl_clock_type_t get_type() const = 0;
   virtual void reset() = 0;
+};
+
+template<class Clock = std::chrono::high_resolution_clock>
+class [[deprecated("use rclcpp::Rate class instead of GenericRate")]] GenericRate : public RateBase
+{
+public:
+  RCLCPP_SMART_PTR_DEFINITIONS(GenericRate)
+
+  explicit GenericRate(double) {}
+  explicit GenericRate(std::chrono::nanoseconds) {}
+
+  virtual bool sleep() {return false;}
+  virtual rcl_clock_type_t get_type() const {return RCL_CLOCK_UNINITIALIZED;}
+  virtual void reset() {}
 };
 
 class Rate : public RateBase
@@ -124,7 +139,6 @@ public:
 };
 
 class ROSRate : public Rate
-
 {
 public:
   explicit ROSRate(const double rate)

--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -120,7 +120,7 @@ private:
   std::chrono::time_point<Clock, ClockDurationNano> last_interval_;
 };
 
-class Rate : public RateBase
+class RCLCPP_PUBLIC Rate : public RateBase
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(Rate)

--- a/rclcpp/src/rclcpp/rate.cpp
+++ b/rclcpp/src/rclcpp/rate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014 Open Source Robotics Foundation, Inc.
+// Copyright 2023 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rclcpp/src/rclcpp/rate.cpp
+++ b/rclcpp/src/rclcpp/rate.cpp
@@ -1,0 +1,75 @@
+// Copyright 2014 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/rate.hpp"
+
+namespace rclcpp
+{
+
+bool
+Rate::sleep()
+{
+  // Time coming into sleep
+  auto now = clock_->now();
+  // Time of next interval
+  auto next_interval = last_interval_ + period_;
+  // Detect backwards time flow
+  if (now < last_interval_) {
+    // Best thing to do is to set the next_interval to now + period
+    next_interval = now + period_;
+  }
+  // Update the interval
+  last_interval_ += period_;
+  // If the time_to_sleep is negative or zero, don't sleep
+  if (next_interval <= now) {
+    // If an entire cycle was missed then reset next interval.
+    // This might happen if the loop took more than a cycle.
+    // Or if time jumps forward.
+    if (now > next_interval + period_) {
+      last_interval_ = now + period_;
+    }
+    // Either way do not sleep and return false
+    return false;
+  }
+  // Calculate the time to sleep
+  auto time_to_sleep = next_interval - now;
+  // Sleep (will get interrupted by ctrl-c, may not sleep full time)
+  return clock_->sleep_for(time_to_sleep);
+}
+
+bool
+Rate::is_steady() const
+{
+  return clock_->get_clock_type() == RCL_STEADY_TIME;
+}
+
+rcl_clock_type_t
+Rate::get_type() const
+{
+  return clock_->get_clock_type();
+}
+
+void
+Rate::reset()
+{
+  last_interval_ = clock_->now();
+}
+
+Duration
+Rate::period() const
+{
+  return period_;
+}
+
+}  // namespace rclcpp

--- a/rclcpp/src/rclcpp/rate.cpp
+++ b/rclcpp/src/rclcpp/rate.cpp
@@ -14,8 +14,29 @@
 
 #include "rclcpp/rate.hpp"
 
+#include <stdexcept>
+
 namespace rclcpp
 {
+
+Rate::Rate(
+  const double rate, Clock::SharedPtr clock)
+: clock_(clock), period_(0, 0), last_interval_(clock_->now())
+{
+  if (rate <= 0.0) {
+    throw std::invalid_argument{"rate must be greater than 0"};
+  }
+  period_ = Duration::from_seconds(1.0 / rate);
+}
+
+Rate::Rate(
+  const Duration & period, Clock::SharedPtr clock)
+: clock_(clock), period_(period), last_interval_(clock_->now())
+{
+  if (period <= Duration(0, 0)) {
+    throw std::invalid_argument{"period must be greater than 0"};
+  }
+}
 
 bool
 Rate::sleep()
@@ -71,5 +92,21 @@ Rate::period() const
 {
   return period_;
 }
+
+WallRate::WallRate(const double rate)
+: Rate(rate, std::make_shared<Clock>(RCL_STEADY_TIME))
+{}
+
+WallRate::WallRate(const Duration & period)
+: Rate(period, std::make_shared<Clock>(RCL_STEADY_TIME))
+{}
+
+ROSRate::ROSRate(const double rate)
+: Rate(rate, std::make_shared<Clock>(RCL_ROS_TIME))
+{}
+
+ROSRate::ROSRate(const Duration & period)
+: Rate(period, std::make_shared<Clock>(RCL_ROS_TIME))
+{}
 
 }  // namespace rclcpp

--- a/rclcpp/test/rclcpp/test_rate.cpp
+++ b/rclcpp/test/rclcpp/test_rate.cpp
@@ -398,3 +398,47 @@ TEST(TestRate, clock_types) {
     EXPECT_EQ(RCL_ROS_TIME, rate.get_type());
   }
 }
+
+TEST(TestRate, incorrect_constuctor) {
+  // Constructor with 0-frequency
+  try {
+    rclcpp::Rate rate(0.0);
+    FAIL() << "Rate with 0-frequency shouldn't be constructed\n";
+  } catch(const std::invalid_argument & ex) {
+    // Do nothing
+  } catch(const std::exception & ex) {
+    FAIL() << "Unexpected fail: " << ex.what() << "\n";
+  }
+
+  // Constructor with negative frequency
+  try {
+    rclcpp::Rate rate(-1.0);
+    FAIL() << "Rate with negative frequency shouldn't be constructed\n";
+  } catch(const std::invalid_argument & ex) {
+    // Do nothing
+  } catch(const std::exception & ex) {
+    FAIL() << "Unexpected fail: " << ex.what() << "\n";
+  }
+
+  // Constructor with 0-duration
+  try {
+    rclcpp::Duration d0(0, 0);
+    rclcpp::Rate rate(d0);
+    FAIL() << "Rate with 0-duration shouldn't be constructed\n";
+  } catch(const std::invalid_argument & ex) {
+    // Do nothing
+  } catch(const std::exception & ex) {
+    FAIL() << "Unexpected fail: " << ex.what() << "\n";
+  }
+
+  // Constructor with negative duration
+  try {
+    rclcpp::Duration dN(-1, 0);
+    rclcpp::Rate rate(dN);
+    FAIL() << "Rate with negative duraiton shouldn't be constructed\n";
+  } catch(const std::invalid_argument & ex) {
+    // Do nothing
+  } catch(const std::exception & ex) {
+    FAIL() << "Unexpected fail: " << ex.what() << "\n";
+  }
+}

--- a/rclcpp/test/rclcpp/test_rate.cpp
+++ b/rclcpp/test/rclcpp/test_rate.cpp
@@ -210,7 +210,8 @@ TEST(TestRate, generic_rate_api) {
 #endif
 
     ASSERT_FALSE(gr.sleep());
-    ASSERT_EQ(RCL_CLOCK_UNINITIALIZED, gr.get_type());
+    ASSERT_FALSE(gr.is_steady());
+    ASSERT_EQ(std::chrono::seconds(1), gr.period());
   }
 
   {
@@ -233,6 +234,7 @@ TEST(TestRate, generic_rate_api) {
 #endif
 
     ASSERT_FALSE(gr.sleep());
-    ASSERT_EQ(RCL_CLOCK_UNINITIALIZED, gr.get_type());
+    ASSERT_FALSE(gr.is_steady());
+    ASSERT_EQ(std::chrono::seconds(1), gr.period());
   }
 }

--- a/rclcpp/test/rclcpp/test_rate.cpp
+++ b/rclcpp/test/rclcpp/test_rate.cpp
@@ -32,7 +32,21 @@ TEST(TestRate, rate_basics) {
   auto start = std::chrono::system_clock::now();
   rclcpp::Rate r(period);
   EXPECT_EQ(rclcpp::Duration(period), r.period());
+// suppress deprecated warnings
+#if !defined(_WIN32)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else  // !defined(_WIN32)
+# pragma warning(push)
+# pragma warning(disable: 4996)
+#endif
   ASSERT_FALSE(r.is_steady());
+// remove warning suppression
+#if !defined(_WIN32)
+# pragma GCC diagnostic pop
+#else  // !defined(_WIN32)
+# pragma warning(pop)
+#endif
   ASSERT_EQ(RCL_SYSTEM_TIME, r.get_type());
   ASSERT_TRUE(r.sleep());
   auto one = std::chrono::system_clock::now();
@@ -77,7 +91,23 @@ TEST(TestRate, wall_rate_basics) {
   auto start = std::chrono::steady_clock::now();
   rclcpp::WallRate r(period);
   EXPECT_EQ(rclcpp::Duration(period), r.period());
+// suppress deprecated warnings
+#if !defined(_WIN32)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else  // !defined(_WIN32)
+# pragma warning(push)
+# pragma warning(disable: 4996)
+#endif
   ASSERT_TRUE(r.is_steady());
+// suppress deprecated warnings
+#if !defined(_WIN32)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else  // !defined(_WIN32)
+# pragma warning(push)
+# pragma warning(disable: 4996)
+#endif
   ASSERT_EQ(RCL_STEADY_TIME, r.get_type());
   ASSERT_TRUE(r.sleep());
   auto one = std::chrono::steady_clock::now();
@@ -124,7 +154,23 @@ TEST(TestRate, ros_rate_basics) {
   auto start = clock.now();
   rclcpp::ROSRate r(period);
   EXPECT_EQ(rclcpp::Duration(period), r.period());
+// suppress deprecated warnings
+#if !defined(_WIN32)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else  // !defined(_WIN32)
+# pragma warning(push)
+# pragma warning(disable: 4996)
+#endif
   ASSERT_FALSE(r.is_steady());
+// suppress deprecated warnings
+#if !defined(_WIN32)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else  // !defined(_WIN32)
+# pragma warning(push)
+# pragma warning(disable: 4996)
+#endif
   ASSERT_EQ(RCL_ROS_TIME, r.get_type());
   ASSERT_TRUE(r.sleep());
   auto one = clock.now();
@@ -170,7 +216,7 @@ TEST(TestRate, generic_rate) {
   {
     auto start = std::chrono::system_clock::now();
 
-// suppress deprecated function warning
+// suppress deprecated warnings
 #if !defined(_WIN32)
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -180,6 +226,7 @@ TEST(TestRate, generic_rate) {
 #endif
 
     rclcpp::GenericRate<std::chrono::system_clock> gr(period);
+    ASSERT_FALSE(gr.is_steady());
 
 // remove warning suppression
 #if !defined(_WIN32)
@@ -189,7 +236,6 @@ TEST(TestRate, generic_rate) {
 #endif
 
     EXPECT_EQ(period, gr.period());
-    ASSERT_FALSE(gr.is_steady());
     ASSERT_TRUE(gr.sleep());
     auto one = std::chrono::system_clock::now();
     auto delta = one - start;
@@ -223,7 +269,7 @@ TEST(TestRate, generic_rate) {
   {
     auto start = std::chrono::steady_clock::now();
 
-// suppress deprecated function warning
+// suppress deprecated warnings
 #if !defined(_WIN32)
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -233,6 +279,7 @@ TEST(TestRate, generic_rate) {
 #endif
 
     rclcpp::GenericRate<std::chrono::steady_clock> gr(period);
+    ASSERT_TRUE(gr.is_steady());
 
 // remove warning suppression
 #if !defined(_WIN32)
@@ -242,7 +289,6 @@ TEST(TestRate, generic_rate) {
 #endif
 
     EXPECT_EQ(period, gr.period());
-    ASSERT_TRUE(gr.is_steady());
     ASSERT_TRUE(gr.sleep());
     auto one = std::chrono::steady_clock::now();
     auto delta = one - start;
@@ -296,17 +342,59 @@ TEST(TestRate, from_double) {
 TEST(TestRate, clock_types) {
   {
     rclcpp::Rate rate(1.0, std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME));
+// suppress deprecated warnings
+#if !defined(_WIN32)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else  // !defined(_WIN32)
+# pragma warning(push)
+# pragma warning(disable: 4996)
+#endif
     EXPECT_FALSE(rate.is_steady());
+// remove warning suppression
+#if !defined(_WIN32)
+# pragma GCC diagnostic pop
+#else  // !defined(_WIN32)
+# pragma warning(pop)
+#endif
     EXPECT_EQ(RCL_SYSTEM_TIME, rate.get_type());
   }
   {
     rclcpp::Rate rate(1.0, std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME));
+// suppress deprecated warnings
+#if !defined(_WIN32)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else  // !defined(_WIN32)
+# pragma warning(push)
+# pragma warning(disable: 4996)
+#endif
     EXPECT_TRUE(rate.is_steady());
+// remove warning suppression
+#if !defined(_WIN32)
+# pragma GCC diagnostic pop
+#else  // !defined(_WIN32)
+# pragma warning(pop)
+#endif
     EXPECT_EQ(RCL_STEADY_TIME, rate.get_type());
   }
   {
     rclcpp::Rate rate(1.0, std::make_shared<rclcpp::Clock>(RCL_ROS_TIME));
+// suppress deprecated warnings
+#if !defined(_WIN32)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else  // !defined(_WIN32)
+# pragma warning(push)
+# pragma warning(disable: 4996)
+#endif
     EXPECT_FALSE(rate.is_steady());
+// remove warning suppression
+#if !defined(_WIN32)
+# pragma GCC diagnostic pop
+#else  // !defined(_WIN32)
+# pragma warning(pop)
+#endif
     EXPECT_EQ(RCL_ROS_TIME, rate.get_type());
   }
 }

--- a/rclcpp/test/rclcpp/test_rate.cpp
+++ b/rclcpp/test/rclcpp/test_rate.cpp
@@ -14,9 +14,12 @@
 
 #include <gtest/gtest.h>
 
+#include <stdexcept>
 #include <string>
 
 #include "rclcpp/rate.hpp"
+
+#include "../utils/rclcpp_gtest_macros.hpp"
 
 /*
    Basic tests for the Rate, WallRate and ROSRate classes.
@@ -403,44 +406,22 @@ TEST(TestRate, clock_types) {
 
 TEST(TestRate, incorrect_constuctor) {
   // Constructor with 0-frequency
-  try {
-    rclcpp::Rate rate(0.0);
-    FAIL() << "Rate with 0-frequency shouldn't be constructed\n";
-  } catch (const std::invalid_argument & ex) {
-    // Do nothing
-  } catch (const std::exception & ex) {
-    FAIL() << "Unexpected fail: " << ex.what() << "\n";
-  }
+  RCLCPP_EXPECT_THROW_EQ(
+    rclcpp::Rate rate(0.0),
+    std::invalid_argument("rate must be greater than 0"));
 
   // Constructor with negative frequency
-  try {
-    rclcpp::Rate rate(-1.0);
-    FAIL() << "Rate with negative frequency shouldn't be constructed\n";
-  } catch (const std::invalid_argument & ex) {
-    // Do nothing
-  } catch (const std::exception & ex) {
-    FAIL() << "Unexpected fail: " << ex.what() << "\n";
-  }
+  RCLCPP_EXPECT_THROW_EQ(
+    rclcpp::Rate rate(-1.0),
+    std::invalid_argument("rate must be greater than 0"));
 
   // Constructor with 0-duration
-  try {
-    rclcpp::Duration d0(0, 0);
-    rclcpp::Rate rate(d0);
-    FAIL() << "Rate with 0-duration shouldn't be constructed\n";
-  } catch (const std::invalid_argument & ex) {
-    // Do nothing
-  } catch (const std::exception & ex) {
-    FAIL() << "Unexpected fail: " << ex.what() << "\n";
-  }
+  RCLCPP_EXPECT_THROW_EQ(
+    rclcpp::Rate rate(rclcpp::Duration(0, 0)),
+    std::invalid_argument("period must be greater than 0"));
 
   // Constructor with negative duration
-  try {
-    rclcpp::Duration dN(-1, 0);
-    rclcpp::Rate rate(dN);
-    FAIL() << "Rate with negative duraiton shouldn't be constructed\n";
-  } catch (const std::invalid_argument & ex) {
-    // Do nothing
-  } catch (const std::exception & ex) {
-    FAIL() << "Unexpected fail: " << ex.what() << "\n";
-  }
+  RCLCPP_EXPECT_THROW_EQ(
+    rclcpp::Rate rate(rclcpp::Duration(-1, 0)),
+    std::invalid_argument("period must be greater than 0"));
 }

--- a/rclcpp/test/rclcpp/test_rate.cpp
+++ b/rclcpp/test/rclcpp/test_rate.cpp
@@ -406,9 +406,9 @@ TEST(TestRate, incorrect_constuctor) {
   try {
     rclcpp::Rate rate(0.0);
     FAIL() << "Rate with 0-frequency shouldn't be constructed\n";
-  } catch(const std::invalid_argument & ex) {
+  } catch (const std::invalid_argument & ex) {
     // Do nothing
-  } catch(const std::exception & ex) {
+  } catch (const std::exception & ex) {
     FAIL() << "Unexpected fail: " << ex.what() << "\n";
   }
 
@@ -416,9 +416,9 @@ TEST(TestRate, incorrect_constuctor) {
   try {
     rclcpp::Rate rate(-1.0);
     FAIL() << "Rate with negative frequency shouldn't be constructed\n";
-  } catch(const std::invalid_argument & ex) {
+  } catch (const std::invalid_argument & ex) {
     // Do nothing
-  } catch(const std::exception & ex) {
+  } catch (const std::exception & ex) {
     FAIL() << "Unexpected fail: " << ex.what() << "\n";
   }
 
@@ -427,9 +427,9 @@ TEST(TestRate, incorrect_constuctor) {
     rclcpp::Duration d0(0, 0);
     rclcpp::Rate rate(d0);
     FAIL() << "Rate with 0-duration shouldn't be constructed\n";
-  } catch(const std::invalid_argument & ex) {
+  } catch (const std::invalid_argument & ex) {
     // Do nothing
-  } catch(const std::exception & ex) {
+  } catch (const std::exception & ex) {
     FAIL() << "Unexpected fail: " << ex.what() << "\n";
   }
 
@@ -438,9 +438,9 @@ TEST(TestRate, incorrect_constuctor) {
     rclcpp::Duration dN(-1, 0);
     rclcpp::Rate rate(dN);
     FAIL() << "Rate with negative duraiton shouldn't be constructed\n";
-  } catch(const std::invalid_argument & ex) {
+  } catch (const std::invalid_argument & ex) {
     // Do nothing
-  } catch(const std::exception & ex) {
+  } catch (const std::exception & ex) {
     FAIL() << "Unexpected fail: " << ex.what() << "\n";
   }
 }

--- a/rclcpp/test/rclcpp/test_rate.cpp
+++ b/rclcpp/test/rclcpp/test_rate.cpp
@@ -235,6 +235,7 @@ TEST(TestRate, generic_rate) {
 # pragma warning(pop)
 #endif
 
+    ASSERT_EQ(gr.get_type(), RCL_SYSTEM_TIME);
     EXPECT_EQ(period, gr.period());
     ASSERT_TRUE(gr.sleep());
     auto one = std::chrono::system_clock::now();
@@ -288,6 +289,7 @@ TEST(TestRate, generic_rate) {
 # pragma warning(pop)
 #endif
 
+    ASSERT_EQ(gr.get_type(), RCL_STEADY_TIME);
     EXPECT_EQ(period, gr.period());
     ASSERT_TRUE(gr.sleep());
     auto one = std::chrono::steady_clock::now();


### PR DESCRIPTION
This is the continue of [#1373] [discussion](https://github.com/ros2/rclcpp/pull/1373#discussion_r1118830044) and related to the https://github.com/ros-planning/navigation2/issues/3325 issue in Nav2

The initial idea is to make `rclcpp::Rate` to work with ROS-time (currently it works only with system and steady times).

What was made:
* Add `rclcpp::Clock` pointer to the `rclcpp::Rate` constructor to allow developer to specify the clock to work with (by-default it is still `RCL_SYSTEM_TIME` if no clock is specified)
* Add `rclcpp::ROSRate` rate class, respective to ROS-time

Current implementation points:
* Getting rid of templates' structure allows developer to select the clock to work with in dynamics
* Renamed `rclcpp::GenericRate` -> to `rclcpp::Rate` and gave it the default clock to work with
* `rclcpp::Rate` and `rclcpp::WallRate` API remaining to be untouched as much as possible
* Although there are some changes in API: `rclcpp::Duration` instead of `std::chrono::nanoseconds` in durations and `Rate::get_type()` routine instead of previously used `Rate::is_steady()`
* New `rclcpp::ROSRate` class that working with ROS time