### PR TITLE
Guard Condition custom Allocator

### DIFF
--- a/rclcpp/include/rclcpp/guard_condition.hpp
+++ b/rclcpp/include/rclcpp/guard_condition.hpp
@@ -17,9 +17,11 @@
 
 #include <atomic>
 
+#include "guard_condition_options.hpp"
 #include "rcl/guard_condition.h"
 
 #include "rclcpp/context.hpp"
+#include "rclcpp/guard_condition_options.hpp"
 #include "rclcpp/contexts/default_context.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/visibility_control.hpp"
@@ -33,25 +35,40 @@ class GuardCondition
 public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(GuardCondition)
 
-  // TODO(wjwwood): support custom allocator, maybe restrict to polymorphic allocator
   /// Construct the guard condition, optionally specifying which Context to use.
   /**
    * \param[in] context Optional custom context to be used.
    *   Defaults to using the global default context singleton.
    *   Shared ownership of the context is held with the guard condition until
    *   destruction.
-   * \param[in] guard_condition_options Optional guard condition options to be used.
+   * \param[in] options Optional guard condition options to be used.
    *   Defaults to using the default guard condition options.
+   *   Can change the underlying rcl_allocator in rcl_guard_options_t
+   *   with the chosen AllocatorT representing a std::allocator
    * \throws std::invalid_argument if the context is nullptr.
    * \throws rclcpp::exceptions::RCLError based exceptions when underlying
    *   rcl functions fail.
    */
   RCLCPP_PUBLIC
+  template<typename AllocatorT = std::allocator<void>>
   explicit GuardCondition(
     rclcpp::Context::SharedPtr context =
     rclcpp::contexts::get_global_default_context(),
-    rcl_guard_condition_options_t guard_condition_options =
-    rcl_guard_condition_get_default_options());
+    rclcpp::GuardConditionWithAllocator<AllocatorT> options =
+    GuardConditionWithAllocator<AllocatorT>())
+: context_(context), rcl_guard_condition_{rcl_get_zero_initialized_guard_condition()}
+{
+  if (!context_) {
+    throw std::invalid_argument("context argument unexpectedly nullptr");
+  }
+  rcl_ret_t ret = rcl_guard_condition_init(
+    &this->rcl_guard_condition_,
+    context_->get_rcl_context().get(),
+    options.to_rcl_guard_condition_options());
+  if (RCL_RET_OK != ret) {
+    rclcpp::exceptions::throw_from_rcl_error(ret, "failed to create guard condition");
+  }
+}
 
   RCLCPP_PUBLIC
   virtual

--- a/rclcpp/include/rclcpp/guard_condition_options.hpp
+++ b/rclcpp/include/rclcpp/guard_condition_options.hpp
@@ -1,0 +1,84 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__GUARD_CONDITION_ALLOCATOR_HPP_
+#define RCLCPP__GUARD_CONDITION_ALLOCATOR_HPP_
+
+#include <memory>
+
+#include "rcl/guard_condition.h"
+
+#include "rclcpp/allocator/allocator_common.hpp"
+#include "rclcpp/guard_condition.hpp"
+
+namespace rclcpp
+{
+
+template<typename Allocator>
+struct GuardConditionWithAllocator
+{
+  /// Optional custom allocator
+  std::shared_ptr<Allocator> allocator = nullptr;
+
+  GuardConditionWithAllocator() {};
+
+  /// Convert this class into a rcl_guard_condition_options_t
+  rcl_guard_condition_options_t
+  to_rcl_guard_condition_options() const
+  {
+    rcl_guard_condition_options_t result = rcl_guard_condition_get_default_options();
+    result.allocator = this->get_allocator();
+    return result;
+  }
+
+  /// Get the allocator, creating one if needed
+  std::shared_ptr<Allocator>
+  get_allocator() const
+  {
+    if (!this->allocator) {
+      if (!allocator_storage_) {
+        allocator_storage_ = std::make_shared<Allocator>();
+      }
+      return allocator_storage_;
+    }
+    return this->allocator;
+  }
+
+  private:
+
+  using PlainAllocator =
+    typename std::allocator_traits<Allocator>::template rebind_alloc<char>;
+
+  rcl_allocator_t
+  get_rcl_allocator() const
+  {
+    if (!plain_allocator_storage_) {
+      std::make_shared<PlainAllocator>(*this->get_rcl_allocator());
+    }
+    return rclcpp::allocator::get_rcl_allocator<char>(*plain_allocator_storage_);
+  }
+
+  // always returns a copy of the same allocator
+  mutable std::shared_ptr<Allocator> allocator_storage_;
+
+  // always returns a copy of the same allocator
+  mutable std::shared_ptr<PlainAllocator> plain_allocator_storage_;
+};
+
+using GuardConditionOptions =
+  GuardConditionWithAllocator<std::allocator<void>>;
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__GUARD_CONDITION_ALLOCATOR_HPP_

--- a/rclcpp/src/rclcpp/guard_condition.cpp
+++ b/rclcpp/src/rclcpp/guard_condition.cpp
@@ -22,23 +22,6 @@
 namespace rclcpp
 {
 
-GuardCondition::GuardCondition(
-  rclcpp::Context::SharedPtr context,
-  rcl_guard_condition_options_t guard_condition_options)
-: context_(context), rcl_guard_condition_{rcl_get_zero_initialized_guard_condition()}
-{
-  if (!context_) {
-    throw std::invalid_argument("context argument unexpectedly nullptr");
-  }
-  rcl_ret_t ret = rcl_guard_condition_init(
-    &this->rcl_guard_condition_,
-    context_->get_rcl_context().get(),
-    guard_condition_options);
-  if (RCL_RET_OK != ret) {
-    rclcpp::exceptions::throw_from_rcl_error(ret, "failed to create guard condition");
-  }
-}
-
 GuardCondition::~GuardCondition()
 {
   rcl_ret_t ret = rcl_guard_condition_fini(&this->rcl_guard_condition_);


### PR DESCRIPTION
This pull request doesn't address a particular issue number, but it attempts to help with a todo [listed here:](https://github.com/ros2/rclcpp/blob/rolling/rclcpp/include/rclcpp/guard_condition.hpp#L36)
>   // TODO(wjwwood): support custom allocator, maybe restrict to polymorphic allocator

This is still a working pull request, but I implemented the start and have been noticing a trend in the rclcpp library where all of the rcl_some_type_options_t almost always have an `rcl_allocator_t` trait to them, so they could all have custom allocators.

 For this though, the original request was a `polymorphic_allocator` which I assumed meant [`std::pmr::polymorphic_allocator`](https://en.cppreference.com/w/cpp/memory/polymorphic_allocator) which is interesting because currently things like [publishers](https://github.com/ros2/rclcpp/blob/rolling/rclcpp/include/rclcpp/publisher.hpp#L76) use the regular `std::allocator`. I couldn't get it to compile originally because I couldn't find the `memory_resource` header that it's in (the standard library), which might just be because of my machine. But I did want to bring up this discussion, to see if runtime dynamic allocation is even worth it compared to basic static allocation. 