### PR TITLE
Serialized Messages with Topic Statistics

### DIFF
--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -44,7 +44,6 @@
 #include "rclcpp/subscription_base.hpp"
 #include "rclcpp/subscription_options.hpp"
 #include "rclcpp/subscription_traits.hpp"
-#include "rclcpp/serialization.hpp"
 #include "rclcpp/type_support_decl.hpp"
 #include "rclcpp/visibility_control.hpp"
 #include "rclcpp/waitable.hpp"

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -326,7 +326,12 @@ public:
     const std::shared_ptr<rclcpp::SerializedMessage> & serialized_message,
     const rclcpp::MessageInfo & message_info) override
   {
-    // TODO(wjwwood): enable topic statistics for serialized messages
+    if (matches_any_intra_process_publishers(&message_info.get_rmw_message_info().publisher_gid)) {
+      // In this case, the message will be delivered via intra process and
+      // we should ignore this copy of the message.
+      return;
+    }
+
     std::chrono::time_point<std::chrono::system_clock> now;
     if (subscription_topic_statistics_) {
       // get current time before executing callback to

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -44,6 +44,7 @@
 #include "rclcpp/subscription_base.hpp"
 #include "rclcpp/subscription_options.hpp"
 #include "rclcpp/subscription_traits.hpp"
+#include "rclcpp/serialization.hpp"
 #include "rclcpp/type_support_decl.hpp"
 #include "rclcpp/visibility_control.hpp"
 #include "rclcpp/waitable.hpp"
@@ -326,7 +327,25 @@ public:
     const rclcpp::MessageInfo & message_info) override
   {
     // TODO(wjwwood): enable topic statistics for serialized messages
+    std::chrono::time_point<std::chrono::system_clock> now;
+    if (subscription_topic_statistics_) {
+      // get current time before executing callback to
+      // exclude callback duration from topic statistics result.
+      now = std::chrono::system_clock::now();
+    }
+
     any_callback_.dispatch(serialized_message, message_info);
+
+    ROSMessageType deserialized_message;
+    auto serializer = rclcpp::Serialization<ROSMessageType>();
+    serializer.deserialize_message(serialized_message.get(), &deserialized_message);
+
+
+    if (subscription_topic_statistics_) {
+      const auto nanos = std::chrono::time_point_cast<std::chrono::nanoseconds>(now);
+      const auto time = rclcpp::Time(nanos.time_since_epoch().count());
+      subscription_topic_statistics_->handle_message(deserialized_message, time);
+    }
   }
 
   void


### PR DESCRIPTION
This pull request was created to solve a [TODO](https://github.com/ros2/rclcpp/blob/rolling/rclcpp/include/rclcpp/subscription.hpp#L328) that was added in pull request #1557, but there's no discussion on the topic. As per the title, the point was to allow the user to use topic statistics when handling a serialized message. I tried to follow the way the other two functions `handle_message` and `handle_loaned_message` handled their topic statistics, but assumed that one couldn't pass a serialized message through the statistics, so I set up a basic serialization process. We only need to make one copy of the message that we create and since `ROSMessageType` is a string in disguise, we can still get all the data from it. Additionally, we still just dispatch the message, before we get an information about the topic statistics, so there shouldn't be any timing issues.

The last time a topic statistics was added to one of them methods was PR #1927, where the author replicated a similar format and didn't add any tests. I don't necessarily know how the test would work, but I can add them if needed, and wanted this PR to be as concise as possible without adding extra messages.