### PR TITLE
Create common structures for executors to use

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -54,9 +54,9 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/executable_list.cpp
   src/rclcpp/executor.cpp
   src/rclcpp/executors.cpp
-  src/rclcpp/executors/executor_notify_waitable.cpp
-  src/rclcpp/executors/executor_entities_collector.cpp
   src/rclcpp/executors/executor_entities_collection.cpp
+  src/rclcpp/executors/executor_entities_collector.cpp
+  src/rclcpp/executors/executor_notify_waitable.cpp
   src/rclcpp/executors/multi_threaded_executor.cpp
   src/rclcpp/executors/single_threaded_executor.cpp
   src/rclcpp/executors/static_executor_entities_collector.cpp

--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -54,6 +54,9 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/executable_list.cpp
   src/rclcpp/executor.cpp
   src/rclcpp/executors.cpp
+  src/rclcpp/executors/executor_notify_waitable.cpp
+  src/rclcpp/executors/executor_entities_collector.cpp
+  src/rclcpp/executors/executor_entities_collection.cpp
   src/rclcpp/executors/multi_threaded_executor.cpp
   src/rclcpp/executors/single_threaded_executor.cpp
   src/rclcpp/executors/static_executor_entities_collector.cpp

--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -180,18 +180,6 @@ public:
     return _find_ptrs_if_impl<rclcpp::Waitable, Function>(func, waitable_ptrs_);
   }
 
-  /// Return if the node that created this callback group still exists
-  /**
-   * As nodes can share ownership of callback groups with an executor, this
-   * may be used to ensure that the executor doesn't operate on a callback
-   * group that has outlived it's creating node.
-   *
-   * \return true if the creating node still exists, otherwise false
-   */
-  RCLCPP_PUBLIC
-  bool
-  has_valid_node() const;
-
   RCLCPP_PUBLIC
   std::atomic_bool &
   can_be_taken_from();

--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -89,6 +89,46 @@ public:
    * added to the executor in either case.
    *
    * \param[in] group_type The type of the callback group.
+   * \param[in] automatically_add_to_executor_with_node A boolean that
+   *   determines whether a callback group is automatically added to an executor
+   *   with the node with which it is associated.
+   */
+  [[deprecated("Use CallbackGroup constructor with context function argument")]]
+  RCLCPP_PUBLIC
+  explicit CallbackGroup(
+    CallbackGroupType group_type,
+    bool automatically_add_to_executor_with_node = true);
+
+  /// Constructor for CallbackGroup.
+  /**
+   * Callback Groups have a type, either 'Mutually Exclusive' or 'Reentrant'
+   * and when creating one the type must be specified.
+   *
+   * Callbacks in Reentrant Callback Groups must be able to:
+   *   - run at the same time as themselves (reentrant)
+   *   - run at the same time as other callbacks in their group
+   *   - run at the same time as other callbacks in other groups
+   *
+   * Callbacks in Mutually Exclusive Callback Groups:
+   *   - will not be run multiple times simultaneously (non-reentrant)
+   *   - will not be run at the same time as other callbacks in their group
+   *   - but must run at the same time as callbacks in other groups
+   *
+   * Additionally, callback groups have a property which determines whether or
+   * not they are added to an executor with their associated node automatically.
+   * When creating a callback group the automatically_add_to_executor_with_node
+   * argument determines this behavior, and if true it will cause the newly
+   * created callback group to be added to an executor with the node when the
+   * Executor::add_node method is used.
+   * If false, this callback group will not be added automatically and would
+   * have to be added to an executor manually using the
+   * Executor::add_callback_group method.
+   *
+   * Whether the node was added to the executor before creating the callback
+   * group, or after, is irrelevant; the callback group will be automatically
+   * added to the executor in either case.
+   *
+   * \param[in] group_type The type of the callback group.
    * \param[in] get_node_context Lambda to retrieve the node context when
    *   checking that the creating node is valid and using the guard condition.
    * \param[in] automatically_add_to_executor_with_node A boolean that
@@ -143,7 +183,7 @@ public:
   /// Return if the node that created this callback group still exists
   /**
    * As nodes can share ownership of callback groups with an executor, this
-   * may be used to ensures that the executor doesn't operate on a callback
+   * may be used to ensure that the executor doesn't operate on a callback
    * group that has outlived it's creating node.
    *
    * \return true if the creating node still exists, otherwise false

--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -190,7 +190,7 @@ public:
    */
   RCLCPP_PUBLIC
   bool
-  has_valid_node();
+  has_valid_node() const;
 
   RCLCPP_PUBLIC
   std::atomic_bool &

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -637,8 +637,9 @@ protected:
   std::atomic_bool spinning;
 
   /// Guard condition for signaling the rmw layer to wake up for special events.
-  rclcpp::GuardCondition interrupt_guard_condition_;
+  std::shared_ptr<rclcpp::GuardCondition> interrupt_guard_condition_;
 
+  /// Guard condition for signaling the rmw layer to wake up for system shutdown. 
   std::shared_ptr<rclcpp::GuardCondition> shutdown_guard_condition_;
 
   /// Wait set for managing entities that the rmw layer waits on.

--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -639,7 +639,7 @@ protected:
   /// Guard condition for signaling the rmw layer to wake up for special events.
   std::shared_ptr<rclcpp::GuardCondition> interrupt_guard_condition_;
 
-  /// Guard condition for signaling the rmw layer to wake up for system shutdown. 
+  /// Guard condition for signaling the rmw layer to wake up for system shutdown.
   std::shared_ptr<rclcpp::GuardCondition> shutdown_guard_condition_;
 
   /// Wait set for managing entities that the rmw layer waits on.

--- a/rclcpp/include/rclcpp/executors/executor_entities_collection.hpp
+++ b/rclcpp/include/rclcpp/executors/executor_entities_collection.hpp
@@ -1,0 +1,137 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__EXECUTORS__EXECUTOR_ENTITIES_COLLECTION_HPP_
+#define RCLCPP__EXECUTORS__EXECUTOR_ENTITIES_COLLECTION_HPP_
+
+#include <deque>
+#include <unordered_map>
+#include <vector>
+
+#include "rcpputils/thread_safety_annotations.hpp"
+
+#include <rclcpp/any_executable.hpp>
+#include <rclcpp/node_interfaces/node_base.hpp>
+#include <rclcpp/callback_group.hpp>
+#include <rclcpp/executors/executor_notify_waitable.hpp>
+#include <rclcpp/visibility_control.hpp>
+#include <rclcpp/wait_result.hpp>
+#include <rclcpp/wait_set.hpp>
+
+namespace rclcpp
+{
+namespace executors
+{
+
+struct ExecutorEntitiesCollection
+{
+  struct TimerEntry
+  {
+    rclcpp::TimerBase::WeakPtr timer;
+    rclcpp::CallbackGroup::WeakPtr callback_group;
+  };
+  using TimerCollection = std::unordered_map<const rcl_timer_t *, TimerEntry>;
+
+  struct SubscriptionEntry
+  {
+    rclcpp::SubscriptionBase::WeakPtr subscription;
+    rclcpp::CallbackGroup::WeakPtr callback_group;
+  };
+  using SubscriptionCollection = std::unordered_map<const rcl_subscription_t *, SubscriptionEntry>;
+
+  struct ClientEntry
+  {
+    rclcpp::ClientBase::WeakPtr client;
+    rclcpp::CallbackGroup::WeakPtr callback_group;
+  };
+  using ClientCollection = std::unordered_map<const rcl_client_t *, ClientEntry>;
+
+  struct ServiceEntry
+  {
+    rclcpp::ServiceBase::WeakPtr service;
+    rclcpp::CallbackGroup::WeakPtr callback_group;
+  };
+  using ServiceCollection = std::unordered_map<const rcl_service_t *, ServiceEntry>;
+
+  struct WaitableEntry
+  {
+    rclcpp::Waitable::WeakPtr waitable;
+    rclcpp::CallbackGroup::WeakPtr callback_group;
+  };
+  using WaitableCollection = std::unordered_map<const rclcpp::Waitable *, WaitableEntry>;
+
+  using GuardConditionCollection = std::unordered_map<const rcl_guard_condition_t *,
+      rclcpp::GuardCondition::WeakPtr>;
+
+  TimerCollection timers;
+  SubscriptionCollection subscriptions;
+  ClientCollection clients;
+  ServiceCollection services;
+  GuardConditionCollection guard_conditions;
+  WaitableCollection waitables;
+
+  void clear();
+
+  using TimerUpdatedFunc = std::function<void (rclcpp::TimerBase::SharedPtr)>;
+  void update_timers(
+    const ExecutorEntitiesCollection::TimerCollection & other,
+    TimerUpdatedFunc timer_added,
+    TimerUpdatedFunc timer_removed);
+
+  using SubscriptionUpdatedFunc = std::function<void (rclcpp::SubscriptionBase::SharedPtr)>;
+  void update_subscriptions(
+    const ExecutorEntitiesCollection::SubscriptionCollection & other,
+    SubscriptionUpdatedFunc subscription_added,
+    SubscriptionUpdatedFunc subscription_removed);
+
+  using ClientUpdatedFunc = std::function<void (rclcpp::ClientBase::SharedPtr)>;
+  void update_clients(
+    const ExecutorEntitiesCollection::ClientCollection & other,
+    ClientUpdatedFunc client_added,
+    ClientUpdatedFunc client_removed);
+
+  using ServiceUpdatedFunc = std::function<void (rclcpp::ServiceBase::SharedPtr)>;
+  void update_services(
+    const ExecutorEntitiesCollection::ServiceCollection & other,
+    ServiceUpdatedFunc service_added,
+    ServiceUpdatedFunc service_removed);
+
+  using GuardConditionUpdatedFunc = std::function<void (rclcpp::GuardCondition::SharedPtr)>;
+  void update_guard_conditions(
+    const ExecutorEntitiesCollection::GuardConditionCollection & other,
+    GuardConditionUpdatedFunc guard_condition_added,
+    GuardConditionUpdatedFunc guard_condition_removed);
+
+  using WaitableUpdatedFunc = std::function<void (rclcpp::Waitable::SharedPtr)>;
+  void update_waitables(
+    const ExecutorEntitiesCollection::WaitableCollection & other,
+    WaitableUpdatedFunc waitable_added,
+    WaitableUpdatedFunc waitable_removed);
+};
+
+void
+build_entities_collection(
+  const std::vector<rclcpp::CallbackGroup::WeakPtr> & callback_groups,
+  ExecutorEntitiesCollection & collection);
+
+std::deque<rclcpp::AnyExecutable>
+ready_executables(
+  const ExecutorEntitiesCollection & collection,
+  rclcpp::WaitResult<rclcpp::WaitSet> & wait_result
+);
+
+}  // namespace executors
+}  // namespace rclcpp
+
+#endif  // RCLCPP__EXECUTORS__EXECUTOR_ENTITIES_COLLECTION_HPP_

--- a/rclcpp/include/rclcpp/executors/executor_entities_collection.hpp
+++ b/rclcpp/include/rclcpp/executors/executor_entities_collection.hpp
@@ -15,7 +15,6 @@
 #ifndef RCLCPP__EXECUTORS__EXECUTOR_ENTITIES_COLLECTION_HPP_
 #define RCLCPP__EXECUTORS__EXECUTOR_ENTITIES_COLLECTION_HPP_
 
-#include "rclcpp/subscription_base.hpp"
 #include <deque>
 #include <unordered_map>
 #include <vector>
@@ -33,18 +32,19 @@ namespace rclcpp
 namespace executors
 {
 
-template <typename EntityValueType>
-struct CollectionEntry {
+template<typename EntityValueType>
+struct CollectionEntry
+{
   typename EntityValueType::WeakPtr entity;
   rclcpp::CallbackGroup::WeakPtr callback_group;
 };
 
-template <typename CollectionType>
+template<typename CollectionType>
 void update_entities(
   const CollectionType & update_from,
   CollectionType update_to,
-  std::function<void (typename CollectionType::mapped_type::EntitySharedPtr) > on_added,
-  std::function<void (typename CollectionType::mapped_type::EntitySharedPtr) > on_removed
+  std::function<void(typename CollectionType::mapped_type::EntitySharedPtr)> on_added,
+  std::function<void(typename CollectionType::mapped_type::EntitySharedPtr)> on_removed
 )
 {
   for (auto it = update_to.begin(); it != update_to.end(); ) {
@@ -68,18 +68,19 @@ void update_entities(
     }
   }
 }
-template <typename EntityKeyType, typename EntityValueType>
-class EntityCollection:
-  public std::unordered_map<const EntityKeyType *, CollectionEntry<EntityValueType>>
+template<typename EntityKeyType, typename EntityValueType>
+class EntityCollection
+  : public std::unordered_map<const EntityKeyType *, CollectionEntry<EntityValueType>>
 {
 public:
   using Key = const EntityKeyType *;
   using EntityWeakPtr = typename EntityValueType::WeakPtr;
   using EntitySharedPtr = typename EntityValueType::SharedPtr;
 
-  void update(const EntityCollection<EntityKeyType, EntityValueType> & other,
-              std::function<void (EntitySharedPtr)> on_added,
-              std::function<void (EntitySharedPtr)> on_removed)
+  void update(
+    const EntityCollection<EntityKeyType, EntityValueType> & other,
+    std::function<void(EntitySharedPtr)> on_added,
+    std::function<void(EntitySharedPtr)> on_removed)
   {
     update_entities(*this, other, on_added, on_removed);
   }

--- a/rclcpp/include/rclcpp/executors/executor_entities_collection.hpp
+++ b/rclcpp/include/rclcpp/executors/executor_entities_collection.hpp
@@ -16,6 +16,7 @@
 #define RCLCPP__EXECUTORS__EXECUTOR_ENTITIES_COLLECTION_HPP_
 
 #include <deque>
+#include <functional>
 #include <unordered_map>
 #include <vector>
 
@@ -67,8 +68,8 @@ template<typename CollectionType>
 void update_entities(
   const CollectionType & update_from,
   CollectionType & update_to,
-  std::function<void(typename CollectionType::EntitySharedPtr)> on_added,
-  std::function<void(typename CollectionType::EntitySharedPtr)> on_removed
+  std::function<void(const typename CollectionType::EntitySharedPtr &)> on_added,
+  std::function<void(const typename CollectionType::EntitySharedPtr &)> on_removed
 )
 {
   for (auto it = update_to.begin(); it != update_to.end(); ) {
@@ -119,8 +120,8 @@ public:
    */
   void update(
     const EntityCollection<EntityKeyType, EntityValueType> & other,
-    std::function<void(EntitySharedPtr)> on_added,
-    std::function<void(EntitySharedPtr)> on_removed)
+    std::function<void(const EntitySharedPtr &)> on_added,
+    std::function<void(const EntitySharedPtr &)> on_removed)
   {
     update_entities(other, *this, on_added, on_removed);
   }

--- a/rclcpp/include/rclcpp/executors/executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/executor_entities_collector.hpp
@@ -1,0 +1,151 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__EXECUTORS__EXECUTOR_ENTITIES_COLLECTOR_HPP_
+#define RCLCPP__EXECUTORS__EXECUTOR_ENTITIES_COLLECTOR_HPP_
+
+#include <list>
+#include <memory>
+#include <set>
+#include <vector>
+
+#include "rcpputils/thread_safety_annotations.hpp"
+
+#include <rclcpp/any_executable.hpp>
+#include <rclcpp/node_interfaces/node_base.hpp>
+#include <rclcpp/callback_group.hpp>
+#include <rclcpp/executors/executor_notify_waitable.hpp>
+#include <rclcpp/visibility_control.hpp>
+#include <rclcpp/wait_set.hpp>
+#include <rclcpp/wait_result.hpp>
+
+namespace rclcpp
+{
+namespace executors
+{
+
+class ExecutorEntitiesCollector
+{
+public:
+  RCLCPP_PUBLIC
+  ExecutorEntitiesCollector();
+
+  RCLCPP_PUBLIC
+  ~ExecutorEntitiesCollector();
+
+  /// Add a node to the entity collector
+  /**
+   * \param[in] node_ptr a shared pointer that points to a node base interface
+   * \throw std::runtime_error if the node is associated with an executor
+   */
+  RCLCPP_PUBLIC
+  void
+  add_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr);
+
+  /// Remove a node from the entity collector
+  /**
+   * \param[in] node_ptr a shared pointer that points to a node base interface
+   * \throw std::runtime_error if the node is associated with an executor
+   * \throw std::runtime_error if the node is associated with this executor
+   */
+  RCLCPP_PUBLIC
+  void
+  remove_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr);
+
+  RCLCPP_PUBLIC
+  bool
+  has_node(const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr);
+
+  /// Add a callback group to the entity collector
+  /**
+   * \param[in] group_ptr a shared pointer that points to a callback group
+   * \throw std::runtime_error if the callback_group is associated with an executor
+   */
+  RCLCPP_PUBLIC
+  void
+  add_callback_group(rclcpp::CallbackGroup::SharedPtr group_ptr);
+
+  /// Remove a callback group from the entity collector
+  /**
+   * \param[in] group_ptr a shared pointer that points to a callback group
+   * \throw std::runtime_error if the callback_group is not associated with an executor
+   * \throw std::runtime_error if the callback_group is not associated with this executor
+   */
+  RCLCPP_PUBLIC
+  void
+  remove_callback_group(rclcpp::CallbackGroup::SharedPtr group_ptr);
+
+  RCLCPP_PUBLIC
+  std::vector<rclcpp::CallbackGroup::WeakPtr>
+  get_all_callback_groups();
+
+  RCLCPP_PUBLIC
+  std::vector<rclcpp::CallbackGroup::WeakPtr>
+  get_manually_added_callback_groups();
+
+  RCLCPP_PUBLIC
+  std::vector<rclcpp::CallbackGroup::WeakPtr>
+  get_automatically_added_callback_groups();
+
+  RCLCPP_PUBLIC
+  void
+  update_collections();
+
+  RCLCPP_PUBLIC
+  std::shared_ptr<ExecutorNotifyWaitable>
+  get_executor_notify_waitable();
+
+protected:
+  using CallbackGroupCollection = std::set<
+    rclcpp::CallbackGroup::WeakPtr,
+    std::owner_less<rclcpp::CallbackGroup::WeakPtr>>;
+
+  RCLCPP_PUBLIC
+  void
+  add_callback_group_to_collection(
+    rclcpp::CallbackGroup::SharedPtr group_ptr,
+    CallbackGroupCollection & collection) RCPPUTILS_TSA_REQUIRES(mutex_);
+
+  RCLCPP_PUBLIC
+  void
+  remove_callback_group_from_collection(
+    rclcpp::CallbackGroup::SharedPtr group_ptr,
+    CallbackGroupCollection & collection) RCPPUTILS_TSA_REQUIRES(mutex_);
+
+  RCLCPP_PUBLIC
+  void
+  add_automatically_associated_callback_groups() RCPPUTILS_TSA_REQUIRES(mutex_);
+
+  RCLCPP_PUBLIC
+  void
+  prune_invalid_nodes_and_groups() RCPPUTILS_TSA_REQUIRES(mutex_);
+
+  mutable std::mutex mutex_;
+
+  CallbackGroupCollection
+  manually_added_groups_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
+
+  CallbackGroupCollection
+  automatically_added_groups_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
+
+  /// nodes that are associated with the executor
+  std::list<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr>
+  weak_nodes_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
+
+  std::shared_ptr<ExecutorNotifyWaitable> notify_waitable_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
+};
+}  // namespace executors
+}  // namespace rclcpp
+
+#endif  // RCLCPP__EXECUTORS__EXECUTOR_ENTITIES_COLLECTOR_HPP_

--- a/rclcpp/include/rclcpp/executors/executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/executor_entities_collector.hpp
@@ -182,7 +182,7 @@ protected:
    */
   RCLCPP_PUBLIC
   NodeCollection::iterator
-  remove_weak_node(NodeCollection::iterator weak_node);
+  remove_weak_node(NodeCollection::iterator weak_node) RCPPUTILS_TSA_REQUIRES(mutex_);
 
   /// Implementation of removing a callback group from the collector.
   /**
@@ -201,7 +201,7 @@ protected:
   CallbackGroupCollection::iterator
   remove_weak_callback_group(
     CallbackGroupCollection::iterator weak_group_it,
-    CallbackGroupCollection & collection);
+    CallbackGroupCollection & collection) RCPPUTILS_TSA_REQUIRES(mutex_);
 
   /// Implementation of adding a callback group
   /**
@@ -212,65 +212,54 @@ protected:
   void
   add_callback_group_to_collection(
     rclcpp::CallbackGroup::SharedPtr group_ptr,
-    CallbackGroupCollection & collection);
-
-  /// Implementation of removing a callback group
-  /**
-   * \param[in] group_ptr the group to remove
-   * \param[in] collection the collection to remove the group from
-   */
-  RCLCPP_PUBLIC
-  void
-  remove_callback_group_from_collection(
-    rclcpp::CallbackGroup::SharedPtr group_ptr,
-    CallbackGroupCollection & collection);
+    CallbackGroupCollection & collection)  RCPPUTILS_TSA_REQUIRES(mutex_);
 
   /// Iterate over queued added/remove nodes and callback_groups
   RCLCPP_PUBLIC
   void
-  process_queues();
+  process_queues() RCPPUTILS_TSA_REQUIRES(mutex_);
 
   /// Check a collection of nodes and add any new callback_groups that
   /// are set to be automatically associated via the node.
   RCLCPP_PUBLIC
   void
   add_automatically_associated_callback_groups(
-    const NodeCollection & nodes_to_check);
+    const NodeCollection & nodes_to_check) RCPPUTILS_TSA_REQUIRES(mutex_);
 
   /// Check all nodes and group for expired weak pointers and remove them.
   RCLCPP_PUBLIC
   void
