### PR TITLE
Do not crash Executor when send_response fails due to client failure.

### DIFF
--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -486,6 +486,14 @@ public:
   {
     rcl_ret_t ret = rcl_send_response(get_service_handle().get(), &req_id, &response);
 
+    if (ret == RCL_RET_TIMEOUT) {
+      RCLCPP_WARN(
+        rclcpp::get_node_logger(node_handle_.get()).get_child("rclcpp"),
+        "failed to send response: %s",
+        rcl_get_error_string().str);
+      rcl_reset_error();
+      return;
+    }
     if (ret != RCL_RET_OK) {
       rclcpp::exceptions::throw_from_rcl_error(ret, "failed to send response");
     }

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -489,7 +489,7 @@ public:
     if (ret == RCL_RET_TIMEOUT) {
       RCLCPP_WARN(
         rclcpp::get_node_logger(node_handle_.get()).get_child("rclcpp"),
-        "failed to send response: %s",
+        "failed to send response (timeout): %s",
         rcl_get_error_string().str);
       rcl_reset_error();
       return;


### PR DESCRIPTION
Related to https://github.com/ros2/ros2/issues/1253

It is not sane that a faulty client can crash our service Executor, as discussed in the referred issue, if the client is not setup properly, send_response may return RCL_RET_TIMEOUT, we should not throw an error in this case.