### PR TITLE
Callback after cancel

### DIFF
--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -409,8 +409,17 @@ public:
    * If the goal is rejected by an action server, then the future is set to a `nullptr`.
    *
    * The returned goal handle is used to monitor the status of the goal and get the final result.
-   * It is valid as long as you hold a reference to the shared pointer or until the
-   * rclcpp_action::Client is destroyed at which point the goal status will become UNKNOWN.
+   *
+   * You will receive callbacks for the goal, as long as you hold a reference to the shared pointer,
+   * or rclcpp_action::Client is destroyed. Dropping the shared pointer will not cancel the goal. In order
+   * to cancel it, you must explicitly call async_cancel_goal.
+   *
+   * WARNING this method has inconsistent behaviour and a memory leak bug.
+   * If you set the result callback, the handle will be self referencing, and you will receive callbacks
+   * even though you do not hold a reference to the shared pointer. In this case, the self reference will
+   * be deleted if the result callback was received. If there is no result callback, there will be a memory leak.
+   *
+   * To prevent the memory leak, you may call stop_callbacks() explicit. This will delete the self reference.
    *
    * \param[in] goal The goal request.
    * \param[in] options Options for sending the goal request. Contains references to callbacks for

--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -405,18 +405,19 @@ public:
 
   /// Send an action goal and asynchronously get the result.
   /**
-   * If the goal is accepted by an action server, the returned future is set to a `ClientGoalHandle`.
+   * If the goal is accepted by an action server, the returned future is set to a `GoalHandle::SharedPtr`.
    * If the goal is rejected by an action server, then the future is set to a `nullptr`.
    *
-   * The returned goal handle is used to monitor the status of the goal and get the final result.
+   * The goal handle in the future is used to monitor the status of the goal and get the final result.
    *
-   * You will receive callbacks for the goal, as long as you hold a reference to the shared pointer,
-   * or rclcpp_action::Client is destroyed. Dropping the shared pointer will not cancel the goal. In order
-   * to cancel it, you must explicitly call async_cancel_goal.
+   * If callbacks were set in @param options, you will receive callbacks, as long as you hold a reference
+   * to the shared pointer contained in the returned future, or rclcpp_action::Client is destroyed. Dropping
+   * the shared pointer to the goal handle will not cancel the goal. In order to cancel it, you must explicitly
+   * call async_cancel_goal.
    *
    * WARNING this method has inconsistent behaviour and a memory leak bug.
-   * If you set the result callback, the handle will be self referencing, and you will receive callbacks
-   * even though you do not hold a reference to the shared pointer. In this case, the self reference will
+   * If you set the result callback in @param options, the handle will be self referencing, and you will receive
+   * callbacks even though you do not hold a reference to the shared pointer. In this case, the self reference will
    * be deleted if the result callback was received. If there is no result callback, there will be a memory leak.
    *
    * To prevent the memory leak, you may call stop_callbacks() explicit. This will delete the self reference.

--- a/rclcpp_action/include/rclcpp_action/client_goal_handle_impl.hpp
+++ b/rclcpp_action/include/rclcpp_action/client_goal_handle_impl.hpp
@@ -75,6 +75,7 @@ ClientGoalHandle<ActionT>::set_result(const WrappedResult & wrapped_result)
   result_promise_.set_value(wrapped_result);
   if (result_callback_) {
     result_callback_(wrapped_result);
+    result_callback_ = ResultCallback();
   }
 }
 


### PR DESCRIPTION
fixes https://github.com/ros2/rclcpp/issues/2265

Note, this commit fixes a bug, that makes the current version of the tutorial 
not work any more, as the code now acts according to its documentation.