-  prune_invalid_nodes_and_groups();
+  prune_invalid_nodes_and_groups() RCPPUTILS_TSA_REQUIRES(mutex_);
 
-  /// mutex to protect pending queues
-  mutable std::mutex pending_mutex_;
+  /// mutex to protect collections and pending queues
+  mutable std::mutex mutex_;
 
   /// Callback groups that were added via `add_callback_group`
-  CallbackGroupCollection manually_added_groups_;
+  CallbackGroupCollection manually_added_groups_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
 
   /// Callback groups that were added by their association with added nodes
-  CallbackGroupCollection automatically_added_groups_;
+  CallbackGroupCollection automatically_added_groups_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
 
   /// nodes that are associated with the executor
-  NodeCollection weak_nodes_;
+  NodeCollection weak_nodes_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
 
   /// Track guard conditions associated with added nodes
-  WeakNodesToGuardConditionsMap weak_nodes_to_guard_conditions_;
+  WeakNodesToGuardConditionsMap weak_nodes_to_guard_conditions_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
 
   /// Track guard conditions associated with added callback groups
-  WeakGroupsToGuardConditionsMap weak_groups_to_guard_conditions_;
+  WeakGroupsToGuardConditionsMap weak_groups_to_guard_conditions_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
 
   /// nodes that have been added since the last update.
-  NodeCollection pending_added_nodes_;
+  NodeCollection pending_added_nodes_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
 
   /// nodes that have been removed since the last update.
-  NodeCollection pending_removed_nodes_;
+  NodeCollection pending_removed_nodes_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
 
   /// callback groups that have been added since the last update.
-  CallbackGroupCollection pending_manually_added_groups_;
+  CallbackGroupCollection pending_manually_added_groups_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
 
   /// callback groups that have been removed since the last update.
-  CallbackGroupCollection pending_manually_removed_groups_;
+  CallbackGroupCollection pending_manually_removed_groups_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
 
   /// Waitable to add guard conditions to
   std::shared_ptr<ExecutorNotifyWaitable> notify_waitable_;

--- a/rclcpp/include/rclcpp/executors/executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/executor_entities_collector.hpp
@@ -174,37 +174,76 @@ protected:
     rclcpp::GuardCondition::WeakPtr,
     std::owner_less<rclcpp::CallbackGroup::WeakPtr>>;
 
+  /// Implementation of removing a node from the collector.
+  /**
+   * This will disassociate the node from the collector and remove any
+   * automatically-added callback groups
+   *
+   * This takes and returns an iterator so it may be used as:
+   *
+   * it = remove_weak_node(it);
+   *
+   * \param[in] weak_node iterator to the weak node to be removed
+   * \return Valid updated iterator in the same collection
+   */
   RCLCPP_PUBLIC
   NodeCollection::iterator
   remove_weak_node(NodeCollection::iterator weak_node);
 
+  /// Implementation of removing a callback gruop from the collector.
+  /**
+   * This will disassociate the callback group from the collector
+   *
+   * This takes and returns an iterator so it may be used as:
+   *
+   * it = remove_weak_callback_group(it);
+   *
+   * \param[in] weak_group_it iterator to the weak group to be removed
+   * \param[in] collection the collection to remove the group from
+   *   (manually or automatically added)
+   * \return Valid updated iterator in the same collection
+   */
   RCLCPP_PUBLIC
   CallbackGroupCollection::iterator
   remove_weak_callback_group(
     CallbackGroupCollection::iterator weak_group_it,
     CallbackGroupCollection & collection);
 
+  /// Implementation of adding a callback group
+  /**
+   * \param[in] group_ptr the group to add
+   * \param[in] collection the collection to add the group to
+   */
   RCLCPP_PUBLIC
   void
   add_callback_group_to_collection(
     rclcpp::CallbackGroup::SharedPtr group_ptr,
     CallbackGroupCollection & collection);
 
+  /// Implementation of removing a callback group
+  /**
+   * \param[in] group_ptr the group to remove
+   * \param[in] collection the collection to remove the group from
+   */
   RCLCPP_PUBLIC
   void
   remove_callback_group_from_collection(
     rclcpp::CallbackGroup::SharedPtr group_ptr,
     CallbackGroupCollection & collection);
 
+  /// Iterate over queued added/remove nodes and callback_groups
   RCLCPP_PUBLIC
   void
   process_queues();
 
+  /// Check a collection of nodes and add any new callback_groups that
+  /// are set to be automatically associated via the node.
   RCLCPP_PUBLIC
   void
   add_automatically_associated_callback_groups(
     const NodeCollection & nodes_to_check);
 
+  /// Check all nodes and group for expired weak pointers and remove them.
   RCLCPP_PUBLIC
   void
   prune_invalid_nodes_and_groups();
@@ -218,15 +257,28 @@ protected:
   /// nodes that are associated with the executor
   NodeCollection weak_nodes_;
 
+  /// mutex to protect pending queues
   std::mutex pending_mutex_;
+
+  /// nodes that have been added since the last update.
   NodeCollection pending_added_nodes_;
+
+  /// nodes that have been removed since the last update.
   NodeCollection pending_removed_nodes_;
+
+  /// callback groups that have been added since the last update.
   CallbackGroupCollection pending_manually_added_groups_;
+
+  /// callback groups that have been removed since the last update.
   CallbackGroupCollection pending_manually_removed_groups_;
 
+  /// Track guard conditions associated with added nodes
   WeakNodesToGuardConditionsMap weak_nodes_to_guard_conditions_;
+
+  /// Track guard conditions associated with added callback groups
   WeakGroupsToGuardConditionsMap weak_groups_to_guard_conditions_;
 
+  /// Waitable to add guard conditions to
   std::shared_ptr<ExecutorNotifyWaitable> notify_waitable_;
 };
 }  // namespace executors

--- a/rclcpp/include/rclcpp/executors/executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/executor_entities_collector.hpp
@@ -63,7 +63,7 @@ public:
    */
   RCLCPP_PUBLIC
   explicit ExecutorEntitiesCollector(
-      std::function<void(void)> on_notify_waitable_callback = {});
+    std::function<void(void)> on_notify_waitable_callback = {});
 
   /// Destructor
   RCLCPP_PUBLIC
@@ -172,7 +172,8 @@ protected:
   RCLCPP_PUBLIC
   void
   add_automatically_associated_callback_groups(
-    std::list<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr> nodes_to_check) RCPPUTILS_TSA_REQUIRES(mutex_);
+    std::list<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr> nodes_to_check)
+  RCPPUTILS_TSA_REQUIRES(mutex_);
 
   RCLCPP_PUBLIC
   void

--- a/rclcpp/include/rclcpp/executors/executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/executor_entities_collector.hpp
@@ -16,6 +16,7 @@
 #define RCLCPP__EXECUTORS__EXECUTOR_ENTITIES_COLLECTOR_HPP_
 
 #include <list>
+#include <map>
 #include <memory>
 #include <set>
 #include <vector>

--- a/rclcpp/include/rclcpp/executors/executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/executor_entities_collector.hpp
@@ -64,7 +64,7 @@ public:
    */
   RCLCPP_PUBLIC
   explicit ExecutorEntitiesCollector(
-    std::function<void(void)> on_notify_waitable_callback = {});
+    std::shared_ptr<ExecutorNotifyWaitable> notify_waitable);
 
   /// Destructor
   RCLCPP_PUBLIC
@@ -144,9 +144,6 @@ public:
   std::vector<rclcpp::CallbackGroup::WeakPtr>
   get_automatically_added_callback_groups();
 
-  RCLCPP_PUBLIC
-  std::shared_ptr<ExecutorNotifyWaitable> get_notify_waitable();
-
   /// Update the underlying collections
   /**
    * This will prune nodes and callback groups that are no longer valid as well
@@ -225,7 +222,7 @@ protected:
 
   WeakGroupsToGuardConditionsMap weak_groups_to_guard_conditions_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
 
-  std::shared_ptr<ExecutorNotifyWaitable> notify_waitable_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
+  std::shared_ptr<ExecutorNotifyWaitable> notify_waitable_;
 };
 }  // namespace executors
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/executors/executor_notify_waitable.hpp
+++ b/rclcpp/include/rclcpp/executors/executor_notify_waitable.hpp
@@ -85,7 +85,7 @@ public:
    */
   RCLCPP_PUBLIC
   void
-  add_guard_condition(rclcpp::GuardCondition * guard_condition);
+  add_guard_condition(const rclcpp::GuardCondition * guard_condition);
 
   /// Remove a guard condition from being waited on.
   /**
@@ -93,7 +93,7 @@ public:
    */
   RCLCPP_PUBLIC
   void
-  remove_guard_condition(rclcpp::GuardCondition * guard_condition);
+  remove_guard_condition(const rclcpp::GuardCondition * guard_condition);
 
   /// Get the number of ready guard_conditions
   /**
@@ -108,7 +108,16 @@ private:
   std::function<void(void)> execute_callback_;
 
   /// The collection of guard conditions to be waited on.
+  std::mutex guard_condition_mutex_;
+
+  /// The collection of guard conditions to be waited on.
   std::list<const rclcpp::GuardCondition *> notify_guard_conditions_;
+
+  /// The collection of guard conditions to be waited on.
+  std::list<const rclcpp::GuardCondition *> to_add_;
+
+  /// The collection of guard conditions to be waited on.
+  std::list<const rclcpp::GuardCondition *> to_remove_;
 };
 
 }  // namespace executors

--- a/rclcpp/include/rclcpp/executors/executor_notify_waitable.hpp
+++ b/rclcpp/include/rclcpp/executors/executor_notify_waitable.hpp
@@ -35,7 +35,6 @@ class ExecutorNotifyWaitable : public rclcpp::Waitable
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(ExecutorNotifyWaitable)
 
-
   // Constructor
   /**
    * \param[in] on_execute_callback Callback to execute when one of the conditions

--- a/rclcpp/include/rclcpp/executors/executor_notify_waitable.hpp
+++ b/rclcpp/include/rclcpp/executors/executor_notify_waitable.hpp
@@ -1,0 +1,117 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__EXECUTORS__EXECUTOR_NOTIFY_WAITABLE_HPP_
+#define RCLCPP__EXECUTORS__EXECUTOR_NOTIFY_WAITABLE_HPP_
+
+#include <list>
+#include <memory>
+
+#include "rclcpp/guard_condition.hpp"
+#include "rclcpp/waitable.hpp"
+
+namespace rclcpp
+{
+namespace executors
+{
+
+/// Maintain a collection of guard conditions from associated nodes and callback groups
+/// to signal to the executor when associated entities have changed.
+class ExecutorNotifyWaitable : public rclcpp::Waitable
+{
+public:
+  RCLCPP_SMART_PTR_DEFINITIONS(ExecutorNotifyWaitable)
+
+  // Constructor
+  /**
+   * \param[in] on_execute_callback Callback to execute when one of the conditions
+   *   of this waitable has signaled the wait_set.
+   */
+  RCLCPP_PUBLIC
+  explicit ExecutorNotifyWaitable(std::function<void(void)> on_execute_callback = {});
+
+  // Destructor
+  RCLCPP_PUBLIC
+  ~ExecutorNotifyWaitable() override = default;
+
+  /// Add conditions to the wait set
+  /**
+   * \param[inout] wait_set structure that conditions will be added to
+   */
+  RCLCPP_PUBLIC
+  void
+  add_to_wait_set(rcl_wait_set_t * wait_set) override;
+
+  /// Check conditions against the wait set
+  /**
+   * \param[inout] wait_set structure that internal elements will be checked against.
+   * \return true if this waitable is ready to be executed, false otherwise.
+   */
+  RCLCPP_PUBLIC
+  bool
+  is_ready(rcl_wait_set_t * wait_set) override;
+
+  /// Perform work associated with the waitable.
+  /**
+   * This will call the callback provided in the constructor.
+   * \param[in] data Data to be use for the execute, if available, else nullptr.
+   */
+  RCLCPP_PUBLIC
+  void
+  execute(std::shared_ptr<void> & data) override;
+
+  /// Retrieve data to be used in the next execute call.
+  /**
+   * \return If available, data to be used, otherwise nullptr
+   */
+  RCLCPP_PUBLIC
+  std::shared_ptr<void>
+  take_data() override;
+
+  /// Add a guard condition to be waited on.
+  /**
+   * \param[in] guard_condition The guard condition to add.
+   */
+  RCLCPP_PUBLIC
+  void
+  add_guard_condition(rclcpp::GuardCondition * guard_condition);
+
+  /// Remove a guard condition from being waited on.
+  /**
+   * \param[in] guard_condition The guard condition to remove.
+   */
+  RCLCPP_PUBLIC
+  void
+  remove_guard_condition(rclcpp::GuardCondition * guard_condition);
+
+  /// Get the number of ready guard_conditions
+  /**
+   * \return The number of guard_conditions associated with the Waitable.
+   */
+  RCLCPP_PUBLIC
+  size_t
+  get_number_of_ready_guard_conditions() override;
+
+private:
+  /// Callback to run when waitable executes
+  std::function<void(void)> execute_callback_;
+
+  /// The collection of guard conditions to be waited on.
+  std::list<const rclcpp::GuardCondition *> notify_guard_conditions_;
+};
+
+}  // namespace executors
+}  // namespace rclcpp
+
+#endif  // RCLCPP__EXECUTORS__EXECUTOR_NOTIFY_WAITABLE_HPP_

--- a/rclcpp/include/rclcpp/executors/executor_notify_waitable.hpp
+++ b/rclcpp/include/rclcpp/executors/executor_notify_waitable.hpp
@@ -17,6 +17,7 @@
 
 #include <list>
 #include <memory>
+#include <set>
 
 #include "rclcpp/guard_condition.hpp"
 #include "rclcpp/waitable.hpp"
@@ -33,6 +34,7 @@ class ExecutorNotifyWaitable : public rclcpp::Waitable
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(ExecutorNotifyWaitable)
 
+
   // Constructor
   /**
    * \param[in] on_execute_callback Callback to execute when one of the conditions
@@ -44,6 +46,13 @@ public:
   // Destructor
   RCLCPP_PUBLIC
   ~ExecutorNotifyWaitable() override = default;
+
+  RCLCPP_PUBLIC
+  ExecutorNotifyWaitable(const ExecutorNotifyWaitable & other);
+
+
+  RCLCPP_PUBLIC
+  ExecutorNotifyWaitable & operator=(const ExecutorNotifyWaitable & other);
 
   /// Add conditions to the wait set
   /**
@@ -85,7 +94,7 @@ public:
    */
   RCLCPP_PUBLIC
   void
-  add_guard_condition(const rclcpp::GuardCondition * guard_condition);
+  add_guard_condition(rclcpp::GuardCondition::WeakPtr guard_condition);
 
   /// Remove a guard condition from being waited on.
   /**
@@ -93,7 +102,7 @@ public:
    */
   RCLCPP_PUBLIC
   void
-  remove_guard_condition(const rclcpp::GuardCondition * guard_condition);
+  remove_guard_condition(rclcpp::GuardCondition::WeakPtr guard_condition);
 
   /// Get the number of ready guard_conditions
   /**
@@ -107,17 +116,11 @@ private:
   /// Callback to run when waitable executes
   std::function<void(void)> execute_callback_;
 
-  /// The collection of guard conditions to be waited on.
   std::mutex guard_condition_mutex_;
 
   /// The collection of guard conditions to be waited on.
-  std::list<const rclcpp::GuardCondition *> notify_guard_conditions_;
-
-  /// The collection of guard conditions to be waited on.
-  std::list<const rclcpp::GuardCondition *> to_add_;
-
-  /// The collection of guard conditions to be waited on.
-  std::list<const rclcpp::GuardCondition *> to_remove_;
+  std::set<rclcpp::GuardCondition::WeakPtr,
+    std::owner_less<rclcpp::GuardCondition::WeakPtr>> notify_guard_conditions_;
 };
 
 }  // namespace executors

--- a/rclcpp/include/rclcpp/executors/executor_notify_waitable.hpp
+++ b/rclcpp/include/rclcpp/executors/executor_notify_waitable.hpp
@@ -15,8 +15,9 @@
 #ifndef RCLCPP__EXECUTORS__EXECUTOR_NOTIFY_WAITABLE_HPP_
 #define RCLCPP__EXECUTORS__EXECUTOR_NOTIFY_WAITABLE_HPP_
 
-#include <list>
+#include <functional>
 #include <memory>
+#include <mutex>
 #include <set>
 
 #include "rclcpp/guard_condition.hpp"

--- a/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
@@ -122,8 +122,12 @@ public:
   get_associated_with_executor_atomic() override;
 
   RCLCPP_PUBLIC
-  rclcpp::GuardCondition &
+  rclcpp::GuardCondition::SharedPtr
   get_notify_guard_condition() override;
+
+  RCLCPP_PUBLIC
+  void
+  trigger_notify_guard_condition() override;
 
   RCLCPP_PUBLIC
   bool
@@ -153,7 +157,7 @@ private:
 
   /// Guard condition for notifying the Executor of changes to this node.
   mutable std::recursive_mutex notify_guard_condition_mutex_;
-  rclcpp::GuardCondition notify_guard_condition_;
+  std::shared_ptr<rclcpp::GuardCondition> notify_guard_condition_;
   bool notify_guard_condition_is_valid_;
 };
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
@@ -121,9 +121,14 @@ public:
   std::atomic_bool &
   get_associated_with_executor_atomic() override;
 
+  [[deprecated("Use get_shared_notify_guard_condition or trigger_notify_guard_condition instead")]]
+  RCLCPP_PUBLIC
+  rclcpp::GuardCondition &
+  get_notify_guard_condition() override;
+
   RCLCPP_PUBLIC
   rclcpp::GuardCondition::SharedPtr
-  get_notify_guard_condition() override;
+  get_shared_notify_guard_condition() override;
 
   RCLCPP_PUBLIC
   void

--- a/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
@@ -148,13 +148,28 @@ public:
   /**
    * For example, this should be notified when a publisher is added or removed.
    *
-   * \return the GuardCondition if it is valid, else thow runtime error
+   * \return the GuardCondition if it is valid, else throw runtime error
+   */
+  RCLCPP_PUBLIC
+  virtual
+  rclcpp::GuardCondition &
+  get_notify_guard_condition() = 0;
+
+  /// Return a guard condition that should be notified when the internal node state changes.
+  /**
+   * For example, this should be notified when a publisher is added or removed.
+   *
+   * \return the GuardCondition if it is valid, else nullptr
    */
   RCLCPP_PUBLIC
   virtual
   rclcpp::GuardCondition::SharedPtr
