### PR TITLE
Adding options to both services and clients

### DIFF
--- a/rclcpp/include/rclcpp/any_service_callback.hpp
+++ b/rclcpp/include/rclcpp/any_service_callback.hpp
@@ -51,10 +51,10 @@ struct can_be_nullptr<T, std::void_t<
 }  // namespace detail
 
 // Forward declare
-template<typename ServiceT>
+template<typename ServiceT, typename AllocatorT>
 class Service;
 
-template<typename ServiceT>
+template<typename ServiceT, typename AllocatorT = std::allocator<void>>
 class AnyServiceCallback
 {
 public:
@@ -152,7 +152,7 @@ public:
   // template<typename Allocator = std::allocator<typename ServiceT::Response>>
   std::shared_ptr<typename ServiceT::Response>
   dispatch(
-    const std::shared_ptr<rclcpp::Service<ServiceT>> & service_handle,
+    const std::shared_ptr<rclcpp::Service<ServiceT, AllocatorT>> & service_handle,
     const std::shared_ptr<rmw_request_id_t> & request_header,
     std::shared_ptr<typename ServiceT::Request> request)
   {
@@ -222,7 +222,7 @@ private:
     )>;
   using SharedPtrDeferResponseCallbackWithServiceHandle = std::function<
     void (
-      std::shared_ptr<rclcpp::Service<ServiceT>>,
+      std::shared_ptr<rclcpp::Service<ServiceT, AllocatorT>>,
       std::shared_ptr<rmw_request_id_t>,
       std::shared_ptr<typename ServiceT::Request>
     )>;

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -29,6 +29,7 @@
 #include <variant>
 #include <vector>
 
+#include "client_options.hpp"
 #include "rcl/client.h"
 #include "rcl/error_handling.h"
 #include "rcl/event_callback.h"
@@ -375,7 +376,7 @@ protected:
   std::atomic<bool> in_use_by_wait_set_{false};
 };
 
