### PR TITLE
Add rcl_logging_interface as an explicit dependency.

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(builtin_interfaces REQUIRED)
 find_package(libstatistics_collector REQUIRED)
 find_package(rcl REQUIRED)
 find_package(rcl_interfaces REQUIRED)
+find_package(rcl_logging_interface REQUIRED)
 find_package(rcl_yaml_param_parser REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
@@ -207,6 +208,7 @@ ament_target_dependencies(${PROJECT_NAME}
   "libstatistics_collector"
   "rcl"
   "rcl_interfaces"
+  "rcl_logging_interface"
   "rcl_yaml_param_parser"
   "rcpputils"
   "rcutils"

--- a/rclcpp/package.xml
+++ b/rclcpp/package.xml
@@ -35,6 +35,7 @@
 
   <depend>libstatistics_collector</depend>
   <depend>rcl</depend>
+  <depend>rcl_logging_interface</depend>
   <depend>rcl_yaml_param_parser</depend>
   <depend>rcpputils</depend>
   <depend>rcutils</depend>


### PR DESCRIPTION
It is depended on by rclcpp/src/rclcpp/logger.cpp, but the dependency was not explicitly declared (it was being inherited from rcl, I believe).  Fix that here.