### PR TITLE
Fixes to silence some clang warnings.

### DIFF
--- a/rclcpp/test/rclcpp/test_function_traits.cpp
+++ b/rclcpp/test/rclcpp/test_function_traits.cpp
@@ -393,6 +393,7 @@ TEST(TestFunctionTraits, argument_types) {
 
   auto bind_one_bool = std::bind(
     &ObjectMember::callback_one_bool, &object_member, std::placeholders::_1);
+  (void)bind_one_bool;  // to quiet clang
 
   static_assert(
     std::is_same<
@@ -402,6 +403,7 @@ TEST(TestFunctionTraits, argument_types) {
 
   auto bind_one_bool_const = std::bind(
     &ObjectMember::callback_one_bool_const, &object_member, std::placeholders::_1);
+  (void)bind_one_bool_const;  // to quiet clang
 
   static_assert(
     std::is_same<
@@ -413,6 +415,7 @@ TEST(TestFunctionTraits, argument_types) {
   auto bind_two_bools = std::bind(
     &ObjectMember::callback_two_bools, &object_member, std::placeholders::_1,
     std::placeholders::_2);
+  (void)bind_two_bools;  // to quiet clang
 
   static_assert(
     std::is_same<
@@ -429,6 +432,7 @@ TEST(TestFunctionTraits, argument_types) {
   auto bind_one_bool_one_float = std::bind(
     &ObjectMember::callback_one_bool_one_float, &object_member, std::placeholders::_1,
     std::placeholders::_2);
+  (void)bind_one_bool_one_float;  // to quiet clang
 
   static_assert(
     std::is_same<
@@ -447,6 +451,7 @@ TEST(TestFunctionTraits, argument_types) {
     >::value, "Functor accepts a float as second argument");
 
   auto bind_one_int = std::bind(func_one_int, std::placeholders::_1);
+  (void)bind_one_int;  // to quiet clang
 
   static_assert(
     std::is_same<
@@ -455,6 +460,7 @@ TEST(TestFunctionTraits, argument_types) {
     >::value, "Functor accepts an int as first argument");
 
   auto bind_two_ints = std::bind(func_two_ints, std::placeholders::_1, std::placeholders::_2);
+  (void)bind_two_ints;  // to quiet clang
 
   static_assert(
     std::is_same<
@@ -470,6 +476,7 @@ TEST(TestFunctionTraits, argument_types) {
 
   auto bind_one_int_one_char = std::bind(
     func_one_int_one_char, std::placeholders::_1, std::placeholders::_2);
+  (void)bind_one_int_one_char;  // to quiet clang
 
   static_assert(
     std::is_same<
@@ -530,18 +537,21 @@ TEST(TestFunctionTraits, check_arguments) {
       (void)one;
       return 1;
     };
+  (void)lambda_one_int;  // to quiet clang
 
   auto lambda_two_ints = [](int one, int two) {
       (void)one;
       (void)two;
       return 2;
     };
+  (void)lambda_two_ints;  // to quiet clang
 
   auto lambda_one_int_one_char = [](int one, char two) {
       (void)one;
       (void)two;
       return 3;
     };
+  (void)lambda_one_int_one_char;  // to quiet clang
 
   static_assert(
     rclcpp::function_traits::check_arguments<decltype(lambda_one_int), int>::value,
@@ -572,6 +582,7 @@ TEST(TestFunctionTraits, check_arguments) {
 
   auto bind_one_bool = std::bind(
     &ObjectMember::callback_one_bool, &object_member, std::placeholders::_1);
+  (void)bind_one_bool;  // to quiet clang
 
   // Test std::bind functions
   static_assert(
@@ -580,6 +591,7 @@ TEST(TestFunctionTraits, check_arguments) {
 
   auto bind_one_bool_const = std::bind(
     &ObjectMember::callback_one_bool_const, &object_member, std::placeholders::_1);
+  (void)bind_one_bool_const;  // to quiet clang
 
   // Test std::bind functions
   static_assert(
@@ -745,6 +757,7 @@ TEST_F(TestMember, bind_member_functor) {
   auto bind_member_functor = std::bind(
     &TestMember::MemberFunctor, this, std::placeholders::_1,
     std::placeholders::_2, std::placeholders::_3);
+  (void)bind_member_functor;  // to quiet clang
 
   static_assert(
     rclcpp::function_traits::check_arguments<decltype(bind_member_functor), int, float,

--- a/rclcpp/test/rclcpp/test_loaned_message.cpp
+++ b/rclcpp/test/rclcpp/test_loaned_message.cpp
@@ -186,7 +186,6 @@ TEST_F(TestLoanedMessage, move_loaned_message) {
   auto loaned_msg_moved_to = LoanedMessageT(std::move(loaned_msg_to_move));
 
   ASSERT_TRUE(loaned_msg_moved_to.is_valid());
-  ASSERT_FALSE(loaned_msg_to_move.is_valid());
 
   loaned_msg_moved_to.get().float32_value = 42.0f;
   ASSERT_EQ(42.0f, loaned_msg_moved_to.get().float32_value);

--- a/rclcpp/test/rclcpp/test_serialized_message.cpp
+++ b/rclcpp/test/rclcpp/test_serialized_message.cpp
@@ -67,8 +67,6 @@ TEST(TestSerializedMessage, various_constructors) {
   rclcpp::SerializedMessage yet_another_serialized_message(std::move(other_serialized_message));
   auto & yet_another_rcl_handle = yet_another_serialized_message.get_rcl_serialized_message();
   EXPECT_TRUE(nullptr == other_rcl_handle.buffer);
-  EXPECT_EQ(0u, other_serialized_message.capacity());
-  EXPECT_EQ(0u, other_serialized_message.size());
   EXPECT_TRUE(nullptr != yet_another_rcl_handle.buffer);
   EXPECT_EQ(content_size, yet_another_serialized_message.size());
   EXPECT_EQ(content_size, yet_another_serialized_message.capacity());

--- a/rclcpp_lifecycle/test/test_lifecycle_publisher.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_publisher.cpp
@@ -133,6 +133,7 @@ TEST_P(TestLifecyclePublisher, publish_managed_by_node) {
     rclcpp_lifecycle::Transition(Transition::TRANSITION_DEACTIVATE), ret);
   ASSERT_EQ(success, ret);
   ret = reset_key;
+  (void)ret;  // Just to make clang happy
   EXPECT_FALSE(node_->publisher()->is_activated());
   {
     auto msg_ptr = std::make_unique<test_msgs::msg::Empty>();


### PR DESCRIPTION
This does 2 separate things:

* Adds (void)unused_variable things where needed.
* Stops doing some checks on moved-from items in tests.

With this in place, most of the remaining clang static analysis warnings are gone.