### PR TITLE
Adding Missing Group Exceptions

### DIFF
--- a/rclcpp/include/rclcpp/exceptions/exceptions.hpp
+++ b/rclcpp/include/rclcpp/exceptions/exceptions.hpp
@@ -222,7 +222,7 @@ public:
   : std::runtime_error("event already registered") {}
 };
 
-/// Thrown when a group is missing from the node, when it wants to utilize the group.
+/// Thrown when a callback group is missing from the node, when it wants to utilize the group.
 class MissingGroupNodeException : public std::runtime_error
 {
 public:

--- a/rclcpp/include/rclcpp/exceptions/exceptions.hpp
+++ b/rclcpp/include/rclcpp/exceptions/exceptions.hpp
@@ -222,6 +222,14 @@ public:
   : std::runtime_error("event already registered") {}
 };
 
+/// Thrown when a group is missing from the node, when it wants to utilize the group.
+class MissingGroupNodeException : public std::runtime_error
+{
+public:
+  explicit MissingGroupNodeException(const std::string & obj_type)
+  : std::runtime_error("cannot create: " + obj_type + " , callback group not in node") {}
+};
+
 /// Thrown if passed parameters are inconsistent or invalid
 class InvalidParametersException : public std::runtime_error
 {

--- a/rclcpp/src/rclcpp/node_interfaces/node_services.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_services.cpp
@@ -32,8 +32,7 @@ NodeServices::add_service(
 {
   if (group) {
     if (!node_base_->callback_group_in_node(group)) {
-      // TODO(jacquelinekay): use custom exception
-      throw std::runtime_error("Cannot create service, group not in node.");
+      throw rclcpp::exceptions::MissingGroupNodeException("service");
     }
   } else {
     group = node_base_->get_default_callback_group();
@@ -58,8 +57,7 @@ NodeServices::add_client(
 {
   if (group) {
     if (!node_base_->callback_group_in_node(group)) {
-      // TODO(jacquelinekay): use custom exception
-      throw std::runtime_error("Cannot create client, group not in node.");
+      throw rclcpp::exceptions::MissingGroupNodeException("client");
     }
   } else {
     group = node_base_->get_default_callback_group();

--- a/rclcpp/src/rclcpp/node_interfaces/node_timers.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_timers.cpp
@@ -34,8 +34,7 @@ NodeTimers::add_timer(
 {
   if (callback_group) {
     if (!node_base_->callback_group_in_node(callback_group)) {
-      // TODO(jacquelinekay): use custom exception
-      throw std::runtime_error("Cannot create timer, group not in node.");
+      throw rclcpp::exceptions::MissingGroupNodeException("timer");
     }
   } else {
     callback_group = node_base_->get_default_callback_group();

--- a/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_topics.cpp
@@ -58,7 +58,7 @@ NodeTopics::add_publisher(
   // Assign to a group.
   if (callback_group) {
     if (!node_base_->callback_group_in_node(callback_group)) {
-      throw std::runtime_error("Cannot create publisher, callback group not in node.");
+      throw rclcpp::exceptions::MissingGroupNodeException("publisher");
     }
   } else {
     callback_group = node_base_->get_default_callback_group();
@@ -97,8 +97,7 @@ NodeTopics::add_subscription(
   // Assign to a group.
   if (callback_group) {
     if (!node_base_->callback_group_in_node(callback_group)) {
-      // TODO(jacquelinekay): use custom exception
-      throw std::runtime_error("Cannot create subscription, callback group not in node.");
+      throw rclcpp::exceptions::MissingGroupNodeException("subscription");
     }
   } else {
     callback_group = node_base_->get_default_callback_group();

--- a/rclcpp/src/rclcpp/node_interfaces/node_waitables.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_waitables.cpp
@@ -32,8 +32,7 @@ NodeWaitables::add_waitable(
 {
   if (group) {
     if (!node_base_->callback_group_in_node(group)) {
-      // TODO(jacobperron): use custom exception
-      throw std::runtime_error("Cannot create waitable, group not in node.");
+      throw rclcpp::exceptions::MissingGroupNodeException("waitable");
     }
   } else {
     group = node_base_->get_default_callback_group();

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_services.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_services.cpp
@@ -92,7 +92,7 @@ TEST_F(TestNodeService, add_service)
     different_node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   RCLCPP_EXPECT_THROW_EQ(
     node_services->add_service(service, callback_group_in_different_node),
-    std::runtime_error("Cannot create service, group not in node."));
+    rclcpp::exceptions::MissingGroupNodeException("service"));
 }
 
 TEST_F(TestNodeService, add_service_rcl_trigger_guard_condition_error)
@@ -119,7 +119,7 @@ TEST_F(TestNodeService, add_client)
     different_node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   RCLCPP_EXPECT_THROW_EQ(
     node_services->add_client(client, callback_group_in_different_node),
-    std::runtime_error("Cannot create client, group not in node."));
+    rclcpp::exceptions::MissingGroupNodeException("client"));
 }
 
 TEST_F(TestNodeService, add_client_rcl_trigger_guard_condition_error)

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_timers.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_timers.cpp
@@ -75,7 +75,7 @@ TEST_F(TestNodeTimers, add_timer)
     different_node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   RCLCPP_EXPECT_THROW_EQ(
     node_timers->add_timer(timer, callback_group_in_different_node),
-    std::runtime_error("Cannot create timer, group not in node."));
+    rclcpp::exceptions::MissingGroupNodeException("timer"));
 }
 
 TEST_F(TestNodeTimers, add_timer_rcl_trigger_guard_condition_error)

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_waitables.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_waitables.cpp
@@ -78,7 +78,7 @@ TEST_F(TestNodeWaitables, add_remove_waitable)
     node_waitables->add_waitable(waitable, callback_group1));
   RCLCPP_EXPECT_THROW_EQ(
     node_waitables->add_waitable(waitable, callback_group2),
-    std::runtime_error("Cannot create waitable, group not in node."));
+    rclcpp::exceptions::MissingGroupNodeException("waitable"));
   EXPECT_NO_THROW(node_waitables->remove_waitable(waitable, callback_group1));
   EXPECT_NO_THROW(node_waitables->remove_waitable(waitable, callback_group2));
 


### PR DESCRIPTION
Follow up of issue #2247 which is meant to address a range of TODOs specifically for `std::runtime_error` with the description of
```
throw std::runtime_error("Cannot create something, group not in node.");
```
All of the errors follow that same format, so we can create a general class in `exceptions.hpp` that just take a `const std::string &` of whatever `something` is and runs the error in a much cleaner format.