-template<typename ServiceT>
+template<typename ServiceT, typename ClientAllocatorT = std::allocator<void>>
 class Client : public ClientBase
 {
 public:
@@ -467,22 +468,28 @@ public:
    * \param[in] node_base NodeBaseInterface pointer that is used in part of the setup.
    * \param[in] node_graph The node graph interface of the corresponding node.
    * \param[in] service_name Name of the topic to publish to.
-   * \param[in] client_options options for the subscription.
+   * \param[in] qos Quality of Service needed for setup of the rcl_client_options
+   * \param[in] client_options options for the subscription, with custom allocators
    */
   Client(
     rclcpp::node_interfaces::NodeBaseInterface * node_base,
     rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph,
     const std::string & service_name,
-    rcl_client_options_t & client_options)
+    const rclcpp::QoS & qos,
+    const rclcpp::ClientOptionsWithAllocator<ClientAllocatorT> & client_options =
+    rclcpp::ClientOptionsWithAllocator<ClientAllocatorT>())
   : ClientBase(node_base, node_graph),
     srv_type_support_handle_(rosidl_typesupport_cpp::get_service_type_support_handle<ServiceT>())
   {
+    rcl_client_options_t client_options_t =
+      client_options.to_rcl_client_options(qos);
+
     rcl_ret_t ret = rcl_client_init(
       this->get_client_handle().get(),
       this->get_rcl_node_handle(),
       srv_type_support_handle_,
       service_name.c_str(),
-      &client_options);
+      &client_options_t);
     if (ret != RCL_RET_OK) {
       if (ret == RCL_RET_SERVICE_NAME_INVALID) {
         auto rcl_node_handle = this->get_rcl_node_handle();

--- a/rclcpp/include/rclcpp/client_factory.hpp
+++ b/rclcpp/include/rclcpp/client_factory.hpp
@@ -1,0 +1,84 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__CLIENT_FACTORY_HPP_
+#define RCLCPP__CLIENT_FACTORY_HPP_
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "rcl/client.h"
+
+#include "rclcpp/client.hpp"
+#include "rclcpp/client_options.hpp"
+#include "rclcpp/node_interfaces/node_graph_interface.hpp"
+#include "rclcpp/visibility_control.hpp"
+#include "rclcpp/qos.hpp"
+
+namespace rclcpp
+{
+
+/// Factory with functions used to create a specific ServiceT.
+/**
+ * This factory class is used to encapsulate the template generated functions
+ * which are used during the creation of a specific client
+ * within a non-templated class.
+ *
+ * It is created using the create_client_factory function, which is usually
+ * called from a templated "create_client" method on the Node class, and
+ * is passed to the non-templated "create_client" method on the NodeTopics
+ * class where it is used to create and setup the Client.
+ *
+ * It also handles the single step construction of Clients, first calling
+ * the constructor
+ */
+struct ClientFactory
+{
+  // Creates a ClientT<ServiceT ...> object and returns it as a ClientBase.
+  using ClientFactoryFunction = std::function<
+    rclcpp::ClientBase::SharedPtr(
+      rclcpp::node_interfaces::NodeBaseInterface * node_base,
+      rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph)>;
+
+  const ClientFactoryFunction create_typed_client;
+};
+
+/// Return a ClientFactory with functions setup for creating a ClientT<ServiceT, AllocatorT>.
+template<typename ServiceT, typename AllocatorT, typename ClientT>
+ClientFactory
+create_client_factory(const rclcpp::ClientOptionsWithAllocator<AllocatorT> & options)
+{
+  ClientFactory factory {
+    // factory function that creates a ServiceT specific ClientT
+    [options](
+      rclcpp::node_interfaces::NodeBaseInterface * node_base,
+      rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph,
+      const std::string & service_name,
+      const rclcpp::QoS & qos
+    ) -> std::shared_ptr<ClientT>
+    {
+      auto client = std::make_shared<ClientT>(
+        node_base, node_graph, service_name, qos, options);
+      return client;
+    }
+  };
+
+  // return the factory now that it is populated
+  return factory;
+}
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__CLIENT_FACTORY_HPP_

--- a/rclcpp/include/rclcpp/client_options.hpp
+++ b/rclcpp/include/rclcpp/client_options.hpp
@@ -1,0 +1,115 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__CLIENT_OPTIONS_HPP_
+#define RCLCPP__CLIENT_OPTIONS_HPP_
+
+#include <memory>
+#include <random>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "rcl/client.h"
+
+#include "rclcpp/allocator/allocator_common.hpp"
+#include "rclcpp/event_handler.hpp"
+#include "rclcpp/qos.hpp"
+#include "rclcpp/qos_overriding_options.hpp"
+
+namespace rclcpp
+{
+
+class CallbackGroup;
+
+struct ClientOptionsBase
+{
+  /// Whether or not to use default callbacks when user doesn't supply any in
+  /// event_callbacks
+  bool use_default_callbacks = true;
+
+  QosOverridingOptions qos_overriding_options;
+
+  /// Callback group in which the waitable items from the client should be
+  /// placed
+  std::shared_ptr<rclcpp::CallbackGroup> callback_group;
+};
+
+template<typename Allocator>
+struct ClientOptionsWithAllocator : public ClientOptionsBase
+{
+  static_assert(
+    std::is_void_v<typename std::allocator_traits<Allocator>::value_type>,
+    "client allocator value type must be void");
+
+  /// Optional custom allocator
+  std::shared_ptr<Allocator> allocator = nullptr;
+
+  ClientOptionsWithAllocator() {}
+
+  /// Constructor using base class as an input
+  explicit ClientOptionsWithAllocator(
+    const ClientOptionsBase & client_options_base)
+  : ClientOptionsBase(client_options_base) {}
+
+  /// Convert this class, and a rclcpp::QoS to the rcl_client_options_t for low
+  /// overhead
+  rcl_client_options_t to_rcl_client_options(const rclcpp::QoS & qos) const
+  {
+    /// Destructure our rcl_client_options_t to set it up with the users values
+    rcl_client_options_t result = rcl_client_get_default_options();
+    result.qos = qos.get_rmw_qos_profile();
+    result.allocator = this->get_rcl_allocator();
+
+    return result;
+  }
+
+  /// Get or create the allocator if needed
+  std::shared_ptr<Allocator> get_allocator() const
+  {
+    if (!this->allocator) {
+      if (!allocator_storage_) {
+        allocator_storage_ = std::make_shared<Allocator>();
+      }
+      return allocator_storage_;
+    }
+    return this->allocator;
+  }
+
+private:
+  using PlainAllocator =
+    typename std::allocator_traits<Allocator>::template rebind_alloc<char>;
+
+  rcl_allocator_t get_rcl_allocator() const
+  {
+    if (!plain_allocator_storage_) {
+      plain_allocator_storage_ =
+        std::make_shared<PlainAllocator>(*this->get_allocator());
+    }
+    return rclcpp::allocator::get_rcl_allocator<char>(
+      *plain_allocator_storage_);
+  }
+
+  // returning a copy of the allocator
+  mutable std::shared_ptr<Allocator> allocator_storage_;
+
+  // returning a copy of the plain allocator
+  mutable std::shared_ptr<PlainAllocator> plain_allocator_storage_;
+};
+
+using ClientOptions = ClientOptionsWithAllocator<std::allocator<void>>;
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__CLIENT_OPTIONS_HPP_

--- a/rclcpp/include/rclcpp/create_client.hpp
+++ b/rclcpp/include/rclcpp/create_client.hpp
@@ -20,6 +20,7 @@
 
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/node_interfaces/node_services_interface.hpp"
+#include "rclcpp/client_options.hpp"
 #include "rclcpp/qos.hpp"
 #include "rmw/rmw.h"
 
@@ -38,48 +39,30 @@ namespace rclcpp
  * \param[in] group Callback group to handle the reply to service calls.
  * \return Shared pointer to the created client.
  */
-template<typename ServiceT>
-typename rclcpp::Client<ServiceT>::SharedPtr
+template<typename ServiceT, typename AllocatorT = std::allocator<void>>
+typename rclcpp::Client<ServiceT, AllocatorT>::SharedPtr
 create_client(
   std::shared_ptr<node_interfaces::NodeBaseInterface> node_base,
   std::shared_ptr<node_interfaces::NodeGraphInterface> node_graph,
   std::shared_ptr<node_interfaces::NodeServicesInterface> node_services,
   const std::string & service_name,
   const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
-  rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  rclcpp::CallbackGroup::SharedPtr group = nullptr,
+  const rclcpp::ClientOptionsWithAllocator<AllocatorT> & options = (
+    rclcpp::ClientOptionsWithAllocator<AllocatorT>()))
 {
-  return create_client<ServiceT>(
-    node_base, node_graph, node_services,
-    service_name,
-    qos.get_rmw_qos_profile(),
-    group);
-}
-
-/// Create a service client with a given type.
-/// \internal
-template<typename ServiceT>
-typename rclcpp::Client<ServiceT>::SharedPtr
-create_client(
-  std::shared_ptr<node_interfaces::NodeBaseInterface> node_base,
-  std::shared_ptr<node_interfaces::NodeGraphInterface> node_graph,
-  std::shared_ptr<node_interfaces::NodeServicesInterface> node_services,
-  const std::string & service_name,
-  const rmw_qos_profile_t & qos_profile,
-  rclcpp::CallbackGroup::SharedPtr group)
-{
-  rcl_client_options_t options = rcl_client_get_default_options();
-  options.qos = qos_profile;
-
-  auto cli = rclcpp::Client<ServiceT>::make_shared(
+  auto cli = rclcpp::Client<ServiceT, AllocatorT>::make_shared(
     node_base.get(),
     node_graph,
     service_name,
+    qos,
     options);
 
   auto cli_base_ptr = std::dynamic_pointer_cast<rclcpp::ClientBase>(cli);
   node_services->add_client(cli_base_ptr, group);
   return cli;
 }
+
 
 }  // namespace rclcpp
 

--- a/rclcpp/include/rclcpp/create_service.hpp
+++ b/rclcpp/include/rclcpp/create_service.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Open Source Robotics Foundation, Inc.
+//  Copyright 2018 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 #include "rclcpp/node_interfaces/node_services_interface.hpp"
 #include "rclcpp/visibility_control.hpp"
 #include "rmw/rmw.h"
+#include "service_options.hpp"
 
 namespace rclcpp
 {
@@ -36,44 +37,32 @@ namespace rclcpp
  * \param[in] callback The callback to call when the service gets a request.
  * \param[in] qos Quality of service profile for the service.
  * \param[in] group Callback group to handle the reply to service calls.
+ * \param[in] options A way to customize the allocator
  * \return Shared pointer to the created service.
  */
-template<typename ServiceT, typename CallbackT>
-typename rclcpp::Service<ServiceT>::SharedPtr
+template<
+  typename ServiceT,
+  typename CallbackT,
+  typename AllocatorT = std::allocator<void>>
+typename rclcpp::Service<ServiceT, AllocatorT>::SharedPtr
 create_service(
   std::shared_ptr<node_interfaces::NodeBaseInterface> node_base,
   std::shared_ptr<node_interfaces::NodeServicesInterface> node_services,
   const std::string & service_name,
   CallbackT && callback,
   const rclcpp::QoS & qos,
-  rclcpp::CallbackGroup::SharedPtr group)
+  rclcpp::CallbackGroup::SharedPtr group,
+  const rclcpp::ServiceOptionsWithAllocator<AllocatorT> & options =
+  rclcpp::ServiceOptionsWithAllocator<AllocatorT>()
+)
 {
-  return create_service<ServiceT, CallbackT>(
-    node_base, node_services, service_name,
-    std::forward<CallbackT>(callback), qos.get_rmw_qos_profile(), group);
-}
-
-/// Create a service with a given type.
-/// \internal
-template<typename ServiceT, typename CallbackT>
-typename rclcpp::Service<ServiceT>::SharedPtr
-create_service(
-  std::shared_ptr<node_interfaces::NodeBaseInterface> node_base,
-  std::shared_ptr<node_interfaces::NodeServicesInterface> node_services,
-  const std::string & service_name,
-  CallbackT && callback,
-  const rmw_qos_profile_t & qos_profile,
-  rclcpp::CallbackGroup::SharedPtr group)
-{
-  rclcpp::AnyServiceCallback<ServiceT> any_service_callback;
+  rclcpp::AnyServiceCallback<ServiceT, AllocatorT> any_service_callback;
   any_service_callback.set(std::forward<CallbackT>(callback));
 
-  rcl_service_options_t service_options = rcl_service_get_default_options();
-  service_options.qos = qos_profile;
-
-  auto serv = Service<ServiceT>::make_shared(
+  auto serv = Service<ServiceT, AllocatorT>::make_shared(
     node_base->get_shared_rcl_node_handle(),
-    service_name, any_service_callback, service_options);
+    service_name, any_service_callback, qos, options);
+
   auto serv_base_ptr = std::dynamic_pointer_cast<ServiceBase>(serv);
   node_services->add_service(serv_base_ptr, group);
   return serv;

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -70,6 +70,7 @@
 #include "rclcpp/time.hpp"
 #include "rclcpp/timer.hpp"
 #include "rclcpp/visibility_control.hpp"
+#include "service_options.hpp"
 
 namespace rclcpp
 {
@@ -258,51 +259,20 @@ public:
 
   /// Create and return a Client.
   /**
-   * \param[in] service_name The topic to service on.
-   * \param[in] qos_profile rmw_qos_profile_t Quality of service profile for client.
-   * \param[in] group Callback group to call the service.
-   * \return Shared pointer to the created client.
-   * \deprecated use rclcpp::QoS instead of rmw_qos_profile_t
-   */
-  template<typename ServiceT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  typename rclcpp::Client<ServiceT>::SharedPtr
-  create_client(
-    const std::string & service_name,
-    const rmw_qos_profile_t & qos_profile,
-    rclcpp::CallbackGroup::SharedPtr group = nullptr);
-
-  /// Create and return a Client.
-  /**
    * \param[in] service_name The name on which the service is accessible.
    * \param[in] qos Quality of service profile for client.
    * \param[in] group Callback group to handle the reply to service calls.
+   * \param[in] options Customization of allocator
    * \return Shared pointer to the created client.
    */
-  template<typename ServiceT>
-  typename rclcpp::Client<ServiceT>::SharedPtr
+  template<typename ServiceT, typename AllocatorT = std::allocator<void>>
+  typename rclcpp::Client<ServiceT, AllocatorT>::SharedPtr
   create_client(
     const std::string & service_name,
     const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
-    rclcpp::CallbackGroup::SharedPtr group = nullptr);
-
-  /// Create and return a Service.
-  /**
-   * \param[in] service_name The topic to service on.
-   * \param[in] callback User-defined callback function.
-   * \param[in] qos_profile rmw_qos_profile_t Quality of service profile for client.
-   * \param[in] group Callback group to call the service.
-   * \return Shared pointer to the created service.
-   * \deprecated use rclcpp::QoS instead of rmw_qos_profile_t
-   */
-  template<typename ServiceT, typename CallbackT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  typename rclcpp::Service<ServiceT>::SharedPtr
-  create_service(
-    const std::string & service_name,
-    CallbackT && callback,
-    const rmw_qos_profile_t & qos_profile,
-    rclcpp::CallbackGroup::SharedPtr group = nullptr);
+    rclcpp::CallbackGroup::SharedPtr group = nullptr,
+    const rclcpp::ClientOptionsWithAllocator<AllocatorT> & options =
+    rclcpp::ClientOptionsWithAllocator<AllocatorT>());
 
   /// Create and return a Service.
   /**
@@ -310,15 +280,22 @@ public:
    * \param[in] callback User-defined callback function.
    * \param[in] qos Quality of service profile for the service.
    * \param[in] group Callback group to call the service.
+   * \param[in] options A way to customize the allocator
    * \return Shared pointer to the created service.
    */
-  template<typename ServiceT, typename CallbackT>
-  typename rclcpp::Service<ServiceT>::SharedPtr
+  template<
+    typename ServiceT,
+    typename CallbackT,
+    typename AllocatorT = std::allocator<void>>
+  typename rclcpp::Service<ServiceT, AllocatorT>::SharedPtr
   create_service(
     const std::string & service_name,
     CallbackT && callback,
     const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
-    rclcpp::CallbackGroup::SharedPtr group = nullptr);
+    rclcpp::CallbackGroup::SharedPtr group = nullptr,
+    const rclcpp::ServiceOptionsWithAllocator<AllocatorT> & options =
+    rclcpp::ServiceOptionsWithAllocator<AllocatorT>()
+  );
 
   /// Create and return a GenericPublisher.
   /**

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -48,6 +48,7 @@
 #include "rclcpp/timer.hpp"
 #include "rclcpp/type_support_decl.hpp"
 #include "rclcpp/visibility_control.hpp"
+#include "service_options.hpp"
 
 #ifndef RCLCPP__NODE_HPP_
 #include "node.hpp"
@@ -138,70 +139,44 @@ Node::create_timer(
     this->node_timers_.get());
 }
 
-template<typename ServiceT>
-typename Client<ServiceT>::SharedPtr
+template<typename ServiceT, typename AllocatorT>
+typename Client<ServiceT, AllocatorT>::SharedPtr
 Node::create_client(
   const std::string & service_name,
   const rclcpp::QoS & qos,
-  rclcpp::CallbackGroup::SharedPtr group)
+  rclcpp::CallbackGroup::SharedPtr group,
+  const rclcpp::ClientOptionsWithAllocator<AllocatorT> & options)
 {
-  return rclcpp::create_client<ServiceT>(
+  return rclcpp::create_client<ServiceT, AllocatorT>(
     node_base_,
     node_graph_,
     node_services_,
     extend_name_with_sub_namespace(service_name, this->get_sub_namespace()),
     qos,
-    group);
+    group,
+    options);
 }
 
-template<typename ServiceT>
-typename Client<ServiceT>::SharedPtr
-Node::create_client(
-  const std::string & service_name,
-  const rmw_qos_profile_t & qos_profile,
-  rclcpp::CallbackGroup::SharedPtr group)
-{
-  return rclcpp::create_client<ServiceT>(
-    node_base_,
-    node_graph_,
-    node_services_,
-    extend_name_with_sub_namespace(service_name, this->get_sub_namespace()),
-    qos_profile,
-    group);
-}
-
-template<typename ServiceT, typename CallbackT>
-typename rclcpp::Service<ServiceT>::SharedPtr
+template<
+  typename ServiceT,
+  typename CallbackT,
+  typename AllocatorT>
+typename rclcpp::Service<ServiceT, AllocatorT>::SharedPtr
 Node::create_service(
   const std::string & service_name,
   CallbackT && callback,
   const rclcpp::QoS & qos,
-  rclcpp::CallbackGroup::SharedPtr group)
+  rclcpp::CallbackGroup::SharedPtr group,
+  const rclcpp::ServiceOptionsWithAllocator<AllocatorT> & options)
 {
-  return rclcpp::create_service<ServiceT, CallbackT>(
+  return rclcpp::create_service<ServiceT, CallbackT, AllocatorT>(
     node_base_,
     node_services_,
     extend_name_with_sub_namespace(service_name, this->get_sub_namespace()),
     std::forward<CallbackT>(callback),
     qos,
-    group);
-}
-
-template<typename ServiceT, typename CallbackT>
-typename rclcpp::Service<ServiceT>::SharedPtr
-Node::create_service(
-  const std::string & service_name,
-  CallbackT && callback,
-  const rmw_qos_profile_t & qos_profile,
-  rclcpp::CallbackGroup::SharedPtr group)
-{
-  return rclcpp::create_service<ServiceT, CallbackT>(
-    node_base_,
-    node_services_,
-    extend_name_with_sub_namespace(service_name, this->get_sub_namespace()),
-    std::forward<CallbackT>(callback),
-    qos_profile,
-    group);
+    group,
+    options);
 }
 
 template<typename AllocatorT>

--- a/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
@@ -25,6 +25,7 @@
 #include "rclcpp/callback_group.hpp"
 #include "rclcpp/context.hpp"
 #include "rclcpp/macros.hpp"
+#include "./logging_mutex.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/visibility_control.hpp"
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_topics.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_topics.hpp
@@ -16,6 +16,7 @@
 #define RCLCPP__NODE_INTERFACES__NODE_TOPICS_HPP_
 
 #include <string>
+#include <memory>
 
 #include "rcl/publisher.h"
 #include "rcl/subscription.h"
@@ -76,6 +77,32 @@ public:
   add_subscription(
     rclcpp::SubscriptionBase::SharedPtr subscription,
     rclcpp::CallbackGroup::SharedPtr callback_group) override;
+
+  RCLCPP_PUBLIC
+  rclcpp::ServiceBase::SharedPtr
+  create_service(
+    std::shared_ptr<rcl_node_t> node_handle,
+    const rclcpp::ServiceFactory & service_factory) override;
+
+  RCLCPP_PUBLIC
+  void
+  add_service(
+    // rclcpp::ServiceBase::SharedPtr service,
+    // rclcpp::CallbackGroup::SharedPtr callback_group
+  ) override;
+
+  RCLCPP_PUBLIC
+  rclcpp::ClientBase::SharedPtr
+  create_client(
+    rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph,
+    const rclcpp::ClientFactory & client_factory) override;
+
+  RCLCPP_PUBLIC
+  void
+  add_client(
+    // rclcpp::ClientBase::SharedPtr client,
+    // rclcpp::CallbackGroup::SharedPtr callback_group
+  ) override;
 
   RCLCPP_PUBLIC
   rclcpp::node_interfaces::NodeBaseInterface *

--- a/rclcpp/include/rclcpp/node_interfaces/node_topics_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_topics_interface.hpp
@@ -16,9 +16,12 @@
 #define RCLCPP__NODE_INTERFACES__NODE_TOPICS_INTERFACE_HPP_
 
 #include <string>
+#include <memory>
 
 #include "rcl/publisher.h"
 #include "rcl/subscription.h"
+#include "rcl/service.h"
+#include "rcl/client.h"
 
 #include "rclcpp/callback_group.hpp"
 #include "rclcpp/macros.hpp"
@@ -29,6 +32,10 @@
 #include "rclcpp/publisher_factory.hpp"
 #include "rclcpp/subscription.hpp"
 #include "rclcpp/subscription_factory.hpp"
+#include "rclcpp/service.hpp"
+#include "rclcpp/service_factory.hpp"
+#include "rclcpp/client.hpp"
+#include "rclcpp/client_factory.hpp"
 #include "rclcpp/visibility_control.hpp"
 
 namespace rclcpp
@@ -75,6 +82,36 @@ public:
   add_subscription(
     rclcpp::SubscriptionBase::SharedPtr subscription,
     rclcpp::CallbackGroup::SharedPtr callback_group) = 0;
+
+  RCLCPP_PUBLIC
+  virtual
+  rclcpp::ServiceBase::SharedPtr
+  create_service(
+    std::shared_ptr<rcl_node_t> node_handle,
+    const rclcpp::ServiceFactory & service_factory) = 0;
+
+  RCLCPP_PUBLIC
+  virtual
+  void
+  add_service(
+    // rclcpp::ServiceBase::SharedPtr service,
+    // rclcpp::CallbackGroup::SharedPtr callback_group
+  ) = 0;
+
+  RCLCPP_PUBLIC
+  virtual
+  rclcpp::ClientBase::SharedPtr
+  create_client(
+    rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph,
+    const rclcpp::ClientFactory & client_factory) = 0;
+
+  RCLCPP_PUBLIC
+  virtual
+  void
+  add_client(
+    // rclcpp::ClientBase::SharedPtr client,
+    // rclcpp::CallbackGroup::SharedPtr callback_group
+  ) = 0;
 
   RCLCPP_PUBLIC
   virtual

--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -58,37 +58,6 @@ public:
    * \param[in] node_topics_interface Node topic base interface.
    * \param[in] node_graph_interface The node graph interface of the corresponding node.
    * \param[in] node_services_interface Node service interface.
-   * \param[in] remote_node_name Name of the remote node
-   * \param[in] qos_profile The rmw qos profile to use to subscribe
-   * \param[in] group (optional) The async parameter client will be added to this callback group.
-   * \deprecated use rclcpp::QoS instead of rmw_qos_profile_t
-   */
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  RCLCPP_PUBLIC
-  AsyncParametersClient(
-    const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
-    const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface,
-    const rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_interface,
-    const rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_interface,
-    const std::string & remote_node_name,
-    const rmw_qos_profile_t & qos_profile,
-    rclcpp::CallbackGroup::SharedPtr group = nullptr)
-  : AsyncParametersClient(
-      node_base_interface,
-      node_topics_interface,
-      node_graph_interface,
-      node_services_interface,
-      remote_node_name,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)),
-      group)
-  {}
-
-  /// Create an async parameters client.
-  /**
-   * \param[in] node_base_interface The node base interface of the corresponding node.
-   * \param[in] node_topics_interface Node topic base interface.
-   * \param[in] node_graph_interface The node graph interface of the corresponding node.
-   * \param[in] node_services_interface Node service interface.
    * \param[in] remote_node_name (optional) name of the remote node
    * \param[in] qos_profile (optional) The qos profile to use to subscribe
    * \param[in] group (optional) The async parameter client will be added to this callback group.
@@ -102,31 +71,6 @@ public:
     const std::string & remote_node_name = "",
     const rclcpp::QoS & qos_profile = rclcpp::ParametersQoS(),
     rclcpp::CallbackGroup::SharedPtr group = nullptr);
-
-  /// Constructor
-  /**
-   * \param[in] node The async parameters client will be added to this node.
-   * \param[in] remote_node_name name of the remote node
-   * \param[in] qos_profile The rmw qos profile to use to subscribe
-   * \param[in] group (optional) The async parameter client will be added to this callback group.
-   * \deprecated use rclcpp::QoS instead of rmw_qos_profile_t
-   */
-  template<typename NodeT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  AsyncParametersClient(
-    const std::shared_ptr<NodeT> node,
-    const std::string & remote_node_name,
-    const rmw_qos_profile_t & qos_profile,
-    rclcpp::CallbackGroup::SharedPtr group = nullptr)
-  : AsyncParametersClient(
-      node->get_node_base_interface(),
-      node->get_node_topics_interface(),
-      node->get_node_graph_interface(),
-      node->get_node_services_interface(),
-      remote_node_name,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)),
-      group)
-  {}
 
   /**
    * \param[in] node The async parameters client will be added to this node.
@@ -147,31 +91,6 @@ public:
       node->get_node_services_interface(),
       remote_node_name,
       qos_profile,
-      group)
-  {}
-
-  /// Constructor
-  /**
-   * \param[in] node The async parameters client will be added to this node.
-   * \param[in] remote_node_name Name of the remote node
-   * \param[in] qos_profile The rmw qos profile to use to subscribe
-   * \param[in] group (optional) The async parameter client will be added to this callback group.
-   * \deprecated use rclcpp::QoS instead of rmw_qos_profile_t
-   */
-  template<typename NodeT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  AsyncParametersClient(
-    NodeT * node,
-    const std::string & remote_node_name,
-    const rmw_qos_profile_t & qos_profile,
-    rclcpp::CallbackGroup::SharedPtr group = nullptr)
-  : AsyncParametersClient(
-      node->get_node_base_interface(),
-      node->get_node_topics_interface(),
-      node->get_node_graph_interface(),
-      node->get_node_services_interface(),
-      remote_node_name,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)),
       group)
   {}
 
