### PR TITLE
Add new node interface TypeDescriptionsInterface to provide GetTypeDescription service

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -92,6 +92,7 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/node_interfaces/node_time_source.cpp
   src/rclcpp/node_interfaces/node_timers.cpp
   src/rclcpp/node_interfaces/node_topics.cpp
+  src/rclcpp/node_interfaces/node_type_descriptions.cpp
   src/rclcpp/node_interfaces/node_waitables.cpp
   src/rclcpp/node_options.cpp
   src/rclcpp/parameter.cpp

--- a/rclcpp/include/rclcpp/any_service_callback.hpp
+++ b/rclcpp/include/rclcpp/any_service_callback.hpp
@@ -162,6 +162,11 @@ public:
       // to pass a callback at construnciton.
       throw std::runtime_error{"unexpected request without any callback set"};
     }
+    if (std::holds_alternative<FullyDeferredCallback>(callback_)) {
+      const auto & cb = std::get<FullyDeferredCallback>(callback_);
+      cb();
+      return nullptr;
+    }
     if (std::holds_alternative<SharedPtrDeferResponseCallback>(callback_)) {
       const auto & cb = std::get<SharedPtrDeferResponseCallback>(callback_);
       cb(request_header, std::move(request));
@@ -226,13 +231,15 @@ private:
       std::shared_ptr<rmw_request_id_t>,
       std::shared_ptr<typename ServiceT::Request>
     )>;
+  using FullyDeferredCallback = std::function<void()>;
 
   std::variant<
     std::monostate,
     SharedPtrCallback,
     SharedPtrWithRequestHeaderCallback,
     SharedPtrDeferResponseCallback,
-    SharedPtrDeferResponseCallbackWithServiceHandle> callback_;
+    SharedPtrDeferResponseCallbackWithServiceHandle,
+    FullyDeferredCallback> callback_;
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/any_service_callback.hpp
+++ b/rclcpp/include/rclcpp/any_service_callback.hpp
@@ -162,11 +162,6 @@ public:
       // to pass a callback at construnciton.
       throw std::runtime_error{"unexpected request without any callback set"};
     }
-    if (std::holds_alternative<FullyDeferredCallback>(callback_)) {
-      const auto & cb = std::get<FullyDeferredCallback>(callback_);
-      cb();
-      return nullptr;
-    }
     if (std::holds_alternative<SharedPtrDeferResponseCallback>(callback_)) {
       const auto & cb = std::get<SharedPtrDeferResponseCallback>(callback_);
       cb(request_header, std::move(request));
@@ -231,15 +226,13 @@ private:
       std::shared_ptr<rmw_request_id_t>,
       std::shared_ptr<typename ServiceT::Request>
     )>;
-  using FullyDeferredCallback = std::function<void()>;
 
   std::variant<
     std::monostate,
     SharedPtrCallback,
     SharedPtrWithRequestHeaderCallback,
     SharedPtrDeferResponseCallback,
-    SharedPtrDeferResponseCallbackWithServiceHandle,
-    FullyDeferredCallback> callback_;
+    SharedPtrDeferResponseCallbackWithServiceHandle> callback_;
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -56,6 +56,7 @@
 #include "rclcpp/node_interfaces/node_time_source_interface.hpp"
 #include "rclcpp/node_interfaces/node_timers_interface.hpp"
 #include "rclcpp/node_interfaces/node_topics_interface.hpp"
+#include "rclcpp/node_interfaces/node_type_descriptions_interface.hpp"
 #include "rclcpp/node_interfaces/node_waitables_interface.hpp"
 #include "rclcpp/node_options.hpp"
 #include "rclcpp/parameter.hpp"
@@ -1456,6 +1457,11 @@ public:
   rclcpp::node_interfaces::NodeTimeSourceInterface::SharedPtr
   get_node_time_source_interface();
 
