### PR TITLE
Node guard condition is superceeded by callback group

### DIFF
--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -660,20 +660,11 @@ protected:
   virtual void
   spin_once_impl(std::chrono::nanoseconds timeout);
 
-  typedef std::map<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr,
-      const rclcpp::GuardCondition *,
-      std::owner_less<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr>>
-    WeakNodesToGuardConditionsMap;
-
   typedef std::map<rclcpp::CallbackGroup::WeakPtr,
       const rclcpp::GuardCondition *,
       std::owner_less<rclcpp::CallbackGroup::WeakPtr>>
+
     WeakCallbackGroupsToGuardConditionsMap;
-
-  /// maps nodes to guard conditions
-  WeakNodesToGuardConditionsMap
-  weak_nodes_to_guard_conditions_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
-
   /// maps callback groups to guard conditions
   WeakCallbackGroupsToGuardConditionsMap
   weak_groups_to_guard_conditions_ RCPPUTILS_TSA_GUARDED_BY(mutex_);

--- a/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
@@ -122,10 +122,6 @@ public:
   get_associated_with_executor_atomic() override;
 
   RCLCPP_PUBLIC
-  rclcpp::GuardCondition &
-  get_notify_guard_condition() override;
-
-  RCLCPP_PUBLIC
   bool
   get_use_intra_process_default() const override;
 
@@ -150,11 +146,6 @@ private:
   std::vector<rclcpp::CallbackGroup::WeakPtr> callback_groups_;
 
   std::atomic_bool associated_with_executor_;
-
-  /// Guard condition for notifying the Executor of changes to this node.
-  mutable std::recursive_mutex notify_guard_condition_mutex_;
-  rclcpp::GuardCondition notify_guard_condition_;
-  bool notify_guard_condition_is_valid_;
 };
 
 }  // namespace node_interfaces

--- a/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
@@ -150,6 +150,8 @@ public:
    *
    * \return the GuardCondition if it is valid, else thow runtime error
    */
+
+  [[deprecated("use 'rclcpp::CallbackGroup::get_notify_guard_condition instead")]]
   RCLCPP_PUBLIC
   virtual
   rclcpp::GuardCondition &

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -112,12 +112,6 @@ Executor::~Executor()
   }
   weak_groups_to_guard_conditions_.clear();
 
-  for (const auto & pair : weak_nodes_to_guard_conditions_) {
-    auto guard_condition = pair.second;
-    memory_strategy_->remove_guard_condition(guard_condition);
-  }
-  weak_nodes_to_guard_conditions_.clear();
-
   // Finalize the wait set.
   if (rcl_wait_set_fini(&wait_set_) != RCL_RET_OK) {
     RCUTILS_LOG_ERROR_NAMED(
@@ -279,12 +273,6 @@ Executor::add_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_pt
           notify);
       }
     });
-
-  const auto & gc = node_ptr->get_notify_guard_condition();
-  weak_nodes_to_guard_conditions_[node_ptr] = &gc;
-  // Add the node's notify condition to the guard condition handles
-  memory_strategy_->add_guard_condition(gc);
-  weak_nodes_.push_back(node_ptr);
 }
 
 void
@@ -387,9 +375,6 @@ Executor::remove_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node
         notify);
     }
   }
-
-  memory_strategy_->remove_guard_condition(&node_ptr->get_notify_guard_condition());
-  weak_nodes_to_guard_conditions_.erase(node_ptr);
 
   std::atomic_bool & has_executor = node_ptr->get_associated_with_executor_atomic();
   has_executor.store(false);
@@ -719,12 +704,6 @@ Executor::wait_for_work(std::chrono::nanoseconds timeout)
         auto weak_node_ptr = pair.second;
         if (weak_group_ptr.expired() || weak_node_ptr.expired()) {
           invalid_group_ptrs.push_back(weak_group_ptr);
-          auto node_guard_pair = weak_nodes_to_guard_conditions_.find(weak_node_ptr);
-          if (node_guard_pair != weak_nodes_to_guard_conditions_.end()) {
-            auto guard_condition = node_guard_pair->second;
-            weak_nodes_to_guard_conditions_.erase(weak_node_ptr);
-            memory_strategy_->remove_guard_condition(guard_condition);
-          }
         }
       }
       std::for_each(

--- a/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
@@ -533,13 +533,6 @@ NodeGraph::notify_graph_change()
     }
   }
   graph_cv_.notify_all();
-  auto & node_gc = node_base_->get_notify_guard_condition();
-  try {
-    node_gc.trigger();
-  } catch (const rclcpp::exceptions::RCLError & ex) {
-    throw std::runtime_error(
-            std::string("failed to notify wait set on graph change: ") + ex.what());
-  }
 }
 
 void

