### PR TITLE
Fix unnecessary allocations in executor.cpp

### DIFF
--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -558,13 +558,14 @@ Executor::execute_any_executable(AnyExecutable & any_exec)
   }
 }
 
+template<typename Taker, typename Handler>
 static
 void
 take_and_do_error_handling(
   const char * action_description,
   const char * topic_or_service_name,
-  std::function<bool()> take_action,
-  std::function<void()> handle_action)
+  Taker take_action,
+  Handler handle_action)
 {
   bool taken = false;
   try {


### PR DESCRIPTION
std::function will allocate on every call of take_and_do_error_handling (at least with libstdc++ as in this implementation std::function's small buffer can only fit two pointers but most of the time, the lambdas will contain 3 pointers). This impose multiple heap allocations (and deallocations) on every callback.

This comes with the cost of increased binary size. But I suppose it's worth it as this change also enables better/easier inling and avoids indirect function calls through the std::function machinery.