+  /// Return the Node's internal NodeTypeDescriptionsInterface implementation.
+  RCLCPP_PUBLIC
+  rclcpp::node_interfaces::NodeTypeDescriptionsInterface::SharedPtr
+  get_node_type_descriptions_interface();
+
   /// Return the sub-namespace, if this is a sub-node, otherwise an empty string.
   /**
    * The returned sub-namespace is either the accumulated sub-namespaces which
@@ -1588,6 +1594,7 @@ private:
   rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_;
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_;
   rclcpp::node_interfaces::NodeTimeSourceInterface::SharedPtr node_time_source_;
+  rclcpp::node_interfaces::NodeTypeDescriptionsInterface::SharedPtr node_type_descriptions_;
   rclcpp::node_interfaces::NodeWaitablesInterface::SharedPtr node_waitables_;
 
   const rclcpp::NodeOptions node_options_;

--- a/rclcpp/include/rclcpp/node_interfaces/node_interfaces.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_interfaces.hpp
@@ -30,6 +30,7 @@
   rclcpp::node_interfaces::NodeTimeSourceInterface, \
   rclcpp::node_interfaces::NodeTimersInterface, \
   rclcpp::node_interfaces::NodeTopicsInterface, \
+  rclcpp::node_interfaces::NodeTypeDescriptionsInterface, \
   rclcpp::node_interfaces::NodeWaitablesInterface
 
 
@@ -118,6 +119,7 @@ public:
    *   - rclcpp::node_interfaces::NodeTimeSourceInterface
    *   - rclcpp::node_interfaces::NodeTimersInterface
    *   - rclcpp::node_interfaces::NodeTopicsInterface
+   *   - rclcpp::node_interfaces::NodeTypeDescriptionsInterface
    *   - rclcpp::node_interfaces::NodeWaitablesInterface
    *
    * Or you use custom interfaces as long as you make a template specialization

--- a/rclcpp/include/rclcpp/node_interfaces/node_type_descriptions.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_type_descriptions.hpp
@@ -26,32 +26,6 @@
 #include "rclcpp/node_interfaces/node_type_descriptions_interface.hpp"
 #include "rclcpp/visibility_control.hpp"
 
-#include "type_description_interfaces/srv/get_type_description.h"
-
-
-namespace type_description_interfaces
-{
-namespace srv
-{
-// Helper wrapper for rclcpp::Service to access ::Request and ::Response types for allocation.
-struct GetTypeDescription__C
-{
-  using Request = type_description_interfaces__srv__GetTypeDescription_Request;
-  using Response = type_description_interfaces__srv__GetTypeDescription_Response;
-  using Event = type_description_interfaces__srv__GetTypeDescription_Event;
-};
-}  // namespace srv
-}  // namespace type_description_interfaces
-
-namespace rosidl_typesupport_cpp
-{
-// Helper function for C typesupport.
-template<>
-RCLCPP_PUBLIC
-rosidl_service_type_support_t const *
-get_service_type_support_handle<type_description_interfaces::srv::GetTypeDescription__C>();
-}  // namespace rosidl_typesupport_cpp
-
 namespace rclcpp
 {
 namespace node_interfaces
@@ -77,14 +51,9 @@ public:
 private:
   RCLCPP_DISABLE_COPY(NodeTypeDescriptions)
 
-  // Pimpl for future backport ABI stability assistance, not for general functionality
+  // Pimpl hides helper types and functions used for wrapping a C service, which would be
+  // awkward to expose in this header.
   class NodeTypeDescriptionsImpl;
-  using ServiceT = type_description_interfaces::srv::GetTypeDescription__C;
-
-  rclcpp::Logger logger_;
-  rclcpp::Service<ServiceT>::SharedPtr type_description_srv_;
-  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
-
   std::unique_ptr<NodeTypeDescriptionsImpl> impl_;
 };
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_type_descriptions.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_type_descriptions.hpp
@@ -51,11 +51,6 @@ public:
 private:
   RCLCPP_DISABLE_COPY(NodeTypeDescriptions)
 
-  // rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
-  // rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_;
-  // rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_;
-  // rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_;
-
   class NodeTypeDescriptionsImpl;
   std::unique_ptr<NodeTypeDescriptionsImpl> impl_;
 };

--- a/rclcpp/include/rclcpp/node_interfaces/node_type_descriptions.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_type_descriptions.hpp
@@ -15,6 +15,8 @@
 #ifndef RCLCPP__NODE_INTERFACES__NODE_TYPE_DESCRIPTIONS_HPP_
 #define RCLCPP__NODE_INTERFACES__NODE_TYPE_DESCRIPTIONS_HPP_
 
+#include <memory>
+
 #include "rclcpp/macros.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/node_interfaces/node_logging_interface.hpp"
@@ -41,8 +43,7 @@ public:
     NodeBaseInterface::SharedPtr node_base,
     NodeLoggingInterface::SharedPtr node_logging,
     NodeParametersInterface::SharedPtr node_parameters,
-    NodeServicesInterface::SharedPtr node_services,
-    NodeTopicsInterface::SharedPtr node_topics);
+    NodeServicesInterface::SharedPtr node_services);
 
   RCLCPP_PUBLIC
   virtual

--- a/rclcpp/include/rclcpp/node_interfaces/node_type_descriptions.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_type_descriptions.hpp
@@ -28,6 +28,30 @@
 
 #include "type_description_interfaces/srv/get_type_description.h"
 
+
+namespace type_description_interfaces
+{
+namespace srv
+{
+// Helper wrapper for rclcpp::Service to access ::Request and ::Response types for allocation.
+struct GetTypeDescription__C
+{
+  using Request = type_description_interfaces__srv__GetTypeDescription_Request;
+  using Response = type_description_interfaces__srv__GetTypeDescription_Response;
+  using Event = type_description_interfaces__srv__GetTypeDescription_Event;
+};
+}  // namespace srv
+}  // namespace type_description_interfaces
+
+namespace rosidl_typesupport_cpp
+{
+// Helper function for C typesupport.
+template<>
+RCLCPP_PUBLIC
+rosidl_service_type_support_t const *
+get_service_type_support_handle<type_description_interfaces::srv::GetTypeDescription__C>();
+}  // namespace rosidl_typesupport_cpp
+
 namespace rclcpp
 {
 namespace node_interfaces
@@ -50,23 +74,15 @@ public:
   virtual
   ~NodeTypeDescriptions();
 
-  // Helper wrapper for rclcpp::Service to access ::Request and ::Response types for allocation.
-  struct GetTypeDescriptionC
-  {
-    using Request = type_description_interfaces__srv__GetTypeDescription_Request;
-    using Response = type_description_interfaces__srv__GetTypeDescription_Response;
-    using Event = type_description_interfaces__srv__GetTypeDescription_Event;
-  };
-
 private:
   RCLCPP_DISABLE_COPY(NodeTypeDescriptions)
 
   // Pimpl for future backport ABI stability assistance, not for general functionality
   class NodeTypeDescriptionsImpl;
-
+  using ServiceT = type_description_interfaces::srv::GetTypeDescription__C;
 
   rclcpp::Logger logger_;
-  rclcpp::Service<GetTypeDescriptionC>::SharedPtr type_description_srv_;
+  rclcpp::Service<ServiceT>::SharedPtr type_description_srv_;
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
 
   std::unique_ptr<NodeTypeDescriptionsImpl> impl_;

--- a/rclcpp/include/rclcpp/node_interfaces/node_type_descriptions.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_type_descriptions.hpp
@@ -26,11 +26,12 @@
 #include "rclcpp/node_interfaces/node_type_descriptions_interface.hpp"
 #include "rclcpp/visibility_control.hpp"
 
+#include "type_description_interfaces/srv/get_type_description.h"
+
 namespace rclcpp
 {
 namespace node_interfaces
 {
-
 
 /// Implementation of the NodeTypeDescriptions part of the Node API.
 class NodeTypeDescriptions : public NodeTypeDescriptionsInterface
@@ -49,10 +50,25 @@ public:
   virtual
   ~NodeTypeDescriptions();
 
+  // Helper wrapper for rclcpp::Service to access ::Request and ::Response types for allocation.
+  struct GetTypeDescriptionC
+  {
+    using Request = type_description_interfaces__srv__GetTypeDescription_Request;
+    using Response = type_description_interfaces__srv__GetTypeDescription_Response;
+    using Event = type_description_interfaces__srv__GetTypeDescription_Event;
+  };
+
 private:
   RCLCPP_DISABLE_COPY(NodeTypeDescriptions)
 
+  // Pimpl for future backport ABI stability assistance, not for general functionality
   class NodeTypeDescriptionsImpl;
+
+
+  rclcpp::Logger logger_;
+  rclcpp::Service<GetTypeDescriptionC>::SharedPtr type_description_srv_;
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
+
   std::unique_ptr<NodeTypeDescriptionsImpl> impl_;
 };
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_type_descriptions.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_type_descriptions.hpp
@@ -1,0 +1,66 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__NODE_INTERFACES__NODE_TYPE_DESCRIPTIONS_HPP_
+#define RCLCPP__NODE_INTERFACES__NODE_TYPE_DESCRIPTIONS_HPP_
+
+#include "rclcpp/macros.hpp"
+#include "rclcpp/node_interfaces/node_base_interface.hpp"
+#include "rclcpp/node_interfaces/node_logging_interface.hpp"
+#include "rclcpp/node_interfaces/node_parameters_interface.hpp"
+#include "rclcpp/node_interfaces/node_services_interface.hpp"
+#include "rclcpp/node_interfaces/node_topics_interface.hpp"
+#include "rclcpp/node_interfaces/node_type_descriptions_interface.hpp"
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+namespace node_interfaces
+{
+
+
+/// Implementation of the NodeTypeDescriptions part of the Node API.
+class NodeTypeDescriptions : public NodeTypeDescriptionsInterface
+{
+public:
+  RCLCPP_SMART_PTR_ALIASES_ONLY(NodeTypeDescriptions)
+
+  RCLCPP_PUBLIC
+  explicit NodeTypeDescriptions(
+    NodeBaseInterface::SharedPtr node_base,
+    NodeLoggingInterface::SharedPtr node_logging,
+    NodeParametersInterface::SharedPtr node_parameters,
+    NodeServicesInterface::SharedPtr node_services,
+    NodeTopicsInterface::SharedPtr node_topics);
+
+  RCLCPP_PUBLIC
+  virtual
+  ~NodeTypeDescriptions();
+
+private:
+  RCLCPP_DISABLE_COPY(NodeTypeDescriptions)
+
+  // rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
+  // rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_;
+  // rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_;
+  // rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_;
+
+  class NodeTypeDescriptionsImpl;
+  std::unique_ptr<NodeTypeDescriptionsImpl> impl_;
+};
+
+}  // namespace node_interfaces
+}  // namespace rclcpp
+
+#endif  // RCLCPP__NODE_INTERFACES__NODE_TYPE_DESCRIPTIONS_HPP_

--- a/rclcpp/include/rclcpp/node_interfaces/node_type_descriptions_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_type_descriptions_interface.hpp
@@ -1,0 +1,44 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__NODE_INTERFACES__NODE_TYPE_DESCRIPTIONS_INTERFACE_HPP_
+#define RCLCPP__NODE_INTERFACES__NODE_TYPE_DESCRIPTIONS_INTERFACE_HPP_
+
+#include "rclcpp/macros.hpp"
+#include "rclcpp/node_interfaces/detail/node_interfaces_helpers.hpp"
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+namespace node_interfaces
+{
+
+/// Pure virtual interface class for the NodeTypeDescriptions part of the Node API.
+class NodeTypeDescriptionsInterface
+{
+public:
+  RCLCPP_SMART_PTR_ALIASES_ONLY(NodeTypeDescriptionsInterface)
+
+  RCLCPP_PUBLIC
+  virtual
+  ~NodeTypeDescriptionsInterface() = default;
+};
+
+}  // namespace node_interfaces
+}  // namespace rclcpp
+
+RCLCPP_NODE_INTERFACE_HELPERS_SUPPORT(
+  rclcpp::node_interfaces::NodeTypeDescriptionsInterface, type_descriptions)
+
+#endif  // RCLCPP__NODE_INTERFACES__NODE_TYPE_DESCRIPTIONS_INTERFACE_HPP_

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -34,6 +34,7 @@
 #include "rclcpp/node_interfaces/node_parameters.hpp"
 #include "rclcpp/node_interfaces/node_services.hpp"
 #include "rclcpp/node_interfaces/node_time_source.hpp"
+#include "rclcpp/node_interfaces/node_type_descriptions.hpp"
 #include "rclcpp/node_interfaces/node_timers.hpp"
 #include "rclcpp/node_interfaces/node_topics.hpp"
 #include "rclcpp/node_interfaces/node_waitables.hpp"
@@ -205,6 +206,13 @@ Node::Node(
       node_parameters_,
       options.clock_qos(),
       options.use_clock_thread()
+    )),
+  node_type_descriptions_(new rclcpp::node_interfaces::NodeTypeDescriptions(
+      node_base_,
+      node_logging_,
+      node_parameters_,
+      node_services_,
+      node_topics_
     )),
   node_waitables_(new rclcpp::node_interfaces::NodeWaitables(node_base_.get())),
   node_options_(options),
@@ -589,6 +597,12 @@ rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr
 Node::get_node_topics_interface()
 {
   return node_topics_;
+}
+
+rclcpp::node_interfaces::NodeTypeDescriptionsInterface::SharedPtr
+Node::get_node_type_descriptions_interface()
+{
+  return node_type_descriptions_;
 }
 
 rclcpp::node_interfaces::NodeServicesInterface::SharedPtr

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -34,9 +34,9 @@
 #include "rclcpp/node_interfaces/node_parameters.hpp"
 #include "rclcpp/node_interfaces/node_services.hpp"
 #include "rclcpp/node_interfaces/node_time_source.hpp"
-#include "rclcpp/node_interfaces/node_type_descriptions.hpp"
 #include "rclcpp/node_interfaces/node_timers.hpp"
 #include "rclcpp/node_interfaces/node_topics.hpp"
+#include "rclcpp/node_interfaces/node_type_descriptions.hpp"
 #include "rclcpp/node_interfaces/node_waitables.hpp"
 #include "rclcpp/qos_overriding_options.hpp"
 
@@ -211,8 +211,7 @@ Node::Node(
       node_base_,
       node_logging_,
       node_parameters_,
-      node_services_,
-      node_topics_
+      node_services_
     )),
   node_waitables_(new rclcpp::node_interfaces::NodeWaitables(node_base_.get())),
   node_options_(options),

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -115,13 +115,11 @@ NodeBase::NodeBase(
     throw_from_rcl_error(ret, "failed to initialize rcl node");
   }
 
-  // If type description service will be initialized, it must capture all
-  // built-in services and topics that the node creates, even the ones by NodeParameters,
-  // which must be initialized first to let NodeTypeDescriptions be parameter-enabled
+  // To capture all types from builtin topics and services, the type cache needs to be initialized
+  // before any other components are initialized.
   ret = rcl_node_type_cache_init(rcl_node.get());
   if (ret != RCL_RET_OK) {
-    throw std::runtime_error("It bad!");
-    // TODO(ek)
+    throw_from_rcl_error(ret, "failed to initialize type cache");
   }
 
   node_handle_.reset(

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -20,6 +20,7 @@
 #include "rclcpp/node_interfaces/node_base.hpp"
 
 #include "rcl/arguments.h"
+#include "rcl/node_type_cache.h"
 #include "rclcpp/exceptions.hpp"
 #include "rcutils/logging_macros.h"
 #include "rmw/validate_namespace.h"
@@ -112,6 +113,15 @@ NodeBase::NodeBase(
       }
     }
     throw_from_rcl_error(ret, "failed to initialize rcl node");
+  }
+
+  // If type description service will be initialized, it must capture all
+  // built-in services and topics that the node creates, even the ones by NodeParameters,
+  // which must be initialized first to let NodeTypeDescriptions be parameter-enabled
+  ret = rcl_node_type_cache_init(rcl_node.get());
+  if (ret != RCL_RET_OK) {
+    throw std::runtime_error("It bad!");
+    // TODO(ek)
   }
 
   node_handle_.reset(

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -115,13 +115,6 @@ NodeBase::NodeBase(
     throw_from_rcl_error(ret, "failed to initialize rcl node");
   }
 
-  // To capture all types from builtin topics and services, the type cache needs to be initialized
-  // before any other components are initialized.
-  ret = rcl_node_type_cache_init(rcl_node.get());
-  if (ret != RCL_RET_OK) {
-    throw_from_rcl_error(ret, "failed to initialize type cache");
-  }
-
   node_handle_.reset(
     rcl_node.release(),
     [logging_mutex](rcl_node_t * node) -> void {

--- a/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
@@ -21,13 +21,11 @@
 
 #include "type_description_interfaces/srv/get_type_description.h"
 
-// Helper function for C typesupport.
 namespace rosidl_typesupport_cpp
 {
 template<>
 rosidl_service_type_support_t const *
-get_service_type_support_handle<
-  rclcpp::node_interfaces::NodeTypeDescriptions::GetTypeDescriptionC>()
+get_service_type_support_handle<type_description_interfaces::srv::GetTypeDescription__C>()
 {
   return ROSIDL_GET_SRV_TYPE_SUPPORT(type_description_interfaces, srv, GetTypeDescription);
 }
@@ -85,12 +83,12 @@ NodeTypeDescriptions::NodeTypeDescriptions(
               "Failed to get initialized ~/get_type_description service from rcl.");
     }
 
-    rclcpp::AnyServiceCallback<GetTypeDescriptionC> cb;
+    rclcpp::AnyServiceCallback<ServiceT> cb;
     cb.set(
       [this](
         std::shared_ptr<rmw_request_id_t> header,
-        std::shared_ptr<GetTypeDescriptionC::Request> request,
-        std::shared_ptr<GetTypeDescriptionC::Response> response
+        std::shared_ptr<ServiceT::Request> request,
+        std::shared_ptr<ServiceT::Response> response
       ) {
         rcl_node_type_description_service_handle_request(
           node_base_->get_rcl_node_handle(),
@@ -99,7 +97,7 @@ NodeTypeDescriptions::NodeTypeDescriptions(
           response.get());
       });
 
-    type_description_srv_ = std::make_shared<Service<GetTypeDescriptionC>>(
+    type_description_srv_ = std::make_shared<Service<ServiceT>>(
       node_base_->get_shared_rcl_node_handle(),
       rcl_srv,
       cb);

--- a/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
@@ -21,23 +21,13 @@
 
 #include "type_description_interfaces/srv/get_type_description.h"
 
-namespace
-{
-// Helper wrapper for rclcpp::Service to access ::Request and ::Response types for allocation.
-struct GetTypeDescriptionC
-{
-  using Request = type_description_interfaces__srv__GetTypeDescription_Request;
-  using Response = type_description_interfaces__srv__GetTypeDescription_Response;
-  using Event = type_description_interfaces__srv__GetTypeDescription_Event;
-};
-}  // namespace
-
 // Helper function for C typesupport.
 namespace rosidl_typesupport_cpp
 {
 template<>
 rosidl_service_type_support_t const *
-get_service_type_support_handle<GetTypeDescriptionC>()
+get_service_type_support_handle<
+  rclcpp::node_interfaces::NodeTypeDescriptions::GetTypeDescriptionC>()
 {
   return ROSIDL_GET_SRV_TYPE_SUPPORT(type_description_interfaces, srv, GetTypeDescription);
 }
@@ -49,101 +39,87 @@ namespace node_interfaces
 {
 
 class NodeTypeDescriptions::NodeTypeDescriptionsImpl
-{
-public:
-  using ServiceT = GetTypeDescriptionC;
-
-  Logger logger_;
-  Service<ServiceT>::SharedPtr type_description_srv_;
-  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
-
-  NodeTypeDescriptionsImpl(
-    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
-    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
-    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
-    rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services)
-  : logger_(node_logging->get_logger()),
-    node_base_(node_base)
-  {
-    const std::string enable_param_name = "start_type_description_service";
-
-    bool enabled = false;
-    try {
-      auto enable_param = node_parameters->declare_parameter(
-        enable_param_name,
-        rclcpp::ParameterValue(true),
-        rcl_interfaces::msg::ParameterDescriptor()
-        .set__name(enable_param_name)
-        .set__type(rclcpp::PARAMETER_BOOL)
-        .set__description("Start the ~/get_type_description service for this node.")
-        .set__read_only(true));
-      enabled = enable_param.get<bool>();
-    } catch (const rclcpp::exceptions::InvalidParameterTypeException & exc) {
-      RCLCPP_ERROR(logger_, "%s", exc.what());
-      throw;
-    }
-
-    if (enabled) {
-      auto rcl_node = node_base->get_rcl_node_handle();
-      rcl_ret_t rcl_ret = rcl_node_type_description_service_init(rcl_node);
-      if (rcl_ret != RCL_RET_OK) {
-        RCLCPP_ERROR(
-          logger_, "Failed to initialize ~/get_type_description_service: %s",
-          rcl_get_error_string().str);
-        throw std::runtime_error(
-                "Failed to initialize ~/get_type_description service.");
-      }
-
-      rcl_service_t * rcl_srv = nullptr;
-      rcl_ret = rcl_node_get_type_description_service(rcl_node, &rcl_srv);
-      if (rcl_ret != RCL_RET_OK) {
-        throw std::runtime_error(
-                "Failed to get initialized ~/get_type_description service from rcl.");
-      }
-
-      rclcpp::AnyServiceCallback<ServiceT> cb;
-      cb.set(
-        [this](
-          std::shared_ptr<rmw_request_id_t> header,
-          std::shared_ptr<ServiceT::Request> request,
-          std::shared_ptr<ServiceT::Response> response
-        ) {
-          rcl_node_type_description_service_handle_request(
-            node_base_->get_rcl_node_handle(),
-            header.get(),
-            request.get(),
-            response.get());
-        });
-
-      type_description_srv_ = std::make_shared<Service<ServiceT>>(
-        node_base_->get_shared_rcl_node_handle(),
-        rcl_srv,
-        cb);
-      node_services->add_service(
-        std::dynamic_pointer_cast<ServiceBase>(type_description_srv_),
-        nullptr);
-    }
-  }
-
-  virtual ~NodeTypeDescriptionsImpl()
-  {}
-};
-
+{};
 
 NodeTypeDescriptions::NodeTypeDescriptions(
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
   rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services)
-: impl_(new NodeTypeDescriptionsImpl(
-      node_base,
-      node_logging,
-      node_parameters,
-      node_services))
-{}
+: logger_(node_logging->get_logger()),
+  node_base_(node_base)
+{
+  const std::string enable_param_name = "start_type_description_service";
+
+  bool enabled = false;
+  try {
+    auto enable_param = node_parameters->declare_parameter(
+      enable_param_name,
+      rclcpp::ParameterValue(true),
+      rcl_interfaces::msg::ParameterDescriptor()
+      .set__name(enable_param_name)
+      .set__type(rclcpp::PARAMETER_BOOL)
+      .set__description("Start the ~/get_type_description service for this node.")
+      .set__read_only(true));
+    enabled = enable_param.get<bool>();
+  } catch (const rclcpp::exceptions::InvalidParameterTypeException & exc) {
+    RCLCPP_ERROR(logger_, "%s", exc.what());
+    throw;
+  }
+
+  if (enabled) {
+    auto rcl_node = node_base->get_rcl_node_handle();
+    rcl_ret_t rcl_ret = rcl_node_type_description_service_init(rcl_node);
+    if (rcl_ret != RCL_RET_OK) {
+      RCLCPP_ERROR(
+        logger_, "Failed to initialize ~/get_type_description_service: %s",
+        rcl_get_error_string().str);
+      throw std::runtime_error(
+              "Failed to initialize ~/get_type_description service.");
+    }
+
+    rcl_service_t * rcl_srv = nullptr;
+    rcl_ret = rcl_node_get_type_description_service(rcl_node, &rcl_srv);
+    if (rcl_ret != RCL_RET_OK) {
+      throw std::runtime_error(
+              "Failed to get initialized ~/get_type_description service from rcl.");
+    }
+
+    rclcpp::AnyServiceCallback<GetTypeDescriptionC> cb;
+    cb.set(
+      [this](
+        std::shared_ptr<rmw_request_id_t> header,
+        std::shared_ptr<GetTypeDescriptionC::Request> request,
+        std::shared_ptr<GetTypeDescriptionC::Response> response
+      ) {
+        rcl_node_type_description_service_handle_request(
+          node_base_->get_rcl_node_handle(),
+          header.get(),
+          request.get(),
+          response.get());
+      });
+
+    type_description_srv_ = std::make_shared<Service<GetTypeDescriptionC>>(
+      node_base_->get_shared_rcl_node_handle(),
+      rcl_srv,
+      cb);
+    node_services->add_service(
+      std::dynamic_pointer_cast<ServiceBase>(type_description_srv_),
+      nullptr);
+  }
+}
 
 NodeTypeDescriptions::~NodeTypeDescriptions()
-{}
+{
+  if (
+    type_description_srv_ &&
+    RCL_RET_OK != rcl_node_type_description_service_fini(node_base_->get_rcl_node_handle()))
+  {
+    RCUTILS_LOG_ERROR_NAMED(
+      "rclcpp",
+      "Error in shutdown of get_type_description service: %s", rcl_get_error_string().str);
+  }
+}
 
 }  // namespace node_interfaces
 }  // namespace rclcpp

--- a/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
@@ -21,11 +21,23 @@
 
 #include "type_description_interfaces/srv/get_type_description.h"
 
+namespace
+{
+// Helper wrapper for rclcpp::Service to access ::Request and ::Response types for allocation.
+struct GetTypeDescription__C
+{
+  using Request = type_description_interfaces__srv__GetTypeDescription_Request;
+  using Response = type_description_interfaces__srv__GetTypeDescription_Response;
+  using Event = type_description_interfaces__srv__GetTypeDescription_Event;
+};
+}  // namespace
+
+// Helper function for C typesupport.
 namespace rosidl_typesupport_cpp
 {
 template<>
 rosidl_service_type_support_t const *
-get_service_type_support_handle<type_description_interfaces::srv::GetTypeDescription__C>()
+get_service_type_support_handle<GetTypeDescription__C>()
 {
   return ROSIDL_GET_SRV_TYPE_SUPPORT(type_description_interfaces, srv, GetTypeDescription);
 }
@@ -37,87 +49,109 @@ namespace node_interfaces
 {
 
 class NodeTypeDescriptions::NodeTypeDescriptionsImpl
-{};
+{
+public:
+  using ServiceT = GetTypeDescription__C;
+
+  rclcpp::Logger logger_;
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
+  rclcpp::Service<ServiceT>::SharedPtr type_description_srv_;
+
+  NodeTypeDescriptionsImpl(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
+    rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services)
+  : logger_(node_logging->get_logger()),
+    node_base_(node_base)
+  {
+    const std::string enable_param_name = "start_type_description_service";
+
+    bool enabled = false;
+    try {
+      auto enable_param = node_parameters->declare_parameter(
+        enable_param_name,
+        rclcpp::ParameterValue(true),
+        rcl_interfaces::msg::ParameterDescriptor()
+        .set__name(enable_param_name)
+        .set__type(rclcpp::PARAMETER_BOOL)
+        .set__description("Start the ~/get_type_description service for this node.")
+        .set__read_only(true));
+      enabled = enable_param.get<bool>();
+    } catch (const rclcpp::exceptions::InvalidParameterTypeException & exc) {
+      RCLCPP_ERROR(logger_, "%s", exc.what());
+      throw;
+    }
+
+    if (enabled) {
+      auto rcl_node = node_base->get_rcl_node_handle();
+      rcl_ret_t rcl_ret = rcl_node_type_description_service_init(rcl_node);
+      if (rcl_ret != RCL_RET_OK) {
+        RCLCPP_ERROR(
+          logger_, "Failed to initialize ~/get_type_description_service: %s",
+          rcl_get_error_string().str);
+        throw std::runtime_error(
+                "Failed to initialize ~/get_type_description service.");
+      }
+
+      rcl_service_t * rcl_srv = nullptr;
+      rcl_ret = rcl_node_get_type_description_service(rcl_node, &rcl_srv);
+      if (rcl_ret != RCL_RET_OK) {
+        throw std::runtime_error(
+                "Failed to get initialized ~/get_type_description service from rcl.");
+      }
+
+      rclcpp::AnyServiceCallback<ServiceT> cb;
+      cb.set(
+        [this](
+          std::shared_ptr<rmw_request_id_t> header,
+          std::shared_ptr<ServiceT::Request> request,
+          std::shared_ptr<ServiceT::Response> response
+        ) {
+          rcl_node_type_description_service_handle_request(
+            node_base_->get_rcl_node_handle(),
+            header.get(),
+            request.get(),
+            response.get());
+        });
+
+      type_description_srv_ = std::make_shared<Service<ServiceT>>(
+        node_base_->get_shared_rcl_node_handle(),
+        rcl_srv,
+        cb);
+      node_services->add_service(
+        std::dynamic_pointer_cast<ServiceBase>(type_description_srv_),
+        nullptr);
+    }
+  }
+
+  ~NodeTypeDescriptionsImpl()
+  {
+    if (
+      type_description_srv_ &&
+      RCL_RET_OK != rcl_node_type_description_service_fini(node_base_->get_rcl_node_handle()))
+    {
+      RCLCPP_ERROR(
+        logger_,
+        "Error in shutdown of get_type_description service: %s", rcl_get_error_string().str);
+    }
+  }
+};
 
 NodeTypeDescriptions::NodeTypeDescriptions(
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
   rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services)
-: logger_(node_logging->get_logger()),
-  node_base_(node_base)
-{
-  const std::string enable_param_name = "start_type_description_service";
-
-  bool enabled = false;
-  try {
-    auto enable_param = node_parameters->declare_parameter(
-      enable_param_name,
-      rclcpp::ParameterValue(true),
-      rcl_interfaces::msg::ParameterDescriptor()
-      .set__name(enable_param_name)
-      .set__type(rclcpp::PARAMETER_BOOL)
-      .set__description("Start the ~/get_type_description service for this node.")
-      .set__read_only(true));
-    enabled = enable_param.get<bool>();
-  } catch (const rclcpp::exceptions::InvalidParameterTypeException & exc) {
-    RCLCPP_ERROR(logger_, "%s", exc.what());
-    throw;
-  }
-
-  if (enabled) {
-    auto rcl_node = node_base->get_rcl_node_handle();
-    rcl_ret_t rcl_ret = rcl_node_type_description_service_init(rcl_node);
-    if (rcl_ret != RCL_RET_OK) {
-      RCLCPP_ERROR(
-        logger_, "Failed to initialize ~/get_type_description_service: %s",
-        rcl_get_error_string().str);
-      throw std::runtime_error(
-              "Failed to initialize ~/get_type_description service.");
-    }
-
-    rcl_service_t * rcl_srv = nullptr;
-    rcl_ret = rcl_node_get_type_description_service(rcl_node, &rcl_srv);
-    if (rcl_ret != RCL_RET_OK) {
-      throw std::runtime_error(
-              "Failed to get initialized ~/get_type_description service from rcl.");
-    }
-
-    rclcpp::AnyServiceCallback<ServiceT> cb;
-    cb.set(
-      [this](
-        std::shared_ptr<rmw_request_id_t> header,
-        std::shared_ptr<ServiceT::Request> request,
-        std::shared_ptr<ServiceT::Response> response
-      ) {
-        rcl_node_type_description_service_handle_request(
-          node_base_->get_rcl_node_handle(),
-          header.get(),
-          request.get(),
-          response.get());
-      });
-
-    type_description_srv_ = std::make_shared<Service<ServiceT>>(
-      node_base_->get_shared_rcl_node_handle(),
-      rcl_srv,
-      cb);
-    node_services->add_service(
-      std::dynamic_pointer_cast<ServiceBase>(type_description_srv_),
-      nullptr);
-  }
-}
+: impl_(new NodeTypeDescriptionsImpl(
+      node_base,
+      node_logging,
+      node_parameters,
+      node_services))
+{}
 
 NodeTypeDescriptions::~NodeTypeDescriptions()
-{
-  if (
-    type_description_srv_ &&
-    RCL_RET_OK != rcl_node_type_description_service_fini(node_base_->get_rcl_node_handle()))
-  {
-    RCUTILS_LOG_ERROR_NAMED(
-      "rclcpp",
-      "Error in shutdown of get_type_description service: %s", rcl_get_error_string().str);
-  }
-}
+{}
 
 }  // namespace node_interfaces
 }  // namespace rclcpp

--- a/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
@@ -53,6 +53,11 @@ public:
 
     rclcpp::ParameterValue enable_param;
     if (!node_parameters->has_parameter(enable_param_name)) {
+      rcl_interfaces::msg::ParameterDescriptor descriptor;
+      descriptor.name = enable_param_name;
+      descriptor.type = rclcpp::PARAMETER_BOOL;
+      descriptor.description = "Enable the ~/get_type_description service for this node.";
+      descriptor.read_only = true;
       enable_param = node_parameters->declare_parameter(
         enable_param_name, rclcpp::ParameterValue(true));
     } else {

--- a/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
@@ -1,0 +1,140 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/node_interfaces/node_type_descriptions.hpp"
+
+#include "rclcpp/parameter_client.hpp"
+
+#include "type_description_interfaces/srv/get_type_description.hpp"
+
+#include <memory>
+#include <string>
+
+using rclcpp::node_interfaces::NodeTypeDescriptions;
+
+namespace rclcpp
+{
+
+static constexpr const char * get_type_description_service_name = "get_type_description";
+
+class NodeTypeDescriptions::NodeTypeDescriptionsImpl
+{
+public:
+  bool enabled_ = false;
+  Logger logger_;
+  node_interfaces::OnSetParametersCallbackHandle param_callback_;
+  std::shared_ptr<rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent>> param_sub_;
+  using ServiceT = Service<type_description_interfaces::srv::GetTypeDescription>;
+
+  ServiceT::SharedPtr type_description_srv_;
+
+
+  NodeTypeDescriptionsImpl(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
+    rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr /* node_topics */)
+    : logger_(node_logging->get_logger())
+  {
+    const std::string enable_param_name = "enable_type_description_service";
+    const std::string service_name = "get_type_description";
+
+    rclcpp::ParameterValue enable_param;
+    if (!node_parameters->has_parameter(enable_param_name)) {
+      enable_param = node_parameters->declare_parameter(
+        enable_param_name, rclcpp::ParameterValue(true));
+    } else {
+      enable_param = node_parameters->get_parameter(enable_param_name).get_parameter_value();
+    }
+    if (enable_param.get_type() == rclcpp::PARAMETER_BOOL) {
+      if (enable_param.get<bool>()) {
+        enabled_ = true;
+      }
+    } else {
+      RCLCPP_ERROR(
+        logger_, "Invalid type '%s' for parameter '%s', should be 'bool'",
+        rclcpp::to_string(enable_param.get_type()).c_str(), enable_param_name.c_str());
+      throw std::invalid_argument(
+        "Invalid type for parameter '" + enable_param_name + "', should be bool");
+    }
+
+    if (enabled_) {
+      auto rcl_node = node_base->get_shared_rcl_node_handle();
+      rcl_ret_t rcl_ret = rcl_node_type_description_service_init(rcl_node.get());
+      if (rcl_ret != RCL_RET_OK) {
+        RCLCPP_ERROR(
+          logger_, "Failed to initialize ~/get_type_description_service: %s",
+          rcl_get_error_string().str);
+        throw std::runtime_error(
+          "Failed to initialize ~/get_type_description service.");
+      }
+
+      rcl_service_t * rcl_srv = NULL;
+      rcl_ret = rcl_node_get_type_description_service(rcl_node.get(), &rcl_srv);
+      if (rcl_ret != RCL_RET_OK) {
+        throw std::runtime_error(
+          "Failed to get initialized ~/get_type_description service from rcl.");
+      }
+
+      rclcpp::AnyServiceCallback<type_description_interfaces::srv::GetTypeDescription> callback;
+      callback.set(
+        [&rcl_node](
+          std::shared_ptr<rmw_request_id_t> /*header*/,
+          std::shared_ptr<type_description_interfaces::srv::GetTypeDescription::Request> /*request*/
+        ) {
+          rcl_node_type_description_service_on_new_request(rcl_node.get());
+        });
+
+      type_description_srv_ = std::make_shared<ServiceT>(rcl_node, rcl_srv, callback);
+      node_services->add_service(
+        std::dynamic_pointer_cast<ServiceBase>(type_description_srv_), nullptr);
+    }
+
+    // param_callback_ = node_parameters->add_on_set_parameters_callback(
+    //   std::bind(&NodeTypeDescriptionsImpl::on_set_parameters, this, std::placeholders::_1));
+    // // TODO(tfoote) use parameters interface not subscribe to events via topic ticketed #609
+    // param_sub_ = rclcpp::AsyncParametersClient::on_parameter_event(
+    //   node_topics,
+    //   std::bind(&NodeTypeDescriptionsImpl::on_parameter_event, this, std::placeholders::_1));
+  }
+};
+
+
+NodeTypeDescriptions::NodeTypeDescriptions(
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
+  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
+  rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters,
+  rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services,
+  rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics)
+:
+  // node_base_(node_base),
+  // node_services_(node_services),
+  // node_logging_(node_logging),
+  // node_parameters_(node_parameters)
+  impl_(new NodeTypeDescriptionsImpl(
+    node_base,
+    node_logging,
+    node_parameters,
+    node_services,
+    node_topics
+  ))
+{
+  // TODO init rcl node type description service and attach callback
+}
+
+NodeTypeDescriptions::~NodeTypeDescriptions()
+{}
+
+}  // namespace rclcpp

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -262,6 +262,11 @@ if(TARGET test_node_interfaces__node_topics)
     "test_msgs")
   target_link_libraries(test_node_interfaces__node_topics ${PROJECT_NAME} mimick)
 endif()