@@ -384,19 +303,6 @@ public:
   RCLCPP_SMART_PTR_DEFINITIONS(SyncParametersClient)
 
   template<typename NodeT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  SyncParametersClient(
-    std::shared_ptr<NodeT> node,
-    const std::string & remote_node_name,
-    const rmw_qos_profile_t & qos_profile)
-  : SyncParametersClient(
-      std::make_shared<rclcpp::executors::SingleThreadedExecutor>(),
-      node,
-      remote_node_name,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)))
-  {}
-
-  template<typename NodeT>
   explicit SyncParametersClient(
     std::shared_ptr<NodeT> node,
     const std::string & remote_node_name = "",
@@ -409,23 +315,6 @@ public:
   {}
 
   template<typename NodeT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  SyncParametersClient(
-    rclcpp::Executor::SharedPtr executor,
-    std::shared_ptr<NodeT> node,
-    const std::string & remote_node_name,
-    const rmw_qos_profile_t & qos_profile)
-  : SyncParametersClient(
-      executor,
-      node->get_node_base_interface(),
-      node->get_node_topics_interface(),
-      node->get_node_graph_interface(),
-      node->get_node_services_interface(),
-      remote_node_name,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)))
-  {}
-
-  template<typename NodeT>
   SyncParametersClient(
     rclcpp::Executor::SharedPtr executor,
     std::shared_ptr<NodeT> node,
@@ -439,19 +328,6 @@ public:
       node->get_node_services_interface(),
       remote_node_name,
       qos_profile)
