### PR TITLE
Add RCLCPP_*_FORMAT logging macros 

### DIFF
--- a/rclcpp/include/rclcpp/logging.hpp
+++ b/rclcpp/include/rclcpp/logging.hpp
@@ -457,6 +457,20 @@
 #define RCLCPP_DEBUG_STREAM_THROTTLE(...)
 /// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
 #define RCLCPP_DEBUG_STREAM_SKIPFIRST_THROTTLE(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_DEBUG_FMT(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_DEBUG_FMT_ONCE(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_DEBUG_FMT_EXPRESSION(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_DEBUG_FMT_FUNCTION(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_DEBUG_FMT_SKIPFIRST(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_DEBUG_FMT_THROTTLE(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_DEBUG_FMT_SKIPFIRST_THROTTLE(...)
 
 #else
 /**
@@ -557,6 +571,54 @@
   RCLCPP_LOG_STREAM_SKIPFIRST_THROTTLE(RCUTILS_LOG_SEVERITY_DEBUG, logger, clock, duration, \
     stream_arg)
 
+/**
+ * \def RCLCPP_DEBUG_FMT
+ * \copydoc RCLCPP_LOG_FMT
+ */
+#define RCLCPP_DEBUG_FMT(logger, ...) RCLCPP_LOG_FMT(RCUTILS_LOG_SEVERITY_DEBUG, logger, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_DEBUG_FMT_ONCE
+ * \copydoc RCLCPP_LOG_FMT_ONCE
+ */
+#define RCLCPP_DEBUG_FMT_ONCE(logger, ...) \
+  RCLCPP_LOG_FMT_ONCE(RCUTILS_LOG_SEVERITY_DEBUG, logger, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_DEBUG_FMT_EXPRESSION
+ * \copydoc RCLCPP_LOG_FMT_EXPRESSION
+ */
+#define RCLCPP_DEBUG_FMT_EXPRESSION(logger, expression, ...) \
+  RCLCPP_LOG_FMT_EXPRESSION(RCUTILS_LOG_SEVERITY_DEBUG, logger, expression, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_DEBUG_FMT_FUNCTION
+ * \copydoc RCLCPP_LOG_FMT_FUNCTION
+ */
+#define RCLCPP_DEBUG_FMT_FUNCTION(logger, function, ...) \
+  RCLCPP_LOG_FMT_FUNCTION(RCUTILS_LOG_SEVERITY_DEBUG, logger, function, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_DEBUG_FMT_SKIPFIRST
+ * \copydoc RCLCPP_LOG_FMT_SKIPFIRST
+ */
+#define RCLCPP_DEBUG_FMT_SKIPFIRST(logger, ...) \
+  RCLCPP_LOG_FMT_SKIPFIRST(RCUTILS_LOG_SEVERITY_DEBUG, logger, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_DEBUG_FMT_THROTTLE
+ * \copydoc RCLCPP_LOG_FMT_THROTTLE
+ */
+#define RCLCPP_DEBUG_FMT_THROTTLE(logger, clock, duration, ...) \
+  RCLCPP_LOG_FMT_THROTTLE(RCUTILS_LOG_SEVERITY_DEBUG, logger, clock, duration, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_DEBUG_FMT_SKIPFIRST_THROTTLE
+ * \copydoc RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE
+ */
+#define RCLCPP_DEBUG_FMT_SKIPFIRST_THROTTLE(logger, clock, duration, ...) \
+  RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE(RCUTILS_LOG_SEVERITY_DEBUG, logger, clock, duration, __VA_ARGS__)
+
 #endif
 
 /** @name Logging macros for severity INFO.
@@ -591,6 +653,20 @@
 #define RCLCPP_INFO_STREAM_THROTTLE(...)
 /// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
 #define RCLCPP_INFO_STREAM_SKIPFIRST_THROTTLE(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_INFO_FMT(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_INFO_FMT_ONCE(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_INFO_FMT_EXPRESSION(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_INFO_FMT_FUNCTION(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_INFO_FMT_SKIPFIRST(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_INFO_FMT_THROTTLE(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_INFO_FMT_SKIPFIRST_THROTTLE(...)
 
 #else
 /**
@@ -691,6 +767,54 @@
   RCLCPP_LOG_STREAM_SKIPFIRST_THROTTLE(RCUTILS_LOG_SEVERITY_INFO, logger, clock, duration, \
     stream_arg)
 
+/**
+ * \def RCLCPP_INFO_FMT
+ * \copydoc RCLCPP_LOG_FMT
+ */
+#define RCLCPP_INFO_FMT(logger, ...) RCLCPP_LOG_FMT(RCUTILS_LOG_SEVERITY_INFO, logger, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_INFO_FMT_ONCE
+ * \copydoc RCLCPP_LOG_FMT_ONCE
+ */
+#define RCLCPP_INFO_FMT_ONCE(logger, ...) \
+  RCLCPP_LOG_FMT_ONCE(RCUTILS_LOG_SEVERITY_INFO, logger, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_INFO_FMT_EXPRESSION
+ * \copydoc RCLCPP_LOG_FMT_EXPRESSION
+ */
+#define RCLCPP_INFO_FMT_EXPRESSION(logger, expression, ...) \
+  RCLCPP_LOG_FMT_EXPRESSION(RCUTILS_LOG_SEVERITY_INFO, logger, expression, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_INFO_FMT_FUNCTION
+ * \copydoc RCLCPP_LOG_FMT_FUNCTION
+ */
+#define RCLCPP_INFO_FMT_FUNCTION(logger, function, ...) \
+  RCLCPP_LOG_FMT_FUNCTION(RCUTILS_LOG_SEVERITY_INFO, logger, function, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_INFO_FMT_SKIPFIRST
+ * \copydoc RCLCPP_LOG_FMT_SKIPFIRST
+ */
+#define RCLCPP_INFO_FMT_SKIPFIRST(logger, ...) \
+  RCLCPP_LOG_FMT_SKIPFIRST(RCUTILS_LOG_SEVERITY_INFO, logger, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_INFO_FMT_THROTTLE
+ * \copydoc RCLCPP_LOG_FMT_THROTTLE
+ */
+#define RCLCPP_INFO_FMT_THROTTLE(logger, clock, duration, ...) \
+  RCLCPP_LOG_FMT_THROTTLE(RCUTILS_LOG_SEVERITY_INFO, logger, clock, duration, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_INFO_FMT_SKIPFIRST_THROTTLE
+ * \copydoc RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE
+ */
+#define RCLCPP_INFO_FMT_SKIPFIRST_THROTTLE(logger, clock, duration, ...) \
+  RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE(RCUTILS_LOG_SEVERITY_INFO, logger, clock, duration, __VA_ARGS__)
+
 #endif
 
 /** @name Logging macros for severity WARN.
@@ -725,6 +849,20 @@
 #define RCLCPP_WARN_STREAM_THROTTLE(...)
 /// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
 #define RCLCPP_WARN_STREAM_SKIPFIRST_THROTTLE(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_WARN_FMT(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_WARN_FMT_ONCE(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_WARN_FMT_EXPRESSION(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_WARN_FMT_FUNCTION(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_WARN_FMT_SKIPFIRST(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_WARN_FMT_THROTTLE(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_WARN_FMT_SKIPFIRST_THROTTLE(...)
 
 #else
 /**
@@ -825,6 +963,54 @@
   RCLCPP_LOG_STREAM_SKIPFIRST_THROTTLE(RCUTILS_LOG_SEVERITY_WARN, logger, clock, duration, \
     stream_arg)
 
+/**
+ * \def RCLCPP_WARN_FMT
+ * \copydoc RCLCPP_LOG_FMT
+ */
+#define RCLCPP_WARN_FMT(logger, ...) RCLCPP_LOG_FMT(RCUTILS_LOG_SEVERITY_WARN, logger, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_WARN_FMT_ONCE
+ * \copydoc RCLCPP_LOG_FMT_ONCE
+ */
+#define RCLCPP_WARN_FMT_ONCE(logger, ...) \
+  RCLCPP_LOG_FMT_ONCE(RCUTILS_LOG_SEVERITY_WARN, logger, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_WARN_FMT_EXPRESSION
+ * \copydoc RCLCPP_LOG_FMT_EXPRESSION
+ */
+#define RCLCPP_WARN_FMT_EXPRESSION(logger, expression, ...) \
+  RCLCPP_LOG_FMT_EXPRESSION(RCUTILS_LOG_SEVERITY_WARN, logger, expression, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_WARN_FMT_FUNCTION
+ * \copydoc RCLCPP_LOG_FMT_FUNCTION
+ */
+#define RCLCPP_WARN_FMT_FUNCTION(logger, function, ...) \
+  RCLCPP_LOG_FMT_FUNCTION(RCUTILS_LOG_SEVERITY_WARN, logger, function, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_WARN_FMT_SKIPFIRST
+ * \copydoc RCLCPP_LOG_FMT_SKIPFIRST
+ */
+#define RCLCPP_WARN_FMT_SKIPFIRST(logger, ...) \
+  RCLCPP_LOG_FMT_SKIPFIRST(RCUTILS_LOG_SEVERITY_WARN, logger, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_WARN_FMT_THROTTLE
+ * \copydoc RCLCPP_LOG_FMT_THROTTLE
+ */
+#define RCLCPP_WARN_FMT_THROTTLE(logger, clock, duration, ...) \
+  RCLCPP_LOG_FMT_THROTTLE(RCUTILS_LOG_SEVERITY_WARN, logger, clock, duration, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_WARN_FMT_SKIPFIRST_THROTTLE
+ * \copydoc RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE
+ */
+#define RCLCPP_WARN_FMT_SKIPFIRST_THROTTLE(logger, clock, duration, ...) \
+  RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE(RCUTILS_LOG_SEVERITY_WARN, logger, clock, duration, __VA_ARGS__)
+
 #endif
 
 /** @name Logging macros for severity ERROR.
@@ -859,6 +1045,20 @@
 #define RCLCPP_ERROR_STREAM_THROTTLE(...)
 /// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
 #define RCLCPP_ERROR_STREAM_SKIPFIRST_THROTTLE(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_ERROR_FMT(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_ERROR_FMT_ONCE(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_ERROR_FMT_EXPRESSION(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_ERROR_FMT_FUNCTION(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_ERROR_FMT_SKIPFIRST(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_ERROR_FMT_THROTTLE(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_ERROR_FMT_SKIPFIRST_THROTTLE(...)
 
 #else
 /**
@@ -959,6 +1159,54 @@
   RCLCPP_LOG_STREAM_SKIPFIRST_THROTTLE(RCUTILS_LOG_SEVERITY_ERROR, logger, clock, duration, \
     stream_arg)
 
+/**
+ * \def RCLCPP_ERROR_FMT
+ * \copydoc RCLCPP_LOG_FMT
+ */
+#define RCLCPP_ERROR_FMT(logger, ...) RCLCPP_LOG_FMT(RCUTILS_LOG_SEVERITY_ERROR, logger, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_ERROR_FMT_ONCE
+ * \copydoc RCLCPP_LOG_FMT_ONCE
+ */
+#define RCLCPP_ERROR_FMT_ONCE(logger, ...) \
+  RCLCPP_LOG_FMT_ONCE(RCUTILS_LOG_SEVERITY_ERROR, logger, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_ERROR_FMT_EXPRESSION
+ * \copydoc RCLCPP_LOG_FMT_EXPRESSION
+ */
+#define RCLCPP_ERROR_FMT_EXPRESSION(logger, expression, ...) \
+  RCLCPP_LOG_FMT_EXPRESSION(RCUTILS_LOG_SEVERITY_ERROR, logger, expression, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_ERROR_FMT_FUNCTION
+ * \copydoc RCLCPP_LOG_FMT_FUNCTION
+ */
+#define RCLCPP_ERROR_FMT_FUNCTION(logger, function, ...) \
+  RCLCPP_LOG_FMT_FUNCTION(RCUTILS_LOG_SEVERITY_ERROR, logger, function, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_ERROR_FMT_SKIPFIRST
+ * \copydoc RCLCPP_LOG_FMT_SKIPFIRST
+ */
+#define RCLCPP_ERROR_FMT_SKIPFIRST(logger, ...) \
+  RCLCPP_LOG_FMT_SKIPFIRST(RCUTILS_LOG_SEVERITY_ERROR, logger, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_ERROR_FMT_THROTTLE
+ * \copydoc RCLCPP_LOG_FMT_THROTTLE
+ */
+#define RCLCPP_ERROR_FMT_THROTTLE(logger, clock, duration, ...) \
+  RCLCPP_LOG_FMT_THROTTLE(RCUTILS_LOG_SEVERITY_ERROR, logger, clock, duration, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_ERROR_FMT_SKIPFIRST_THROTTLE
+ * \copydoc RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE
+ */
+#define RCLCPP_ERROR_FMT_SKIPFIRST_THROTTLE(logger, clock, duration, ...) \
+  RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE(RCUTILS_LOG_SEVERITY_ERROR, logger, clock, duration, __VA_ARGS__)
+
 #endif
 
 /** @name Logging macros for severity FATAL.
@@ -993,6 +1241,20 @@
 #define RCLCPP_FATAL_STREAM_THROTTLE(...)
 /// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
 #define RCLCPP_FATAL_STREAM_SKIPFIRST_THROTTLE(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_FATAL_FMT(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_FATAL_FMT_ONCE(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_FATAL_FMT_EXPRESSION(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_FATAL_FMT_FUNCTION(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_FATAL_FMT_SKIPFIRST(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_FATAL_FMT_THROTTLE(...)
+/// Empty logging macro due to the preprocessor definition of RCLCPP_LOG_MIN_SEVERITY.
+#define RCLCPP_FATAL_FMT_SKIPFIRST_THROTTLE(...)
 
 #else
 /**
@@ -1092,6 +1354,54 @@
 #define RCLCPP_FATAL_STREAM_SKIPFIRST_THROTTLE(logger, clock, duration, stream_arg) \
   RCLCPP_LOG_STREAM_SKIPFIRST_THROTTLE(RCUTILS_LOG_SEVERITY_FATAL, logger, clock, duration, \
     stream_arg)
+
+/**
+ * \def RCLCPP_FATAL_FMT
+ * \copydoc RCLCPP_LOG_FMT
+ */
+#define RCLCPP_FATAL_FMT(logger, ...) RCLCPP_LOG_FMT(RCUTILS_LOG_SEVERITY_FATAL, logger, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_FATAL_FMT_ONCE
+ * \copydoc RCLCPP_LOG_FMT_ONCE
+ */
+#define RCLCPP_FATAL_FMT_ONCE(logger, ...) \
+  RCLCPP_LOG_FMT_ONCE(RCUTILS_LOG_SEVERITY_FATAL, logger, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_FATAL_FMT_EXPRESSION
+ * \copydoc RCLCPP_LOG_FMT_EXPRESSION
+ */
+#define RCLCPP_FATAL_FMT_EXPRESSION(logger, expression, ...) \
+  RCLCPP_LOG_FMT_EXPRESSION(RCUTILS_LOG_SEVERITY_FATAL, logger, expression, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_FATAL_FMT_FUNCTION
+ * \copydoc RCLCPP_LOG_FMT_FUNCTION
+ */
+#define RCLCPP_FATAL_FMT_FUNCTION(logger, function, ...) \
+  RCLCPP_LOG_FMT_FUNCTION(RCUTILS_LOG_SEVERITY_FATAL, logger, function, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_FATAL_FMT_SKIPFIRST
+ * \copydoc RCLCPP_LOG_FMT_SKIPFIRST
+ */
+#define RCLCPP_FATAL_FMT_SKIPFIRST(logger, ...) \
+  RCLCPP_LOG_FMT_SKIPFIRST(RCUTILS_LOG_SEVERITY_FATAL, logger, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_FATAL_FMT_THROTTLE
+ * \copydoc RCLCPP_LOG_FMT_THROTTLE
+ */
+#define RCLCPP_FATAL_FMT_THROTTLE(logger, clock, duration, ...) \
+  RCLCPP_LOG_FMT_THROTTLE(RCUTILS_LOG_SEVERITY_FATAL, logger, clock, duration, __VA_ARGS__)
+
+/**
+ * \def RCLCPP_FATAL_FMT_SKIPFIRST_THROTTLE
+ * \copydoc RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE
+ */
+#define RCLCPP_FATAL_FMT_SKIPFIRST_THROTTLE(logger, clock, duration, ...) \
+  RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE(RCUTILS_LOG_SEVERITY_FATAL, logger, clock, duration, __VA_ARGS__)
 
 #endif
 

--- a/rclcpp/include/rclcpp/logging.hpp
+++ b/rclcpp/include/rclcpp/logging.hpp
@@ -15,6 +15,7 @@
 #ifndef RCLCPP__LOGGING_HPP_
 #define RCLCPP__LOGGING_HPP_
 
+#include <format>
 #include <sstream>
 #include <type_traits>
 
@@ -298,6 +299,120 @@
       duration, \
       (logger).get_name(), \
       "%s", rclcpp_stream_ss_.str().c_str()); \
+  } while (0)
+
+/**
+ * \def RCLCPP_LOG_FMT
+ * Log a message with given severity.
+ *
+ * \param logger The `rclcpp::Logger` to use
+ * \param ... The variable arguments passed into std::format
+ */
+#define RCLCPP_LOG_FMT(severity, logger, ...) \
+  do { \
+    RCLCPP_STATIC_ASSERT_LOGGER(logger); \
+    RCUTILS_LOG_NAMED(severity, (logger).get_name(), "%s", std::format(__VA_ARGS__).c_str()); \
+  } while (0)
+
+/**
+ * \def RCLCPP_LOG_FMT_ONCE
+ * Log a message with given severity with the following condition:
+ * - All log calls except the first one are ignored.
+ *
+ * \param logger The `rclcpp::Logger` to use
+ * \param ... The variable arguments passed into std::format
+ */
+#define RCLCPP_LOG_FMT_ONCE(severity, logger, ...) \
+  do { \
+    RCLCPP_STATIC_ASSERT_LOGGER(logger); \
+    RCUTILS_LOG_ONCE_NAMED(severity, (logger).get_name(), "%s", std::format(__VA_ARGS__).c_str()); \
+  } while (0)
+
+/**
+ * \def RCLCPP_LOG_FMT_EXPRESSION
+ * Log a message with given severity with the following condition:
+ * - Log calls are ignored when the expression evaluates to false.
+ *
+ * \param logger The `rclcpp::Logger` to use
+ * \param expression The expression determining if the message should be logged
+ * \param ... The variable arguments passed into std::format
+ */
+#define RCLCPP_LOG_FMT_EXPRESSION(severity, logger, expression, ...) \
+  do { \
+    RCLCPP_STATIC_ASSERT_LOGGER(logger); \
+    RCUTILS_LOG_EXPRESSION_NAMED(severity, expression, (logger).get_name(), "%s", std::format(__VA_ARGS__).c_str()); \
+  } while (0)
+
+/**
+ * \def RCLCPP_LOG_FMT_FUNCTION
+ * Log a message with given severity with the following condition:
+ * - Log calls are ignored when the function returns false.
+ *
+ * \param logger The `rclcpp::Logger` to use
+ * \param function The functions return value determines if the message should be logged
+ * \param ... The variable arguments passed into std::format
+ */
+#define RCLCPP_LOG_FMT_FUNCTION(severity, logger, function, ...) \
+  do { \
+    RCLCPP_STATIC_ASSERT_LOGGER(logger); \
+    RCUTILS_LOG_FUNCTION_NAMED(severity, function, (logger).get_name(), "%s", std::format(__VA_ARGS__).c_str()); \
+  } while (0)
+
+/**
+ * \def RCLCPP_LOG_FMT_SKIPFIRST
+ * Log a message with given severity with the following condition:
+ * - The first log call is ignored but all subsequent calls are processed.
+ *
+ * \param logger The `rclcpp::Logger` to use
+ * \param ... The variable arguments passed into std::format
+ */
+#define RCLCPP_LOG_FMT_SKIPFIRST(severity, logger, ...) \
+  do { \
+    RCLCPP_STATIC_ASSERT_LOGGER(logger); \
+    RCUTILS_LOG_SKIPFIRST_NAMED(severity, (logger).get_name(), "%s", std::format(__VA_ARGS__).c_str()); \
+  } while (0)
+
+/**
+ * \def RCLCPP_LOG_FMT_THROTTLE
+ * Log a message with given severity with the following condition:
+ * - Log calls are ignored if the last logged message is not longer ago than the specified duration.
+ *
+ * \param logger The `rclcpp::Logger` to use
+ * \param clock rclcpp::Clock that will be used to get the time point.
+ * \param duration The duration of the throttle interval as an integral value in milliseconds.
+ * \param ... The variable arguments passed into std::format
+ */
+#define RCLCPP_LOG_FMT_THROTTLE(severity, logger, clock, duration, ...) \
+  do { \
+    RCLCPP_STATIC_ASSERT_LOGGER(logger); \
+    RCUTILS_LOG_THROTTLE_NAMED( \
+      severity, \
+      RCLCPP_LOG_TIME_POINT_FUNC(clock), \
+      duration, \
+      (logger).get_name(), \
+      "%s", std::format(__VA_ARGS__).c_str()); \
+  } while (0)
+
+/**
+ * \def RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE
+ * Log a message with given severity with the following conditions:
+ * - The first log call is ignored but all subsequent calls are processed.
+ * - Log calls are ignored if the last logged message is not longer ago than the specified duration.
+ *
+ * \param logger The `rclcpp::Logger` to use
+ * \param clock rclcpp::Clock that will be used to get the time point.
+ * \param duration The duration of the throttle interval as an integral value in milliseconds.
+ * \param ... The variable arguments passed into std::format
+ */
+#define RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE(severity, logger, clock, duration, ...) \
+  do { \
+    RCLCPP_STATIC_ASSERT_LOGGER(logger); \
+    RCUTILS_LOG_SKIPFIRST_THROTTLE_NAMED( \
+      severity, \
+      RCLCPP_LOG_TIME_POINT_FUNC(clock), \
+      duration, \
+      (logger).get_name(), \
+      "%s", std::format(__VA_ARGS__).c_str()); \
   } while (0)
 
 /**

--- a/rclcpp/include/rclcpp/logging.hpp
+++ b/rclcpp/include/rclcpp/logging.hpp
@@ -340,7 +340,11 @@
 #define RCLCPP_LOG_FMT_EXPRESSION(severity, logger, expression, ...) \
   do { \
     RCLCPP_STATIC_ASSERT_LOGGER(logger); \
-    RCUTILS_LOG_EXPRESSION_NAMED(severity, expression, (logger).get_name(), "%s", std::format(__VA_ARGS__).c_str()); \
+    RCUTILS_LOG_EXPRESSION_NAMED( \
+      severity, \
+      expression, \
+      (logger).get_name(), \
+      "%s", std::format(__VA_ARGS__).c_str()); \
   } while (0)
 
 /**
@@ -355,7 +359,11 @@
 #define RCLCPP_LOG_FMT_FUNCTION(severity, logger, function, ...) \
   do { \
     RCLCPP_STATIC_ASSERT_LOGGER(logger); \
-    RCUTILS_LOG_FUNCTION_NAMED(severity, function, (logger).get_name(), "%s", std::format(__VA_ARGS__).c_str()); \
+    RCUTILS_LOG_FUNCTION_NAMED( \
+      severity, \
+      function, \
+      (logger).get_name(), \
+      "%s", std::format(__VA_ARGS__).c_str()); \
   } while (0)
 
 /**
@@ -369,7 +377,10 @@
 #define RCLCPP_LOG_FMT_SKIPFIRST(severity, logger, ...) \
   do { \
     RCLCPP_STATIC_ASSERT_LOGGER(logger); \
-    RCUTILS_LOG_SKIPFIRST_NAMED(severity, (logger).get_name(), "%s", std::format(__VA_ARGS__).c_str()); \
+    RCUTILS_LOG_SKIPFIRST_NAMED( \
+      severity, \
+      (logger).get_name(), \
+      "%s", std::format(__VA_ARGS__).c_str()); \
   } while (0)
 
 /**
@@ -575,7 +586,8 @@
  * \def RCLCPP_DEBUG_FMT
  * \copydoc RCLCPP_LOG_FMT
  */
-#define RCLCPP_DEBUG_FMT(logger, ...) RCLCPP_LOG_FMT(RCUTILS_LOG_SEVERITY_DEBUG, logger, __VA_ARGS__)
+#define RCLCPP_DEBUG_FMT(logger, ...) \
+  RCLCPP_LOG_FMT(RCUTILS_LOG_SEVERITY_DEBUG, logger, __VA_ARGS__)
 
 /**
  * \def RCLCPP_DEBUG_FMT_ONCE
@@ -617,7 +629,8 @@
  * \copydoc RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE
  */
 #define RCLCPP_DEBUG_FMT_SKIPFIRST_THROTTLE(logger, clock, duration, ...) \
-  RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE(RCUTILS_LOG_SEVERITY_DEBUG, logger, clock, duration, __VA_ARGS__)
+  RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE(RCUTILS_LOG_SEVERITY_DEBUG, logger, clock, duration, \
+    __VA_ARGS__)
 
 #endif
 
@@ -1163,7 +1176,8 @@
  * \def RCLCPP_ERROR_FMT
  * \copydoc RCLCPP_LOG_FMT
  */
-#define RCLCPP_ERROR_FMT(logger, ...) RCLCPP_LOG_FMT(RCUTILS_LOG_SEVERITY_ERROR, logger, __VA_ARGS__)
+#define RCLCPP_ERROR_FMT(logger, ...) \
+  RCLCPP_LOG_FMT(RCUTILS_LOG_SEVERITY_ERROR, logger, __VA_ARGS__)
 
 /**
  * \def RCLCPP_ERROR_FMT_ONCE
@@ -1205,7 +1219,8 @@
  * \copydoc RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE
  */
 #define RCLCPP_ERROR_FMT_SKIPFIRST_THROTTLE(logger, clock, duration, ...) \
-  RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE(RCUTILS_LOG_SEVERITY_ERROR, logger, clock, duration, __VA_ARGS__)
+  RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE(RCUTILS_LOG_SEVERITY_ERROR, logger, clock, duration, \
+    __VA_ARGS__)
 
 #endif
 
@@ -1359,7 +1374,8 @@
  * \def RCLCPP_FATAL_FMT
  * \copydoc RCLCPP_LOG_FMT
  */
-#define RCLCPP_FATAL_FMT(logger, ...) RCLCPP_LOG_FMT(RCUTILS_LOG_SEVERITY_FATAL, logger, __VA_ARGS__)
+#define RCLCPP_FATAL_FMT(logger, ...) \
+  RCLCPP_LOG_FMT(RCUTILS_LOG_SEVERITY_FATAL, logger, __VA_ARGS__)
 
 /**
  * \def RCLCPP_FATAL_FMT_ONCE
@@ -1401,7 +1417,8 @@
  * \copydoc RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE
  */
 #define RCLCPP_FATAL_FMT_SKIPFIRST_THROTTLE(logger, clock, duration, ...) \
-  RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE(RCUTILS_LOG_SEVERITY_FATAL, logger, clock, duration, __VA_ARGS__)
+  RCLCPP_LOG_FMT_SKIPFIRST_THROTTLE(RCUTILS_LOG_SEVERITY_FATAL, logger, clock, duration, \
+    __VA_ARGS__)
 
 #endif
 

--- a/rclcpp/test/rclcpp/test_logging.cpp
+++ b/rclcpp/test/rclcpp/test_logging.cpp
@@ -124,6 +124,20 @@ TEST_F(TestLoggingMacros, test_logging_stream) {
   EXPECT_EQ("message 5", g_last_log_event.message);
 }
 
+TEST_F(TestLoggingMacros, test_logging_format) {
+  for (std::string i : {"one", "two", "three"}) {
+    RCLCPP_DEBUG_FMT(g_logger, "message {}", i);
+  }
+  EXPECT_EQ(3u, g_log_calls);
+  EXPECT_EQ("message three", g_last_log_event.message);
+
+  RCLCPP_DEBUG_FMT(g_logger, "{}th message", 4);
+  EXPECT_EQ("4th message", g_last_log_event.message);
+
+  RCLCPP_DEBUG_FMT(g_logger, "{1} {0}", 5, "message");
+  EXPECT_EQ("message 5", g_last_log_event.message);
+}
+
 TEST_F(TestLoggingMacros, test_logging_once) {
   for (int i : {1, 2, 3}) {
     RCLCPP_INFO_ONCE(g_logger, "message %d", i);


### PR DESCRIPTION
Similar to the `RCLCPP_*_STREAM` family of macros, which enable the use of C++'s stream-based output, these new logging macros allow users to conveniently invoke the new C++20 [`std::format()`](https://en.cppreference.com/w/cpp/utility/format/format) function for generating formatted text.

It should be noted that `rclcpp` (as of [Iron](https://www.ros.org/reps/rep-2000.html#iron-irwini-may-2023-november-2024)) still has a minimum requirement of C++17, which predates `std::format`. Moreover, many compilers only recently implemented support for this feature. (See the entry for P0645R10 [here](https://en.cppreference.com/w/cpp/compiler_support/20#C.2B.2B20_library_features).)

To account for this, the relevant standard library header is only included conditionally if it exists. This should guarantee that the include doesn't introduce errors for compilers without or with partial C++20 support, unless the user actually invokes the `RCLCPP_*_FORMAT` macros.

These macros are not strictly necessary. As seen in the implementation, one can mechanically replace any call to a `RCLCPP_*_FORMAT_*` macro with the corresponding printf-style `RCLCPP_*_*` macro, passing in the variadic arguments `"%s", std::format(...).c_str()`. However, this is less readable and more error prone.