+ament_add_gtest(test_node_interfaces__node_type_descriptions
+  node_interfaces/test_node_type_descriptions.cpp)
+if(TARGET test_node_interfaces__node_type_descriptions)
+  target_link_libraries(test_node_interfaces__node_type_descriptions ${PROJECT_NAME} mimick)
+endif()
 ament_add_gtest(test_node_interfaces__node_waitables
   node_interfaces/test_node_waitables.cpp)
 if(TARGET test_node_interfaces__node_waitables)

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_parameters.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_parameters.cpp
@@ -77,7 +77,7 @@ TEST_F(TestNodeParameters, list_parameters)
   std::vector<std::string> prefixes;
   const auto list_result = node_parameters->list_parameters(prefixes, 1u);
 
-  // currently 'use_sim_time' and 'start_type_description_service'
+  // Currently the default parameters are 'use_sim_time' and 'start_type_description_service'
   size_t number_of_parameters = list_result.names.size();
   EXPECT_GE(2u, number_of_parameters);
 

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_parameters.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_parameters.cpp
@@ -77,9 +77,9 @@ TEST_F(TestNodeParameters, list_parameters)
   std::vector<std::string> prefixes;
   const auto list_result = node_parameters->list_parameters(prefixes, 1u);
 
-  // Currently the only default parameter is 'use_sim_time', but that may change.
+  // currently 'use_sim_time' and 'start_type_description_service'
   size_t number_of_parameters = list_result.names.size();