-  {}
-
-  template<typename NodeT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  SyncParametersClient(
-    NodeT * node,
-    const std::string & remote_node_name,
-    const rmw_qos_profile_t & qos_profile)
-  : SyncParametersClient(
-      std::make_shared<rclcpp::executors::SingleThreadedExecutor>(),
-      node,
-      remote_node_name,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)))
   {}
 
   template<typename NodeT>
@@ -467,23 +343,6 @@ public:
   {}
 
   template<typename NodeT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  SyncParametersClient(
-    rclcpp::Executor::SharedPtr executor,
-    NodeT * node,
-    const std::string & remote_node_name,
-    const rmw_qos_profile_t & qos_profile)
-  : SyncParametersClient(
-      executor,
-      node->get_node_base_interface(),
-      node->get_node_topics_interface(),
-      node->get_node_graph_interface(),
-      node->get_node_services_interface(),
-      remote_node_name,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)))
-  {}
-
-  template<typename NodeT>
   SyncParametersClient(
     rclcpp::Executor::SharedPtr executor,
     NodeT * node,
@@ -498,28 +357,6 @@ public:
       remote_node_name,
       qos_profile)
   {}
-
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  RCLCPP_PUBLIC
-  SyncParametersClient(
-    rclcpp::Executor::SharedPtr executor,
-    const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
-    const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface,
-    const rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_interface,
-    const rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_interface,
-    const std::string & remote_node_name,
-    const rmw_qos_profile_t & qos_profile)
-  : executor_(executor), node_base_interface_(node_base_interface)
-  {
-    async_parameters_client_ =
-      std::make_shared<AsyncParametersClient>(
-      node_base_interface,
-      node_topics_interface,
-      node_graph_interface,
-      node_services_interface,
-      remote_node_name,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)));
-  }
 
   RCLCPP_PUBLIC
   SyncParametersClient(

--- a/rclcpp/include/rclcpp/parameter_service.hpp
+++ b/rclcpp/include/rclcpp/parameter_service.hpp
@@ -40,20 +40,6 @@ class ParameterService
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(ParameterService)
 
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  RCLCPP_PUBLIC
-  ParameterService(
-    const std::shared_ptr<node_interfaces::NodeBaseInterface> node_base,
-    const std::shared_ptr<node_interfaces::NodeServicesInterface> node_services,
-    rclcpp::node_interfaces::NodeParametersInterface * node_params,
-    const rmw_qos_profile_t & qos_profile)
-  : ParameterService(
-      node_base,
-      node_services,
-      node_params,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)))
-  {}
-
   RCLCPP_PUBLIC
   ParameterService(
     const std::shared_ptr<node_interfaces::NodeBaseInterface> node_base,

--- a/rclcpp/include/rclcpp/service_factory.hpp
+++ b/rclcpp/include/rclcpp/service_factory.hpp
@@ -1,0 +1,83 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__SERVICE_FACTORY_HPP_
+#define RCLCPP__SERVICE_FACTORY_HPP_
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "rcl/service.h"
+
+#include "rclcpp/service.hpp"
+#include "rclcpp/qos.hpp"
+#include "rclcpp/service_options.hpp"
+#include "rclcpp/any_service_callback.hpp"
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+
+/// Factory with functions used to create a specific ServiceT.
+/**
+ * This factory class is used to encapsulate the template generated functions
+ * which are used during the creation of a specific service
+ * within a non-templated class.
+ *
+ * It is created using the create_service_factory function, which is usually
+ * called from a templated "create_service" method on the Node class, and
+ * is passed to the non-templated "create_service" method on the NodeTopics
+ * class where it is used to create and setup the Service.
+ *
+ * It also handles the single step construction of Services, first calling
+ * the constructor
+ */
+struct ServiceFactory
+{
+  // Creates a service object and returns it as a ServiceBase.
+  using ServiceFactoryFunction = std::function<
+    rclcpp::ServiceBase::SharedPtr(std::shared_ptr<rcl_node_t> node_handle)>;
+
+  const ServiceFactoryFunction create_typed_service;
+};
+
+/// Return a ServiceFactory with functions setup for creating a
+/// ServiceClass<ServiceT, AllocatorT>
+template<typename ServiceT, typename AllocatorT, typename ServiceClass>
+ServiceFactory
+create_service_factory(const rclcpp::ServiceOptionsWithAllocator<AllocatorT> & options)
+{
+  ServiceFactory factory {
+    // factory function that creates a specific ServiceT
+    [options](
+      std::shared_ptr<rcl_node_t> node_handle,
+      const std::string & service_name,
+      AnyServiceCallback<ServiceT, AllocatorT> any_callback,
+      const rclcpp::QoS & qos
+    ) -> std::shared_ptr<ServiceClass>
+    {
+      auto service = std::make_shared<ServiceClass>(
+        node_handle, service_name, any_callback, qos, options);
+      return service;
+    }
+  };
+
+  // return the factory now that it is populated
+  return factory;
+}
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__SERVICE_FACTORY_HPP_

--- a/rclcpp/include/rclcpp/service_options.hpp
+++ b/rclcpp/include/rclcpp/service_options.hpp
@@ -1,0 +1,115 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__SERVICE_OPTIONS_HPP_
+#define RCLCPP__SERVICE_OPTIONS_HPP_
+
+#include <memory>
+#include <random>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "rcl/service.h"
+
+#include "rclcpp/allocator/allocator_common.hpp"
+#include "rclcpp/qos.hpp"
+#include "rclcpp/qos_overriding_options.hpp"
+#include "rclcpp/event_handler.hpp"
+
+namespace rclcpp
+{
+
+class CallbackGroup;
+
+struct ServiceOptionsBase
+{
+  /// Whether or not to use default callbacks when user doesn't supply any in event_callbacks
+  bool use_default_callbacks = true;
+
+  QosOverridingOptions qos_overriding_options;
+
+  /// Callback group in which the waitable items from the service should be placed
+  std::shared_ptr<rclcpp::CallbackGroup> callback_group;
+};
+
+
+template<typename Allocator>
+struct ServiceOptionsWithAllocator : public ServiceOptionsBase
+{
+  static_assert(
+    std::is_void_v<typename std::allocator_traits<Allocator>::value_type>,
+    "Service allocator value type must be void");
+
+  /// Optional custom allocator
+  std::shared_ptr<Allocator> allocator = nullptr;
+
+  ServiceOptionsWithAllocator() {}
+
+  /// Constructor using base class as an input
+  explicit ServiceOptionsWithAllocator(const ServiceOptionsBase & service_options_base)
+  : ServiceOptionsBase(service_options_base)
+  {}
+
+  /// Convert this class, and a rclcpp::QoS to the rcl_service_options_t for low overhead
+  rcl_service_options_t
+  to_rcl_service_options(const rclcpp::QoS & qos) const
+  {
+    /// Destructure our rcl_service_options_t to set it up with the users values
+    rcl_service_options_t result = rcl_service_get_default_options();
+    result.qos = qos.get_rmw_qos_profile();
+    result.allocator = this->get_rcl_allocator();
+
+    return result;
+  }
+
+  /// Get or create the allocator if needed
+  std::shared_ptr<Allocator>
+  get_allocator() const
+  {
+    if (!this->allocator) {
+      if (!allocator_storage_) {
+        allocator_storage_ = std::make_shared<Allocator>();
+      }
+      return allocator_storage_;
+    }
+    return this->allocator;
+  }
+
+private:
+  using PlainAllocator =
+    typename std::allocator_traits<Allocator>::template rebind_alloc<char>;
+
+  rcl_allocator_t
+  get_rcl_allocator() const
+  {
+    if (!plain_allocator_storage_) {
+      plain_allocator_storage_ =
+        std::make_shared<PlainAllocator>(*this->get_allocator());
+    }
+    return rclcpp::allocator::get_rcl_allocator<char>(*plain_allocator_storage_);
+  }
+
+  // returning a copy of the allocator
+  mutable std::shared_ptr<Allocator> allocator_storage_;
+
+  // returning a copy of the plain allocator
+  mutable std::shared_ptr<PlainAllocator> plain_allocator_storage_;
+};
+
+using ServiceOptions = ServiceOptionsWithAllocator<std::allocator<void>>;
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__SERVICE_OPTIONS_HPP_

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -26,8 +26,6 @@
 #include "rmw/validate_namespace.h"
 #include "rmw/validate_node_name.h"
 
-#include "../logging_mutex.hpp"
-
 using rclcpp::exceptions::throw_from_rcl_error;
 
 using rclcpp::node_interfaces::NodeBase;

--- a/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
@@ -127,6 +127,42 @@ NodeTopics::add_subscription(
   }
 }
 
+rclcpp::ServiceBase::SharedPtr
+NodeTopics::create_service(
+  std::shared_ptr<rcl_node_t> node_handle,
+  const rclcpp::ServiceFactory & service_factory)
+{
+  // Create the ServiceT specific Service using the factory, but return it as ServiceBase.
+  return service_factory.create_typed_service(node_handle);
+}
+
+// TODO(cursedrock17): Work on the event_callback implementations
+// for the services and clients
+void
+NodeTopics::add_service(
+  // rclcpp::ServiceBase::SharedPtr service,
+  // rclcpp::CallbackGroup::SharedPtr callback_group
+)
+{
+}
+
+rclcpp::ClientBase::SharedPtr
+NodeTopics::create_client(
+  rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph,
+  const rclcpp::ClientFactory & client_factory)
+{
+  // Create the ServiceT specific Client using the factory, but return it as ClientBase.
+  return client_factory.create_typed_client(node_base_, node_graph);
+}
+
+void
+NodeTopics::add_client(
+  // rclcpp::ClientBase::SharedPtr client,
+  // rclcpp::CallbackGroup::SharedPtr callback_group
+)
+{
+}
+
 rclcpp::node_interfaces::NodeBaseInterface *
 NodeTopics::get_node_base_interface() const
 {

--- a/rclcpp/src/rclcpp/parameter_client.cpp
+++ b/rclcpp/src/rclcpp/parameter_client.cpp
@@ -35,7 +35,7 @@ AsyncParametersClient::AsyncParametersClient(
   const rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_interface,
   const rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_interface,
   const std::string & remote_node_name,
-  const rclcpp::QoS & qos_profile,
+  const rclcpp::QoS & qos,
   rclcpp::CallbackGroup::SharedPtr group)
 : node_topics_interface_(node_topics_interface)
 {
@@ -45,9 +45,6 @@ AsyncParametersClient::AsyncParametersClient(
     remote_node_name_ = node_base_interface->get_fully_qualified_name();
   }
 
-  rcl_client_options_t options = rcl_client_get_default_options();
-  options.qos = qos_profile.get_rmw_qos_profile();
-
   using rclcpp::Client;
   using rclcpp::ClientBase;
 
@@ -55,7 +52,7 @@ AsyncParametersClient::AsyncParametersClient(
     node_base_interface.get(),
     node_graph_interface,
     remote_node_name_ + "/" + parameter_service_names::get_parameters,
-    options);
+    qos);
   auto get_parameters_base = std::dynamic_pointer_cast<ClientBase>(get_parameters_client_);
   node_services_interface->add_client(get_parameters_base, group);
 
@@ -63,7 +60,7 @@ AsyncParametersClient::AsyncParametersClient(
     node_base_interface.get(),
     node_graph_interface,
     remote_node_name_ + "/" + parameter_service_names::get_parameter_types,
-    options);
+    qos);
   auto get_parameter_types_base =
     std::dynamic_pointer_cast<ClientBase>(get_parameter_types_client_);
   node_services_interface->add_client(get_parameter_types_base, group);
@@ -72,7 +69,7 @@ AsyncParametersClient::AsyncParametersClient(
     node_base_interface.get(),
     node_graph_interface,
     remote_node_name_ + "/" + parameter_service_names::set_parameters,
-    options);
+    qos);
   auto set_parameters_base = std::dynamic_pointer_cast<ClientBase>(set_parameters_client_);
   node_services_interface->add_client(set_parameters_base, group);
 
