### PR TITLE
Adding Custom Unknown Type Error

### DIFF
--- a/rclcpp/include/rclcpp/exceptions/exceptions.hpp
+++ b/rclcpp/include/rclcpp/exceptions/exceptions.hpp
@@ -206,6 +206,14 @@ public:
   const std::vector<std::string> unknown_ros_args;
 };
 
+/// Thrown when an unknown type is passed
+class UnknownTypeError : public std::runtime_error
+{
+public:
+  explicit UnknownTypeError(const std::string & type)
+  : std::runtime_error("Unknown type: " + type) {}
+};
+
 /// Thrown when an invalid rclcpp::Event object or SharedPtr is encountered.
 class InvalidEventError : public std::runtime_error
 {

--- a/rclcpp/include/rclcpp/parameter_value.hpp
+++ b/rclcpp/include/rclcpp/parameter_value.hpp
@@ -24,6 +24,7 @@
 
 #include "rcl_interfaces/msg/parameter_type.hpp"
 #include "rcl_interfaces/msg/parameter_value.hpp"
+#include "rclcpp/exceptions/exceptions.hpp"
 #include "rclcpp/visibility_control.hpp"
 
 namespace rclcpp

--- a/rclcpp/src/rclcpp/parameter_value.cpp
+++ b/rclcpp/src/rclcpp/parameter_value.cpp
@@ -129,8 +129,7 @@ ParameterValue::ParameterValue(const rcl_interfaces::msg::ParameterValue & value
     case PARAMETER_NOT_SET:
       break;
     default:
-      // TODO(wjwwood): use custom exception
-      throw std::runtime_error("Unknown type: " + std::to_string(value.type));
+      throw rclcpp::exceptions::UnknownTypeError(std::to_string(value.type));
   }
 }
 


### PR DESCRIPTION
Fixing a previous TODO to add a custom error/exception handler, similar to PR #2256, relating to issue #2247. This is a really basic error handler to just specifies to the user, if there was an unknown type that was passed. 