-  EXPECT_GE(1u, number_of_parameters);
+  EXPECT_GE(2u, number_of_parameters);
 
   const std::string parameter_name = "new_parameter";
   const rclcpp::ParameterValue value(true);

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_type_descriptions.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_type_descriptions.cpp
@@ -1,0 +1,63 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rclcpp/node.hpp"
+#include "rclcpp/node_interfaces/node_type_descriptions.hpp"
+
+class TestNodeTypeDescriptions : public ::testing::Test
+{
+public:
+  void SetUp()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown()
+  {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(TestNodeTypeDescriptions, interface_created)
+{
+  rclcpp::Node node{"node", "ns"};
+  ASSERT_NE(nullptr, node.get_node_type_descriptions_interface());
+}
+
+TEST_F(TestNodeTypeDescriptions, disabled_no_service)
+{
+  rclcpp::NodeOptions node_options;
+  node_options.append_parameter_override("start_type_description_service", false);
+  rclcpp::Node node{"node", "ns", node_options};
+
+  rcl_node_t * rcl_node = node.get_node_base_interface()->get_rcl_node_handle();
+  rcl_service_t * srv = nullptr;
+  rcl_ret_t ret = rcl_node_get_type_description_service(rcl_node, &srv);
+  ASSERT_EQ(RCL_RET_NOT_INIT, ret);
+}
+
+TEST_F(TestNodeTypeDescriptions, enabled_creates_service)
+{
+  rclcpp::NodeOptions node_options;
+  node_options.append_parameter_override("start_type_description_service", true);
+  rclcpp::Node node{"node", "ns", node_options};
+
+  rcl_node_t * rcl_node = node.get_node_base_interface()->get_rcl_node_handle();
+  rcl_service_t * srv = nullptr;
+  rcl_ret_t ret = rcl_node_get_type_description_service(rcl_node, &srv);
+  ASSERT_EQ(RCL_RET_OK, ret);
+  ASSERT_NE(nullptr, srv);
+}

--- a/rclcpp/test/rclcpp/test_parameter_client.cpp
+++ b/rclcpp/test/rclcpp/test_parameter_client.cpp
@@ -59,6 +59,7 @@ protected:
     node_with_option.reset();
   }
 
+  // "start_type_description_service" and "use_sim_time"
   const uint64_t builtin_param_count = 2;
   rclcpp::Node::SharedPtr node;
   rclcpp::Node::SharedPtr node_with_option;

--- a/rclcpp/test/rclcpp/test_parameter_client.cpp
+++ b/rclcpp/test/rclcpp/test_parameter_client.cpp
@@ -59,6 +59,7 @@ protected:
     node_with_option.reset();
   }
 