@@ -81,7 +78,7 @@ AsyncParametersClient::AsyncParametersClient(
     node_base_interface.get(),
     node_graph_interface,
     remote_node_name_ + "/" + parameter_service_names::set_parameters_atomically,
-    options);
+    qos);
   auto set_parameters_atomically_base = std::dynamic_pointer_cast<ClientBase>(
     set_parameters_atomically_client_);
   node_services_interface->add_client(set_parameters_atomically_base, group);
@@ -90,7 +87,7 @@ AsyncParametersClient::AsyncParametersClient(
     node_base_interface.get(),
     node_graph_interface,
     remote_node_name_ + "/" + parameter_service_names::list_parameters,
-    options);
+    qos);
   auto list_parameters_base = std::dynamic_pointer_cast<ClientBase>(list_parameters_client_);
   node_services_interface->add_client(list_parameters_base, group);
 
@@ -98,7 +95,7 @@ AsyncParametersClient::AsyncParametersClient(
     node_base_interface.get(),
     node_graph_interface,
     remote_node_name_ + "/" + parameter_service_names::describe_parameters,
-    options);
+    qos);
   auto describe_parameters_base =
     std::dynamic_pointer_cast<ClientBase>(describe_parameters_client_);
   node_services_interface->add_client(describe_parameters_base, group);