--- a/rclcpp/src/rclcpp/node_interfaces/node_services.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_services.cpp
@@ -40,16 +40,7 @@ NodeServices::add_service(
   }
 
   group->add_service(service_base_ptr);
-
-  // Notify the executor that a new service was created using the parent Node.
-  auto & node_gc = node_base_->get_notify_guard_condition();
-  try {
-    node_gc.trigger();
-    group->trigger_notify_guard_condition();
-  } catch (const rclcpp::exceptions::RCLError & ex) {
-    throw std::runtime_error(
-            std::string("failed to notify wait set on service creation: ") + ex.what());
-  }
+  group->trigger_notify_guard_condition();
 }
 
 void
@@ -67,16 +58,7 @@ NodeServices::add_client(
   }
 
   group->add_client(client_base_ptr);
-
-  // Notify the executor that a new client was created using the parent Node.
-  auto & node_gc = node_base_->get_notify_guard_condition();
-  try {
-    node_gc.trigger();
-    group->trigger_notify_guard_condition();
-  } catch (const rclcpp::exceptions::RCLError & ex) {
-    throw std::runtime_error(
-            std::string("failed to notify wait set on client creation: ") + ex.what());
-  }
+  group->trigger_notify_guard_condition();
 }
 
 std::string

--- a/rclcpp/src/rclcpp/node_interfaces/node_timers.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_timers.cpp
@@ -41,15 +41,7 @@ NodeTimers::add_timer(
     callback_group = node_base_->get_default_callback_group();
   }
   callback_group->add_timer(timer);
-
-  auto & node_gc = node_base_->get_notify_guard_condition();
-  try {
-    node_gc.trigger();
-    callback_group->trigger_notify_guard_condition();
-  } catch (const rclcpp::exceptions::RCLError & ex) {
-    throw std::runtime_error(
-            std::string("failed to notify wait set on timer creation: ") + ex.what());
-  }
+  callback_group->trigger_notify_guard_condition();
 
   TRACEPOINT(
     rclcpp_timer_link_node,

--- a/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
@@ -69,15 +69,8 @@ NodeTopics::add_publisher(
     callback_group->add_waitable(publisher_event);
   }
 
-  // Notify the executor that a new publisher was created using the parent Node.
-  auto & node_gc = node_base_->get_notify_guard_condition();
-  try {
-    node_gc.trigger();
-    callback_group->trigger_notify_guard_condition();
-  } catch (const rclcpp::exceptions::RCLError & ex) {
-    throw std::runtime_error(
-            std::string("failed to notify wait set on publisher creation: ") + ex.what());
-  }
+  // Notify the executor that a new publisher was created using callback group.
+  callback_group->trigger_notify_guard_condition();
 }
 
 rclcpp::SubscriptionBase::SharedPtr
@@ -119,14 +112,7 @@ NodeTopics::add_subscription(
   }
 
   // Notify the executor that a new subscription was created using the parent Node.
-  auto & node_gc = node_base_->get_notify_guard_condition();
-  try {
-    node_gc.trigger();
-    callback_group->trigger_notify_guard_condition();
-  } catch (const rclcpp::exceptions::RCLError & ex) {
-    throw std::runtime_error(
-            std::string("failed to notify wait set on subscription creation: ") + ex.what());
-  }
+  callback_group->trigger_notify_guard_condition();
 }
 
 rclcpp::node_interfaces::NodeBaseInterface *

--- a/rclcpp/src/rclcpp/node_interfaces/node_waitables.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_waitables.cpp
@@ -40,16 +40,7 @@ NodeWaitables::add_waitable(
   }
 
   group->add_waitable(waitable_ptr);
-
-  // Notify the executor that a new waitable was created using the parent Node.
-  auto & node_gc = node_base_->get_notify_guard_condition();
-  try {
-    node_gc.trigger();
-    group->trigger_notify_guard_condition();
-  } catch (const rclcpp::exceptions::RCLError & ex) {
-    throw std::runtime_error(
-            std::string("failed to notify wait set on waitable creation: ") + ex.what());
-  }
+  group->trigger_notify_guard_condition();
 }
 
 void


### PR DESCRIPTION
The node guard condition was used to signal when publishers/subscriptions/timers/etc were added to a node previously.  This has been superceeded by the signal emitted from individual callback groups.  Anywhere that the node guard condition is signaled, we additionally signal the corresponding callback groups.

Going forward, using this method should be deprecated (and then removed).

Currently, the static single threaded executor still makes use of this guard condition, but I'm working on removing that usage as well.