### PR TITLE
Support publishing loaned messages in LifecyclePublisher

### DIFF
--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_publisher.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_publisher.hpp
@@ -98,7 +98,8 @@ public:
    * to the actual rclcpp Publisher base class
    */
   virtual void
-  publish(rclcpp::LoanedMessage<typename rclcpp::Publisher<MessageT, Alloc>::ROSMessageType, Alloc> && loaned_msg)
+  publish(rclcpp::LoanedMessage<typename rclcpp::Publisher<MessageT,
+		  		Alloc>::ROSMessageType, Alloc> && loaned_msg)
   {
     if (!this->is_activated()) {
       log_publisher_not_enabled();

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_publisher.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_publisher.hpp
@@ -99,7 +99,7 @@ public:
    */
   virtual void
   publish(rclcpp::LoanedMessage<typename rclcpp::Publisher<MessageT,
-		  		Alloc>::ROSMessageType, Alloc> && loaned_msg)
+                                Alloc>::ROSMessageType, Alloc> && loaned_msg)
   {
     if (!this->is_activated()) {
       log_publisher_not_enabled();

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_publisher.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_publisher.hpp
@@ -98,8 +98,9 @@ public:
    * to the actual rclcpp Publisher base class
    */
   virtual void
-  publish(rclcpp::LoanedMessage<typename rclcpp::Publisher<MessageT,
-                                Alloc>::ROSMessageType, Alloc> && loaned_msg)
+  publish(
+    rclcpp::LoanedMessage<typename rclcpp::Publisher<MessageT,
+    Alloc>::ROSMessageType, Alloc> && loaned_msg)
   {
     if (!this->is_activated()) {
       log_publisher_not_enabled();

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_publisher.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_publisher.hpp
@@ -91,6 +91,22 @@ public:
     rclcpp::Publisher<MessageT, Alloc>::publish(msg);
   }
 
+  /// LifecyclePublisher publish function
+  /**
+   * The publish function checks whether the communication
+   * was enabled or disabled and forwards the message
+   * to the actual rclcpp Publisher base class
+   */
+  virtual void
+  publish(rclcpp::LoanedMessage<typename rclcpp::Publisher<MessageT, Alloc>::ROSMessageType, Alloc> && loaned_msg)
+  {
+    if (!this->is_activated()) {
+      log_publisher_not_enabled();
+      return;
+    }
+    rclcpp::Publisher<MessageT, Alloc>::publish(std::move(loaned_msg));
+  }
+
   void
   on_activate() override
   {

--- a/rclcpp_lifecycle/test/test_lifecycle_publisher.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_publisher.cpp
@@ -129,6 +129,10 @@ TEST_P(TestLifecyclePublisher, publish_managed_by_node) {
     auto msg_ptr = std::make_unique<test_msgs::msg::Empty>();
     EXPECT_NO_THROW(node_->publisher()->publish(std::move(msg_ptr)));
   }
+  {
+    auto loaned_msg = node_->publisher()->borrow_loaned_message();
+    EXPECT_NO_THROW(node_->publisher()->publish(std::move(loaned_msg)));
+  }
   node_->trigger_transition(
     rclcpp_lifecycle::Transition(Transition::TRANSITION_DEACTIVATE), ret);
   ASSERT_EQ(success, ret);
@@ -142,6 +146,10 @@ TEST_P(TestLifecyclePublisher, publish_managed_by_node) {
   {
     auto msg_ptr = std::make_unique<test_msgs::msg::Empty>();
     EXPECT_NO_THROW(node_->publisher()->publish(std::move(msg_ptr)));
+  }
+  {
+    auto loaned_msg = node_->publisher()->borrow_loaned_message();
+    EXPECT_NO_THROW(node_->publisher()->publish(std::move(loaned_msg)));
   }
 }
 
@@ -157,6 +165,10 @@ TEST_P(TestLifecyclePublisher, publish) {
     auto msg_ptr = std::make_unique<test_msgs::msg::Empty>();
     EXPECT_NO_THROW(node_->publisher()->publish(std::move(msg_ptr)));
   }
+  {
+    auto loaned_msg = node_->publisher()->borrow_loaned_message();
+    EXPECT_NO_THROW(node_->publisher()->publish(std::move(loaned_msg)));
+  }
   node_->publisher()->on_activate();
   EXPECT_TRUE(node_->publisher()->is_activated());
   {
@@ -166,6 +178,10 @@ TEST_P(TestLifecyclePublisher, publish) {
   {
     auto msg_ptr = std::make_unique<test_msgs::msg::Empty>();
     EXPECT_NO_THROW(node_->publisher()->publish(std::move(msg_ptr)));
+  }
+  {
+    auto loaned_msg = node_->publisher()->borrow_loaned_message();
+    EXPECT_NO_THROW(node_->publisher()->publish(std::move(loaned_msg)));
   }
 }
 


### PR DESCRIPTION
## Problem
Right now LifecyclePublisher doesn't support publishing `LoanedMessage`s. 

## Solution
Override publish for loaned message, implementation is the same as in other overloads, check if publisher is activated and if so, pass message to base publisher