-  get_notify_guard_condition() = 0;
+  get_shared_notify_guard_condition() = 0;
 
+  /// Trigger the guard condition that notifies of internal node state changes.
+  /**
+   * For example, this should be notified when a publisher is added or removed.
+   */
   RCLCPP_PUBLIC
   virtual
   void

--- a/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
@@ -152,8 +152,13 @@ public:
    */
   RCLCPP_PUBLIC
   virtual
-  rclcpp::GuardCondition &
+  rclcpp::GuardCondition::SharedPtr
   get_notify_guard_condition() = 0;
+
+  RCLCPP_PUBLIC
+  virtual
+  void
+  trigger_notify_guard_condition() = 0;
 
   /// Return the default preference for using intra process communication.
   RCLCPP_PUBLIC

--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -146,10 +146,8 @@ CallbackGroup::get_notify_guard_condition()
   if (!this->get_context_) {
     throw std::runtime_error("Callback group was created without context and not passed context");
   }
-
   auto context_ptr = this->get_context_();
   if (context_ptr && context_ptr->is_valid()) {
-    std::lock_guard<std::recursive_mutex> lock(notify_guard_condition_mutex_);
     if (notify_guard_condition_ && context_ptr != notify_guard_condition_->get_context()) {
       if (associated_with_executor_) {
         trigger_notify_guard_condition();

--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -142,6 +142,11 @@ rclcpp::GuardCondition::SharedPtr
 CallbackGroup::get_notify_guard_condition()
 {
   std::lock_guard<std::recursive_mutex> lock(notify_guard_condition_mutex_);
+
+  if (!this->get_context_) {
+    throw std::runtime_error("Callback group was created without context and not passed context");
+  }
+
   auto context_ptr = this->get_context_();
   if (context_ptr && context_ptr->is_valid()) {
     std::lock_guard<std::recursive_mutex> lock(notify_guard_condition_mutex_);
@@ -151,14 +156,10 @@ CallbackGroup::get_notify_guard_condition()
       }
       notify_guard_condition_ = nullptr;
     }
-
     if (!notify_guard_condition_) {
       notify_guard_condition_ = std::make_shared<rclcpp::GuardCondition>(context_ptr);
     }
-
     return notify_guard_condition_;
-  } else {
-    throw std::runtime_error("Couldn't get guard condition from invalid context");
   }
   return nullptr;
 }

--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -141,6 +141,7 @@ CallbackGroup::get_notify_guard_condition(const rclcpp::Context::SharedPtr conte
 rclcpp::GuardCondition::SharedPtr
 CallbackGroup::get_notify_guard_condition()
 {
+  std::lock_guard<std::recursive_mutex> lock(notify_guard_condition_mutex_);
   auto context_ptr = this->get_context_();
   if (context_ptr && context_ptr->is_valid()) {
     std::lock_guard<std::recursive_mutex> lock(notify_guard_condition_mutex_);
@@ -156,6 +157,8 @@ CallbackGroup::get_notify_guard_condition()
     }
 
     return notify_guard_condition_;
+  } else {
+    throw std::runtime_error("Couldn't get guard condition from invalid context");
   }
   return nullptr;
 }

--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -43,8 +43,8 @@ CallbackGroup::~CallbackGroup()
 {
   trigger_notify_guard_condition();
 }
-
 bool
+
 CallbackGroup::has_valid_node()
 {
   return nullptr != this->get_context_();

--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -43,12 +43,6 @@ CallbackGroup::~CallbackGroup()
 {
   trigger_notify_guard_condition();
 }
-bool
-
-CallbackGroup::has_valid_node() const
-{
-  return nullptr != this->get_context_();
-}
 
 std::atomic_bool &
 CallbackGroup::can_be_taken_from()
@@ -142,7 +136,6 @@ rclcpp::GuardCondition::SharedPtr
 CallbackGroup::get_notify_guard_condition()
 {
   std::lock_guard<std::recursive_mutex> lock(notify_guard_condition_mutex_);
-
   if (!this->get_context_) {
     throw std::runtime_error("Callback group was created without context and not passed context");
   }

--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -45,7 +45,7 @@ CallbackGroup::~CallbackGroup()
 }
 bool
 
-CallbackGroup::has_valid_node()
+CallbackGroup::has_valid_node() const
 {
   return nullptr != this->get_context_();
 }

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -38,14 +38,11 @@
 using namespace std::chrono_literals;
 
 using rclcpp::exceptions::throw_from_rcl_error;
-using rclcpp::AnyExecutable;
 using rclcpp::Executor;
-using rclcpp::ExecutorOptions;
-using rclcpp::FutureReturnCode;
 
 Executor::Executor(const rclcpp::ExecutorOptions & options)
 : spinning(false),
-  interrupt_guard_condition_(options.context),
+  interrupt_guard_condition_(std::make_shared<rclcpp::GuardCondition>(options.context)),
   shutdown_guard_condition_(std::make_shared<rclcpp::GuardCondition>(options.context)),
   memory_strategy_(options.memory_strategy)
 {
@@ -65,7 +62,7 @@ Executor::Executor(const rclcpp::ExecutorOptions & options)
   memory_strategy_->add_guard_condition(*shutdown_guard_condition_.get());
 
   // Put the executor's guard condition in
-  memory_strategy_->add_guard_condition(interrupt_guard_condition_);
+  memory_strategy_->add_guard_condition(*interrupt_guard_condition_.get());
   rcl_allocator_t allocator = memory_strategy_->get_allocator();
 
   rcl_ret_t ret = rcl_wait_set_init(
@@ -127,7 +124,7 @@ Executor::~Executor()
   }
   // Remove and release the sigint guard condition
   memory_strategy_->remove_guard_condition(shutdown_guard_condition_.get());
-  memory_strategy_->remove_guard_condition(&interrupt_guard_condition_);
+  memory_strategy_->remove_guard_condition(interrupt_guard_condition_.get());
 
   // Remove shutdown callback handle registered to Context
   if (!context_->remove_on_shutdown_callback(shutdown_callback_handle_)) {
@@ -231,7 +228,7 @@ Executor::add_callback_group_to_map(
   if (notify) {
     // Interrupt waiting to handle new node
     try {
-      interrupt_guard_condition_.trigger();
+      interrupt_guard_condition_->trigger();
     } catch (const rclcpp::exceptions::RCLError & ex) {
       throw std::runtime_error(
               std::string(
@@ -279,10 +276,10 @@ Executor::add_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_pt
       }
     });
 
-  const auto & gc = node_ptr->get_notify_guard_condition();
-  weak_nodes_to_guard_conditions_[node_ptr] = &gc;
+  const auto gc = node_ptr->get_notify_guard_condition();
+  weak_nodes_to_guard_conditions_[node_ptr] = gc.get();
   // Add the node's notify condition to the guard condition handles
-  memory_strategy_->add_guard_condition(gc);
+  memory_strategy_->add_guard_condition(*gc);
   weak_nodes_.push_back(node_ptr);
 }
 
@@ -319,7 +316,7 @@ Executor::remove_callback_group_from_map(
 
     if (notify) {
       try {
-        interrupt_guard_condition_.trigger();
+        interrupt_guard_condition_->trigger();
       } catch (const rclcpp::exceptions::RCLError & ex) {
         throw std::runtime_error(
                 std::string(
@@ -387,7 +384,7 @@ Executor::remove_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node
     }
   }
 
-  memory_strategy_->remove_guard_condition(&node_ptr->get_notify_guard_condition());
+  memory_strategy_->remove_guard_condition(node_ptr->get_notify_guard_condition().get());
   weak_nodes_to_guard_conditions_.erase(node_ptr);
 
   std::atomic_bool & has_executor = node_ptr->get_associated_with_executor_atomic();
@@ -500,7 +497,7 @@ Executor::cancel()
 {
   spinning.store(false);
   try {
-    interrupt_guard_condition_.trigger();
+    interrupt_guard_condition_->trigger();
   } catch (const rclcpp::exceptions::RCLError & ex) {
     throw std::runtime_error(
             std::string("Failed to trigger guard condition in cancel: ") + ex.what());
@@ -549,7 +546,7 @@ Executor::execute_any_executable(AnyExecutable & any_exec)
   // Wake the wait, because it may need to be recalculated or work that
   // was previously blocked is now available.
   try {
-    interrupt_guard_condition_.trigger();
+    interrupt_guard_condition_->trigger();
   } catch (const rclcpp::exceptions::RCLError & ex) {
     throw std::runtime_error(
             std::string(

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -222,8 +222,7 @@ Executor::add_callback_group_to_map(
   weak_groups_to_nodes_.insert(std::make_pair(weak_group_ptr, node_ptr));
 
   if (node_ptr->get_context()->is_valid()) {
-    auto callback_group_guard_condition =
-      group_ptr->get_notify_guard_condition(node_ptr->get_context());
+    auto callback_group_guard_condition = group_ptr->get_notify_guard_condition();
     weak_groups_to_guard_conditions_[weak_group_ptr] = callback_group_guard_condition.get();
     // Add the callback_group's notify condition to the guard condition handles
     memory_strategy_->add_guard_condition(*callback_group_guard_condition);

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -276,7 +276,7 @@ Executor::add_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_pt
       }
     });
 
-  const auto gc = node_ptr->get_notify_guard_condition();
+  const auto gc = node_ptr->get_shared_notify_guard_condition();
   weak_nodes_to_guard_conditions_[node_ptr] = gc.get();
   // Add the node's notify condition to the guard condition handles
   memory_strategy_->add_guard_condition(*gc);
@@ -384,7 +384,7 @@ Executor::remove_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node
     }
   }
 
-  memory_strategy_->remove_guard_condition(node_ptr->get_notify_guard_condition().get());
+  memory_strategy_->remove_guard_condition(node_ptr->get_shared_notify_guard_condition().get());
   weak_nodes_to_guard_conditions_.erase(node_ptr);
 
   std::atomic_bool & has_executor = node_ptr->get_associated_with_executor_atomic();

--- a/rclcpp/src/rclcpp/executors/executor_entities_collection.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_entities_collection.cpp
@@ -1,0 +1,356 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/executors/executor_entities_collection.hpp"
+
+namespace rclcpp
+{
+namespace executors
+{
+
+void ExecutorEntitiesCollection::clear()
+{
+  subscriptions.clear();
+  timers.clear();
+  guard_conditions.clear();
+  clients.clear();
+  services.clear();
+  waitables.clear();
+}
+
+void ExecutorEntitiesCollection::update_timers(
+  const ExecutorEntitiesCollection::TimerCollection & other,
+  TimerUpdatedFunc timer_added,
+  TimerUpdatedFunc timer_removed)
+{
+  for (auto it = this->timers.begin(); it != this->timers.end(); ) {
+    if (other.count(it->first) == 0) {
+      auto timer = it->second.timer.lock();
+      if (timer) {
+        timer_removed(timer);
+      }
+      it = this->timers.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  for (auto it = other.begin(); it != other.end(); ++it) {
+    if (this->timers.count(it->first) == 0) {
+      auto timer = it->second.timer.lock();
+      if (timer) {
+        timer_added(timer);
+      }
+      this->timers.insert(*it);
+    }
+  }
+}
+
+void ExecutorEntitiesCollection::update_subscriptions(
+  const ExecutorEntitiesCollection::SubscriptionCollection & other,
+  SubscriptionUpdatedFunc subscription_added,
+  SubscriptionUpdatedFunc subscription_removed)
+{
+  for (auto it = this->subscriptions.begin(); it != this->subscriptions.end(); ) {
+    if (other.count(it->first) == 0) {
+      auto subscription = it->second.subscription.lock();
+      if (subscription) {
+        subscription_removed(subscription);
+      }
+      it = this->subscriptions.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  for (auto it = other.begin(); it != other.end(); ++it) {
+    if (this->subscriptions.count(it->first) == 0) {
+      auto subscription = it->second.subscription.lock();
+      if (subscription) {
+        subscription_added(subscription);
+      }
+      this->subscriptions.insert(*it);
+    }
+  }
+}
+
+void ExecutorEntitiesCollection::update_clients(
+  const ExecutorEntitiesCollection::ClientCollection & other,
+  ClientUpdatedFunc client_added,
+  ClientUpdatedFunc client_removed)
+{
+  for (auto it = this->clients.begin(); it != this->clients.end(); ) {
+    if (other.count(it->first) == 0) {
+      auto client = it->second.client.lock();
+      if (client) {
+        client_removed(client);
+      }
+      it = this->clients.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  for (auto it = other.begin(); it != other.end(); ++it) {
+    if (this->clients.count(it->first) == 0) {
+      auto client = it->second.client.lock();
+      if (client) {
+        client_added(client);
+      }
+      this->clients.insert(*it);
+    }
+  }
+}
+
+void ExecutorEntitiesCollection::update_services(
+  const ExecutorEntitiesCollection::ServiceCollection & other,
+  ServiceUpdatedFunc service_added,
+  ServiceUpdatedFunc service_removed)
+{
+  for (auto it = this->services.begin(); it != this->services.end(); ) {
+    if (other.count(it->first) == 0) {
+      auto service = it->second.service.lock();
+      if (service) {
+        service_removed(service);
+      }
+      it = this->services.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  for (auto it = other.begin(); it != other.end(); ++it) {
+    if (this->services.count(it->first) == 0) {
+      auto service = it->second.service.lock();
+      if (service) {
+        service_added(service);
+      }
+      this->services.insert(*it);
+    }
+  }
+}
+
+void ExecutorEntitiesCollection::update_guard_conditions(
+  const ExecutorEntitiesCollection::GuardConditionCollection & other,
+  GuardConditionUpdatedFunc guard_condition_added,
+  GuardConditionUpdatedFunc guard_condition_removed)
+{
+  for (auto it = this->guard_conditions.begin(); it != this->guard_conditions.end(); ) {
+    if (other.count(it->first) == 0) {
+      auto guard_condition = it->second.lock();
+      if (guard_condition) {
+        guard_condition_removed(guard_condition);
+      }
+      it = this->guard_conditions.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  for (auto it = other.begin(); it != other.end(); ++it) {
+    if (this->guard_conditions.count(it->first) == 0) {
+      auto guard_condition = it->second.lock();
+      if (guard_condition) {
+        guard_condition_added(guard_condition);
+      }
+      this->guard_conditions.insert(*it);
+    }
+  }
+}
+
+void ExecutorEntitiesCollection::update_waitables(
+  const ExecutorEntitiesCollection::WaitableCollection & other,
+  WaitableUpdatedFunc waitable_added,
+  WaitableUpdatedFunc waitable_removed)
+{
+  for (auto it = this->waitables.begin(); it != this->waitables.end(); ) {
+    if (other.count(it->first) == 0) {
+      auto waitable = it->second.waitable.lock();
+      if (waitable) {
+        waitable_removed(waitable);
+      }
+      it = this->waitables.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  for (auto it = other.begin(); it != other.end(); ++it) {
+    if (this->waitables.count(it->first) == 0) {
+      auto waitable = it->second.waitable.lock();
+      if (waitable) {
+        waitable_added(waitable);
+      }
+      this->waitables.insert({it->first, it->second});
+    }
+  }
+}
+
+
+void
+build_entities_collection(
+  const std::vector<rclcpp::CallbackGroup::WeakPtr> & callback_groups,
+  ExecutorEntitiesCollection & collection)
+{
+  collection.clear();
+
+  for (auto weak_group_ptr : callback_groups) {
+    auto group_ptr = weak_group_ptr.lock();
+    if (!group_ptr) {
+      continue;
+    }
+
+    group_ptr->collect_all_ptrs(
+      [&collection, weak_group_ptr](const rclcpp::SubscriptionBase::SharedPtr & subscription) {
+        collection.subscriptions.insert(
+          {
+            subscription->get_subscription_handle().get(),
+            {subscription, weak_group_ptr}
+          });
+      },
+      [&collection, weak_group_ptr](const rclcpp::ServiceBase::SharedPtr & service) {
+        collection.services.insert(
+          {
+            service->get_service_handle().get(),
+            {service, weak_group_ptr}
+          });
+      },
+      [&collection, weak_group_ptr](const rclcpp::ClientBase::SharedPtr & client) {
+        collection.clients.insert(
+          {
+            client->get_client_handle().get(),
+            {client, weak_group_ptr}
+          });
+      },
+      [&collection, weak_group_ptr](const rclcpp::TimerBase::SharedPtr & timer) {
+        collection.timers.insert(
+          {
+            timer->get_timer_handle().get(),
+            {timer, weak_group_ptr}
+          });
+      },
+      [&collection, weak_group_ptr](const rclcpp::Waitable::SharedPtr & waitable) {
+        collection.waitables.insert(
+          {
+            waitable.get(),
+            {waitable, weak_group_ptr}
+          });
+      }
+    );
+  }
+}
+
+std::deque<rclcpp::AnyExecutable>
+ready_executables(
+  const ExecutorEntitiesCollection & collection,
+  rclcpp::WaitResult<rclcpp::WaitSet> & wait_result
+)
+{
+  std::deque<rclcpp::AnyExecutable> ret;
+
+  if (wait_result.kind() != rclcpp::WaitResultKind::Ready) {
+    return ret;
+  }
+
+  auto rcl_wait_set = wait_result.get_wait_set().get_rcl_wait_set();
+
+  for (size_t ii = 0; ii < rcl_wait_set.size_of_timers; ++ii) {
+    if (rcl_wait_set.timers[ii]) {
+      auto timer_iter = collection.timers.find(rcl_wait_set.timers[ii]);
+      if (timer_iter != collection.timers.end()) {
+        auto timer = timer_iter->second.timer.lock();
+        auto group = timer_iter->second.callback_group.lock();
+        if (!timer || !group || !group->can_be_taken_from().load()) {
+          continue;
+        }
+
+        if (!timer->call()) {
+          continue;
+        }
+
+        rclcpp::AnyExecutable exec;
+        exec.timer = timer;
+        exec.callback_group = group;
+        ret.push_back(exec);
+      }
+    }
+  }
+
+  for (size_t ii = 0; ii < rcl_wait_set.size_of_subscriptions; ++ii) {
+    if (rcl_wait_set.subscriptions[ii]) {
+      auto subscription_iter = collection.subscriptions.find(rcl_wait_set.subscriptions[ii]);
+      if (subscription_iter != collection.subscriptions.end()) {
+        auto subscription = subscription_iter->second.subscription.lock();
+        auto group = subscription_iter->second.callback_group.lock();
+        if (!subscription || !group || !group->can_be_taken_from().load()) {
+          continue;
+        }
+
+        rclcpp::AnyExecutable exec;
+        exec.subscription = subscription;
+        exec.callback_group = group;
+        ret.push_back(exec);
+      }
+    }
+  }
+
+  for (size_t ii = 0; ii < rcl_wait_set.size_of_services; ++ii) {
+    if (rcl_wait_set.services[ii]) {
+      auto service_iter = collection.services.find(rcl_wait_set.services[ii]);
+      if (service_iter != collection.services.end()) {
+        auto service = service_iter->second.service.lock();
+        auto group = service_iter->second.callback_group.lock();
+        if (!service || !group || !group->can_be_taken_from().load()) {
+          continue;
+        }
+
+        rclcpp::AnyExecutable exec;
+        exec.service = service;
+        exec.callback_group = group;
+        ret.push_back(exec);
+      }
+    }
+  }
+
+  for (size_t ii = 0; ii < rcl_wait_set.size_of_clients; ++ii) {
+    if (rcl_wait_set.clients[ii]) {
+      auto client_iter = collection.clients.find(rcl_wait_set.clients[ii]);
+      if (client_iter != collection.clients.end()) {
+        auto client = client_iter->second.client.lock();
+        auto group = client_iter->second.callback_group.lock();
+        if (!client || !group || !group->can_be_taken_from().load()) {
+          continue;
+        }
+
+        rclcpp::AnyExecutable exec;
+        exec.client = client;
+        exec.callback_group = group;
+        ret.push_back(exec);
+      }
+    }
+  }
+
+  for (auto & [handle, entry] : collection.waitables) {
+    auto waitable = entry.waitable.lock();
+    if (waitable && waitable->is_ready(&rcl_wait_set)) {
+      auto group = entry.callback_group.lock();
+      if (!group || !group->can_be_taken_from().load()) {
+        continue;
+      }
+
+      rclcpp::AnyExecutable exec;
+      exec.waitable = waitable;
+      exec.callback_group = group;
+      ret.push_back(exec);
+    }
+  }
+  return ret;
+}
+
+}  // namespace executors
+}  // namespace rclcpp

--- a/rclcpp/src/rclcpp/executors/executor_entities_collection.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_entities_collection.cpp
@@ -29,169 +29,6 @@ void ExecutorEntitiesCollection::clear()
   waitables.clear();
 }
 
-void ExecutorEntitiesCollection::update_timers(
-  const ExecutorEntitiesCollection::TimerCollection & other,
-  TimerUpdatedFunc timer_added,
-  TimerUpdatedFunc timer_removed)
-{
-  for (auto it = this->timers.begin(); it != this->timers.end(); ) {
-    if (other.count(it->first) == 0) {
-      auto timer = it->second.timer.lock();
-      if (timer) {
-        timer_removed(timer);
-      }
-      it = this->timers.erase(it);
-    } else {
-      ++it;
-    }
-  }
-  for (auto it = other.begin(); it != other.end(); ++it) {
-    if (this->timers.count(it->first) == 0) {
-      auto timer = it->second.timer.lock();
-      if (timer) {
-        timer_added(timer);
-      }
-      this->timers.insert(*it);
-    }
-  }
-}
-
-void ExecutorEntitiesCollection::update_subscriptions(
-  const ExecutorEntitiesCollection::SubscriptionCollection & other,
-  SubscriptionUpdatedFunc subscription_added,
-  SubscriptionUpdatedFunc subscription_removed)
-{
-  for (auto it = this->subscriptions.begin(); it != this->subscriptions.end(); ) {
-    if (other.count(it->first) == 0) {
-      auto subscription = it->second.subscription.lock();
-      if (subscription) {
-        subscription_removed(subscription);
-      }
-      it = this->subscriptions.erase(it);
-    } else {
-      ++it;
-    }
-  }
-  for (auto it = other.begin(); it != other.end(); ++it) {
-    if (this->subscriptions.count(it->first) == 0) {
-      auto subscription = it->second.subscription.lock();
-      if (subscription) {
-        subscription_added(subscription);
-      }
-      this->subscriptions.insert(*it);
-    }
-  }
-}
-
-void ExecutorEntitiesCollection::update_clients(
-  const ExecutorEntitiesCollection::ClientCollection & other,
-  ClientUpdatedFunc client_added,
-  ClientUpdatedFunc client_removed)
-{
-  for (auto it = this->clients.begin(); it != this->clients.end(); ) {
-    if (other.count(it->first) == 0) {
-      auto client = it->second.client.lock();
-      if (client) {
-        client_removed(client);
-      }
-      it = this->clients.erase(it);
-    } else {
-      ++it;
-    }
-  }
-  for (auto it = other.begin(); it != other.end(); ++it) {
-    if (this->clients.count(it->first) == 0) {
-      auto client = it->second.client.lock();
-      if (client) {
-        client_added(client);
-      }
-      this->clients.insert(*it);
-    }
-  }
-}
-
-void ExecutorEntitiesCollection::update_services(
-  const ExecutorEntitiesCollection::ServiceCollection & other,
-  ServiceUpdatedFunc service_added,
-  ServiceUpdatedFunc service_removed)
-{
-  for (auto it = this->services.begin(); it != this->services.end(); ) {
-    if (other.count(it->first) == 0) {
-      auto service = it->second.service.lock();
-      if (service) {
-        service_removed(service);
-      }
-      it = this->services.erase(it);
-    } else {
-      ++it;
-    }
-  }
-  for (auto it = other.begin(); it != other.end(); ++it) {
-    if (this->services.count(it->first) == 0) {
-      auto service = it->second.service.lock();
-      if (service) {
-        service_added(service);
-      }
-      this->services.insert(*it);
-    }
-  }
-}
-
-void ExecutorEntitiesCollection::update_guard_conditions(
-  const ExecutorEntitiesCollection::GuardConditionCollection & other,
-  GuardConditionUpdatedFunc guard_condition_added,
-  GuardConditionUpdatedFunc guard_condition_removed)
-{
-  for (auto it = this->guard_conditions.begin(); it != this->guard_conditions.end(); ) {
-    if (other.count(it->first) == 0) {
-      auto guard_condition = it->second.lock();
-      if (guard_condition) {
-        guard_condition_removed(guard_condition);
-      }
-      it = this->guard_conditions.erase(it);
-    } else {
-      ++it;
-    }
-  }
-  for (auto it = other.begin(); it != other.end(); ++it) {
-    if (this->guard_conditions.count(it->first) == 0) {
-      auto guard_condition = it->second.lock();
-      if (guard_condition) {
-        guard_condition_added(guard_condition);
-      }
-      this->guard_conditions.insert(*it);
-    }
-  }
-}
-
-void ExecutorEntitiesCollection::update_waitables(
-  const ExecutorEntitiesCollection::WaitableCollection & other,
-  WaitableUpdatedFunc waitable_added,
-  WaitableUpdatedFunc waitable_removed)
-{
-  for (auto it = this->waitables.begin(); it != this->waitables.end(); ) {
-    if (other.count(it->first) == 0) {
-      auto waitable = it->second.waitable.lock();
-      if (waitable) {
-        waitable_removed(waitable);
-      }
-      it = this->waitables.erase(it);
-    } else {
-      ++it;
-    }
-  }
-  for (auto it = other.begin(); it != other.end(); ++it) {
-    if (this->waitables.count(it->first) == 0) {
-      auto waitable = it->second.waitable.lock();
-      if (waitable) {
-        waitable_added(waitable);
-      }
-      this->waitables.insert({it->first, it->second});
-    }
-  }
-}
-
-
 void
 build_entities_collection(
   const std::vector<rclcpp::CallbackGroup::WeakPtr> & callback_groups,
@@ -245,6 +82,35 @@ build_entities_collection(
   }
 }
 
+template <typename EntityCollectionType>
+void check_ready(
+  EntityCollectionType & collection,
+  std::deque<rclcpp::AnyExecutable> & executables,
+  size_t size_of_waited_entities,
+  typename EntityCollectionType::Key * waited_entities,
+  std::function<bool(rclcpp::AnyExecutable, typename EntityCollectionType::EntitySharedPtr)> fill_executable)
+{
+  for (size_t ii = 0; ii < size_of_waited_entities; ++ii) {
+    if (waited_entities[ii]) {
+      auto entity_iter = collection.find(waited_entities[ii]);
+      if (entity_iter != collection.end()) {
+        auto entity = entity_iter->second.entity.lock();
+        auto callback_group = entity_iter->second.callback_group.lock();
+
+        if (!entity || !callback_group || !callback_group->can_be_taken_from().load()) {
+          continue;
+        }
+
+        rclcpp::AnyExecutable exec;
+        exec.callback_group = callback_group;
+        if (fill_executable(exec, entity)) {
+          executables.push_back(exec);
+        }
+      }
+    }
+  }
+}
+
 std::deque<rclcpp::AnyExecutable>
 ready_executables(
   const ExecutorEntitiesCollection & collection,
@@ -259,84 +125,51 @@ ready_executables(
 
   auto rcl_wait_set = wait_result.get_wait_set().get_rcl_wait_set();
 
-  for (size_t ii = 0; ii < rcl_wait_set.size_of_timers; ++ii) {
-    if (rcl_wait_set.timers[ii]) {
-      auto timer_iter = collection.timers.find(rcl_wait_set.timers[ii]);
-      if (timer_iter != collection.timers.end()) {
-        auto timer = timer_iter->second.timer.lock();
-        auto group = timer_iter->second.callback_group.lock();
-        if (!timer || !group || !group->can_be_taken_from().load()) {
-          continue;
-        }
-
-        if (!timer->call()) {
-          continue;
-        }
-
-        rclcpp::AnyExecutable exec;
-        exec.timer = timer;
-        exec.callback_group = group;
-        ret.push_back(exec);
+  check_ready(
+    collection.timers,
+    ret,
+    rcl_wait_set.size_of_timers,
+    rcl_wait_set.timers,
+    [](auto exec, auto timer){
+      if (!timer->call()) {
+        return false;
       }
-    }
-  }
+      exec.timer = timer;
+      return true;
+    });
 
-  for (size_t ii = 0; ii < rcl_wait_set.size_of_subscriptions; ++ii) {
-    if (rcl_wait_set.subscriptions[ii]) {
-      auto subscription_iter = collection.subscriptions.find(rcl_wait_set.subscriptions[ii]);
-      if (subscription_iter != collection.subscriptions.end()) {
-        auto subscription = subscription_iter->second.subscription.lock();
-        auto group = subscription_iter->second.callback_group.lock();
-        if (!subscription || !group || !group->can_be_taken_from().load()) {
-          continue;
-        }
+  check_ready(
+    collection.subscriptions,
+    ret,
+    rcl_wait_set.size_of_subscriptions,
+    rcl_wait_set.subscriptions,
+    [](auto exec, auto subscription){
+      exec.subscription = subscription;
+      return true;
+    });
 
-        rclcpp::AnyExecutable exec;
-        exec.subscription = subscription;
-        exec.callback_group = group;
-        ret.push_back(exec);
-      }
-    }
-  }
+  check_ready(
+    collection.services,
+    ret,
+    rcl_wait_set.size_of_services,
+    rcl_wait_set.services,
+    [](auto exec, auto service){
+      exec.service = service;
+      return true;
+    });
 
-  for (size_t ii = 0; ii < rcl_wait_set.size_of_services; ++ii) {
-    if (rcl_wait_set.services[ii]) {
-      auto service_iter = collection.services.find(rcl_wait_set.services[ii]);
-      if (service_iter != collection.services.end()) {
-        auto service = service_iter->second.service.lock();
-        auto group = service_iter->second.callback_group.lock();
-        if (!service || !group || !group->can_be_taken_from().load()) {
-          continue;
-        }
-
-        rclcpp::AnyExecutable exec;
-        exec.service = service;
-        exec.callback_group = group;
-        ret.push_back(exec);
-      }
-    }
-  }
-
-  for (size_t ii = 0; ii < rcl_wait_set.size_of_clients; ++ii) {
-    if (rcl_wait_set.clients[ii]) {
-      auto client_iter = collection.clients.find(rcl_wait_set.clients[ii]);
-      if (client_iter != collection.clients.end()) {
-        auto client = client_iter->second.client.lock();
-        auto group = client_iter->second.callback_group.lock();
-        if (!client || !group || !group->can_be_taken_from().load()) {
-          continue;
-        }
-
-        rclcpp::AnyExecutable exec;
-        exec.client = client;
-        exec.callback_group = group;
-        ret.push_back(exec);
-      }
-    }
-  }
+  check_ready(
+    collection.clients,
+    ret,
+    rcl_wait_set.size_of_clients,
+    rcl_wait_set.clients,
+    [](auto exec, auto client){
+      exec.client = client;
+      return true;
+    });
 
   for (auto & [handle, entry] : collection.waitables) {
-    auto waitable = entry.waitable.lock();
+    auto waitable = entry.entity.lock();
     if (waitable && waitable->is_ready(&rcl_wait_set)) {
       auto group = entry.callback_group.lock();
       if (!group || !group->can_be_taken_from().load()) {

--- a/rclcpp/src/rclcpp/executors/executor_entities_collection.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_entities_collection.cpp
@@ -20,12 +20,12 @@ namespace executors
 {
 bool ExecutorEntitiesCollection::empty() const
 {
-  return (subscriptions.empty() &&
-          timers.empty() &&
-          guard_conditions.empty() &&
-          clients.empty() &&
-          services.empty() &&
-           waitables.empty());
+  return subscriptions.empty() &&
+         timers.empty() &&
+         guard_conditions.empty() &&
+         clients.empty() &&
+         services.empty() &&
+         waitables.empty();
 }
 
 void ExecutorEntitiesCollection::clear()
@@ -52,8 +52,7 @@ build_entities_collection(
       continue;
     }
 
-    if (group_ptr->can_be_taken_from().load())
-    {
+    if (group_ptr->can_be_taken_from().load()) {
       group_ptr->collect_all_ptrs(
         [&collection, weak_group_ptr](const rclcpp::SubscriptionBase::SharedPtr & subscription) {
           collection.subscriptions.insert(
@@ -102,7 +101,7 @@ void check_ready(
   size_t size_of_waited_entities,
   typename EntityCollectionType::Key * waited_entities,
   std::function<bool(rclcpp::AnyExecutable &,
-                     typename EntityCollectionType::EntitySharedPtr &)> fill_executable)
+  typename EntityCollectionType::EntitySharedPtr &)> fill_executable)
 {
   for (size_t ii = 0; ii < size_of_waited_entities; ++ii) {
     if (waited_entities[ii]) {
@@ -122,7 +121,6 @@ void check_ready(
         exec.callback_group = callback_group;
         if (fill_executable(exec, entity)) {
           executables.push_back(exec);
-        } else {
         }
       }
     }

--- a/rclcpp/src/rclcpp/executors/executor_entities_collection.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_entities_collection.cpp
@@ -82,13 +82,14 @@ build_entities_collection(
   }
 }
 
-template <typename EntityCollectionType>
+template<typename EntityCollectionType>
 void check_ready(
   EntityCollectionType & collection,
   std::deque<rclcpp::AnyExecutable> & executables,
   size_t size_of_waited_entities,
   typename EntityCollectionType::Key * waited_entities,
-  std::function<bool(rclcpp::AnyExecutable, typename EntityCollectionType::EntitySharedPtr)> fill_executable)
+  std::function<bool(rclcpp::AnyExecutable,
+  typename EntityCollectionType::EntitySharedPtr)> fill_executable)
 {
   for (size_t ii = 0; ii < size_of_waited_entities; ++ii) {
     if (waited_entities[ii]) {
@@ -130,7 +131,7 @@ ready_executables(
     ret,
     rcl_wait_set.size_of_timers,
     rcl_wait_set.timers,
-    [](auto exec, auto timer){
+    [](auto exec, auto timer) {
       if (!timer->call()) {
         return false;
       }
@@ -143,7 +144,7 @@ ready_executables(
     ret,
     rcl_wait_set.size_of_subscriptions,
     rcl_wait_set.subscriptions,
-    [](auto exec, auto subscription){
+    [](auto exec, auto subscription) {
       exec.subscription = subscription;
       return true;
     });
@@ -153,7 +154,7 @@ ready_executables(
     ret,
     rcl_wait_set.size_of_services,
     rcl_wait_set.services,
-    [](auto exec, auto service){
+    [](auto exec, auto service) {
       exec.service = service;
       return true;
     });
@@ -163,7 +164,7 @@ ready_executables(
     ret,
     rcl_wait_set.size_of_clients,
     rcl_wait_set.clients,
-    [](auto exec, auto client){
+    [](auto exec, auto client) {
       exec.client = client;
       return true;
     });

--- a/rclcpp/src/rclcpp/executors/executor_entities_collection.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_entities_collection.cpp
@@ -104,24 +104,23 @@ void check_ready(
   typename EntityCollectionType::EntitySharedPtr &)> fill_executable)
 {
   for (size_t ii = 0; ii < size_of_waited_entities; ++ii) {
-    if (waited_entities[ii]) {
-      auto entity_iter = collection.find(waited_entities[ii]);
-      if (entity_iter != collection.end()) {
-        auto entity = entity_iter->second.entity.lock();
-        if (!entity) {
-          continue;
-        }
+    if (!waited_entities[ii]) {continue;}
+    auto entity_iter = collection.find(waited_entities[ii]);
+    if (entity_iter != collection.end()) {
+      auto entity = entity_iter->second.entity.lock();
+      if (!entity) {
+        continue;
+      }
 
-        auto callback_group = entity_iter->second.callback_group.lock();
-        if (callback_group && !callback_group->can_be_taken_from().load()) {
-          continue;
-        }
-        rclcpp::AnyExecutable exec;
+      auto callback_group = entity_iter->second.callback_group.lock();
+      if (callback_group && !callback_group->can_be_taken_from().load()) {
+        continue;
+      }
+      rclcpp::AnyExecutable exec;
 
-        exec.callback_group = callback_group;
-        if (fill_executable(exec, entity)) {
-          executables.push_back(exec);
-        }
+      exec.callback_group = callback_group;
+      if (fill_executable(exec, entity)) {
+        executables.push_back(exec);
       }
     }
   }

--- a/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
@@ -47,8 +47,6 @@ ExecutorEntitiesCollector::~ExecutorEntitiesCollector()
     weak_group_it = remove_weak_callback_group(weak_group_it, manually_added_groups_);
   }
 
-  std::lock_guard<std::mutex> pending_lock(pending_mutex_);
-
   for (auto weak_node_ptr : pending_added_nodes_) {
     auto node_ptr = weak_node_ptr.lock();
     if (node_ptr) {
@@ -71,7 +69,7 @@ ExecutorEntitiesCollector::~ExecutorEntitiesCollector()
 bool
 ExecutorEntitiesCollector::has_pending() const
 {
-  std::lock_guard<std::mutex> pending_lock(pending_mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
   return pending_manually_added_groups_.size() != 0 ||
          pending_manually_removed_groups_.size() != 0 ||
          pending_added_nodes_.size() != 0 ||
@@ -89,7 +87,7 @@ ExecutorEntitiesCollector::add_node(rclcpp::node_interfaces::NodeBaseInterface::
             "' has already been added to an executor.");
   }
 
-  std::lock_guard<std::mutex> pending_lock(pending_mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
   bool associated = weak_nodes_.count(node_ptr) != 0;
   bool add_queued = pending_added_nodes_.count(node_ptr) != 0;
   bool remove_queued = pending_removed_nodes_.count(node_ptr) != 0;
@@ -113,7 +111,7 @@ ExecutorEntitiesCollector::remove_node(
             "' needs to be associated with an executor.");
   }
 
-  std::lock_guard<std::mutex> pending_lock(pending_mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
   bool associated = weak_nodes_.count(node_ptr) != 0;
   bool add_queued = pending_added_nodes_.count(node_ptr) != 0;
   bool remove_queued = pending_removed_nodes_.count(node_ptr) != 0;
@@ -135,7 +133,7 @@ ExecutorEntitiesCollector::add_callback_group(rclcpp::CallbackGroup::SharedPtr g
     throw std::runtime_error("Callback group has already been added to an executor.");
   }
 
-  std::lock_guard<std::mutex> pending_lock(pending_mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
   bool associated = manually_added_groups_.count(group_ptr) != 0;
   bool add_queued = pending_manually_added_groups_.count(group_ptr) != 0;
   bool remove_queued = pending_manually_removed_groups_.count(group_ptr) != 0;
@@ -160,7 +158,7 @@ ExecutorEntitiesCollector::remove_callback_group(rclcpp::CallbackGroup::SharedPt
 
   auto weak_group_ptr = rclcpp::CallbackGroup::WeakPtr(group_ptr);
 
-  std::lock_guard<std::mutex> pending_lock(pending_mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
   bool associated = manually_added_groups_.count(group_ptr) != 0;
   bool add_queued = pending_manually_added_groups_.count(group_ptr) != 0;
   bool remove_queued = pending_manually_removed_groups_.count(group_ptr) != 0;
@@ -176,7 +174,7 @@ std::vector<rclcpp::CallbackGroup::WeakPtr>
 ExecutorEntitiesCollector::get_all_callback_groups() const
 {
   std::vector<rclcpp::CallbackGroup::WeakPtr> groups;
-
+  std::lock_guard<std::mutex> lock(mutex_);
   for (const auto & group_ptr : manually_added_groups_) {
     groups.push_back(group_ptr);
   }
@@ -190,6 +188,7 @@ std::vector<rclcpp::CallbackGroup::WeakPtr>
 ExecutorEntitiesCollector::get_manually_added_callback_groups() const
 {
   std::vector<rclcpp::CallbackGroup::WeakPtr> groups;
+  std::lock_guard<std::mutex> lock(mutex_);
   for (const auto & group_ptr : manually_added_groups_) {
     groups.push_back(group_ptr);
   }
@@ -200,6 +199,7 @@ std::vector<rclcpp::CallbackGroup::WeakPtr>
 ExecutorEntitiesCollector::get_automatically_added_callback_groups() const
 {
   std::vector<rclcpp::CallbackGroup::WeakPtr> groups;
+  std::lock_guard<std::mutex> lock(mutex_);
   for (auto const & group_ptr : automatically_added_groups_) {
     groups.push_back(group_ptr);
   }
@@ -209,6 +209,7 @@ ExecutorEntitiesCollector::get_automatically_added_callback_groups() const
 void
 ExecutorEntitiesCollector::update_collections()
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   this->process_queues();
   this->add_automatically_associated_callback_groups(this->weak_nodes_);
   this->prune_invalid_nodes_and_groups();
@@ -280,24 +281,8 @@ ExecutorEntitiesCollector::add_callback_group_to_collection(
 }
 
 void
-ExecutorEntitiesCollector::remove_callback_group_from_collection(
-  rclcpp::CallbackGroup::SharedPtr group_ptr,
-  CallbackGroupCollection & collection)
-{
-  auto group_it = collection.find(group_ptr);
-
-  if (group_it != collection.end()) {
-    remove_weak_callback_group(group_it, collection);
-  } else {
-    throw std::runtime_error("Attempting to remove a callback group not added to this executor.");
-  }
-}
-
-void
 ExecutorEntitiesCollector::process_queues()
 {
-  std::lock_guard pending_lock(pending_mutex_);
-
   for (auto weak_node_ptr : pending_added_nodes_) {
     auto node_ptr = weak_node_ptr.lock();
     if (!node_ptr) {
@@ -348,7 +333,13 @@ ExecutorEntitiesCollector::process_queues()
   for (auto weak_group_ptr : pending_manually_removed_groups_) {
     auto group_ptr = weak_group_ptr.lock();
     if (group_ptr) {
-      this->remove_callback_group_from_collection(group_ptr, manually_added_groups_);
+      auto group_it = manually_added_groups_.find(group_ptr);
+      if (group_it != manually_added_groups_.end()) {
+        remove_weak_callback_group(group_it, manually_added_groups_);
+      } else {
+        throw std::runtime_error(
+          "Attempting to remove a callback group not added to this executor.");
+      }
     }
   }
   pending_manually_removed_groups_.clear();

--- a/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
@@ -306,7 +306,7 @@ ExecutorEntitiesCollector::process_queues()
     this->add_automatically_associated_callback_groups({weak_node_ptr});
 
     // Store node guard condition in map and add it to the notify waitable
-    auto node_guard_condition = node_ptr->get_notify_guard_condition();
+    auto node_guard_condition = node_ptr->get_shared_notify_guard_condition();
     weak_nodes_to_guard_conditions_.insert({weak_node_ptr, node_guard_condition});
     this->notify_waitable_->add_guard_condition(node_guard_condition);
   }

--- a/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
@@ -33,16 +33,20 @@ ExecutorEntitiesCollector::~ExecutorEntitiesCollector()
 {
   std::lock_guard<std::mutex> guard{mutex_};
 
-  for (auto weak_node_it = weak_nodes_.begin(); weak_node_it != weak_nodes_.end();) {
+  for (auto weak_node_it = weak_nodes_.begin(); weak_node_it != weak_nodes_.end(); ) {
     weak_node_it = remove_weak_node(weak_node_it);
   }
 
-  for (auto weak_group_it = automatically_added_groups_.begin(); weak_group_it != automatically_added_groups_.end(); ) {
-    weak_group_it= remove_weak_callback_group(weak_group_it, automatically_added_groups_);
+  for (auto weak_group_it = automatically_added_groups_.begin();
+    weak_group_it != automatically_added_groups_.end(); )
+  {
+    weak_group_it = remove_weak_callback_group(weak_group_it, automatically_added_groups_);
   }
 
-  for (auto weak_group_it = manually_added_groups_.begin(); weak_group_it != manually_added_groups_.end(); ) {
-    weak_group_it= remove_weak_callback_group(weak_group_it, manually_added_groups_);
+  for (auto weak_group_it = manually_added_groups_.begin();
+    weak_group_it != manually_added_groups_.end(); )
+  {
+    weak_group_it = remove_weak_callback_group(weak_group_it, manually_added_groups_);
   }
 }
 
@@ -86,13 +90,12 @@ ExecutorEntitiesCollector::remove_node(
   }
 
   for (auto group_it = automatically_added_groups_.begin();
-       group_it != automatically_added_groups_.end();)
+    group_it != automatically_added_groups_.end(); )
   {
     auto group_ptr = group_it->lock();
     if (node_ptr->callback_group_in_node(group_ptr)) {
       group_it = remove_weak_callback_group(group_it, automatically_added_groups_);
-    }
-    else {
+    } else {
       ++group_it;
     }
   }
@@ -168,8 +171,7 @@ ExecutorEntitiesCollector::remove_weak_node(NodeCollection::iterator weak_node)
 {
   // Disassociate the guard condition from the executor notify waitable
   auto guard_condition_it = weak_nodes_to_guard_conditions_.find(*weak_node);
-  if (guard_condition_it != weak_nodes_to_guard_conditions_.end())
-  {
+  if (guard_condition_it != weak_nodes_to_guard_conditions_.end()) {
     this->notify_waitable_->remove_guard_condition(guard_condition_it->second);
     weak_nodes_to_guard_conditions_.erase(guard_condition_it);
   }
@@ -193,8 +195,7 @@ ExecutorEntitiesCollector::remove_weak_callback_group(
 {
   // Disassociate the guard condition from the executor notify waitable
   auto guard_condition_it = weak_groups_to_guard_conditions_.find(*weak_group_it);
-  if (guard_condition_it != weak_groups_to_guard_conditions_.end())
-  {
+  if (guard_condition_it != weak_groups_to_guard_conditions_.end()) {
     this->notify_waitable_->remove_guard_condition(guard_condition_it->second);
     weak_groups_to_guard_conditions_.erase(guard_condition_it);
   }

--- a/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
@@ -151,13 +151,18 @@ ExecutorEntitiesCollector::remove_callback_group(rclcpp::CallbackGroup::SharedPt
   if (!group_ptr->get_associated_with_executor_atomic().load()) {
     throw std::runtime_error("Callback group needs to be associated with an executor.");
   }
-
+  /**
+   * TODO(mjcarroll): The callback groups, being created by a node, should never outlive
+   * the node. Since we haven't historically enforced this, turning this on may cause
+   * previously-functional code to fail.
+   * Consider re-enablng this check (along with corresponding CallbackGroup::has_valid_node),
+   * when we can guarantee node/group lifetimes.
   if (!group_ptr->has_valid_node()) {
     throw std::runtime_error("Node must not be deleted before its callback group(s).");
   }
+  */
 
   auto weak_group_ptr = rclcpp::CallbackGroup::WeakPtr(group_ptr);
-
   std::lock_guard<std::mutex> lock(mutex_);
   bool associated = manually_added_groups_.count(group_ptr) != 0;
   bool add_queued = pending_manually_added_groups_.count(group_ptr) != 0;
@@ -251,11 +256,17 @@ ExecutorEntitiesCollector::remove_weak_callback_group(
 
   // Mark the node as disassociated (if the group is still valid)
   auto group_ptr = weak_group_it->lock();
-
   if (group_ptr) {
+    /**
+     * TODO(mjcarroll): The callback groups, being created by a node, should never outlive
+     * the node. Since we haven't historically enforced this, turning this on may cause
+     * previously-functional code to fail.
+     * Consider re-enablng this check (along with corresponding CallbackGroup::has_valid_node),
+     * when we can guarantee node/group lifetimes.
     if (!group_ptr->has_valid_node()) {
       throw std::runtime_error("Node must not be deleted before its callback group(s).");
     }
+    */
     std::atomic_bool & has_executor = group_ptr->get_associated_with_executor_atomic();
     has_executor.store(false);
   }

--- a/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
@@ -68,7 +68,8 @@ ExecutorEntitiesCollector::~ExecutorEntitiesCollector()
   pending_manually_removed_groups_.clear();
 }
 
-bool ExecutorEntitiesCollector::has_pending()
+bool
+ExecutorEntitiesCollector::has_pending() const
 {
   std::lock_guard<std::mutex> pending_lock(pending_mutex_);
   return pending_manually_added_groups_.size() != 0 ||
@@ -172,7 +173,7 @@ ExecutorEntitiesCollector::remove_callback_group(rclcpp::CallbackGroup::SharedPt
 }
 
 std::vector<rclcpp::CallbackGroup::WeakPtr>
-ExecutorEntitiesCollector::get_all_callback_groups()
+ExecutorEntitiesCollector::get_all_callback_groups() const
 {
   std::vector<rclcpp::CallbackGroup::WeakPtr> groups;
 
@@ -186,7 +187,7 @@ ExecutorEntitiesCollector::get_all_callback_groups()
 }
 
 std::vector<rclcpp::CallbackGroup::WeakPtr>
-ExecutorEntitiesCollector::get_manually_added_callback_groups()
+ExecutorEntitiesCollector::get_manually_added_callback_groups() const
 {
   std::vector<rclcpp::CallbackGroup::WeakPtr> groups;
   for (const auto & group_ptr : manually_added_groups_) {
@@ -196,7 +197,7 @@ ExecutorEntitiesCollector::get_manually_added_callback_groups()
 }
 
 std::vector<rclcpp::CallbackGroup::WeakPtr>
-ExecutorEntitiesCollector::get_automatically_added_callback_groups()
+ExecutorEntitiesCollector::get_automatically_added_callback_groups() const
 {
   std::vector<rclcpp::CallbackGroup::WeakPtr> groups;
   for (auto const & group_ptr : automatically_added_groups_) {

--- a/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
@@ -24,8 +24,8 @@ namespace executors
 {
 
 ExecutorEntitiesCollector::ExecutorEntitiesCollector(
-  std::function<void(void)> on_notify_waitable_callback)
-: notify_waitable_(std::make_shared<ExecutorNotifyWaitable>(on_notify_waitable_callback))
+  std::shared_ptr<ExecutorNotifyWaitable> notify_waitable)
+: notify_waitable_(notify_waitable)
 {
 }
 
@@ -150,12 +150,6 @@ ExecutorEntitiesCollector::get_automatically_added_callback_groups()
     groups.push_back(group_ptr);
   }
   return groups;
-}
-
-std::shared_ptr<ExecutorNotifyWaitable>
-ExecutorEntitiesCollector::get_notify_waitable()
-{
-  return this->notify_waitable_;
 }
 
 void

--- a/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
@@ -24,10 +24,9 @@ namespace executors
 {
 
 ExecutorEntitiesCollector::ExecutorEntitiesCollector(
-    std::function<void(void)> on_notify_waitable_callback) {
-  notify_waitable_ = std::make_shared<ExecutorNotifyWaitable>(
-    [on_notify_waitable_callback](){on_notify_waitable_callback();});
-
+  std::function<void(void)> on_notify_waitable_callback)
+: notify_waitable_(std::make_shared<ExecutorNotifyWaitable>(on_notify_waitable_callback))
+{
 }
 
 ExecutorEntitiesCollector::~ExecutorEntitiesCollector()

--- a/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
@@ -261,10 +261,6 @@ ExecutorEntitiesCollector::add_callback_group_to_collection(
   rclcpp::CallbackGroup::SharedPtr group_ptr,
   CallbackGroupCollection & collection)
 {
-  std::atomic_bool & has_executor = group_ptr->get_associated_with_executor_atomic();
-  if (has_executor.exchange(true)) {
-    throw std::runtime_error("Callback group has already been added to an executor.");
-  }
   auto iter = collection.insert(group_ptr);
   if (iter.second == false) {
     throw std::runtime_error("Callback group has already been added to this executor.");

--- a/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
@@ -295,7 +295,7 @@ ExecutorEntitiesCollector::process_queues()
 {
   std::lock_guard pending_lock(pending_mutex_);
 
-  for (auto weak_node_ptr: pending_added_nodes_) {
+  for (auto weak_node_ptr : pending_added_nodes_) {
     auto node_ptr = weak_node_ptr.lock();
     if (!node_ptr) {
       continue;
@@ -310,7 +310,7 @@ ExecutorEntitiesCollector::process_queues()
   }
   pending_added_nodes_.clear();
 
-  for (auto weak_node_ptr: pending_removed_nodes_) {
+  for (auto weak_node_ptr : pending_removed_nodes_) {
     auto node_it = weak_nodes_.find(weak_node_ptr);
     if (node_it != weak_nodes_.end()) {
       remove_weak_node(node_it);
@@ -334,7 +334,7 @@ ExecutorEntitiesCollector::process_queues()
   }
   pending_removed_nodes_.clear();
 
-  for (auto weak_group_ptr: pending_manually_added_groups_) {
+  for (auto weak_group_ptr : pending_manually_added_groups_) {
     auto group_ptr = weak_group_ptr.lock();
     if (group_ptr) {
       this->add_callback_group_to_collection(group_ptr, manually_added_groups_);
@@ -342,7 +342,7 @@ ExecutorEntitiesCollector::process_queues()
   }
   pending_manually_added_groups_.clear();
 
-  for (auto weak_group_ptr: pending_manually_removed_groups_) {
+  for (auto weak_group_ptr : pending_manually_removed_groups_) {
     auto group_ptr = weak_group_ptr.lock();
     if (group_ptr) {
       this->remove_callback_group_from_collection(group_ptr, manually_added_groups_);

--- a/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
@@ -1,0 +1,287 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <set>
+
+#include "rclcpp/executors/executor_entities_collector.hpp"
+#include "rclcpp/executors/executor_notify_waitable.hpp"
+
+namespace rclcpp
+{
+namespace executors
+{
+
+ExecutorEntitiesCollector::ExecutorEntitiesCollector()
+: notify_waitable_(std::make_shared<ExecutorNotifyWaitable>())
+{
+}
+
+ExecutorEntitiesCollector::~ExecutorEntitiesCollector()
+{
+  std::lock_guard<std::mutex> guard{mutex_};
+
+  //  Disassociate each node from this executor collector
+  std::for_each(
+    weak_nodes_.begin(), weak_nodes_.end(), []
+      (rclcpp::node_interfaces::NodeBaseInterface::WeakPtr weak_node_ptr) {
+      auto shared_node_ptr = weak_node_ptr.lock();
+      if (shared_node_ptr) {
+        std::atomic_bool & has_executor = shared_node_ptr->get_associated_with_executor_atomic();
+        has_executor.store(false);
+      }
+    });
+  weak_nodes_.clear();
+
+  //  Disassociate each automatically-added callback group from this executor collector
+  std::for_each(
+    automatically_added_groups_.begin(), automatically_added_groups_.end(), []
+      (rclcpp::CallbackGroup::WeakPtr weak_group_ptr) {
+      auto group_ptr = weak_group_ptr.lock();
+      if (group_ptr) {
+        std::atomic_bool & has_executor = group_ptr->get_associated_with_executor_atomic();
+        has_executor.store(false);
+      }
+    });
+  automatically_added_groups_.clear();
+
+  //  Disassociate each manually-added callback group from this executor collector
+  std::for_each(
+    manually_added_groups_.begin(), manually_added_groups_.end(), []
+      (rclcpp::CallbackGroup::WeakPtr weak_group_ptr) {
+      auto group_ptr = weak_group_ptr.lock();
+      if (group_ptr) {
+        std::atomic_bool & has_executor = group_ptr->get_associated_with_executor_atomic();
+        has_executor.store(false);
+      }
+    });
+  manually_added_groups_.clear();
+}
+
+void
+ExecutorEntitiesCollector::add_node(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr)
+{
+  std::lock_guard<std::mutex> guard{mutex_};
+  // If the node already has an executor
+  std::atomic_bool & has_executor = node_ptr->get_associated_with_executor_atomic();
+  if (has_executor.exchange(true)) {
+    throw std::runtime_error(
+            std::string("Node '") + node_ptr->get_fully_qualified_name() +
+            "' has already been added to an executor.");
+  }
+  weak_nodes_.push_back(node_ptr);
+  this->notify_waitable_->add_guard_condition(&node_ptr->get_notify_guard_condition());
+  this->add_automatically_associated_callback_groups();
+}
+
+void
+ExecutorEntitiesCollector::remove_node(
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr)
+{
+  std::lock_guard<std::mutex> guard{mutex_};
+  if (!node_ptr->get_associated_with_executor_atomic().load()) {
+    throw std::runtime_error("Node needs to be associated with an executor.");
+  }
+
+  bool found_node = false;
+  auto node_it = weak_nodes_.begin();
+  while (node_it != weak_nodes_.end()) {
+    bool matched = (node_it->lock() == node_ptr);
+    if (matched) {
+      found_node = true;
+      node_it = weak_nodes_.erase(node_it);
+    } else {
+      ++node_it;
+    }
+  }
+  if (!found_node) {
+    throw std::runtime_error("Node needs to be associated with this executor.");
+  }
+
+  for (auto group_it = automatically_added_groups_.begin();
+    group_it != automatically_added_groups_.end(); )
+  {
+    auto group_ptr = group_it->lock();
+    if (node_ptr->callback_group_in_node(group_ptr)) {
+      std::atomic_bool & has_executor = group_ptr->get_associated_with_executor_atomic();
+      has_executor.store(false);
+      group_it = automatically_added_groups_.erase(group_it);
+    } else {
+      group_it++;
+    }
+  }
+
+  this->notify_waitable_->remove_guard_condition(&node_ptr->get_notify_guard_condition());
+  std::atomic_bool & has_executor = node_ptr->get_associated_with_executor_atomic();
+  has_executor.store(false);
+}
+
+void
+ExecutorEntitiesCollector::add_callback_group(rclcpp::CallbackGroup::SharedPtr group_ptr)
+{
+  std::lock_guard<std::mutex> guard{mutex_};
+  this->add_callback_group_to_collection(group_ptr, manually_added_groups_);
+}
+
+void
+ExecutorEntitiesCollector::remove_callback_group(rclcpp::CallbackGroup::SharedPtr group_ptr)
+{
+  std::lock_guard<std::mutex> guard{mutex_};
+  this->remove_callback_group_from_collection(group_ptr, manually_added_groups_);
+}
+
+std::vector<rclcpp::CallbackGroup::WeakPtr>
+ExecutorEntitiesCollector::get_all_callback_groups()
+{
+  std::vector<rclcpp::CallbackGroup::WeakPtr> groups;
+  std::lock_guard<std::mutex> guard{mutex_};
+
+  this->update_collections();
+
+  for (const auto & group_ptr : manually_added_groups_) {
+    groups.push_back(group_ptr);
+  }
+  for (auto const & group_ptr : automatically_added_groups_) {
+    groups.push_back(group_ptr);
+  }
+  return groups;
+}
+
+std::vector<rclcpp::CallbackGroup::WeakPtr>
+ExecutorEntitiesCollector::get_manually_added_callback_groups()
+{
+  std::vector<rclcpp::CallbackGroup::WeakPtr> groups;
+  std::lock_guard<std::mutex> guard{mutex_};
+  for (const auto & group_ptr : manually_added_groups_) {
+    groups.push_back(group_ptr);
+  }
+  return groups;
+}
+
+std::vector<rclcpp::CallbackGroup::WeakPtr>
+ExecutorEntitiesCollector::get_automatically_added_callback_groups()
+{
+  std::vector<rclcpp::CallbackGroup::WeakPtr> groups;
+  std::lock_guard<std::mutex> guard{mutex_};
+  for (auto const & group_ptr : automatically_added_groups_) {
+    groups.push_back(group_ptr);
+  }
+  return groups;
+}
+
+void
+ExecutorEntitiesCollector::update_collections()
+{
+  this->add_automatically_associated_callback_groups();
+  this->prune_invalid_nodes_and_groups();
+}
+
+std::shared_ptr<ExecutorNotifyWaitable>
+ExecutorEntitiesCollector::get_executor_notify_waitable()
+{
+  return this->notify_waitable_;
+}
+
+void
+ExecutorEntitiesCollector::add_callback_group_to_collection(
+  rclcpp::CallbackGroup::SharedPtr group_ptr,
+  CallbackGroupCollection & collection)
+{
+  std::atomic_bool & has_executor = group_ptr->get_associated_with_executor_atomic();
+  if (has_executor.exchange(true)) {
+    throw std::runtime_error("Callback group has already been added to an executor.");
+  }
+  auto iter = collection.insert(group_ptr);
+  if (iter.second == false) {
+    throw std::runtime_error("Callback group has already been added to this executor.");
+  }
+  this->notify_waitable_->add_guard_condition(group_ptr->get_notify_guard_condition().get());
+}
+
+void
+ExecutorEntitiesCollector::remove_callback_group_from_collection(
+  rclcpp::CallbackGroup::SharedPtr group_ptr,
+  CallbackGroupCollection & collection)
+{
+  rclcpp::CallbackGroup::WeakPtr weak_group_ptr(group_ptr);
+  auto iter = collection.find(weak_group_ptr);
+  if (iter != collection.end()) {
+    // Check that the group hasn't been orphaned from it's respective node
+    if (!group_ptr->has_valid_node()) {
+      throw std::runtime_error("Node must not be deleted before its callback group(s).");
+    }
+
+    // Disassociate the callback group with the executor
+    std::atomic_bool & has_executor = group_ptr->get_associated_with_executor_atomic();
+    has_executor.store(false);
+    collection.erase(iter);
+    this->notify_waitable_->remove_guard_condition(group_ptr->get_notify_guard_condition().get());
+  } else {
+    throw std::runtime_error("Callback group needs to be associated with executor.");
+  }
+}
+
+void
+ExecutorEntitiesCollector::add_automatically_associated_callback_groups()
+{
+  for (auto & weak_node : weak_nodes_) {
+    auto node = weak_node.lock();
+    if (node) {
+      node->for_each_callback_group(
+        [this, node](rclcpp::CallbackGroup::SharedPtr group_ptr)
+        {
+          if (!group_ptr->get_associated_with_executor_atomic().load() &&
+          group_ptr->automatically_add_to_executor_with_node())
+          {
+            this->add_callback_group_to_collection(group_ptr, this->automatically_added_groups_);
+          }
+        });
+    }
+  }
+}
+
+void
+ExecutorEntitiesCollector::prune_invalid_nodes_and_groups()
+{
+  for (auto node_it = weak_nodes_.begin();
+    node_it != weak_nodes_.end(); )
+  {
+    if (node_it->expired()) {
+      node_it = weak_nodes_.erase(node_it);
+    } else {
+      node_it++;
+    }
+  }
+
+  for (auto group_it = automatically_added_groups_.begin();
+    group_it != automatically_added_groups_.end(); )
+  {
+    if (group_it->expired()) {
+      group_it = automatically_added_groups_.erase(group_it);
+    } else {
+      group_it++;
+    }
+  }
+  for (auto group_it = manually_added_groups_.begin();
+    group_it != manually_added_groups_.end(); )
+  {
+    if (group_it->expired()) {
+      group_it = manually_added_groups_.erase(group_it);
+    } else {
+      group_it++;
+    }
+  }
+}
+
+}  // namespace executors
+}  // namespace rclcpp

--- a/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_entities_collector.cpp
@@ -338,7 +338,7 @@ ExecutorEntitiesCollector::process_queues()
         remove_weak_callback_group(group_it, manually_added_groups_);
       } else {
         throw std::runtime_error(
-          "Attempting to remove a callback group not added to this executor.");
+                "Attempting to remove a callback group not added to this executor.");
       }
     }
   }

--- a/rclcpp/src/rclcpp/executors/executor_notify_waitable.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_notify_waitable.cpp
@@ -14,8 +14,8 @@
 
 #include <iostream>
 
+#include "rclcpp/exceptions.hpp"
 #include "rclcpp/executors/executor_notify_waitable.hpp"
-#include "rclcpp/detail/add_guard_condition_to_rcl_wait_set.hpp"
 
 namespace rclcpp
 {
@@ -30,14 +30,25 @@ ExecutorNotifyWaitable::ExecutorNotifyWaitable(std::function<void(void)> on_exec
 void
 ExecutorNotifyWaitable::add_to_wait_set(rcl_wait_set_t * wait_set)
 {
+  std::lock_guard<std::mutex> lock(guard_condition_mutex_);
   for (auto guard_condition : this->notify_guard_conditions_) {
-    detail::add_guard_condition_to_rcl_wait_set(*wait_set, *guard_condition);
+    auto rcl_guard_condition = guard_condition->get_rcl_guard_condition();
+
+    rcl_ret_t ret = rcl_wait_set_add_guard_condition(
+      wait_set,
+      &rcl_guard_condition, NULL);
+
+    if (RCL_RET_OK != ret) {
+      rclcpp::exceptions::throw_from_rcl_error(
+        ret, "failed to add guard condition to wait set");
+    }
   }
 }
 
 bool
 ExecutorNotifyWaitable::is_ready(rcl_wait_set_t * wait_set)
 {
+  std::lock_guard<std::mutex> lock(guard_condition_mutex_);
   for (size_t ii = 0; ii < wait_set->size_of_guard_conditions; ++ii) {
     auto rcl_guard_condition = wait_set->guard_conditions[ii];
 
@@ -51,7 +62,6 @@ ExecutorNotifyWaitable::is_ready(rcl_wait_set_t * wait_set)
       }
     }
   }
-
   return false;
 }
 
@@ -69,38 +79,52 @@ ExecutorNotifyWaitable::take_data()
 }
 
 void
-ExecutorNotifyWaitable::add_guard_condition(rclcpp::GuardCondition * guard_condition)
+ExecutorNotifyWaitable::add_guard_condition(const rclcpp::GuardCondition * guard_condition)
 {
   if (guard_condition == nullptr) {
     throw std::runtime_error("Attempting to add null guard condition.");
   }
-
-  for (const auto & existing_guard_condition : notify_guard_conditions_) {
-    if (existing_guard_condition == guard_condition) {
-      return;
-    }
-  }
-  notify_guard_conditions_.push_back(guard_condition);
+  std::lock_guard<std::mutex> lock(guard_condition_mutex_);
+  to_add_.push_back(guard_condition);
 }
 
 void
-ExecutorNotifyWaitable::remove_guard_condition(rclcpp::GuardCondition * guard_condition)
+ExecutorNotifyWaitable::remove_guard_condition(const rclcpp::GuardCondition * guard_condition)
 {
   if (guard_condition == nullptr) {
     throw std::runtime_error("Attempting to remove null guard condition.");
   }
-
-  for (auto it = notify_guard_conditions_.begin(); it != notify_guard_conditions_.end(); ++it) {
-    if (*it == guard_condition) {
-      notify_guard_conditions_.erase(it);
-      break;
-    }
-  }
+  std::lock_guard<std::mutex> lock(guard_condition_mutex_);
+  to_remove_.push_back(guard_condition);
 }
 
 size_t
 ExecutorNotifyWaitable::get_number_of_ready_guard_conditions()
 {
+  std::lock_guard<std::mutex> lock(guard_condition_mutex_);
+
+  for (auto add_guard_condition: to_add_)
+  {
+    auto guard_it = std::find(notify_guard_conditions_.begin(),
+                              notify_guard_conditions_.end(),
+                              add_guard_condition);
+    if (guard_it == notify_guard_conditions_.end()) {
+      notify_guard_conditions_.push_back(add_guard_condition);
+    }
+  }
+  to_add_.clear();
+
+  for (auto remove_guard_condition: to_remove_)
+  {
+    auto guard_it = std::find(notify_guard_conditions_.begin(),
+                              notify_guard_conditions_.end(),
+                              remove_guard_condition);
+    if (guard_it != notify_guard_conditions_.end()){
+      notify_guard_conditions_.erase(guard_it);
+    }
+  }
+  to_remove_.clear();
+
   return notify_guard_conditions_.size();
 }
 

--- a/rclcpp/src/rclcpp/executors/executor_notify_waitable.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_notify_waitable.cpp
@@ -1,0 +1,108 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+
+#include "rclcpp/executors/executor_notify_waitable.hpp"
+#include "rclcpp/detail/add_guard_condition_to_rcl_wait_set.hpp"
+
+namespace rclcpp
+{
+namespace executors
+{
+
+ExecutorNotifyWaitable::ExecutorNotifyWaitable(std::function<void(void)> on_execute_callback)
+: execute_callback_(on_execute_callback)
+{
+}
+
+void
+ExecutorNotifyWaitable::add_to_wait_set(rcl_wait_set_t * wait_set)
+{
+  for (auto guard_condition : this->notify_guard_conditions_) {
+    detail::add_guard_condition_to_rcl_wait_set(*wait_set, *guard_condition);
+  }
+}
+
+bool
+ExecutorNotifyWaitable::is_ready(rcl_wait_set_t * wait_set)
+{
+  for (size_t ii = 0; ii < wait_set->size_of_guard_conditions; ++ii) {
+    auto rcl_guard_condition = wait_set->guard_conditions[ii];
+
+    if (nullptr == rcl_guard_condition) {
+      continue;
+    }
+
+    for (auto guard_condition : this->notify_guard_conditions_) {
+      if (&guard_condition->get_rcl_guard_condition() == rcl_guard_condition) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+void
+ExecutorNotifyWaitable::execute(std::shared_ptr<void> & data)
+{
+  (void) data;
+  this->execute_callback_();
+}
+
+std::shared_ptr<void>
+ExecutorNotifyWaitable::take_data()
+{
+  return nullptr;
+}
+
+void
+ExecutorNotifyWaitable::add_guard_condition(rclcpp::GuardCondition * guard_condition)
+{
+  if (guard_condition == nullptr) {
+    throw std::runtime_error("Attempting to add null guard condition.");
+  }
+
+  for (const auto & existing_guard_condition : notify_guard_conditions_) {
+    if (existing_guard_condition == guard_condition) {
+      return;
+    }
+  }
+  notify_guard_conditions_.push_back(guard_condition);
+}
+
+void
+ExecutorNotifyWaitable::remove_guard_condition(rclcpp::GuardCondition * guard_condition)
+{
+  if (guard_condition == nullptr) {
+    throw std::runtime_error("Attempting to remove null guard condition.");
+  }
+
+  for (auto it = notify_guard_conditions_.begin(); it != notify_guard_conditions_.end(); ++it) {
+    if (*it == guard_condition) {
+      notify_guard_conditions_.erase(it);
+      break;
+    }
+  }
+}
+
+size_t
+ExecutorNotifyWaitable::get_number_of_ready_guard_conditions()
+{
+  return notify_guard_conditions_.size();
+}
+
+}  // namespace executors
+}  // namespace rclcpp

--- a/rclcpp/src/rclcpp/executors/executor_notify_waitable.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_notify_waitable.cpp
@@ -100,11 +100,12 @@ ExecutorNotifyWaitable::take_data()
 }
 
 void
-ExecutorNotifyWaitable::add_guard_condition(rclcpp::GuardCondition::WeakPtr guard_condition)
+ExecutorNotifyWaitable::add_guard_condition(rclcpp::GuardCondition::WeakPtr weak_guard_condition)
 {
   std::lock_guard<std::mutex> lock(guard_condition_mutex_);
-  if (notify_guard_conditions_.count(guard_condition) == 0) {
-    notify_guard_conditions_.insert(guard_condition);
+  auto guard_condition = weak_guard_condition.lock();
+  if (guard_condition && notify_guard_conditions_.count(weak_guard_condition) == 0) {
+    notify_guard_conditions_.insert(weak_guard_condition);
   }
 }
 

--- a/rclcpp/src/rclcpp/executors/executor_notify_waitable.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_notify_waitable.cpp
@@ -103,23 +103,23 @@ ExecutorNotifyWaitable::get_number_of_ready_guard_conditions()
 {
   std::lock_guard<std::mutex> lock(guard_condition_mutex_);
 
-  for (auto add_guard_condition: to_add_)
-  {
-    auto guard_it = std::find(notify_guard_conditions_.begin(),
-                              notify_guard_conditions_.end(),
-                              add_guard_condition);
+  for (auto add_guard_condition : to_add_) {
+    auto guard_it = std::find(
+      notify_guard_conditions_.begin(),
+      notify_guard_conditions_.end(),
+      add_guard_condition);
     if (guard_it == notify_guard_conditions_.end()) {
       notify_guard_conditions_.push_back(add_guard_condition);
     }
   }
   to_add_.clear();
 
-  for (auto remove_guard_condition: to_remove_)
-  {
-    auto guard_it = std::find(notify_guard_conditions_.begin(),
-                              notify_guard_conditions_.end(),
-                              remove_guard_condition);
-    if (guard_it != notify_guard_conditions_.end()){
+  for (auto remove_guard_condition : to_remove_) {
+    auto guard_it = std::find(
+      notify_guard_conditions_.begin(),
+      notify_guard_conditions_.end(),
+      remove_guard_condition);
+    if (guard_it != notify_guard_conditions_.end()) {
       notify_guard_conditions_.erase(guard_it);
     }
   }

--- a/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
@@ -109,7 +109,8 @@ StaticExecutorEntitiesCollector::execute(std::shared_ptr<void> & data)
   std::lock_guard<std::mutex> guard{new_nodes_mutex_};
   for (const auto & weak_node : new_nodes_) {
     if (auto node_ptr = weak_node.lock()) {
-      weak_nodes_to_guard_conditions_[node_ptr] = node_ptr->get_notify_guard_condition().get();
+      weak_nodes_to_guard_conditions_[node_ptr] =
+        node_ptr->get_shared_notify_guard_condition().get();
     }
   }
   new_nodes_.clear();

--- a/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
@@ -109,8 +109,7 @@ StaticExecutorEntitiesCollector::execute(std::shared_ptr<void> & data)
   std::lock_guard<std::mutex> guard{new_nodes_mutex_};
   for (const auto & weak_node : new_nodes_) {
     if (auto node_ptr = weak_node.lock()) {
-      const auto & gc = node_ptr->get_notify_guard_condition();
-      weak_nodes_to_guard_conditions_[node_ptr] = &gc;
+      weak_nodes_to_guard_conditions_[node_ptr] = node_ptr->get_notify_guard_condition().get();
     }
   }
   new_nodes_.clear();

--- a/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
@@ -139,7 +139,7 @@ StaticSingleThreadedExecutor::add_callback_group(
   bool is_new_node = entities_collector_->add_callback_group(group_ptr, node_ptr);
   if (is_new_node && notify) {
     // Interrupt waiting to handle new node
-    interrupt_guard_condition_.trigger();
+    interrupt_guard_condition_->trigger();
   }
 }
 
@@ -150,7 +150,7 @@ StaticSingleThreadedExecutor::add_node(
   bool is_new_node = entities_collector_->add_node(node_ptr);
   if (is_new_node && notify) {
     // Interrupt waiting to handle new node
-    interrupt_guard_condition_.trigger();
+    interrupt_guard_condition_->trigger();
   }
 }
 
@@ -167,7 +167,7 @@ StaticSingleThreadedExecutor::remove_callback_group(
   bool node_removed = entities_collector_->remove_callback_group(group_ptr);
   // If the node was matched and removed, interrupt waiting
   if (node_removed && notify) {
-    interrupt_guard_condition_.trigger();
+    interrupt_guard_condition_->trigger();
   }
 }
 
@@ -181,7 +181,7 @@ StaticSingleThreadedExecutor::remove_node(
   }
   // If the node was matched and removed, interrupt waiting
   if (notify) {
-    interrupt_guard_condition_.trigger();
+    interrupt_guard_condition_->trigger();
   }
 }
 

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -129,13 +129,6 @@ NodeBase::NodeBase(
       delete node;
     });
 
-  // Create the default callback group, if needed.
-  if (nullptr == default_callback_group_) {
-    using rclcpp::CallbackGroupType;
-    default_callback_group_ =
-      NodeBase::create_callback_group(CallbackGroupType::MutuallyExclusive);
-  }
-
   // Indicate the notify_guard_condition is now valid.
   notify_guard_condition_is_valid_ = true;
 }
@@ -205,8 +198,7 @@ NodeBase::create_callback_group(
   auto weak_ptr = this->weak_from_this();
   auto group = std::make_shared<rclcpp::CallbackGroup>(
     group_type,
-    [this]() -> rclcpp::Context::SharedPtr {
-      auto weak_ptr = this->weak_from_this();
+    [weak_ptr]() -> rclcpp::Context::SharedPtr {
       auto node_ptr = weak_ptr.lock();
       if (node_ptr) {
         return node_ptr->get_context();
@@ -222,6 +214,13 @@ NodeBase::create_callback_group(
 rclcpp::CallbackGroup::SharedPtr
 NodeBase::get_default_callback_group()
 {
+  // Create the default callback group, if needed.
+  if (nullptr == default_callback_group_) {
+    using rclcpp::CallbackGroupType;
+    default_callback_group_ =
+      NodeBase::create_callback_group(CallbackGroupType::MutuallyExclusive);
+  }
+
   return default_callback_group_;
 }
 

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -216,6 +216,13 @@ NodeBase::create_callback_group(
     automatically_add_to_executor_with_node);
   std::lock_guard<std::mutex> lock(callback_groups_mutex_);
   callback_groups_.push_back(group);
+
+  // If this is creating the default callback group, then the
+  // notify guard condition won't be ready or needed yet.
+  if (notify_guard_condition_is_valid_) {
+    this->trigger_notify_guard_condition();
+  }
+
   return group;
 }
 

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -254,12 +254,22 @@ NodeBase::get_associated_with_executor_atomic()
   return associated_with_executor_;
 }
 
-rclcpp::GuardCondition::SharedPtr
+rclcpp::GuardCondition &
 NodeBase::get_notify_guard_condition()
 {
   std::lock_guard<std::recursive_mutex> notify_condition_lock(notify_guard_condition_mutex_);
   if (!notify_guard_condition_is_valid_) {
     throw std::runtime_error("failed to get notify guard condition because it is invalid");
+  }
+  return *notify_guard_condition_;
+}
+
+rclcpp::GuardCondition::SharedPtr
+NodeBase::get_shared_notify_guard_condition()
+{
+  std::lock_guard<std::recursive_mutex> notify_condition_lock(notify_guard_condition_mutex_);
+  if (!notify_guard_condition_is_valid_) {
+    return nullptr;
   }
   return notify_guard_condition_;
 }

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -205,7 +205,6 @@ NodeBase::create_callback_group(
   bool automatically_add_to_executor_with_node)
 {
   auto weak_context = this->get_context()->weak_from_this();
-
   auto get_node_context = [weak_context]() -> rclcpp::Context::SharedPtr {
       return weak_context.lock();
     };
@@ -217,12 +216,15 @@ NodeBase::create_callback_group(
   std::lock_guard<std::mutex> lock(callback_groups_mutex_);
   callback_groups_.push_back(group);
 
-  // If this is creating the default callback group, then the
-  // notify guard condition won't be ready or needed yet.
-  if (notify_guard_condition_is_valid_) {
+  // This guard condition is generally used to signal to this node's executor that a callback
+  // group has been added that should be considered for new entities.
+  // If this is creating the default callback group, then the notify guard condition won't be
+  // ready or needed yet, as the node is not done being constructed and therefore cannot be added.
+  // If the callback group is not automatically associated with this node's executors, then
+  // triggering the guard condition is also unnecessary, it will be manually added to an exector.
+  if (notify_guard_condition_is_valid_ && automatically_add_to_executor_with_node) {
     this->trigger_notify_guard_condition();
   }
-
   return group;
 }
 

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -202,8 +202,17 @@ NodeBase::create_callback_group(
   rclcpp::CallbackGroupType group_type,
   bool automatically_add_to_executor_with_node)
 {
+  auto weak_ptr = this->weak_from_this();
   auto group = std::make_shared<rclcpp::CallbackGroup>(
     group_type,
+    [this]() -> rclcpp::Context::SharedPtr {
+      auto weak_ptr = this->weak_from_this();
+      auto node_ptr = weak_ptr.lock();
+      if (node_ptr) {
+        return node_ptr->get_context();
+      }
+      return nullptr;
+    },
     automatically_add_to_executor_with_node);
   std::lock_guard<std::mutex> lock(callback_groups_mutex_);
   callback_groups_.push_back(group);

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -129,6 +129,15 @@ NodeBase::NodeBase(
       delete node;
     });
 
+  // Create the default callback group, if needed.
+  if (nullptr == default_callback_group_) {
+    using rclcpp::CallbackGroupType;
+    // Default callback group is mutually exclusive and automatically associated with
+    // any executors that this node is added to.
+    default_callback_group_ =
+      NodeBase::create_callback_group(CallbackGroupType::MutuallyExclusive, true);
+  }
+
   // Indicate the notify_guard_condition is now valid.
   notify_guard_condition_is_valid_ = true;
 }
@@ -195,16 +204,15 @@ NodeBase::create_callback_group(
   rclcpp::CallbackGroupType group_type,
   bool automatically_add_to_executor_with_node)
 {
-  auto weak_ptr = this->weak_from_this();
+  auto weak_context = this->get_context()->weak_from_this();
+
+  auto get_node_context = [weak_context]() -> rclcpp::Context::SharedPtr {
+      return weak_context.lock();
+    };
+
   auto group = std::make_shared<rclcpp::CallbackGroup>(
     group_type,
-    [weak_ptr]() -> rclcpp::Context::SharedPtr {
-      auto node_ptr = weak_ptr.lock();
-      if (node_ptr) {
-        return node_ptr->get_context();
-      }
-      return nullptr;
-    },
+    get_node_context,
     automatically_add_to_executor_with_node);
   std::lock_guard<std::mutex> lock(callback_groups_mutex_);
   callback_groups_.push_back(group);
@@ -214,13 +222,6 @@ NodeBase::create_callback_group(
 rclcpp::CallbackGroup::SharedPtr
 NodeBase::get_default_callback_group()
 {
-  // Create the default callback group, if needed.
-  if (nullptr == default_callback_group_) {
-    using rclcpp::CallbackGroupType;
-    default_callback_group_ =
-      NodeBase::create_callback_group(CallbackGroupType::MutuallyExclusive);
-  }
-
   return default_callback_group_;
 }
 

--- a/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
@@ -533,9 +533,8 @@ NodeGraph::notify_graph_change()
     }
   }
   graph_cv_.notify_all();
-  auto & node_gc = node_base_->get_notify_guard_condition();
   try {
-    node_gc.trigger();
+    node_base_->trigger_notify_guard_condition();
   } catch (const rclcpp::exceptions::RCLError & ex) {
     throw std::runtime_error(
             std::string("failed to notify wait set on graph change: ") + ex.what());

--- a/rclcpp/src/rclcpp/node_interfaces/node_services.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_services.cpp
@@ -42,9 +42,8 @@ NodeServices::add_service(
   group->add_service(service_base_ptr);
 
   // Notify the executor that a new service was created using the parent Node.
-  auto & node_gc = node_base_->get_notify_guard_condition();
   try {
-    node_gc.trigger();
+    node_base_->trigger_notify_guard_condition();
     group->trigger_notify_guard_condition();
   } catch (const rclcpp::exceptions::RCLError & ex) {
     throw std::runtime_error(
@@ -69,9 +68,8 @@ NodeServices::add_client(
   group->add_client(client_base_ptr);
 
   // Notify the executor that a new client was created using the parent Node.
-  auto & node_gc = node_base_->get_notify_guard_condition();
   try {
-    node_gc.trigger();
+    node_base_->trigger_notify_guard_condition();
     group->trigger_notify_guard_condition();
   } catch (const rclcpp::exceptions::RCLError & ex) {
     throw std::runtime_error(

--- a/rclcpp/src/rclcpp/node_interfaces/node_timers.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_timers.cpp
@@ -42,9 +42,8 @@ NodeTimers::add_timer(
   }
   callback_group->add_timer(timer);
 
-  auto & node_gc = node_base_->get_notify_guard_condition();
   try {
-    node_gc.trigger();
+    node_base_->trigger_notify_guard_condition();
     callback_group->trigger_notify_guard_condition();
   } catch (const rclcpp::exceptions::RCLError & ex) {
     throw std::runtime_error(

--- a/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
@@ -70,9 +70,8 @@ NodeTopics::add_publisher(
   }
 
   // Notify the executor that a new publisher was created using the parent Node.
-  auto & node_gc = node_base_->get_notify_guard_condition();
   try {
-    node_gc.trigger();
+    node_base_->trigger_notify_guard_condition();
     callback_group->trigger_notify_guard_condition();
   } catch (const rclcpp::exceptions::RCLError & ex) {
     throw std::runtime_error(
@@ -119,9 +118,8 @@ NodeTopics::add_subscription(
   }
 
   // Notify the executor that a new subscription was created using the parent Node.
-  auto & node_gc = node_base_->get_notify_guard_condition();
   try {
-    node_gc.trigger();
+    node_base_->trigger_notify_guard_condition();
     callback_group->trigger_notify_guard_condition();
   } catch (const rclcpp::exceptions::RCLError & ex) {
     throw std::runtime_error(

--- a/rclcpp/src/rclcpp/node_interfaces/node_waitables.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_waitables.cpp
@@ -42,9 +42,8 @@ NodeWaitables::add_waitable(
   group->add_waitable(waitable_ptr);
 
   // Notify the executor that a new waitable was created using the parent Node.
-  auto & node_gc = node_base_->get_notify_guard_condition();
   try {
-    node_gc.trigger();
+    node_base_->trigger_notify_guard_condition();
     group->trigger_notify_guard_condition();
   } catch (const rclcpp::exceptions::RCLError & ex) {
     throw std::runtime_error(

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -688,6 +688,15 @@ if(TARGET test_static_executor_entities_collector)
   target_link_libraries(test_static_executor_entities_collector ${PROJECT_NAME} mimick)
 endif()
 
+ament_add_gtest(test_executor_notify_waitable executors/test_executor_notify_waitable.cpp
+  APPEND_LIBRARY_DIRS "${append_library_dirs}" TIMEOUT 120)
+if(TARGET test_executor_notify_waitable)
+  ament_target_dependencies(test_executor_notify_waitable
+    "rcl"
+    "test_msgs")
+  target_link_libraries(test_executor_notify_waitable ${PROJECT_NAME} mimick)
+endif()
+
 ament_add_gtest(test_guard_condition test_guard_condition.cpp
   APPEND_LIBRARY_DIRS "${append_library_dirs}")
 if(TARGET test_guard_condition)

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -688,6 +688,15 @@ if(TARGET test_static_executor_entities_collector)
   target_link_libraries(test_static_executor_entities_collector ${PROJECT_NAME} mimick)
 endif()
 
+ament_add_gtest(test_entities_collector executors/test_entities_collector.cpp
+  APPEND_LIBRARY_DIRS "${append_library_dirs}" TIMEOUT 120)
+if(TARGET test_entities_collector)
+  ament_target_dependencies(test_entities_collector
+    "rcl"
+    "test_msgs")
+  target_link_libraries(test_entities_collector ${PROJECT_NAME} mimick)
+endif()
+
 ament_add_gtest(test_executor_notify_waitable executors/test_executor_notify_waitable.cpp
   APPEND_LIBRARY_DIRS "${append_library_dirs}" TIMEOUT 120)
 if(TARGET test_executor_notify_waitable)

--- a/rclcpp/test/rclcpp/executors/test_entities_collector.cpp
+++ b/rclcpp/test/rclcpp/executors/test_entities_collector.cpp
@@ -239,11 +239,14 @@ TEST_F(TestExecutorEntitiesCollector, remove_callback_group_after_node) {
 
   node.reset();
 
-  ASSERT_FALSE(cb_group->has_valid_node());
-
+  /**
+   * TODO(mjcarroll): Assert this when we are enforcing that nodes must be destroyed
+   * after their created callback groups.
   RCLCPP_EXPECT_THROW_EQ(
     entities_collector.remove_callback_group(cb_group),
     std::runtime_error("Node must not be deleted before its callback group(s)."));
+  */
+  EXPECT_NO_THROW(entities_collector.update_collections());
 }
 
 TEST_F(TestExecutorEntitiesCollector, remove_callback_group_after_node2) {
@@ -269,11 +272,15 @@ TEST_F(TestExecutorEntitiesCollector, remove_callback_group_after_node2) {
   EXPECT_NO_THROW(entities_collector.remove_callback_group(cb_group));
 
   node.reset();
-  ASSERT_FALSE(cb_group->has_valid_node());
 
+  /**
+   * TODO(mjcarroll): Assert this when we are enforcing that nodes must be destroyed
+   * after their created callback groups.
   RCLCPP_EXPECT_THROW_EQ(
-    entities_collector.update_collections(),
+    entities_collector.remove_callback_group(cb_group),
     std::runtime_error("Node must not be deleted before its callback group(s)."));
+  */
+  EXPECT_NO_THROW(entities_collector.update_collections());
 }
 
 TEST_F(TestExecutorEntitiesCollector, remove_callback_group_twice) {

--- a/rclcpp/test/rclcpp/executors/test_entities_collector.cpp
+++ b/rclcpp/test/rclcpp/executors/test_entities_collector.cpp
@@ -1,0 +1,185 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/executors/executor_entities_collector.hpp"
+
+#include "../../utils/rclcpp_gtest_macros.hpp"
+
+class TestExecutorEntitiesCollector : public ::testing::Test
+{
+public:
+  void SetUp()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown()
+  {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(TestExecutorEntitiesCollector, add_remove_node) {
+  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector();
+
+  auto node1 = std::make_shared<rclcpp::Node>("node1", "ns");
+  auto node2 = std::make_shared<rclcpp::Node>("node2", "ns");
+
+  // Add a node
+  EXPECT_NO_THROW(entities_collector.add_node(node1->get_node_base_interface()));
+
+  // Add the same node a second time
+  RCLCPP_EXPECT_THROW_EQ(
+    entities_collector.add_node(node1->get_node_base_interface()),
+    std::runtime_error("Node '/ns/node1' has already been added to an executor."));
+
+  // Remove a node before adding
+  RCLCPP_EXPECT_THROW_EQ(
+    entities_collector.remove_node(node2->get_node_base_interface()),
+    std::runtime_error("Node needs to be associated with an executor."));
+
+  // Simulate node being associated somewhere else
+  auto & has_executor = node2->get_node_base_interface()->get_associated_with_executor_atomic();
+  has_executor.store(true);
+
+  // Add an already-associated node
+  RCLCPP_EXPECT_THROW_EQ(
+    entities_collector.remove_node(node2->get_node_base_interface()),
+    std::runtime_error("Node needs to be associated with this executor."));
+
+  has_executor.store(false);
+
+  // Add the now-disassociated node
+  EXPECT_NO_THROW(entities_collector.add_node(node2->get_node_base_interface()));
+
+  // Remove an existing node
+  EXPECT_NO_THROW(entities_collector.remove_node(node1->get_node_base_interface()));
+  // Remove the same node a second time
+  RCLCPP_EXPECT_THROW_EQ(
+    entities_collector.remove_node(node1->get_node_base_interface()),
+    std::runtime_error("Node needs to be associated with an executor."));
+
+  // Remove an existing node
+  EXPECT_NO_THROW(entities_collector.remove_node(node2->get_node_base_interface()));
+}
+
+TEST_F(TestExecutorEntitiesCollector, add_callback_group) {
+  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector();
+
+  auto node = std::make_shared<rclcpp::Node>("node1", "ns");
+  rclcpp::CallbackGroup::SharedPtr cb_group = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
+
+  entities_collector.add_callback_group(cb_group);
+  ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 1u);
+  ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 1u);
+  ASSERT_EQ(entities_collector.get_automatically_added_callback_groups().size(), 0u);
+}
+
+TEST_F(TestExecutorEntitiesCollector, add_node_default_callback_group) {
+  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector();
+
+  auto node = std::make_shared<rclcpp::Node>("node1", "ns");
+  entities_collector.add_node(node->get_node_base_interface());
+
+  ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 1u);
+  ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 0u);
+  ASSERT_EQ(entities_collector.get_automatically_added_callback_groups().size(), 1u);
+}
+
+TEST_F(TestExecutorEntitiesCollector, add_callback_group_after_add_node) {
+  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector();
+
+  auto node = std::make_shared<rclcpp::Node>("node1", "ns");
+  rclcpp::CallbackGroup::SharedPtr cb_group = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
+
+  entities_collector.add_node(node->get_node_base_interface());
+  RCLCPP_EXPECT_THROW_EQ(
+    entities_collector.add_callback_group(cb_group),
+    std::runtime_error("Callback group has already been added to an executor."));
+}
+
+TEST_F(TestExecutorEntitiesCollector, add_callback_group_twice) {
+  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector();
+
+  auto node = std::make_shared<rclcpp::Node>("node1", "ns");
+  rclcpp::CallbackGroup::SharedPtr cb_group = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
+
+  entities_collector.add_callback_group(cb_group);
+  ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 1u);
+  ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 1u);
+  ASSERT_EQ(entities_collector.get_automatically_added_callback_groups().size(), 0u);
+
+  cb_group->get_associated_with_executor_atomic().exchange(false);
+  RCLCPP_EXPECT_THROW_EQ(
+    entities_collector.add_callback_group(cb_group),
+    std::runtime_error("Callback group has already been added to this executor."));
+}
+
+TEST_F(TestExecutorEntitiesCollector, remove_callback_group_after_node) {
+  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector();
+
+  auto node = std::make_shared<rclcpp::Node>("node1", "ns");
+  rclcpp::CallbackGroup::SharedPtr cb_group = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
+
+  entities_collector.add_callback_group(cb_group);
+  ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 1u);
+  ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 1u);
+  ASSERT_EQ(entities_collector.get_automatically_added_callback_groups().size(), 0u);
+
+  node.reset();
+
+  ASSERT_FALSE(cb_group->has_valid_node());
+
+  RCLCPP_EXPECT_THROW_EQ(
+    entities_collector.remove_callback_group(cb_group),
+    std::runtime_error("Node must not be deleted before its callback group(s)."));
+}
+
+TEST_F(TestExecutorEntitiesCollector, remove_callback_group_twice) {
+  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector();
+
+  auto node = std::make_shared<rclcpp::Node>("node1", "ns");
+  rclcpp::CallbackGroup::SharedPtr cb_group = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
+
+  entities_collector.add_callback_group(cb_group);
+  ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 1u);
+  ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 1u);
+  ASSERT_EQ(entities_collector.get_automatically_added_callback_groups().size(), 0u);
+
+  entities_collector.remove_callback_group(cb_group);
+
+  RCLCPP_EXPECT_THROW_EQ(
+    entities_collector.remove_callback_group(cb_group),
+    std::runtime_error("Callback group needs to be associated with executor."));
+}
+
+TEST_F(TestExecutorEntitiesCollector, remove_node_opposite_order) {
+  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector();
+
+  auto node1 = std::make_shared<rclcpp::Node>("node1", "ns");
+  EXPECT_NO_THROW(entities_collector.add_node(node1->get_node_base_interface()));
+
+  auto node2 = std::make_shared<rclcpp::Node>("node2", "ns");
+  EXPECT_NO_THROW(entities_collector.add_node(node2->get_node_base_interface()));
+
+  EXPECT_NO_THROW(entities_collector.remove_node(node2->get_node_base_interface()));
+}

--- a/rclcpp/test/rclcpp/executors/test_entities_collector.cpp
+++ b/rclcpp/test/rclcpp/executors/test_entities_collector.cpp
@@ -26,57 +26,94 @@ public:
   void SetUp()
   {
     rclcpp::init(0, nullptr);
+
+    notify_waitable = std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>();
+    entities_collector = std::make_shared<rclcpp::executors::ExecutorEntitiesCollector>(notify_waitable);
   }
 
   void TearDown()
   {
     rclcpp::shutdown();
   }
+
+  std::shared_ptr<rclcpp::executors::ExecutorNotifyWaitable> notify_waitable;
+  std::shared_ptr<rclcpp::executors::ExecutorEntitiesCollector> entities_collector;
 };
 
 TEST_F(TestExecutorEntitiesCollector, add_remove_node) {
+
+  auto node1 = std::make_shared<rclcpp::Node>("node1", "ns");
+
+  // Add a node
+  EXPECT_NO_THROW(entities_collector->add_node(node1->get_node_base_interface()));
+  EXPECT_NO_THROW(entities_collector->update_collections());
+
+  // Remove a node
+  EXPECT_NO_THROW(entities_collector->remove_node(node1->get_node_base_interface()));
+  EXPECT_NO_THROW(entities_collector->update_collections());
+}
+
+TEST_F(TestExecutorEntitiesCollector, add_node_twice) {
+
+  auto node1 = std::make_shared<rclcpp::Node>("node1", "ns");
+
+  EXPECT_NO_THROW(entities_collector->add_node(node1->get_node_base_interface()));
+
+  RCLCPP_EXPECT_THROW_EQ(
+    entities_collector->add_node(node1->get_node_base_interface()),
+    std::runtime_error("Node '/ns/node1' has already been added to an executor."));
+
+  EXPECT_NO_THROW(entities_collector->update_collections());
+}
+
+TEST_F(TestExecutorEntitiesCollector, add_associated_node) {
+
+  auto node1 = std::make_shared<rclcpp::Node>("node1", "ns");
+
+  // Simulate node being associated somewhere else
+  auto & has_executor = node1->get_node_base_interface()->get_associated_with_executor_atomic();
+  has_executor.store(true);
+
+  // Add an already-associated node
+  RCLCPP_EXPECT_THROW_EQ(
+    entities_collector->remove_node(node1->get_node_base_interface()),
+    std::runtime_error("Node '/ns/node1' needs to be associated with this executor."));
+
+  has_executor.store(false);
+}
+
+TEST_F(TestExecutorEntitiesCollector, remove_unassociated_node) {
+
+  auto node1 = std::make_shared<rclcpp::Node>("node1", "ns");
+
+  // Add an already-associated node
+  RCLCPP_EXPECT_THROW_EQ(
+    entities_collector->remove_node(node1->get_node_base_interface()),
+    std::runtime_error("Node '/ns/node1' needs to be associated with an executor."));
+
+  // Simulate node being associated somewhere else
+  auto & has_executor = node1->get_node_base_interface()->get_associated_with_executor_atomic();
+  has_executor.store(true);
+
+  // Add an already-associated node
+  RCLCPP_EXPECT_THROW_EQ(
+    entities_collector->remove_node(node1->get_node_base_interface()),
+    std::runtime_error("Node '/ns/node1' needs to be associated with this executor."));
+}
+
+TEST_F(TestExecutorEntitiesCollector, add_remove_node_before_update) {
   auto notify_waitable = std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>();
   auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector(notify_waitable);
 
   auto node1 = std::make_shared<rclcpp::Node>("node1", "ns");
   auto node2 = std::make_shared<rclcpp::Node>("node2", "ns");
 
-  // Add a node
+  // Add and remove nodes without running updatenode
   EXPECT_NO_THROW(entities_collector.add_node(node1->get_node_base_interface()));
-
-  // Add the same node a second time
-  RCLCPP_EXPECT_THROW_EQ(
-    entities_collector.add_node(node1->get_node_base_interface()),
-    std::runtime_error("Node '/ns/node1' has already been added to an executor."));
-
-  // Remove a node before adding
-  RCLCPP_EXPECT_THROW_EQ(
-    entities_collector.remove_node(node2->get_node_base_interface()),
-    std::runtime_error("Node needs to be associated with an executor."));
-
-  // Simulate node being associated somewhere else
-  auto & has_executor = node2->get_node_base_interface()->get_associated_with_executor_atomic();
-  has_executor.store(true);
-
-  // Add an already-associated node
-  RCLCPP_EXPECT_THROW_EQ(
-    entities_collector.remove_node(node2->get_node_base_interface()),
-    std::runtime_error("Node needs to be associated with this executor."));
-
-  has_executor.store(false);
-
-  // Add the now-disassociated node
   EXPECT_NO_THROW(entities_collector.add_node(node2->get_node_base_interface()));
-
-  // Remove an existing node
   EXPECT_NO_THROW(entities_collector.remove_node(node1->get_node_base_interface()));
-  // Remove the same node a second time
-  RCLCPP_EXPECT_THROW_EQ(
-    entities_collector.remove_node(node1->get_node_base_interface()),
-    std::runtime_error("Node needs to be associated with an executor."));
-
-  // Remove an existing node
   EXPECT_NO_THROW(entities_collector.remove_node(node2->get_node_base_interface()));
+  EXPECT_NO_THROW(entities_collector.update_collections());
 }
 
 TEST_F(TestExecutorEntitiesCollector, add_callback_group) {
@@ -87,9 +124,30 @@ TEST_F(TestExecutorEntitiesCollector, add_callback_group) {
   rclcpp::CallbackGroup::SharedPtr cb_group = node->create_callback_group(
     rclcpp::CallbackGroupType::MutuallyExclusive);
 
+  // Add a callback group and update
   entities_collector.add_callback_group(cb_group);
+
+  ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 0u);
+  ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 0u);
+  ASSERT_EQ(entities_collector.get_automatically_added_callback_groups().size(), 0u);
+
+  entities_collector.update_collections();
+
   ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 1u);
   ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 1u);
+  ASSERT_EQ(entities_collector.get_automatically_added_callback_groups().size(), 0u);
+
+  // Remove callback group and update
+  entities_collector.remove_callback_group(cb_group);
+
+  ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 1u);
+  ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 1u);
+  ASSERT_EQ(entities_collector.get_automatically_added_callback_groups().size(), 0u);
+
+  entities_collector.update_collections();
+
+  ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 0u);
+  ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 0u);
   ASSERT_EQ(entities_collector.get_automatically_added_callback_groups().size(), 0u);
 }
 
@@ -99,6 +157,12 @@ TEST_F(TestExecutorEntitiesCollector, add_node_default_callback_group) {
 
   auto node = std::make_shared<rclcpp::Node>("node1", "ns");
   entities_collector.add_node(node->get_node_base_interface());
+
+  ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 0u);
+  ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 0u);
+  ASSERT_EQ(entities_collector.get_automatically_added_callback_groups().size(), 0u);
+
+  entities_collector.update_collections();
 
   ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 1u);
   ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 0u);
@@ -114,6 +178,17 @@ TEST_F(TestExecutorEntitiesCollector, add_callback_group_after_add_node) {
     rclcpp::CallbackGroupType::MutuallyExclusive);
 
   entities_collector.add_node(node->get_node_base_interface());
+
+  ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 0u);
+  ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 0u);
+  ASSERT_EQ(entities_collector.get_automatically_added_callback_groups().size(), 0u);
+
+  entities_collector.update_collections();
+
+  ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 2u);
+  ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 0u);
+  ASSERT_EQ(entities_collector.get_automatically_added_callback_groups().size(), 2u);
+
   RCLCPP_EXPECT_THROW_EQ(
     entities_collector.add_callback_group(cb_group),
     std::runtime_error("Callback group has already been added to an executor."));
@@ -128,6 +203,13 @@ TEST_F(TestExecutorEntitiesCollector, add_callback_group_twice) {
     rclcpp::CallbackGroupType::MutuallyExclusive);
 
   entities_collector.add_callback_group(cb_group);
+
+  ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 0u);
+  ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 0u);
+  ASSERT_EQ(entities_collector.get_automatically_added_callback_groups().size(), 0u);
+
+  entities_collector.update_collections();
+
   ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 1u);
   ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 1u);
   ASSERT_EQ(entities_collector.get_automatically_added_callback_groups().size(), 0u);
@@ -147,6 +229,13 @@ TEST_F(TestExecutorEntitiesCollector, remove_callback_group_after_node) {
     rclcpp::CallbackGroupType::MutuallyExclusive);
 
   entities_collector.add_callback_group(cb_group);
+
+  ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 0u);
+  ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 0u);
+  ASSERT_EQ(entities_collector.get_automatically_added_callback_groups().size(), 0u);
+
+  entities_collector.update_collections();
+
   ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 1u);
   ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 1u);
   ASSERT_EQ(entities_collector.get_automatically_added_callback_groups().size(), 0u);
@@ -160,6 +249,36 @@ TEST_F(TestExecutorEntitiesCollector, remove_callback_group_after_node) {
     std::runtime_error("Node must not be deleted before its callback group(s)."));
 }
 
+TEST_F(TestExecutorEntitiesCollector, remove_callback_group_after_node2) {
+  auto notify_waitable = std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>();
+  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector(notify_waitable);
+
+  auto node = std::make_shared<rclcpp::Node>("node1", "ns");
+  rclcpp::CallbackGroup::SharedPtr cb_group = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
+
+  entities_collector.add_callback_group(cb_group);
+
+  ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 0u);
+  ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 0u);
+  ASSERT_EQ(entities_collector.get_automatically_added_callback_groups().size(), 0u);
+
+  entities_collector.update_collections();
+
+  ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 1u);
+  ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 1u);
+  ASSERT_EQ(entities_collector.get_automatically_added_callback_groups().size(), 0u);
+
+  EXPECT_NO_THROW(entities_collector.remove_callback_group(cb_group));
+
+  node.reset();
+  ASSERT_FALSE(cb_group->has_valid_node());
+
+  RCLCPP_EXPECT_THROW_EQ(
+    entities_collector.update_collections(),
+    std::runtime_error("Node must not be deleted before its callback group(s)."));
+}
+
 TEST_F(TestExecutorEntitiesCollector, remove_callback_group_twice) {
   auto notify_waitable = std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>();
   auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector(notify_waitable);
@@ -169,15 +288,18 @@ TEST_F(TestExecutorEntitiesCollector, remove_callback_group_twice) {
     rclcpp::CallbackGroupType::MutuallyExclusive);
 
   entities_collector.add_callback_group(cb_group);
+  entities_collector.update_collections();
+
   ASSERT_EQ(entities_collector.get_all_callback_groups().size(), 1u);
   ASSERT_EQ(entities_collector.get_manually_added_callback_groups().size(), 1u);
   ASSERT_EQ(entities_collector.get_automatically_added_callback_groups().size(), 0u);
 
   entities_collector.remove_callback_group(cb_group);
+  entities_collector.update_collections();
 
   RCLCPP_EXPECT_THROW_EQ(
     entities_collector.remove_callback_group(cb_group),
-    std::runtime_error("Callback group needs to be associated with executor."));
+    std::runtime_error("Callback group needs to be associated with an executor."));
 }
 
 TEST_F(TestExecutorEntitiesCollector, remove_node_opposite_order) {

--- a/rclcpp/test/rclcpp/executors/test_entities_collector.cpp
+++ b/rclcpp/test/rclcpp/executors/test_entities_collector.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include "rclcpp/executors/executor_notify_waitable.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/executors/executor_entities_collector.hpp"
 
@@ -34,7 +35,8 @@ public:
 };
 
 TEST_F(TestExecutorEntitiesCollector, add_remove_node) {
-  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector();
+  auto notify_waitable = std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>();
+  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector(notify_waitable);
 
   auto node1 = std::make_shared<rclcpp::Node>("node1", "ns");
   auto node2 = std::make_shared<rclcpp::Node>("node2", "ns");
@@ -78,7 +80,8 @@ TEST_F(TestExecutorEntitiesCollector, add_remove_node) {
 }
 
 TEST_F(TestExecutorEntitiesCollector, add_callback_group) {
-  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector();
+  auto notify_waitable = std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>();
+  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector(notify_waitable);
 
   auto node = std::make_shared<rclcpp::Node>("node1", "ns");
   rclcpp::CallbackGroup::SharedPtr cb_group = node->create_callback_group(
@@ -91,7 +94,8 @@ TEST_F(TestExecutorEntitiesCollector, add_callback_group) {
 }
 
 TEST_F(TestExecutorEntitiesCollector, add_node_default_callback_group) {
-  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector();
+  auto notify_waitable = std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>();
+  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector(notify_waitable);
 
   auto node = std::make_shared<rclcpp::Node>("node1", "ns");
   entities_collector.add_node(node->get_node_base_interface());
@@ -102,7 +106,8 @@ TEST_F(TestExecutorEntitiesCollector, add_node_default_callback_group) {
 }
 
 TEST_F(TestExecutorEntitiesCollector, add_callback_group_after_add_node) {
-  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector();
+  auto notify_waitable = std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>();
+  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector(notify_waitable);
 
   auto node = std::make_shared<rclcpp::Node>("node1", "ns");
   rclcpp::CallbackGroup::SharedPtr cb_group = node->create_callback_group(
@@ -115,7 +120,8 @@ TEST_F(TestExecutorEntitiesCollector, add_callback_group_after_add_node) {
 }
 
 TEST_F(TestExecutorEntitiesCollector, add_callback_group_twice) {
-  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector();
+  auto notify_waitable = std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>();
+  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector(notify_waitable);
 
   auto node = std::make_shared<rclcpp::Node>("node1", "ns");
   rclcpp::CallbackGroup::SharedPtr cb_group = node->create_callback_group(
@@ -133,7 +139,8 @@ TEST_F(TestExecutorEntitiesCollector, add_callback_group_twice) {
 }
 
 TEST_F(TestExecutorEntitiesCollector, remove_callback_group_after_node) {
-  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector();
+  auto notify_waitable = std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>();
+  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector(notify_waitable);
 
   auto node = std::make_shared<rclcpp::Node>("node1", "ns");
   rclcpp::CallbackGroup::SharedPtr cb_group = node->create_callback_group(
@@ -154,7 +161,8 @@ TEST_F(TestExecutorEntitiesCollector, remove_callback_group_after_node) {
 }
 
 TEST_F(TestExecutorEntitiesCollector, remove_callback_group_twice) {
-  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector();
+  auto notify_waitable = std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>();
+  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector(notify_waitable);
 
   auto node = std::make_shared<rclcpp::Node>("node1", "ns");
   rclcpp::CallbackGroup::SharedPtr cb_group = node->create_callback_group(
@@ -173,7 +181,8 @@ TEST_F(TestExecutorEntitiesCollector, remove_callback_group_twice) {
 }
 
 TEST_F(TestExecutorEntitiesCollector, remove_node_opposite_order) {
-  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector();
+  auto notify_waitable = std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>();
+  auto entities_collector = rclcpp::executors::ExecutorEntitiesCollector(notify_waitable);
 
   auto node1 = std::make_shared<rclcpp::Node>("node1", "ns");
   EXPECT_NO_THROW(entities_collector.add_node(node1->get_node_base_interface()));

--- a/rclcpp/test/rclcpp/executors/test_entities_collector.cpp
+++ b/rclcpp/test/rclcpp/executors/test_entities_collector.cpp
@@ -28,7 +28,8 @@ public:
     rclcpp::init(0, nullptr);
 
     notify_waitable = std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>();
-    entities_collector = std::make_shared<rclcpp::executors::ExecutorEntitiesCollector>(notify_waitable);
+    entities_collector = std::make_shared<rclcpp::executors::ExecutorEntitiesCollector>(
+      notify_waitable);
   }
 
   void TearDown()
@@ -41,7 +42,6 @@ public:
 };
 
 TEST_F(TestExecutorEntitiesCollector, add_remove_node) {
-
   auto node1 = std::make_shared<rclcpp::Node>("node1", "ns");
 
   // Add a node
@@ -54,7 +54,6 @@ TEST_F(TestExecutorEntitiesCollector, add_remove_node) {
 }
 
 TEST_F(TestExecutorEntitiesCollector, add_node_twice) {
-
   auto node1 = std::make_shared<rclcpp::Node>("node1", "ns");
 
   EXPECT_NO_THROW(entities_collector->add_node(node1->get_node_base_interface()));
@@ -67,7 +66,6 @@ TEST_F(TestExecutorEntitiesCollector, add_node_twice) {
 }
 
 TEST_F(TestExecutorEntitiesCollector, add_associated_node) {
-
   auto node1 = std::make_shared<rclcpp::Node>("node1", "ns");
 
   // Simulate node being associated somewhere else
@@ -83,7 +81,6 @@ TEST_F(TestExecutorEntitiesCollector, add_associated_node) {
 }
 
 TEST_F(TestExecutorEntitiesCollector, remove_unassociated_node) {
-
   auto node1 = std::make_shared<rclcpp::Node>("node1", "ns");
 
   // Add an already-associated node

--- a/rclcpp/test/rclcpp/executors/test_executor_notify_waitable.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executor_notify_waitable.cpp
@@ -1,0 +1,95 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <stdexcept>
+
+#include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include "rcpputils/scope_exit.hpp"
+
+#include "rclcpp/executors/executor_notify_waitable.hpp"
+
+#include "../../utils/rclcpp_gtest_macros.hpp"
+
+
+class TestExecutorNotifyWaitable : public ::testing::Test
+{
+public:
+  void SetUp()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown()
+  {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(TestExecutorNotifyWaitable, construct_destruct) {
+  {
+    auto waitable = std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>();
+    waitable.reset();
+  }
+  {
+    auto on_execute_callback = []() {};
+    auto waitable =
+      std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>(on_execute_callback);
+    waitable.reset();
+  }
+}
+
+TEST_F(TestExecutorNotifyWaitable, add_remove_guard_conditions) {
+  auto on_execute_callback = []() {};
+  auto waitable =
+    std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>(on_execute_callback);
+
+  auto node = std::make_shared<rclcpp::Node>("my_node", "/ns");
+  auto & notify_guard_condition = node->get_node_base_interface()->get_notify_guard_condition();
+
+  EXPECT_NO_THROW(waitable->add_guard_condition(&notify_guard_condition));
+  EXPECT_NO_THROW(waitable->remove_guard_condition(&notify_guard_condition));
+}
+
+TEST_F(TestExecutorNotifyWaitable, wait) {
+  int on_execute_calls = 0;
+  auto on_execute_callback = [&on_execute_calls]() {on_execute_calls++;};
+
+  auto waitable =
+    std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>(on_execute_callback);
+
+  auto node = std::make_shared<rclcpp::Node>("my_node", "/ns");
+  auto & notify_guard_condition = node->get_node_base_interface()->get_notify_guard_condition();
+  EXPECT_NO_THROW(waitable->add_guard_condition(&notify_guard_condition));
+
+  auto default_cbg = node->get_node_base_interface()->get_default_callback_group();
+  ASSERT_NE(nullptr, default_cbg->get_notify_guard_condition());
+
+  auto waitables = node->get_node_waitables_interface();
+  waitables->add_waitable(std::static_pointer_cast<rclcpp::Waitable>(waitable), default_cbg);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+  executor.spin_all(std::chrono::seconds(1));
+  EXPECT_EQ(1u, on_execute_calls);
+
+  // on_execute_callback doesn't change if the topology doesn't change
+  executor.spin_all(std::chrono::seconds(1));
+  EXPECT_EQ(1u, on_execute_calls);
+}

--- a/rclcpp/test/rclcpp/executors/test_executor_notify_waitable.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executor_notify_waitable.cpp
@@ -61,10 +61,10 @@ TEST_F(TestExecutorNotifyWaitable, add_remove_guard_conditions) {
     std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>(on_execute_callback);
 
   auto node = std::make_shared<rclcpp::Node>("my_node", "/ns");
-  auto & notify_guard_condition = node->get_node_base_interface()->get_notify_guard_condition();
+  auto notify_guard_condition = node->get_node_base_interface()->get_notify_guard_condition();
 
-  EXPECT_NO_THROW(waitable->add_guard_condition(&notify_guard_condition));
-  EXPECT_NO_THROW(waitable->remove_guard_condition(&notify_guard_condition));
+  EXPECT_NO_THROW(waitable->add_guard_condition(notify_guard_condition));
+  EXPECT_NO_THROW(waitable->remove_guard_condition(notify_guard_condition));
 }
 
 TEST_F(TestExecutorNotifyWaitable, wait) {
@@ -75,8 +75,8 @@ TEST_F(TestExecutorNotifyWaitable, wait) {
     std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>(on_execute_callback);
 
   auto node = std::make_shared<rclcpp::Node>("my_node", "/ns");
-  auto & notify_guard_condition = node->get_node_base_interface()->get_notify_guard_condition();
-  EXPECT_NO_THROW(waitable->add_guard_condition(&notify_guard_condition));
+  auto notify_guard_condition = node->get_node_base_interface()->get_notify_guard_condition();
+  EXPECT_NO_THROW(waitable->add_guard_condition(notify_guard_condition));
 
   auto default_cbg = node->get_node_base_interface()->get_default_callback_group();
   ASSERT_NE(nullptr, default_cbg->get_notify_guard_condition());

--- a/rclcpp/test/rclcpp/executors/test_executor_notify_waitable.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executor_notify_waitable.cpp
@@ -61,8 +61,9 @@ TEST_F(TestExecutorNotifyWaitable, add_remove_guard_conditions) {
     std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>(on_execute_callback);
 
   auto node = std::make_shared<rclcpp::Node>("my_node", "/ns");
-  auto notify_guard_condition = node->get_node_base_interface()->get_notify_guard_condition();
+  auto notify_guard_condition =
 
+    node->get_node_base_interface()->get_shared_notify_guard_condition();
   EXPECT_NO_THROW(waitable->add_guard_condition(notify_guard_condition));
   EXPECT_NO_THROW(waitable->remove_guard_condition(notify_guard_condition));
 }
@@ -75,7 +76,8 @@ TEST_F(TestExecutorNotifyWaitable, wait) {
     std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>(on_execute_callback);
 
   auto node = std::make_shared<rclcpp::Node>("my_node", "/ns");
-  auto notify_guard_condition = node->get_node_base_interface()->get_notify_guard_condition();
+  auto notify_guard_condition =
+    node->get_node_base_interface()->get_shared_notify_guard_condition();
   EXPECT_NO_THROW(waitable->add_guard_condition(notify_guard_condition));
 
   auto default_cbg = node->get_node_base_interface()->get_default_callback_group();


### PR DESCRIPTION
Broken off of #2142 so that it can be used as a base for #2140.

This introduces a few main structures:

* ExecutorNotifyWaitable - an object used to collect node and callback group guard conditions from things associated with an executor.
* ExecutorEntitiesCollector - an object to collect entities from executor-associated nodes and callback groups
* ExecutorEntitiesCollection - a collection of entities that are associated with an executor via callback groups and nodes.

CC: @alsora @mauropasse 