### PR TITLE
If executor has been cancelled should not spin

### DIFF
--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -637,6 +637,9 @@ protected:
   /// Spinning state, used to prevent multi threaded calls to spin and to cancel blocking spins.
   std::atomic_bool spinning;
 
+  /// Flag specifying that the executor has been cancelled and should not spin
+  std::atomic_bool executor_canceled{false};
+
   /// Guard condition for signaling the rmw layer to wake up for special events.
   std::shared_ptr<rclcpp::GuardCondition> interrupt_guard_condition_;
 

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -500,6 +500,8 @@ void
 Executor::cancel()
 {
   spinning.store(false);
+  executor_canceled.store(true);
+
   try {
     interrupt_guard_condition_->trigger();
   } catch (const rclcpp::exceptions::RCLError & ex) {

--- a/rclcpp/src/rclcpp/executors/single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/single_threaded_executor.cpp
@@ -27,6 +27,10 @@ SingleThreadedExecutor::~SingleThreadedExecutor() {}
 void
 SingleThreadedExecutor::spin()
 {
+  if (executor_canceled.exchange(false)) {
+    return;
+  }
+
   if (spinning.exchange(true)) {
     throw std::runtime_error("spin() called while already spinning");
   }

--- a/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
@@ -41,6 +41,10 @@ StaticSingleThreadedExecutor::~StaticSingleThreadedExecutor()
 void
 StaticSingleThreadedExecutor::spin()
 {
+  if (executor_canceled.exchange(false)) {
+    return;
+  }
+
   if (spinning.exchange(true)) {
     throw std::runtime_error("spin() called while already spinning");
   }

--- a/rclcpp/src/rclcpp/experimental/executors/events_executor/events_executor.cpp
+++ b/rclcpp/src/rclcpp/experimental/executors/events_executor/events_executor.cpp
@@ -106,6 +106,10 @@ EventsExecutor::~EventsExecutor()
 void
 EventsExecutor::spin()
 {
+  if (executor_canceled.exchange(false)) {
+    return;
+  }
+
   if (spinning.exchange(true)) {
     throw std::runtime_error("spin() called while already spinning");
   }

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -373,6 +373,25 @@ TYPED_TEST(TestExecutors, testSpinUntilFutureCompleteWithTimeout)
   spinner.join();
 }
 
+TYPED_TEST(TestExecutors, testCancel)
+{
+  using ExecutorType = TypeParam;
+  // rmw_connextdds doesn't support events-executor
+  if (
+    std::is_same<ExecutorType, rclcpp::experimental::executors::EventsExecutor>() &&
+    std::string(rmw_get_implementation_identifier()).find("rmw_connextdds") == 0)
+  {
+    GTEST_SKIP();
+  }
+
+  ExecutorType executor;
+
+  auto executor_thread = std::thread([&](){ executor.spin();});
+  executor.cancel();
+  // This should not timeout
+  executor_thread.join();
+}
+
 class TestWaitable : public rclcpp::Waitable
 {
 public:


### PR DESCRIPTION
This simple code would hang forever:
```
  ExecutorType executor; // Any executor
  auto executor_thread = std::thread([&](){ executor.spin();});
  executor.cancel();
  executor_thread.join();
```
If `executor.cancel()` gets called before `executor.spin()`, cancel won't have any effect and the executor will keep spinning.

In this PR I add an extra bool to check if the executor was cancelled before blocking in `spin()`