+  const uint64_t builtin_param_count = 2;
   rclcpp::Node::SharedPtr node;
   rclcpp::Node::SharedPtr node_with_option;
 };
@@ -925,6 +926,7 @@ TEST_F(TestParameterClient, sync_parameter_delete_parameters) {
   Coverage for async load_parameters
  */
 TEST_F(TestParameterClient, async_parameter_load_parameters) {
+  const uint64_t expected_param_count = 4 + builtin_param_count;
   auto load_node = std::make_shared<rclcpp::Node>(
     "load_node",
     "namespace",
@@ -944,12 +946,13 @@ TEST_F(TestParameterClient, async_parameter_load_parameters) {
   auto list_parameters = asynchronous_client->list_parameters({}, 3);
   rclcpp::spin_until_future_complete(
     load_node, list_parameters, std::chrono::milliseconds(100));
-  ASSERT_EQ(list_parameters.get().names.size(), static_cast<uint64_t>(5));
+  ASSERT_EQ(list_parameters.get().names.size(), expected_param_count);
 }
 /*
   Coverage for sync load_parameters
  */
 TEST_F(TestParameterClient, sync_parameter_load_parameters) {
+  const uint64_t expected_param_count = 4 + builtin_param_count;
   auto load_node = std::make_shared<rclcpp::Node>(
     "load_node",
     "namespace",
@@ -964,13 +967,14 @@ TEST_F(TestParameterClient, sync_parameter_load_parameters) {
   ASSERT_EQ(load_future[0].successful, true);
   // list parameters
   auto list_parameters = synchronous_client->list_parameters({}, 3);
-  ASSERT_EQ(list_parameters.names.size(), static_cast<uint64_t>(5));
+  ASSERT_EQ(list_parameters.names.size(), static_cast<uint64_t>(expected_param_count));
 }
 
 /*
   Coverage for async load_parameters with complicated regex expression
  */
 TEST_F(TestParameterClient, async_parameter_load_parameters_complicated_regex) {
+  const uint64_t expected_param_count = 5 + builtin_param_count;
   auto load_node = std::make_shared<rclcpp::Node>(
     "load_node",
     "namespace",
@@ -990,7 +994,7 @@ TEST_F(TestParameterClient, async_parameter_load_parameters_complicated_regex) {
   auto list_parameters = asynchronous_client->list_parameters({}, 3);
   rclcpp::spin_until_future_complete(
     load_node, list_parameters, std::chrono::milliseconds(100));
-  ASSERT_EQ(list_parameters.get().names.size(), static_cast<uint64_t>(6));
+  ASSERT_EQ(list_parameters.get().names.size(), expected_param_count);
   // to check the parameter "a_value"
   std::string param_name = "a_value";
   auto param = load_node->get_parameter(param_name);
@@ -1020,6 +1024,7 @@ TEST_F(TestParameterClient, async_parameter_load_no_valid_parameter) {
   Coverage for async load_parameters from maps with complicated regex expression
  */
 TEST_F(TestParameterClient, async_parameter_load_parameters_from_map) {
+  const uint64_t expected_param_count = 5 + builtin_param_count;
   auto load_node = std::make_shared<rclcpp::Node>(
     "load_node",
     "namespace",
@@ -1068,7 +1073,7 @@ TEST_F(TestParameterClient, async_parameter_load_parameters_from_map) {
   auto list_parameters = asynchronous_client->list_parameters({}, 3);
   rclcpp::spin_until_future_complete(
     load_node, list_parameters, std::chrono::milliseconds(100));
-  ASSERT_EQ(list_parameters.get().names.size(), static_cast<uint64_t>(6));
+  ASSERT_EQ(list_parameters.get().names.size(), expected_param_count);
   // to check the parameter "a_value"
   std::string param_name = "a_value";
   auto param = load_node->get_parameter(param_name);

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -72,6 +72,7 @@
 #include "rclcpp/node_interfaces/node_time_source_interface.hpp"
 #include "rclcpp/node_interfaces/node_timers_interface.hpp"
 #include "rclcpp/node_interfaces/node_topics_interface.hpp"
+#include "rclcpp/node_interfaces/node_type_descriptions_interface.hpp"
 #include "rclcpp/node_interfaces/node_waitables_interface.hpp"
 #include "rclcpp/parameter.hpp"
 #include "rclcpp/publisher.hpp"
@@ -823,6 +824,10 @@ public:
   rclcpp::node_interfaces::NodeTimeSourceInterface::SharedPtr
   get_node_time_source_interface();
 
+  RCLCPP_LIFECYCLE_PUBLIC
+  rclcpp::node_interfaces::NodeTypeDescriptionsInterface::SharedPtr
+  get_node_type_descriptions_interface();
+
   /// Return the Node's internal NodeWaitablesInterface implementation.
   /**
    * \sa rclcpp::Node::get_node_waitables_interface
@@ -1085,6 +1090,7 @@ private:
   rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_;
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_;
   rclcpp::node_interfaces::NodeTimeSourceInterface::SharedPtr node_time_source_;
+  rclcpp::node_interfaces::NodeTypeDescriptionsInterface::SharedPtr node_type_descriptions_;
   rclcpp::node_interfaces::NodeWaitablesInterface::SharedPtr node_waitables_;
 
   const rclcpp::NodeOptions node_options_;

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -41,9 +41,9 @@
 #include "rclcpp/node_interfaces/node_parameters.hpp"
 #include "rclcpp/node_interfaces/node_services.hpp"
 #include "rclcpp/node_interfaces/node_time_source.hpp"
-#include "rclcpp/node_interfaces/node_type_descriptions.hpp"
 #include "rclcpp/node_interfaces/node_timers.hpp"
 #include "rclcpp/node_interfaces/node_topics.hpp"
+#include "rclcpp/node_interfaces/node_type_descriptions.hpp"
 #include "rclcpp/node_interfaces/node_waitables.hpp"
 #include "rclcpp/parameter_service.hpp"
 #include "rclcpp/qos.hpp"
@@ -118,8 +118,7 @@ LifecycleNode::LifecycleNode(
       node_base_,
       node_logging_,
       node_parameters_,
-      node_services_,
-      node_topics_
+      node_services_
     )),
   node_waitables_(new rclcpp::node_interfaces::NodeWaitables(node_base_.get())),
   node_options_(options),

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -116,9 +116,10 @@ LifecycleNode::LifecycleNode(
     )),
   node_type_descriptions_(new rclcpp::node_interfaces::NodeTypeDescriptions(
       node_base_,
-      node_services_,
       node_logging_,
-      node_parameters_
+      node_parameters_,
+      node_services_,
+      node_topics_
     )),
   node_waitables_(new rclcpp::node_interfaces::NodeWaitables(node_base_.get())),
   node_options_(options),

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -41,6 +41,7 @@
 #include "rclcpp/node_interfaces/node_parameters.hpp"
 #include "rclcpp/node_interfaces/node_services.hpp"
 #include "rclcpp/node_interfaces/node_time_source.hpp"
+#include "rclcpp/node_interfaces/node_type_descriptions.hpp"
 #include "rclcpp/node_interfaces/node_timers.hpp"
 #include "rclcpp/node_interfaces/node_topics.hpp"
 #include "rclcpp/node_interfaces/node_waitables.hpp"
@@ -112,6 +113,12 @@ LifecycleNode::LifecycleNode(
       node_parameters_,
       options.clock_qos(),
       options.use_clock_thread()
+    )),
+  node_type_descriptions_(new rclcpp::node_interfaces::NodeTypeDescriptions(
+      node_base_,
+      node_services_,
+      node_logging_,
+      node_parameters_
     )),
   node_waitables_(new rclcpp::node_interfaces::NodeWaitables(node_base_.get())),
   node_options_(options),

--- a/rclcpp_lifecycle/test/test_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_node.cpp
@@ -427,11 +427,14 @@ TEST_F(TestDefaultStateMachine, lifecycle_subscriber) {
 // Parameters are tested more thoroughly in rclcpp's test_node.cpp
 // These are provided for coverage of lifecycle node's API
 TEST_F(TestDefaultStateMachine, declare_parameters) {
+  const uint64_t builtin_param_count = 2;
+  const uint64_t expected_param_count = 6 + builtin_param_count;
   auto test_node = std::make_shared<EmptyLifecycleNode>("testnode");
 
   auto list_result = test_node->list_parameters({}, 0u);
-  EXPECT_EQ(list_result.names.size(), 1u);
-  EXPECT_STREQ(list_result.names[0].c_str(), "use_sim_time");
+  EXPECT_EQ(list_result.names.size(), builtin_param_count);
+  EXPECT_STREQ(list_result.names[0].c_str(), "start_type_description_service");
+  EXPECT_STREQ(list_result.names[1].c_str(), "use_sim_time");
 
   const std::string bool_name = "test_boolean";
   const std::string int_name = "test_int";
@@ -469,10 +472,11 @@ TEST_F(TestDefaultStateMachine, declare_parameters) {
   test_node->declare_parameters("test_double", double_parameters);
 
   list_result = test_node->list_parameters({}, 0u);
-  EXPECT_EQ(list_result.names.size(), 7u);
+  EXPECT_EQ(list_result.names.size(), expected_param_count);
 
   // The order of these names is not controlled by lifecycle_node, doing set equality
   std::set<std::string> expected_names = {
+    "start_type_description_service",
     "test_boolean",
     "test_double.double_one",
     "test_double.double_two",
@@ -487,11 +491,13 @@ TEST_F(TestDefaultStateMachine, declare_parameters) {
 }
 
 TEST_F(TestDefaultStateMachine, check_parameters) {
+  const uint64_t builtin_param_count = 2;
   auto test_node = std::make_shared<EmptyLifecycleNode>("testnode");
 
   auto list_result = test_node->list_parameters({}, 0u);
-  EXPECT_EQ(list_result.names.size(), 1u);
-  EXPECT_STREQ(list_result.names[0].c_str(), "use_sim_time");
+  EXPECT_EQ(list_result.names.size(), builtin_param_count);
+  EXPECT_STREQ(list_result.names[0].c_str(), "start_type_description_service");
+  EXPECT_STREQ(list_result.names[1].c_str(), "use_sim_time");
 
   const std::string bool_name = "test_boolean";
   const std::string int_name = "test_int";
@@ -549,8 +555,7 @@ TEST_F(TestDefaultStateMachine, check_parameters) {
   std::map<std::string, rclcpp::ParameterValue> parameter_map;
   EXPECT_TRUE(test_node->get_parameters({}, parameter_map));
 
-  // int param, bool param, and use_sim_time
-  EXPECT_EQ(parameter_map.size(), 3u);
+  EXPECT_EQ(parameter_map.size(), parameter_names.size() + builtin_param_count);
 
   // Check parameter types
   auto parameter_types = test_node->get_parameter_types(parameter_names);
@@ -585,10 +590,12 @@ TEST_F(TestDefaultStateMachine, check_parameters) {
 
   // List parameters
   list_result = test_node->list_parameters({}, 0u);
-  EXPECT_EQ(list_result.names.size(), 3u);
-  EXPECT_STREQ(list_result.names[0].c_str(), parameter_names[0].c_str());
-  EXPECT_STREQ(list_result.names[1].c_str(), parameter_names[1].c_str());
-  EXPECT_STREQ(list_result.names[2].c_str(), "use_sim_time");
+  EXPECT_EQ(list_result.names.size(), parameter_names.size() + builtin_param_count);
+  size_t index = 0;
+  EXPECT_STREQ(list_result.names[index++].c_str(), "start_type_description_service");
+  EXPECT_STREQ(list_result.names[index++].c_str(), parameter_names[0].c_str());
+  EXPECT_STREQ(list_result.names[index++].c_str(), parameter_names[1].c_str());
+  EXPECT_STREQ(list_result.names[index++].c_str(), "use_sim_time");
 
   // Undeclare parameter
   test_node->undeclare_parameter(bool_name);

--- a/rclcpp_lifecycle/test/test_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_node.cpp
@@ -427,6 +427,7 @@ TEST_F(TestDefaultStateMachine, lifecycle_subscriber) {
 // Parameters are tested more thoroughly in rclcpp's test_node.cpp
 // These are provided for coverage of lifecycle node's API
 TEST_F(TestDefaultStateMachine, declare_parameters) {
+  // "start_type_description_service" and "use_sim_time"
   const uint64_t builtin_param_count = 2;
   const uint64_t expected_param_count = 6 + builtin_param_count;
   auto test_node = std::make_shared<EmptyLifecycleNode>("testnode");


### PR DESCRIPTION
Part of ros2/ros2#1159

<s>Depends on ros2/rcl#1052</s>

Linked with https://github.com/ros2/system_tests/pull/520

Defines and implements new node interface `TypeDescriptionsInterface`, which provides the `~/get_type_description` service from ros2/rcl#1052.

Uses parameter `start_type_description_service` to start the service - defaulting to true!

This will not be a trivial backport to Iron - I propose moving forward with this as the "correct thing to build", then the backport can dump most of it into `node.cpp` for Iron.