### PR TITLE
doc fix: call `canceled` only after goal state is in canceling.

### DIFF
--- a/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
+++ b/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
@@ -196,7 +196,7 @@ public:
 
   /// Indicate that a goal has been canceled.
   /**
-   * Only call this if the goal is executing or pending, but has been canceled.
+   * Only call this if the goal is canceling.
    * This is a terminal state, no more methods should be called on a goal handle after this is
    * called.
    *


### PR DESCRIPTION
address part of https://github.com/ros2/rclcpp/issues/2242