### PR TITLE
add qos policy names from rmw

### DIFF
--- a/rclcpp/src/rclcpp/qos.cpp
+++ b/rclcpp/src/rclcpp/qos.cpp
@@ -40,6 +40,12 @@ std::string qos_policy_name_from_kind(rmw_qos_policy_kind_t policy_kind)
       return "HISTORY_QOS_POLICY";
     case RMW_QOS_POLICY_LIFESPAN:
       return "LIFESPAN_QOS_POLICY";
+    case RMW_QOS_POLICY_DEPTH:
+      return "DEPTH_QOS_POLICY";
+    case RMW_QOS_POLICY_LIVELINESS_LEASE_DURATION:
+      return "LIVELINESS_LEASE_DURATION_QOS_POLICY";
+    case RMW_QOS_POLICY_AVOID_ROS_NAMESPACE_CONVENTIONS:
+      return "AVOID_ROS_NAMESPACE_CONVENTIONS_QOS_POLICY";
     default:
       return "INVALID_QOS_POLICY";
   }

--- a/rclcpp/test/rclcpp/test_qos.cpp
+++ b/rclcpp/test/rclcpp/test_qos.cpp
@@ -218,6 +218,18 @@ TEST(TestQoS, policy_name_from_kind) {
   EXPECT_EQ(
     "LIFESPAN_QOS_POLICY",
     rclcpp::qos_policy_name_from_kind(RMW_QOS_POLICY_LIFESPAN));
+
+  EXPECT_EQ(
+    "DEPTH_QOS_POLICY",
+    rclcpp::qos_policy_name_from_kind(RMW_QOS_POLICY_DEPTH));
+
+  EXPECT_EQ(
+    "LIVELINESS_LEASE_DURATION_QOS_POLICY",
+    rclcpp::qos_policy_name_from_kind(RMW_QOS_POLICY_LIVELINESS_LEASE_DURATION));
+
+  EXPECT_EQ(
+    "AVOID_ROS_NAMESPACE_CONVENTIONS_QOS_POLICY",
+    rclcpp::qos_policy_name_from_kind(RMW_QOS_POLICY_AVOID_ROS_NAMESPACE_CONVENTIONS));
 }
 
 TEST(TestQoS, qos_check_compatible)


### PR DESCRIPTION
Fix available qos policy kinds from [ros2/rmw/include/rmw/qos_policy_kind.h](https://github.com/ros2/rmw/blob/bb044d59df89fac9fed8706aa58a8d7092fa31a2/rmw/include/rmw/qos_policy_kind.h#L27)