### PR TITLE
Fix thread safety in LifecycleNode::get_current_state() for Humble

### DIFF
--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -20,6 +20,8 @@ find_package(lifecycle_msgs REQUIRED)
 add_library(rclcpp_lifecycle
   src/lifecycle_node.cpp
   src/managed_entity.cpp
+  src/mutex_map.cpp
+  src/mutex_map.hpp
   src/node_interfaces/lifecycle_node_interface.cpp
   src/state.cpp
   src/transition.cpp

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/state.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/state.hpp
@@ -24,6 +24,8 @@
 
 namespace rclcpp_lifecycle
 {
+/// Forward declaration of mutex helper class
+class MutexMap;
 
 /// Abstract class for the Lifecycle's states.
 /**
@@ -92,6 +94,21 @@ protected:
   bool owns_rcl_state_handle_;
 
   rcl_lifecycle_state_t * state_handle_;
+
+private:
+  /// Maps state handle mutexes to each instance of State.
+  /**
+   * \details A mutex is added to this map when each new instance of State is constructed.
+   *
+   * The mutex is removed when the instance of State is destroyed.
+   *
+   * The mutex is locked while state_handle_ is being accessed.
+   *
+   * This static member exists to allow implementing the fix described in ros2/rclcpp#1756
+   * in Humble without breaking ABI compatibility, since adding a new static data
+   * member is permitted under REP-0009.
+   */
+  static MutexMap state_handle_mutex_map_;
 };
 
 }  // namespace rclcpp_lifecycle

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -405,7 +405,7 @@ public:
         RCUTILS_LOG_ERROR(
           "Unable to change state for state machine for %s: %s",
           node_base_interface_->get_name(), rcl_get_error_string().str);
