### PR TITLE
Add type_hash to cpp TopicEndpointInfo

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
@@ -57,7 +57,8 @@ public:
     node_namespace_(info.node_namespace),
     topic_type_(info.topic_type),
     endpoint_type_(static_cast<rclcpp::EndpointType>(info.endpoint_type)),
-    qos_profile_({info.qos_profile.history, info.qos_profile.depth}, info.qos_profile)
+    qos_profile_({info.qos_profile.history, info.qos_profile.depth}, info.qos_profile),
+    topic_type_hash_(info.topic_type_hash)
   {
     std::copy(info.endpoint_gid, info.endpoint_gid + RMW_GID_STORAGE_SIZE, endpoint_gid_.begin());
   }
@@ -122,6 +123,14 @@ public:
   const rclcpp::QoS &
   qos_profile() const;
 
+  RCLCPP_PUBLIC
+  rosidl_type_hash_t &
+  topic_type_hash();
+
+  RCLCPP_PUBLIC
+  const rosidl_type_hash_t &
+  topic_type_hash() const;
+
 private:
   std::string node_name_;
   std::string node_namespace_;
@@ -129,6 +138,7 @@ private:
   rclcpp::EndpointType endpoint_type_;
   std::array<uint8_t, RMW_GID_STORAGE_SIZE> endpoint_gid_;
   rclcpp::QoS qos_profile_;
+  rosidl_type_hash_t topic_type_hash_;
 };
 
 namespace node_interfaces

--- a/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
@@ -123,10 +123,12 @@ public:
   const rclcpp::QoS &
   qos_profile() const;
 
+  /// Get a mutable reference to the type hash of the topic endpoint.
   RCLCPP_PUBLIC
   rosidl_type_hash_t &
   topic_type_hash();
 
+  /// Get a const reference to the type hash of the topic endpoint.
   RCLCPP_PUBLIC
   const rosidl_type_hash_t &
   topic_type_hash() const;

--- a/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
@@ -789,3 +789,15 @@ rclcpp::TopicEndpointInfo::qos_profile() const
 {
   return qos_profile_;
 }
+
+rosidl_type_hash_t &
+rclcpp::TopicEndpointInfo::topic_type_hash()
+{
+  return topic_type_hash_;
+}
+
+const rosidl_type_hash_t &
+rclcpp::TopicEndpointInfo::topic_type_hash() const
+{
+  return topic_type_hash_;
+}

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_graph.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_graph.cpp
@@ -599,6 +599,9 @@ TEST_F(TestNodeGraph, get_info_by_topic)
   rclcpp::QoS const_actual_qos = const_publisher_endpoint_info.qos_profile();
   EXPECT_EQ(const_actual_qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
 
+  const rosidl_type_hash_t type_hash = rosidl_get_zero_initialized_type_hash();
+  EXPECT_EQ(0, memcmp(&publisher_endpoint_info.topic_type_hash(), &type_hash, sizeof(rosidl_type_hash_t)));
+
   auto endpoint_gid = publisher_endpoint_info.endpoint_gid();
   auto const_endpoint_gid = const_publisher_endpoint_info.endpoint_gid();
   bool endpoint_gid_is_all_zeros = true;

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_graph.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_graph.cpp
@@ -28,6 +28,7 @@
 #include "rclcpp/node_interfaces/node_graph.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rcutils/strdup.h"
+#include "test_msgs/msg/empty.h"
 #include "test_msgs/msg/empty.hpp"
 #include "test_msgs/srv/empty.hpp"
 
@@ -599,7 +600,7 @@ TEST_F(TestNodeGraph, get_info_by_topic)
   rclcpp::QoS const_actual_qos = const_publisher_endpoint_info.qos_profile();
   EXPECT_EQ(const_actual_qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
 
-  const rosidl_type_hash_t expected_type_hash = test_msgs::msg::Empty::TYPE_HASH;
+  const rosidl_type_hash_t expected_type_hash = *test_msgs__msg__Empty__get_type_hash(nullptr);
   EXPECT_EQ(
     0, memcmp(
       &publisher_endpoint_info.topic_type_hash(),

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_graph.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_graph.cpp
@@ -599,8 +599,17 @@ TEST_F(TestNodeGraph, get_info_by_topic)
   rclcpp::QoS const_actual_qos = const_publisher_endpoint_info.qos_profile();
   EXPECT_EQ(const_actual_qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
 
-  const rosidl_type_hash_t type_hash = rosidl_get_zero_initialized_type_hash();
-  EXPECT_EQ(0, memcmp(&publisher_endpoint_info.topic_type_hash(), &type_hash, sizeof(rosidl_type_hash_t)));
+  const rosidl_type_hash_t expected_type_hash = test_msgs::msg::Empty::TYPE_HASH;
+  EXPECT_EQ(
+    0, memcmp(
+      &publisher_endpoint_info.topic_type_hash(),
+      &expected_type_hash,
+      sizeof(rosidl_type_hash_t)));
+  EXPECT_EQ(
+    0, memcmp(
+      &const_publisher_endpoint_info.topic_type_hash(),
+      &expected_type_hash,
+      sizeof(rosidl_type_hash_t)));
 
   auto endpoint_gid = publisher_endpoint_info.endpoint_gid();
   auto const_endpoint_gid = const_publisher_endpoint_info.endpoint_gid();


### PR DESCRIPTION
Part of ros2/ros2#1159

From rep-2011 work, expose the new RMW endpoint info's type hash to the C++ endpoint struct.