--- a/rclcpp/test/rclcpp/test_client.cpp
+++ b/rclcpp/test/rclcpp/test_client.cpp
@@ -93,26 +93,6 @@ TEST_F(TestClient, construction_and_destruction) {
     auto client = node->create_client<ListParameters>("service");
   }
   {
-    // suppress deprecated function warning
-    #if !defined(_WIN32)
-    # pragma GCC diagnostic push
-    # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    #else  // !defined(_WIN32)
-    # pragma warning(push)
-    # pragma warning(disable: 4996)
-    #endif
-
-    auto client = node->create_client<ListParameters>(
-      "service", rmw_qos_profile_services_default);
-
-    // remove warning suppression
-    #if !defined(_WIN32)
-    # pragma GCC diagnostic pop
-    #else  // !defined(_WIN32)
-    # pragma warning(pop)
-    #endif
-  }
-  {
     auto client = node->create_client<ListParameters>(
       "service", rclcpp::ServicesQoS());
   }
@@ -126,27 +106,6 @@ TEST_F(TestClient, construction_and_destruction) {
 }
 
 TEST_F(TestClient, construction_with_free_function) {
-  {
-    auto client = rclcpp::create_client<rcl_interfaces::srv::ListParameters>(
-      node->get_node_base_interface(),
-      node->get_node_graph_interface(),
-      node->get_node_services_interface(),
-      "service",
-      rmw_qos_profile_services_default,
-      nullptr);
-  }
-  {
-    ASSERT_THROW(
-    {
-      auto client = rclcpp::create_client<rcl_interfaces::srv::ListParameters>(
-        node->get_node_base_interface(),
-        node->get_node_graph_interface(),
-        node->get_node_services_interface(),
-        "invalid_?service",
-        rmw_qos_profile_services_default,
-        nullptr);
-    }, rclcpp::exceptions::InvalidServiceNameError);
-  }
   {
     auto client = rclcpp::create_client<rcl_interfaces::srv::ListParameters>(
       node->get_node_base_interface(),

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -282,56 +282,39 @@ public:
 
   /// Create and return a Client.
   /**
-   * \sa rclcpp::Node::create_client
-   * \deprecated use rclcpp::QoS instead of rmw_qos_profile_t
-   */
-  template<typename ServiceT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  typename rclcpp::Client<ServiceT>::SharedPtr
-  create_client(
-    const std::string & service_name,
-    const rmw_qos_profile_t & qos_profile,
-    rclcpp::CallbackGroup::SharedPtr group = nullptr);
-
-  /// Create and return a Client.
-  /**
    * \param[in] service_name The name on which the service is accessible.
    * \param[in] qos Quality of service profile for client.
    * \param[in] group Callback group to handle the reply to service calls.
+   * \param[in[ options Customization for allocator.
    * \return Shared pointer to the created client.
    */
-  template<typename ServiceT>
+  template<typename ServiceT, typename AllocatorT>
   typename rclcpp::Client<ServiceT>::SharedPtr
   create_client(
     const std::string & service_name,
     const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
-    rclcpp::CallbackGroup::SharedPtr group = nullptr);
-
-  /// Create and return a Service.
-  /**
-   * \sa rclcpp::Node::create_service
-   * \deprecated use rclcpp::QoS instead of rmw_qos_profile_t
-   */
-  template<typename ServiceT, typename CallbackT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  typename rclcpp::Service<ServiceT>::SharedPtr
-  create_service(
-    const std::string & service_name,
-    CallbackT && callback,
-    const rmw_qos_profile_t & qos_profile,
-    rclcpp::CallbackGroup::SharedPtr group = nullptr);
+    rclcpp::CallbackGroup::SharedPtr group = nullptr,
+    const rclcpp::ClientOptionsWithAllocator<AllocatorT> & options =
+    rclcpp::ClientOptionsWithAllocator<AllocatorT>()
+  );
 
   /// Create and return a Service.
   /**
    * \sa rclcpp::Node::create_service
    */
-  template<typename ServiceT, typename CallbackT>
+  template<
+    typename ServiceT,
+    typename CallbackT,
+    typename AllocatorT>
   typename rclcpp::Service<ServiceT>::SharedPtr
   create_service(
     const std::string & service_name,
     CallbackT && callback,
     const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
-    rclcpp::CallbackGroup::SharedPtr group = nullptr);
+    rclcpp::CallbackGroup::SharedPtr group = nullptr,
+    const rclcpp::ServiceOptionsWithAllocator<AllocatorT> & options =
+    rclcpp::ServiceOptionsWithAllocator<AllocatorT>()
+  );
 
   /// Create and return a GenericPublisher.
   /**

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
@@ -120,54 +120,35 @@ LifecycleNode::create_timer(
     this->node_timers_.get());
 }
 
-template<typename ServiceT>
-typename rclcpp::Client<ServiceT>::SharedPtr
-LifecycleNode::create_client(
-  const std::string & service_name,
-  const rmw_qos_profile_t & qos_profile,
-  rclcpp::CallbackGroup::SharedPtr group)
-{
-  return rclcpp::create_client<ServiceT>(
-    node_base_, node_graph_, node_services_,
-    service_name, qos_profile, group);
-}
-
-template<typename ServiceT>
+template<typename ServiceT, typename AllocatorT = std::allocator<void>>
 typename rclcpp::Client<ServiceT>::SharedPtr
 LifecycleNode::create_client(
   const std::string & service_name,
   const rclcpp::QoS & qos,
-  rclcpp::CallbackGroup::SharedPtr group)
+  rclcpp::CallbackGroup::SharedPtr group,
+  const rclcpp::ClientOptionsWithAllocator<AllocatorT> & options)
 {
-  return rclcpp::create_client<ServiceT>(
+  return rclcpp::create_client<ServiceT, AllocatorT>(
     node_base_, node_graph_, node_services_,
-    service_name, qos, group);
+    service_name, qos, group, options);
 }
 
-template<typename ServiceT, typename CallbackT>
-typename rclcpp::Service<ServiceT>::SharedPtr
-LifecycleNode::create_service(
-  const std::string & service_name,
-  CallbackT && callback,
-  const rmw_qos_profile_t & qos_profile,
-  rclcpp::CallbackGroup::SharedPtr group)
-{
-  return rclcpp::create_service<ServiceT, CallbackT>(
-    node_base_, node_services_,
-    service_name, std::forward<CallbackT>(callback), qos_profile, group);
-}
-
-template<typename ServiceT, typename CallbackT>
+template<
+  typename ServiceT,
+  typename CallbackT,
+  typename AllocatorT = std::allocator<void>>
 typename rclcpp::Service<ServiceT>::SharedPtr
 LifecycleNode::create_service(
   const std::string & service_name,
   CallbackT && callback,
   const rclcpp::QoS & qos,
-  rclcpp::CallbackGroup::SharedPtr group)
+  rclcpp::CallbackGroup::SharedPtr group,
+  const rclcpp::ServiceOptionsWithAllocator<AllocatorT> & options
+)
 {
-  return rclcpp::create_service<ServiceT, CallbackT>(
+  return rclcpp::create_service<ServiceT, CallbackT, AllocatorT>(
     node_base_, node_services_,
-    service_name, std::forward<CallbackT>(callback), qos, group);
+    service_name, std::forward<CallbackT>(callback), qos, group, options);
 }
 
 template<typename AllocatorT>

--- a/rclcpp_lifecycle/test/test_client.cpp
+++ b/rclcpp_lifecycle/test/test_client.cpp
@@ -62,27 +62,6 @@ TEST_F(TestClient, construction_and_destruction) {
     EXPECT_TRUE(client);
   }
   {
-    // suppress deprecated function warning
-    #if !defined(_WIN32)
-    # pragma GCC diagnostic push
-    # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    #else  // !defined(_WIN32)
-    # pragma warning(push)
-    # pragma warning(disable: 4996)
-    #endif
-
-    auto client = node_->create_client<ListParameters>(
-      "service", rmw_qos_profile_services_default);
-    EXPECT_TRUE(client);
-
-    // remove warning suppression
-    #if !defined(_WIN32)
-    # pragma GCC diagnostic pop
-    #else  // !defined(_WIN32)
-    # pragma warning(pop)
-    #endif
-  }
-  {
     auto client = node_->create_client<ListParameters>(
       "service", rclcpp::ServicesQoS());
     EXPECT_TRUE(client);
@@ -97,28 +76,6 @@ TEST_F(TestClient, construction_and_destruction) {
 }
 
 TEST_F(TestClient, construction_with_free_function) {
-  {
-    auto client = rclcpp::create_client<rcl_interfaces::srv::ListParameters>(
-      node_->get_node_base_interface(),
-      node_->get_node_graph_interface(),
-      node_->get_node_services_interface(),
-      "service",
-      rmw_qos_profile_services_default,
-      nullptr);
-    EXPECT_TRUE(client);
-  }
-  {
-    ASSERT_THROW(
-    {
-      auto client = rclcpp::create_client<rcl_interfaces::srv::ListParameters>(
-        node_->get_node_base_interface(),
-        node_->get_node_graph_interface(),
-        node_->get_node_services_interface(),
-        "invalid_?service",
-        rmw_qos_profile_services_default,
-        nullptr);
-    }, rclcpp::exceptions::InvalidServiceNameError);
-  }
   {
     auto client = rclcpp::create_client<rcl_interfaces::srv::ListParameters>(
       node_->get_node_base_interface(),

--- a/rclcpp_lifecycle/test/test_service.cpp
+++ b/rclcpp_lifecycle/test/test_service.cpp
@@ -68,30 +68,6 @@ TEST_F(TestService, construction_and_destruction) {
     const rclcpp::ServiceBase * const_service_base = service.get();
     EXPECT_NE(nullptr, const_service_base->get_service_handle());
   }
-  {
-    // suppress deprecated function warning
-    #if !defined(_WIN32)
-    # pragma GCC diagnostic push
-    # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    #else  // !defined(_WIN32)
-    # pragma warning(push)
-    # pragma warning(disable: 4996)
-    #endif
-
-    auto service = node->create_service<Empty>(
-      "service", callback, rmw_qos_profile_services_default);
-
-    // remove warning suppression
-    #if !defined(_WIN32)
-    # pragma GCC diagnostic pop
-    #else  // !defined(_WIN32)
-    # pragma warning(pop)
-    #endif
-
-    EXPECT_NE(nullptr, service->get_service_handle());
-    const rclcpp::ServiceBase * const_service_base = service.get();
-    EXPECT_NE(nullptr, const_service_base->get_service_handle());
-  }
 
   {
     ASSERT_THROW(


### PR DESCRIPTION
This is a pull request meant to handle issue #1989 which wanted to add customization to allocators in services and clients. The change ended up being longer than I expected and the way I have it right now, may be too much for this pull request, it may need to be split into two.

So I did do what was originally asked and created the `ServiceOptionsBase`, `ClientsOptionsBase`, `ServiceOptionsWithAllocator`, and `ClientOptionsWithAllocator` classes. These classes ended up being smaller than the publisher/subscriber side because there are [no rmw options](https://github.com/ros2/rcl/blob/960bb4ad353a43abfde5ecb831bd87823454bfc0/rcl/include/rcl/publisher.h#L51). Then these implementations were handled correctly in their respective create methods, by passing default `std::allocator<void>` allocators, therefore there shouldn't have been any breaking changes, which was the goal. 

According to the [distributions page](https://docs.ros.org/en/rolling/Releases.html) 
>  Rolling is continuously updated and can have in-place updates that include breaking changes.

Therefore, I created a breaking change when it game to how the user dealt with `qos`. Last July (2022), after the Humble release [this pull request](https://github.com/ros2/rclcpp/pull/1969/files) was made, which made services accept `rclcpp::QoS` and there are multiple sections of code with this deprecation warning: 
```
[[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
```
because it's now been after the release of Iron, I figured that I would remove these functions, this is because in the `ServiceOptionsWithAllocator` class [`to_rcl_service_options`](https://github.com/CursedRock17/rclcpp/blob/f970c3aeb383e413802c87b24d905b60a448c5a9/rclcpp/include/rclcpp/service_options.hpp#L67-L75) takes in a qos object and by default sets the default value of the result.qos. 

To be honest, I never thought about just adding another method that takes in a `rmw_qos_profile_t` beforehand, then just defaulting the `result.qos` that way, but if we need to prevent breaking change we can do that. Additionally if we need to prevent breaking change, I would restore the previous classes and just create symmetrical methods of those that we already have, except that they take in a `rmw_qos_profile_t` instead of a `rclcpp::QoS & qos`. Though I think removing the deprecating functions and doing this for the user makes the code base simpler, less error-prone, and more modern.

Aside from that concern, I began to follow up with the second part of the original issue 
> It may also be good to copy the Factory design pattern used on the publisher/subscriber implementation for consistency.

by creating those separate files/classes/methods and adding the functions to the `NodeTopics` class. But I stopped going too far because I felt that adding a bunch settings for callbacks and even more methods moved too far away from the original issues of service/client allocators, just wanted to make sure that they had a decent foundation here. After this is solved, I can open an issue/pull request that finishes that.

In terms of testing, I didn't add any special unit/performance tests because the changes passed all the original tests and because these are default values, they shouldn't fail, but I can add custom allocator tests if need be. Sorry if it's confusing or long.