-          return RCL_RET_ERROR;
+        return RCL_RET_ERROR;
       }
       // keep the initial state to pass to a transition callback
       initial_state = State(state_machine_.current_state);

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.hpp
@@ -20,6 +20,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 #include <utility>
@@ -64,7 +65,11 @@ public:
   ~LifecycleNodeInterfaceImpl()
   {
     rcl_node_t * node_handle = node_base_interface_->get_rcl_node_handle();
-    auto ret = rcl_lifecycle_state_machine_fini(&state_machine_, node_handle);
+    rcl_ret_t ret;
+    {
+      std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+      ret = rcl_lifecycle_state_machine_fini(&state_machine_, node_handle);
+    }
     if (ret != RCL_RET_OK) {
       RCUTILS_LOG_FATAL_NAMED(
         "rclcpp_lifecycle",
@@ -78,7 +83,6 @@ public:
     rcl_node_t * node_handle = node_base_interface_->get_rcl_node_handle();
     const rcl_node_options_t * node_options =
       rcl_node_get_options(node_base_interface_->get_rcl_node_handle());
-    state_machine_ = rcl_lifecycle_get_zero_initialized_state_machine();
     auto state_machine_options = rcl_lifecycle_get_default_state_machine_options();
     state_machine_options.enable_com_interface = enable_communication_interface;
     state_machine_options.allocator = node_options->allocator;
@@ -89,6 +93,8 @@ public:
     // The publisher takes a C-Typesupport since the publishing (i.e. creating
     // the message) is done fully in RCL.
     // Services are handled in C++, so that it needs a C++ typesupport structure.
+    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+    state_machine_ = rcl_lifecycle_get_zero_initialized_state_machine();
     rcl_ret_t ret = rcl_lifecycle_state_machine_init(
       &state_machine_,
       node_handle,
@@ -104,6 +110,8 @@ public:
               std::string("Couldn't initialize state machine for node ") +
               node_base_interface_->get_name());
     }
+
+    current_state_ = State(state_machine_.current_state);
 
     if (enable_communication_interface) {
       { // change_state
@@ -206,28 +214,30 @@ public:
     std::shared_ptr<ChangeStateSrv::Response> resp)
   {
     (void)header;
-    if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
-      throw std::runtime_error(
-              "Can't get state. State machine is not initialized.");
-    }
-
-    auto transition_id = req->transition.id;
-    // if there's a label attached to the request,
-    // we check the transition attached to this label.
-    // we further can't compare the id of the looked up transition
-    // because ros2 service call defaults all intergers to zero.
-    // that means if we call ros2 service call ... {transition: {label: shutdown}}
-    // the id of the request is 0 (zero) whereas the id from the lookup up transition
-    // can be different.
-    // the result of this is that the label takes presedence of the id.
-    if (req->transition.label.size() != 0) {
-      auto rcl_transition = rcl_lifecycle_get_transition_by_label(
-        state_machine_.current_state, req->transition.label.c_str());
-      if (rcl_transition == nullptr) {
-        resp->success = false;
-        return;
+    std::uint8_t transition_id;
+    {
+      std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+      if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
+        throw std::runtime_error("Can't get state. State machine is not initialized.");
       }
-      transition_id = static_cast<std::uint8_t>(rcl_transition->id);
+      transition_id = req->transition.id;
+      // if there's a label attached to the request,
+      // we check the transition attached to this label.
+      // we further can't compare the id of the looked up transition
+      // because ros2 service call defaults all intergers to zero.
+      // that means if we call ros2 service call ... {transition: {label: shutdown}}
+      // the id of the request is 0 (zero) whereas the id from the lookup up transition
+      // can be different.
+      // the result of this is that the label takes presedence of the id.
+      if (req->transition.label.size() != 0) {
+        auto rcl_transition = rcl_lifecycle_get_transition_by_label(
+          state_machine_.current_state, req->transition.label.c_str());
+        if (rcl_transition == nullptr) {
+          resp->success = false;
+          return;
+        }
+        transition_id = static_cast<std::uint8_t>(rcl_transition->id);
+      }
     }
 
     node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code;
@@ -248,6 +258,7 @@ public:
   {
     (void)header;
     (void)req;
+    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
     if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
       throw std::runtime_error(
               "Can't get state. State machine is not initialized.");
@@ -264,6 +275,7 @@ public:
   {
     (void)header;
     (void)req;
+    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
     if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
       throw std::runtime_error(
               "Can't get available states. State machine is not initialized.");
@@ -286,6 +298,7 @@ public:
   {
     (void)header;
     (void)req;
+    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
     if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
       throw std::runtime_error(
               "Can't get available transitions. State machine is not initialized.");
@@ -313,6 +326,7 @@ public:
   {
     (void)header;
     (void)req;
+    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
     if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
       throw std::runtime_error(
               "Can't get available transitions. State machine is not initialized.");
@@ -343,6 +357,7 @@ public:
   get_available_states()
   {
     std::vector<State> states;
+    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
     states.reserve(state_machine_.transition_map.states_size);
 
     for (unsigned int i = 0; i < state_machine_.transition_map.states_size; ++i) {
@@ -355,6 +370,7 @@ public:
   get_available_transitions()
   {
     std::vector<Transition> transitions;
+    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
     transitions.reserve(state_machine_.current_state->valid_transition_size);
 
     for (unsigned int i = 0; i < state_machine_.current_state->valid_transition_size; ++i) {
@@ -367,6 +383,7 @@ public:
   get_transition_graph()
   {
     std::vector<Transition> transitions;
+    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
     transitions.reserve(state_machine_.transition_map.transitions_size);
 
     for (unsigned int i = 0; i < state_machine_.transition_map.transitions_size; ++i) {
@@ -378,26 +395,32 @@ public:
   rcl_ret_t
   change_state(std::uint8_t transition_id, LifecycleNodeInterface::CallbackReturn & cb_return_code)
   {
-    if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
-      RCUTILS_LOG_ERROR(
-        "Unable to change state for state machine for %s: %s",
-        node_base_interface_->get_name(), rcl_get_error_string().str);
-      return RCL_RET_ERROR;
-    }
-
     constexpr bool publish_update = true;
-    // keep the initial state to pass to a transition callback
-    State initial_state(state_machine_.current_state);
+    State initial_state;
+    unsigned int current_state_id;
 
-    if (
-      rcl_lifecycle_trigger_transition_by_id(
-        &state_machine_, transition_id, publish_update) != RCL_RET_OK)
     {
-      RCUTILS_LOG_ERROR(
-        "Unable to start transition %u from current state %s: %s",
-        transition_id, state_machine_.current_state->label, rcl_get_error_string().str);
-      rcutils_reset_error();
-      return RCL_RET_ERROR;
+      std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+      if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
+        RCUTILS_LOG_ERROR(
+          "Unable to change state for state machine for %s: %s",
+          node_base_interface_->get_name(), rcl_get_error_string().str);
+          return RCL_RET_ERROR;
+      }
+      // keep the initial state to pass to a transition callback
+      initial_state = State(state_machine_.current_state);
+
+      if (
+        rcl_lifecycle_trigger_transition_by_id(
+          &state_machine_, transition_id, publish_update) != RCL_RET_OK)
+      {
+        RCUTILS_LOG_ERROR(
+          "Unable to start transition %u from current state %s: %s",
+          transition_id, state_machine_.current_state->label, rcl_get_error_string().str);
+        rcutils_reset_error();
+        return RCL_RET_ERROR;
+      }
+      current_state_id = state_machine_.current_state->id;
     }
 
     auto get_label_for_return_code =
@@ -411,18 +434,22 @@ public:
         return rcl_lifecycle_transition_error_label;
       };
 
-    cb_return_code = execute_callback(state_machine_.current_state->id, initial_state);
+    cb_return_code = execute_callback(current_state_id, initial_state);
     auto transition_label = get_label_for_return_code(cb_return_code);
 
-    if (
-      rcl_lifecycle_trigger_transition_by_label(
-        &state_machine_, transition_label, publish_update) != RCL_RET_OK)
     {
-      RCUTILS_LOG_ERROR(
-        "Failed to finish transition %u. Current state is now: %s (%s)",
-        transition_id, state_machine_.current_state->label, rcl_get_error_string().str);
-      rcutils_reset_error();
-      return RCL_RET_ERROR;
+      std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+      if (
+        rcl_lifecycle_trigger_transition_by_label(
+          &state_machine_, transition_label, publish_update) != RCL_RET_OK)
+      {
+        RCUTILS_LOG_ERROR(
+          "Failed to finish transition %u. Current state is now: %s (%s)",
+          transition_id, state_machine_.current_state->label, rcl_get_error_string().str);
+        rcutils_reset_error();
+        return RCL_RET_ERROR;
+      }
+      current_state_id = state_machine_.current_state->id;
     }
 
     // error handling ?!
@@ -430,8 +457,9 @@ public:
     if (cb_return_code == node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR) {
       RCUTILS_LOG_WARN("Error occurred while doing error handling.");
 
-      auto error_cb_code = execute_callback(state_machine_.current_state->id, initial_state);
+      auto error_cb_code = execute_callback(current_state_id, initial_state);
       auto error_cb_label = get_label_for_return_code(error_cb_code);
+      std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
       if (
         rcl_lifecycle_trigger_transition_by_label(
           &state_machine_, error_cb_label, publish_update) != RCL_RET_OK)
@@ -476,8 +504,13 @@ public:
   const State & trigger_transition(
     const char * transition_label, LifecycleNodeInterface::CallbackReturn & cb_return_code)
   {
-    auto transition =
-      rcl_lifecycle_get_transition_by_label(state_machine_.current_state, transition_label);
+    const rcl_lifecycle_transition_t * transition;
+    {
+      std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+
+      transition =
+        rcl_lifecycle_get_transition_by_label(state_machine_.current_state, transition_label);
+    }
     if (transition) {
       change_state(static_cast<uint8_t>(transition->id), cb_return_code);
     }
@@ -534,6 +567,7 @@ public:
     }
   }
 
+  mutable std::recursive_mutex state_machine_mutex_;
   rcl_lifecycle_state_machine_t state_machine_;
   State current_state_;
   std::map<

--- a/rclcpp_lifecycle/src/mutex_map.cpp
+++ b/rclcpp_lifecycle/src/mutex_map.cpp
@@ -18,19 +18,22 @@ namespace rclcpp_lifecycle
 {
 void MutexMap::add(const State * key)
 {
-  std::scoped_lock lock(map_access_mutex_);
+  // Adding a new mutex to the map requires exclusive access
+  std::unique_lock lock(map_access_mutex_);
   mutex_map_.emplace(key, std::make_unique<std::recursive_mutex>());
 }
 
 std::recursive_mutex & MutexMap::getMutex(const State * key)
 {
-  std::lock_guard<std::mutex> lock(map_access_mutex_);
+  // Multiple threads can retrieve mutexes from the map at the same time
+  std::shared_lock lock(map_access_mutex_);
   return *(mutex_map_.at(key));
 }
 
 void MutexMap::remove(const State * key)
 {
-  std::lock_guard<std::mutex> lock(map_access_mutex_);
+  // Removing a mutex from the map requires exclusive access
+  std::unique_lock lock(map_access_mutex_);
   mutex_map_.erase(key);
 }
 }  // namespace rclcpp_lifecycle

--- a/rclcpp_lifecycle/src/mutex_map.cpp
+++ b/rclcpp_lifecycle/src/mutex_map.cpp
@@ -23,7 +23,7 @@ void MutexMap::add(const State * key)
   mutex_map_.emplace(key, std::make_unique<std::recursive_mutex>());
 }
 
-std::recursive_mutex & MutexMap::getMutex(const State * key)
+std::recursive_mutex & MutexMap::getMutex(const State * key) const
 {
   // Multiple threads can retrieve mutexes from the map at the same time
   std::shared_lock lock(map_access_mutex_);

--- a/rclcpp_lifecycle/src/mutex_map.cpp
+++ b/rclcpp_lifecycle/src/mutex_map.cpp
@@ -1,0 +1,36 @@
+// Copyright 2023 PickNik, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mutex_map.hpp"
+
+namespace rclcpp_lifecycle
+{
+void MutexMap::add(const State * key)
+{
+  std::scoped_lock lock(map_access_mutex_);
+  mutex_map_.emplace(key, std::make_unique<std::recursive_mutex>());
+}
+
+std::recursive_mutex & MutexMap::getMutex(const State * key)
+{
+  std::lock_guard<std::mutex> lock(map_access_mutex_);
+  return *(mutex_map_.at(key));
+}
+
+void MutexMap::remove(const State * key)
+{
+  std::lock_guard<std::mutex> lock(map_access_mutex_);
+  mutex_map_.erase(key);
+}
+}  // namespace rclcpp_lifecycle

--- a/rclcpp_lifecycle/src/mutex_map.cpp
+++ b/rclcpp_lifecycle/src/mutex_map.cpp
@@ -14,6 +14,10 @@
 
 #include "mutex_map.hpp"
 
+#include <memory>
+#include <shared_mutex>
+#include <thread>
+
 namespace rclcpp_lifecycle
 {
 void MutexMap::add(const State * key)

--- a/rclcpp_lifecycle/src/mutex_map.hpp
+++ b/rclcpp_lifecycle/src/mutex_map.hpp
@@ -18,6 +18,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 
 #include "rclcpp_lifecycle/state.hpp"
 
@@ -57,7 +58,7 @@ private:
   std::map<const State *, std::unique_ptr<std::recursive_mutex>> mutex_map_;
 
   /// @brief Controls access to mutex_map_.
-  mutable std::mutex map_access_mutex_;
+  mutable std::shared_mutex map_access_mutex_;
 };
 }  // namespace rclcpp_lifecycle
 

--- a/rclcpp_lifecycle/src/mutex_map.hpp
+++ b/rclcpp_lifecycle/src/mutex_map.hpp
@@ -1,0 +1,64 @@
+// Copyright 2023 PickNik, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MUTEX_MAP_HPP_
+#define MUTEX_MAP_HPP_
+
+#include <map>
+#include <memory>
+#include <mutex>
+
+#include "rclcpp_lifecycle/state.hpp"
+
+namespace rclcpp_lifecycle
+{
+/// @brief Associates instances of recursive_mutex with instances of State.
+class MutexMap
+{
+public:
+  MutexMap() = default;
+
+  /// \brief Add a new mutex for an instance of State.
+  /**
+   * \param[in] key Raw pointer to the instance of State which will use the mutex.
+   */
+  void add(const State * key);
+
+  /// \brief Retrieve the mutex for an instance of State.
+  /**
+   * \param key Raw pointer to an instance of State.
+   * \return A reference to the mutex associated with the key.
+   */
+  std::recursive_mutex & getMutex(const State * key);
+
+  /// \brief Remove the mutex for an instance of State.
+  /**
+   * \param key Raw pointer to an instance of State.
+   */
+  void remove(const State * key);
+
+private:
+  /// \brief Map that stores the mutexes
+  /**
+   * \details The mutexes are emplaced as unique_ptrs because mutexes are
+   * not copyable or movable.
+   */
+  std::map<const State *, std::unique_ptr<std::recursive_mutex>> mutex_map_;
+
+  /// @brief Controls access to mutex_map_.
+  mutable std::mutex map_access_mutex_;
+};
+}  // namespace rclcpp_lifecycle
+
+#endif  // MUTEX_MAP_HPP_

--- a/rclcpp_lifecycle/src/mutex_map.hpp
+++ b/rclcpp_lifecycle/src/mutex_map.hpp
@@ -41,7 +41,7 @@ public:
    * \param key Raw pointer to an instance of State.
    * \return A reference to the mutex associated with the key.
    */
-  std::recursive_mutex & getMutex(const State * key);
+  std::recursive_mutex & getMutex(const State * key) const;
 
   /// \brief Remove the mutex for an instance of State.
   /**

--- a/rclcpp_lifecycle/src/state.cpp
+++ b/rclcpp_lifecycle/src/state.cpp
@@ -25,12 +25,17 @@
 
 #include "rcutils/allocator.h"
 
+#include "mutex_map.hpp"
+
 namespace rclcpp_lifecycle
 {
+MutexMap State::state_handle_mutex_map_;
 
 State::State(rcutils_allocator_t allocator)
 : State(lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN, "unknown", allocator)
-{}
+{
+  state_handle_mutex_map_.add(this);
+}
 
 State::State(
   uint8_t id,
@@ -40,6 +45,8 @@ State::State(
   owns_rcl_state_handle_(true),
   state_handle_(nullptr)
 {
+  state_handle_mutex_map_.add(this);
+
   if (label.empty()) {
     throw std::runtime_error("Lifecycle State cannot have an empty label.");
   }
@@ -67,6 +74,8 @@ State::State(
   owns_rcl_state_handle_(false),
   state_handle_(nullptr)
 {
+  state_handle_mutex_map_.add(this);
+
   if (!rcl_lifecycle_state_handle) {
     throw std::runtime_error("rcl_lifecycle_state_handle is null");
   }
@@ -78,12 +87,15 @@ State::State(const State & rhs)
   owns_rcl_state_handle_(false),
   state_handle_(nullptr)
 {
+  state_handle_mutex_map_.add(this);
+
   *this = rhs;
 }
 
 State::~State()
 {
   reset();
+  state_handle_mutex_map_.remove(this);
 }
 
 State &
@@ -92,6 +104,8 @@ State::operator=(const State & rhs)
   if (this == &rhs) {
     return *this;
   }
+
+  const auto lock = std::lock_guard<std::recursive_mutex>(state_handle_mutex_map_.getMutex(this));
 
   // reset all currently used resources
   reset();
@@ -128,6 +142,7 @@ State::operator=(const State & rhs)
 uint8_t
 State::id() const
 {
+  const auto lock = std::lock_guard<std::recursive_mutex>(state_handle_mutex_map_.getMutex(this));
   if (!state_handle_) {
     throw std::runtime_error("Error in state! Internal state_handle is NULL.");
   }
@@ -137,6 +152,7 @@ State::id() const
 std::string
 State::label() const
 {
+  const auto lock = std::lock_guard<std::recursive_mutex>(state_handle_mutex_map_.getMutex(this));
   if (!state_handle_) {
     throw std::runtime_error("Error in state! Internal state_handle is NULL.");
   }
@@ -146,6 +162,8 @@ State::label() const
 void
 State::reset() noexcept
 {
+  const auto lock = std::lock_guard<std::recursive_mutex>(state_handle_mutex_map_.getMutex(this));
+
   if (!owns_rcl_state_handle_) {
     state_handle_ = nullptr;
   }
@@ -163,5 +181,4 @@ State::reset() noexcept
       "rcl_lifecycle_transition_fini did not complete successfully, leaking memory");
   }
 }
-
 }  // namespace rclcpp_lifecycle

--- a/rclcpp_lifecycle/src/state.cpp
+++ b/rclcpp_lifecycle/src/state.cpp
@@ -181,4 +181,5 @@ State::reset() noexcept
       "rcl_lifecycle_transition_fini did not complete successfully, leaking memory");
   }
 }
+
 }  // namespace rclcpp_lifecycle


### PR DESCRIPTION
Implements #2172.

- Backports the changes to `LifecycleNodeInterfaceImpl` from #1756. It's OK to apply these changes to Humble because they do not modify the public ABI.
- Improve thread safety when using `State::state_handle_`:
  - Add a new `MutexMap` class to associate a mutex with each instance of `State`.
  - Add a private static `MutexMap` member to `State`. This type of change is allowed under [REP-0009](https://www.ros.org/reps/rep-0009.html).
- Add a unit test based on the example code from #1746 which fails without the above changes.