### PR TITLE
Virtual run method for MultithreadedExecutor #2157

### DIFF
--- a/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
@@ -75,7 +75,7 @@ public:
 
 protected:
   RCLCPP_PUBLIC
-  void
+  virtual void
   run(size_t this_thread_number);
 
 private:

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -61,8 +61,10 @@ MultiThreadedExecutor::spin()
   {
     std::lock_guard wait_lock{wait_mutex_};
     for (; thread_id < number_of_threads_ - 1; ++thread_id) {
-      auto func = std::bind(&MultiThreadedExecutor::run, this, thread_id);
-      threads.emplace_back(func);
+      threads.emplace_back(
+        [&](size_t this_thread_number) -> void {
+          this->run(this_thread_number);
+        }, thread_id);
     }
   }
 


### PR DESCRIPTION
Change the MultiThreadedExecutor::run method to be virtual in order to allow overriding of the functionality. This helps to add exception handling and other functionality not specific to the executor itself.

issue: #2157