### PR TITLE
Do not crash Executor when send_response fails due to client failure.

### DIFF
--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -488,9 +488,9 @@ public:
 
     if (ret == RCL_RET_TIMEOUT) {
       RCLCPP_WARN(
-        rclcpp::get_node_logger(node_handle_.get()).get_child("rclcpp"),
-        "failed to send response (timeout): %s",
-        rcl_get_error_string().str);
+        node_logger_.get_child("rclcpp"),
+        "failed to send response to %s (timeout): %s",
+        this->get_service_name(), rcl_get_error_string().str);
       rcl_reset_error();
       return;
     }

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -486,6 +486,14 @@ public:
   {
     rcl_ret_t ret = rcl_send_response(get_service_handle().get(), &req_id, &response);
 
+    if (ret == RCL_RET_TIMEOUT) {
+      RCLCPP_WARN(
+        rclcpp::get_node_logger(node_handle_.get()).get_child("rclcpp"),
+        "failed to send response: %s",
+        rcl_get_error_string().str);
+      rcl_reset_error();
+      return;
+    }
     if (ret != RCL_RET_OK) {
       rclcpp::exceptions::throw_from_rcl_error(ret, "failed to send response");
     }

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -489,7 +489,7 @@ public:
     if (ret == RCL_RET_TIMEOUT) {
       RCLCPP_WARN(
         rclcpp::get_node_logger(node_handle_.get()).get_child("rclcpp"),
-        "failed to send response: %s",
+        "failed to send response (timeout): %s",
         rcl_get_error_string().str);
       rcl_reset_error();
       return;


### PR DESCRIPTION
replace of https://github.com/ros2/rclcpp/pull/2215