### PR TITLE
Service Type Adaptations

### DIFF
--- a/rclcpp/include/rclcpp/get_service_type_support_handle.hpp
+++ b/rclcpp/include/rclcpp/get_service_type_support_handle.hpp
@@ -1,0 +1,154 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__GET_SERVICE_TYPE_SUPPORT_HANDLE_HPP_
+#define RCLCPP__GET_SERVICE_TYPE_SUPPORT_HANDLE_HPP_
+
+#include <stdexcept>
+#include <type_traits>
+
+#include "rosidl_runtime_cpp/traits.hpp"
+#include "rosidl_runtime_cpp/service_type_support_decl.hpp"
+#include "rosidl_typesupport_cpp/service_type_support.hpp"
+
+#include "rclcpp/type_adapter.hpp"
+
+namespace rclcpp
+{
+
+#ifdef DOXYGEN_ONLY
+
+/// Returns the service type support for the given `ServiceT` type.
+/**
+ * \tparam ServiceT an actual ROS service type or an adapted type using `rclcpp::TypeAdapter`
+ */
+template<typename ServiceT>
+constexpr const rosidl_service_type_support_t & get_service_type_support_handle();
+
+#else
+
+template<typename ServiceT>
+constexpr
+std::enable_if_t<
+  rosidl_generator_traits::is_service<ServiceT>::value,
+  const rosidl_service_type_support_t &
+>
+get_service_type_support_handle()
+{
+  auto handle = rosidl_typesupport_cpp::get_service_type_support_handle<ServiceT>();
+  if (!handle) {
+    throw std::runtime_error("Type support handle unexpectedly nullptr");
+  }
+  return *handle;
+}
+
+/// The following checks will fix for the 4 different ways you could assemble
+/// the TypeAdapter struct when using custom or ROS types.
+template<typename AdaptedTypeStruct>
+constexpr
+std::enable_if_t<
+  !rosidl_generator_traits::is_service<AdaptedTypeStruct>::value &&
+  rclcpp::TypeAdapter<AdaptedTypeStruct::Request>::is_specialized::value &&,
+  rclcpp::TypeAdapter<AdaptedTypeStruct::Response>::is_specialized::value,
+  const rosidl_service_type_support_t &
+>
+get_service_type_support_handle()
+{
+  struct AdaptedTypeStructTemp
+  {
+      using Request = typename TypeAdapter<AdaptedTypeStruct::Request>::ros_message_type;
+      using Response = typename TypeAdapter<AdaptedTypeStruct::Response>::ros_message_type;
+  };
+
+  auto handle = rosidl_typesupport_cpp::get_service_type_support_handle<AdaptedTypeStructTemp
+    >();
+  if (!handle) {
+    throw std::runtime_error("Type support handle unexpectedly nullptr");
+  }
+  return *handle;
+}
+
+template<typename AdaptedTypeStruct>
+constexpr
+std::enable_if_t<
+  !rosidl_generator_traits::is_service<AdaptedTypeStruct>::value &&
+  !rclcpp::TypeAdapter<AdaptedTypeStruct::Request>::is_specialized::value &&,
+  rclcpp::TypeAdapter<AdaptedTypeStruct::Response>::is_specialized::value,
+  const rosidl_service_type_support_t &
+>
+get_service_type_support_handle()
+{
+  struct AdaptedTypeStructTemp
+  {
+      using Request = typename TypeAdapter<AdaptedTypeStruct::Request>::custom_type;
+      using Response = typename TypeAdapter<AdaptedTypeStruct::Response>::ros_message_type;
+  };
+
+  auto handle = rosidl_typesupport_cpp::get_service_type_support_handle<AdaptedTypeStructTemp
+    >();
+  if (!handle) {
+    throw std::runtime_error("Type support handle unexpectedly nullptr");
+  }
+  return *handle;
+}
+
+template<typename AdaptedTypeStruct>
+constexpr
+std::enable_if_t<
+  !rosidl_generator_traits::is_service<AdaptedTypeStruct>::value &&
+  rclcpp::TypeAdapter<AdaptedTypeStruct::Request>::is_specialized::value &&,
+  !rclcpp::TypeAdapter<AdaptedTypeStruct::Response>::is_specialized::value,
+  const rosidl_service_type_support_t &
+>
+get_service_type_support_handle()
+{
+  struct AdaptedTypeStructTemp
+  {
+      using Request = typename TypeAdapter<AdaptedTypeStruct::Request>::ros_message_type;
+      using Response = typename TypeAdapter<AdaptedTypeStruct::Response>::custom_type;
+  };
+
+  auto handle = rosidl_typesupport_cpp::get_service_type_support_handle<AdaptedTypeStructTemp
+    >();
+  if (!handle) {
+    throw std::runtime_error("Type support handle unexpectedly nullptr");
+  }
+  return *handle;
+}
+
+// This specialization is a pass through runtime check, which allows a better
+// static_assert to catch this issue further down the line.
+// This should never get to be called in practice, and is purely defensive.
+template<
+  typename AdaptedTypeStruct
+>
+constexpr
+typename std::enable_if_t<
+  !rosidl_generator_traits::is_service<AdaptedTypeStruct>::value &&
+  !TypeAdapter<AdaptedTypeStruct::Request>::is_specialized::value,
+  !TypeAdapter<AdaptedTypeStruct::Response>::is_specialized::value,
+  const rosidl_service_type_support_t &
+>
+get_service_type_support_handle()
+{
+  throw std::runtime_error(
+          "this specialization of rclcpp::get_service_type_support_handle() "
+          "should never be called");
+}
+
+#endif  // DOXYGEN_ONLY
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__GET_SERVICE_TYPE_SUPPORT_HANDLE_HPP_

--- a/rclcpp/include/rclcpp/get_service_type_support_handle.hpp
+++ b/rclcpp/include/rclcpp/get_service_type_support_handle.hpp
@@ -59,16 +59,18 @@ template<typename AdaptedTypeStruct>
 constexpr
 std::enable_if_t<
   !rosidl_generator_traits::is_service<AdaptedTypeStruct>::value &&
-  rclcpp::TypeAdapter<AdaptedTypeStruct::Request>::is_specialized::value &&,
-  rclcpp::TypeAdapter<AdaptedTypeStruct::Response>::is_specialized::value,
+  rclcpp::TypeAdapter<typename AdaptedTypeStruct::Request>::is_specialized::value &&
+  rclcpp::TypeAdapter<typename AdaptedTypeStruct::Response>::is_specialized::value,
   const rosidl_service_type_support_t &
 >
 get_service_type_support_handle()
 {
   struct AdaptedTypeStructTemp
   {
-      using Request = typename TypeAdapter<AdaptedTypeStruct::Request>::ros_message_type;
-      using Response = typename TypeAdapter<AdaptedTypeStruct::Response>::ros_message_type;
+      using Request =
+        typename TypeAdapter<typename AdaptedTypeStruct::Request>::ros_message_type;
+      using Response =
+        typename TypeAdapter<typename AdaptedTypeStruct::Response>::ros_message_type;
   };
 
   auto handle = rosidl_typesupport_cpp::get_service_type_support_handle<AdaptedTypeStructTemp
@@ -83,16 +85,18 @@ template<typename AdaptedTypeStruct>
 constexpr
 std::enable_if_t<
   !rosidl_generator_traits::is_service<AdaptedTypeStruct>::value &&
-  !rclcpp::TypeAdapter<AdaptedTypeStruct::Request>::is_specialized::value &&,
-  rclcpp::TypeAdapter<AdaptedTypeStruct::Response>::is_specialized::value,
+  !rclcpp::TypeAdapter<typename AdaptedTypeStruct::Request>::is_specialized::value &&
+  rclcpp::TypeAdapter<typename AdaptedTypeStruct::Response>::is_specialized::value,
   const rosidl_service_type_support_t &
 >
 get_service_type_support_handle()
 {
   struct AdaptedTypeStructTemp
   {
-      using Request = typename TypeAdapter<AdaptedTypeStruct::Request>::custom_type;
-      using Response = typename TypeAdapter<AdaptedTypeStruct::Response>::ros_message_type;
+      using Request =
+        typename TypeAdapter<typename AdaptedTypeStruct::Request>::custom_type;
+      using Response =
+        typename TypeAdapter<typename AdaptedTypeStruct::Response>::ros_message_type;
   };
 
   auto handle = rosidl_typesupport_cpp::get_service_type_support_handle<AdaptedTypeStructTemp
@@ -107,16 +111,18 @@ template<typename AdaptedTypeStruct>
 constexpr
 std::enable_if_t<
   !rosidl_generator_traits::is_service<AdaptedTypeStruct>::value &&
-  rclcpp::TypeAdapter<AdaptedTypeStruct::Request>::is_specialized::value &&,
-  !rclcpp::TypeAdapter<AdaptedTypeStruct::Response>::is_specialized::value,
+  rclcpp::TypeAdapter<typename AdaptedTypeStruct::Request>::is_specialized::value &&
+  !rclcpp::TypeAdapter<typename AdaptedTypeStruct::Response>::is_specialized::value,
   const rosidl_service_type_support_t &
 >
 get_service_type_support_handle()
 {
   struct AdaptedTypeStructTemp
   {
-      using Request = typename TypeAdapter<AdaptedTypeStruct::Request>::ros_message_type;
-      using Response = typename TypeAdapter<AdaptedTypeStruct::Response>::custom_type;
+      using Request =
+        typename TypeAdapter<typename AdaptedTypeStruct::Request>::ros_message_type;
+      using Response =
+        typename TypeAdapter<typename AdaptedTypeStruct::Response>::custom_type;
   };
 
   auto handle = rosidl_typesupport_cpp::get_service_type_support_handle<AdaptedTypeStructTemp
@@ -130,14 +136,12 @@ get_service_type_support_handle()
 // This specialization is a pass through runtime check, which allows a better
 // static_assert to catch this issue further down the line.
 // This should never get to be called in practice, and is purely defensive.
-template<
-  typename AdaptedTypeStruct
->
+template<typename AdaptedTypeStruct>
 constexpr
 typename std::enable_if_t<
   !rosidl_generator_traits::is_service<AdaptedTypeStruct>::value &&
-  !TypeAdapter<AdaptedTypeStruct::Request>::is_specialized::value,
-  !TypeAdapter<AdaptedTypeStruct::Response>::is_specialized::value,
+  !TypeAdapter<typename AdaptedTypeStruct::Request>::is_specialized::value &&
+  !TypeAdapter<typename AdaptedTypeStruct::Response>::is_specialized::value,
   const rosidl_service_type_support_t &
 >
 get_service_type_support_handle()

--- a/rclcpp/include/rclcpp/get_service_type_support_handle.hpp
+++ b/rclcpp/include/rclcpp/get_service_type_support_handle.hpp
@@ -68,9 +68,9 @@ get_service_type_support_handle()
   struct AdaptedTypeStructTemp
   {
       using Request =
-        typename TypeAdapter<typename AdaptedTypeStruct::Request>::ros_message_type;
+        typename rclcpp::TypeAdapter<typename AdaptedTypeStruct::Request>::ros_message_type;
       using Response =
-        typename TypeAdapter<typename AdaptedTypeStruct::Response>::ros_message_type;
+        typename rclcpp::TypeAdapter<typename AdaptedTypeStruct::Response>::ros_message_type;
   };
 
   auto handle = rosidl_typesupport_cpp::get_service_type_support_handle<AdaptedTypeStructTemp
@@ -94,9 +94,9 @@ get_service_type_support_handle()
   struct AdaptedTypeStructTemp
   {
       using Request =
-        typename TypeAdapter<typename AdaptedTypeStruct::Request>::custom_type;
+        typename rclcpp::TypeAdapter<typename AdaptedTypeStruct::Request>::custom_type;
       using Response =
-        typename TypeAdapter<typename AdaptedTypeStruct::Response>::ros_message_type;
+        typename rclcpp::TypeAdapter<typename AdaptedTypeStruct::Response>::ros_message_type;
   };
 
   auto handle = rosidl_typesupport_cpp::get_service_type_support_handle<AdaptedTypeStructTemp
@@ -120,9 +120,9 @@ get_service_type_support_handle()
   struct AdaptedTypeStructTemp
   {
       using Request =
-        typename TypeAdapter<typename AdaptedTypeStruct::Request>::ros_message_type;
+        typename rclcpp::TypeAdapter<typename AdaptedTypeStruct::Request>::ros_message_type;
       using Response =
-        typename TypeAdapter<typename AdaptedTypeStruct::Response>::custom_type;
+        typename rclcpp::TypeAdapter<typename AdaptedTypeStruct::Response>::custom_type;
   };
 
   auto handle = rosidl_typesupport_cpp::get_service_type_support_handle<AdaptedTypeStructTemp

--- a/rclcpp/include/rclcpp/is_ros_compatible_type.hpp
+++ b/rclcpp/include/rclcpp/is_ros_compatible_type.hpp
@@ -30,6 +30,15 @@ struct is_ros_compatible_type
     rclcpp::TypeAdapter<T>::is_specialized::value;
 };
 
+template<typename T>
+struct is_ros_compatible_service_type
+{
+  static constexpr bool value =
+    rosidl_generator_traits::is_service<T>::value ||
+    rclcpp::TypeAdapter<typename T::Request>::is_specialized::value ||
+    rclcpp::TypeAdapter<typename T::Response>::is_specialized::value;
+};
+
 }  // namespace rclcpp
 
 #endif  // RCLCPP__IS_ROS_COMPATIBLE_TYPE_HPP_

--- a/rclcpp/include/rclcpp/is_ros_compatible_type.hpp
+++ b/rclcpp/include/rclcpp/is_ros_compatible_type.hpp
@@ -36,7 +36,7 @@ struct is_ros_compatible_service_type
   static constexpr bool value =
     rosidl_generator_traits::is_service<T>::value ||
     rclcpp::TypeAdapter<typename T::Request>::is_specialized::value ||
-    rclcpp::TypeAdapter<typename T::Response>::is_specialized::value;
+    rclcpp::TypeAdapter<typename T::Request>::is_specialized::value;
 };
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -39,7 +39,7 @@
 #include "rclcpp/detail/cpp_callback_trampoline.hpp"
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/expand_topic_or_service_name.hpp"
-#include "rclcpp/get_message_type_support_handle.hpp"
+#include "rclcpp/get_service_type_support_handle.hpp"
 #include "rclcpp/is_ros_compatible_type.hpp"
 #include "rclcpp/logging.hpp"
 #include "rclcpp/macros.hpp"

--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -311,8 +311,12 @@ class Service
 {
 public:
   static_assert(
-    rclcpp::is_ros_compatible_service_type<ServiceT>::value,
+    rclcpp::is_ros_compatible_type<typename ServiceT::Request>::value,
     "Service Request type is not compatible with ROS 2 and cannot be used with a Service");
+
+  static_assert(
+    rclcpp::is_ros_compatible_type<typename ServiceT::Response>::value,
+    "Service Response type is not compatible with ROS 2 and cannot be used with a Service");
 
   /// ServiceT::Request::custom_type if ServiceT is a TypeAdapter, otherwise just the
   /// ServiceT::Request

--- a/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
@@ -18,8 +18,10 @@
 
 #include "rclcpp/node_interfaces/node_type_descriptions.hpp"
 #include "rclcpp/parameter_client.hpp"
+#include "rclcpp/type_adapter.hpp"
 
 #include "type_description_interfaces/srv/get_type_description.h"
+#include "type_description_interfaces/srv/get_type_description.hpp"
 
 namespace
 {
@@ -30,6 +32,79 @@ struct GetTypeDescription__C
   using Response = type_description_interfaces__srv__GetTypeDescription_Response;
   using Event = type_description_interfaces__srv__GetTypeDescription_Event;
 };
+
+/*
+template<>
+struct rclcpp::TypeAdapter<
+  type_description_interfaces__srv__GetTypeDescription_Request,
+  type_description_interfaces::srv::GetTypeDescription::Request
+>
+{
+  using is_specialized = std::true_type;
+  using custom_type = type_description_interfaces__srv__GetTypeDescription_Request;
+  using ros_message_type = type_description_interfaces::srv::GetTypeDescription::Request;
+
+  static
+  void
+  convert_to_ros_message(
+    const custom_type & source,
+    ros_message_type & destination)
+  {
+    destination.data = source;
+  }
+
+  static
+  void
+  convert_to_custom(
+    const ros_message_type & source,
+    custom_type & destination)
+  {
+    destination = source.data;
+  }
+};
+
+template<>
+struct rclcpp::TypeAdapter<
+  type_description_interfaces__srv__GetTypeDescription_Response,
+  type_description_interfaces::srv::GetTypeDescription::Response
+>
+{
+  using is_specialized = std::true_type;
+  using custom_type = type_description_interfaces__srv__GetTypeDescription_Request;
+  using ros_message_type = type_description_interfaces::srv::GetTypeDescription::Request;
+
+  static
+  void
+  convert_to_ros_message(
+    const custom_type & source,
+    ros_message_type & destination)
+  {
+    destination.data = source;
+  }
+
+  static
+  void
+  convert_to_custom(
+    const ros_message_type & source,
+    custom_type & destination)
+  {
+    destination = source.data;
+  }
+};
+
+  using TypeRequest = rclcpp::TypeAdapter<
+    type_description_interfaces__srv__GetTypeDescription_Request,
+    type_description_interfaces::srv::GetTypeDescription::Request>;
+  using TypeResponse = rclcpp::TypeAdapter<
+    type_description_interfaces__srv__GetTypeDescription_Response,
+    type_description_interfaces::srv::GetTypeDescription::Response>;
+
+struct CustomDescriptionTypes
+{
+  using Request = TypeRequest;
+  using Response = TypeResponse;
+};
+*/
 }  // namespace
 
 // Helper function for C typesupport.
@@ -50,12 +125,13 @@ namespace node_interfaces
 
 class NodeTypeDescriptions::NodeTypeDescriptionsImpl
 {
+
 public:
   using ServiceT = GetTypeDescription__C;
 
   rclcpp::Logger logger_;
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
-  rclcpp::Service<ServiceT>::SharedPtr type_description_srv_;
+  //rclcpp::Service<ServiceT>::SharedPtr type_description_srv_;
 
   NodeTypeDescriptionsImpl(
     rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
@@ -65,6 +141,7 @@ public:
   : logger_(node_logging->get_logger()),
     node_base_(node_base)
   {
+    /*
     const std::string enable_param_name = "start_type_description_service";
 
     bool enabled = false;
@@ -123,12 +200,13 @@ public:
         std::dynamic_pointer_cast<ServiceBase>(type_description_srv_),
         nullptr);
     }
+    */
   }
 
   ~NodeTypeDescriptionsImpl()
   {
     if (
-      type_description_srv_ &&
+//      type_description_srv_ &&
       RCL_RET_OK != rcl_node_type_description_service_fini(node_base_->get_rcl_node_handle()))
     {
       RCLCPP_ERROR(

--- a/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
@@ -18,10 +18,8 @@
 
 #include "rclcpp/node_interfaces/node_type_descriptions.hpp"
 #include "rclcpp/parameter_client.hpp"
-#include "rclcpp/type_adapter.hpp"
 
 #include "type_description_interfaces/srv/get_type_description.h"
-#include "type_description_interfaces/srv/get_type_description.hpp"
 
 namespace
 {
@@ -32,79 +30,6 @@ struct GetTypeDescription__C
   using Response = type_description_interfaces__srv__GetTypeDescription_Response;
   using Event = type_description_interfaces__srv__GetTypeDescription_Event;
 };
-
-/*
-template<>
-struct rclcpp::TypeAdapter<
-  type_description_interfaces__srv__GetTypeDescription_Request,
-  type_description_interfaces::srv::GetTypeDescription::Request
->
-{
-  using is_specialized = std::true_type;
-  using custom_type = type_description_interfaces__srv__GetTypeDescription_Request;
-  using ros_message_type = type_description_interfaces::srv::GetTypeDescription::Request;
-
-  static
-  void
-  convert_to_ros_message(
-    const custom_type & source,
-    ros_message_type & destination)
-  {
-    destination.data = source;
-  }
-
-  static
-  void
-  convert_to_custom(
-    const ros_message_type & source,
-    custom_type & destination)
-  {
-    destination = source.data;
-  }
-};
-
-template<>
-struct rclcpp::TypeAdapter<
-  type_description_interfaces__srv__GetTypeDescription_Response,
-  type_description_interfaces::srv::GetTypeDescription::Response
->
-{
-  using is_specialized = std::true_type;
-  using custom_type = type_description_interfaces__srv__GetTypeDescription_Request;
-  using ros_message_type = type_description_interfaces::srv::GetTypeDescription::Request;
-
-  static
-  void
-  convert_to_ros_message(
-    const custom_type & source,
-    ros_message_type & destination)
-  {
-    destination.data = source;
-  }
-
-  static
-  void
-  convert_to_custom(
-    const ros_message_type & source,
-    custom_type & destination)
-  {
-    destination = source.data;
-  }
-};
-
-  using TypeRequest = rclcpp::TypeAdapter<
-    type_description_interfaces__srv__GetTypeDescription_Request,
-    type_description_interfaces::srv::GetTypeDescription::Request>;
-  using TypeResponse = rclcpp::TypeAdapter<
-    type_description_interfaces__srv__GetTypeDescription_Response,
-    type_description_interfaces::srv::GetTypeDescription::Response>;
-
-struct CustomDescriptionTypes
-{
-  using Request = TypeRequest;
-  using Response = TypeResponse;
-};
-*/
 }  // namespace
 
 // Helper function for C typesupport.
@@ -125,13 +50,12 @@ namespace node_interfaces
 
 class NodeTypeDescriptions::NodeTypeDescriptionsImpl
 {
-
 public:
   using ServiceT = GetTypeDescription__C;
 
   rclcpp::Logger logger_;
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_;
-  //rclcpp::Service<ServiceT>::SharedPtr type_description_srv_;
+  rclcpp::Service<ServiceT>::SharedPtr type_description_srv_;
 
   NodeTypeDescriptionsImpl(
     rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
@@ -141,7 +65,6 @@ public:
   : logger_(node_logging->get_logger()),
     node_base_(node_base)
   {
-    /*
     const std::string enable_param_name = "start_type_description_service";
 
     bool enabled = false;
@@ -200,13 +123,12 @@ public:
         std::dynamic_pointer_cast<ServiceBase>(type_description_srv_),
         nullptr);
     }
-    */
   }
 
   ~NodeTypeDescriptionsImpl()
   {
     if (
-//      type_description_srv_ &&
+      type_description_srv_ &&
       RCL_RET_OK != rcl_node_type_description_service_fini(node_base_->get_rcl_node_handle()))
     {
       RCLCPP_ERROR(

--- a/rclcpp/test/msg/Bool.msg
+++ b/rclcpp/test/msg/Bool.msg
@@ -1,0 +1,1 @@
+bool data

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -8,12 +8,20 @@ rosidl_generate_interfaces(${PROJECT_NAME}_test_msgs
   ../msg/Header.msg
   ../msg/MessageWithHeader.msg
   ../msg/String.msg
+  ../msg/Bool.msg
+  DEPENDENCIES builtin_interfaces
+  LIBRARY_NAME ${PROJECT_NAME}
+  SKIP_INSTALL
+)
+
+rosidl_generate_interfaces(${PROJECT_NAME}_test_srvs
+  ../srv/SetBool.srv
   DEPENDENCIES builtin_interfaces
   LIBRARY_NAME ${PROJECT_NAME}
   SKIP_INSTALL
 )
 # Need the target name to depend on generated interface libraries
-rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}_test_msgs" "rosidl_typesupport_cpp")
+rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}_test_msgs" "${PROJECT_NAME}_test_srvs" "rosidl_typesupport_cpp")
 
 ament_add_gtest(
   test_allocator_common
@@ -530,6 +538,16 @@ if(TARGET test_service)
   )
   target_link_libraries(test_service_introspection ${PROJECT_NAME} mimick)
 endif()
+
+ament_add_gtest(test_service_with_type_adapter test_service_with_type_adapter.cpp
+  APPEND_LIBRARY_DIRS "${append_library_dirs}"
+)
+if(TARGET test_service_with_type_adapter)
+  target_link_libraries(test_service_with_type_adapter
+    ${PROJECT_NAME}
+    ${cpp_typesupport_target})
+endif()
+
 # Creating and destroying nodes is slow with Connext, so this needs larger timeout.
 ament_add_gtest(test_subscription test_subscription.cpp TIMEOUT 120)
 if(TARGET test_subscription)

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -9,6 +9,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}_test_msgs
   ../msg/MessageWithHeader.msg
   ../msg/String.msg
   ../msg/Bool.msg
+  ../msg/Empty.msg
   ../srv/SetBool.srv
   DEPENDENCIES builtin_interfaces
   LIBRARY_NAME ${PROJECT_NAME}

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -9,19 +9,14 @@ rosidl_generate_interfaces(${PROJECT_NAME}_test_msgs
   ../msg/MessageWithHeader.msg
   ../msg/String.msg
   ../msg/Bool.msg
-  DEPENDENCIES builtin_interfaces
-  LIBRARY_NAME ${PROJECT_NAME}
-  SKIP_INSTALL
-)
-
-rosidl_generate_interfaces(${PROJECT_NAME}_test_srvs
   ../srv/SetBool.srv
   DEPENDENCIES builtin_interfaces
   LIBRARY_NAME ${PROJECT_NAME}
   SKIP_INSTALL
 )
+
 # Need the target name to depend on generated interface libraries
-rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}_test_msgs" "${PROJECT_NAME}_test_srvs" "rosidl_typesupport_cpp")
+rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}_test_msgs" "rosidl_typesupport_cpp")
 
 ament_add_gtest(
   test_allocator_common

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -89,6 +89,14 @@ if(TARGET test_client)
   )
   target_link_libraries(test_client ${PROJECT_NAME} mimick)
 endif()
+ament_add_gtest(test_client_with_type_adapter test_client_with_type_adapter.cpp
+  APPEND_LIBRARY_DIRS "${append_library_dirs}"
+)
+if(TARGET test_client_with_type_adapter)
+  target_link_libraries(test_client_with_type_adapter
+    ${PROJECT_NAME}
+    ${cpp_typesupport_target})
+endif()
 ament_add_gtest(test_create_timer test_create_timer.cpp)
 if(TARGET test_create_timer)
   ament_target_dependencies(test_create_timer

--- a/rclcpp/test/rclcpp/test_client_with_type_adapter.cpp
+++ b/rclcpp/test/rclcpp/test_client_with_type_adapter.cpp
@@ -129,16 +129,17 @@ struct rclcpp::TypeAdapter<int, rclcpp::msg::String>
   }
 };
 
-
 /*
  * Testing the basic creation of clients with a TypeAdapter for both Request and Response
  */
 TEST_F(TestClient, total_type_adaption_client_creation)
 {
-  using AdaptedRequestType = rclcpp::TypeAdapter<std::string, rclcpp::msg::String>;
-  using AdaptedResponseType = rclcpp::TypeAdapter<bool, rclcpp::msg::Bool>;
 
   std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("my_node");
+
+  {
+  using AdaptedRequestType = rclcpp::TypeAdapter<std::string, rclcpp::msg::String>;
+  using AdaptedResponseType = rclcpp::TypeAdapter<bool, rclcpp::msg::Bool>;
 
   struct AdaptedTypeStruct {
     using Request = AdaptedRequestType;
@@ -148,8 +149,8 @@ TEST_F(TestClient, total_type_adaption_client_creation)
   auto client = node->create_client<AdaptedTypeStruct>("client");
 
   /// Now try to adapt the type with the `as` metafunction
-  (void)client;
-
+  }
+  {
   using AdaptedRequestType = rclcpp::adapt_type<std::string>::as<rclcpp::msg::String>;
   using AdaptedResponseType = rclcpp::adapt_type<bool>::as<rclcpp::msg::Bool>;
 
@@ -160,6 +161,7 @@ TEST_F(TestClient, total_type_adaption_client_creation)
 
   auto Asclient = node->create_client<AdaptedTypeAsStruct>("client");
   (void)Asclient;
+  }
 }
 
 TEST_F(TestClient, request_type_adaption_client_creation)

--- a/rclcpp/test/rclcpp/test_client_with_type_adapter.cpp
+++ b/rclcpp/test/rclcpp/test_client_with_type_adapter.cpp
@@ -26,20 +26,15 @@
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-#include "../mocking_utils/patch.hpp"
 #include "../utils/rclcpp_gtest_macros.hpp"
 
-#include "test_msgs/msg/empty.hpp"
+#include "rclcpp/msg/empty.hpp"
 #include "rclcpp/msg/string.hpp"
 #include "rclcpp/msg/bool.hpp"
 
 #include "rclcpp/srv/set_bool.hpp"
 
 using namespace std::chrono_literals;
-
-static const int g_max_loops = 200;
-static const std::chrono::milliseconds g_sleep_per_loop(10);
-
 
 class TestClient: public ::testing::Test
 {
@@ -57,10 +52,9 @@ public:
   }
 };
 
-namespace rclcpp
-{
+
 template<>
-struct TypeAdapter<bool, rclcpp::msg::Bool>
+struct rclcpp::TypeAdapter<bool, rclcpp::msg::Bool>
 {
   using is_specialized = std::true_type;
   using custom_type = bool;
@@ -84,7 +78,7 @@ struct TypeAdapter<bool, rclcpp::msg::Bool>
 };
 
 template<>
-struct TypeAdapter<std::string, rclcpp::msg::String>
+struct rclcpp::TypeAdapter<std::string, rclcpp::msg::String>
 {
   using is_specialized = std::true_type;
   using custom_type = std::string;
@@ -109,7 +103,7 @@ struct TypeAdapter<std::string, rclcpp::msg::String>
 
 // Throws in conversion
 template<>
-struct TypeAdapter<int, rclcpp::msg::String>
+struct rclcpp::TypeAdapter<int, rclcpp::msg::String>
 {
   using is_specialized = std::true_type;
   using custom_type = int;
@@ -135,15 +129,14 @@ struct TypeAdapter<int, rclcpp::msg::String>
   }
 };
 
-}  // namespace rclcpp
 
 /*
  * Testing the basic creation of clients with a TypeAdapter for both Request and Response
  */
 TEST_F(TestClient, total_type_adaption_client_creation)
 {
-  using AdaptedRequestType = rclcpp::TypeAdapter<std::string, rclcpp::msg::String>>;
-  using AdaptedResponseType = rclcpp::TypeAdapter<bool, rclcpp::msg::Bool>>;
+  using AdaptedRequestType = rclcpp::TypeAdapter<std::string, rclcpp::msg::String>;
+  using AdaptedResponseType = rclcpp::TypeAdapter<bool, rclcpp::msg::Bool>;
 
   std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("my_node");
 
@@ -160,20 +153,20 @@ TEST_F(TestClient, total_type_adaption_client_creation)
   using AdaptedRequestType = rclcpp::adapt_type<std::string>::as<rclcpp::msg::String>;
   using AdaptedResponseType = rclcpp::adapt_type<bool>::as<rclcpp::msg::Bool>;
 
-  struct AdaptedTypeStruct {
+  struct AdaptedTypeAsStruct {
     using Request = AdaptedRequestType;
     using Response = AdaptedResponseType;
   };
 
-  auto client = node->create_client<AdaptedTypeStruct>("client");
-  (void)client;
+  auto Asclient = node->create_client<AdaptedTypeAsStruct>("client");
+  (void)Asclient;
 }
 
 TEST_F(TestClient, request_type_adaption_client_creation)
 {
   std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("my_node");
 
-  using AdaptedRequestType = rclcpp::TypeAdapter<std::string, rclcpp::msg::String>>;
+  using AdaptedRequestType = rclcpp::TypeAdapter<std::string, rclcpp::msg::String>;
 
   struct AdaptedTypeStruct {
     using Request = AdaptedRequestType;
@@ -187,20 +180,20 @@ TEST_F(TestClient, request_type_adaption_client_creation)
 
   using AdaptedRequestType = rclcpp::adapt_type<std::string>::as<rclcpp::msg::String>;
 
-  struct AdaptedTypeStruct {
+  struct AdaptedTypeAsStruct {
     using Request = AdaptedRequestType;
     using Response = rclcpp::srv::SetBool::Response;
   };
 
-  auto client = node->create_client<AdaptedTypeStruct>("client");
-  (void)client;
+  auto Asclient = node->create_client<AdaptedTypeAsStruct>("client");
+  (void)Asclient;
 }
 
 TEST_F(TestClient, response_type_adaption_client_creation)
 {
   std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("my_node");
 
-  using AdaptedResponseType = rclcpp::TypeAdapter<bool, rclcpp::msg::Bool>>;
+  using AdaptedResponseType = rclcpp::TypeAdapter<bool, rclcpp::msg::Bool>;
 
   struct AdaptedTypeStruct {
     using Request = rclcpp::msg::String;
@@ -214,13 +207,13 @@ TEST_F(TestClient, response_type_adaption_client_creation)
 
   using AdaptedResponseType = rclcpp::adapt_type<bool>::as<rclcpp::msg::Bool>;
 
-  struct AdaptedTypeStruct {
+  struct AdaptedTypeAsStruct {
     using Request = rclcpp::msg::String;
     using Response = AdaptedResponseType;
   };
 
-  auto client = node->create_client<AdaptedTypeStruct>("client");
-  (void)client;
+  auto Asclient = node->create_client<AdaptedTypeAsStruct>("client");
+  (void)Asclient;
 }
 
 /// Testing that conversion errors are passed up
@@ -228,12 +221,13 @@ TEST_F(TestClient, conversion_exception_is_passed_up)
 {
   std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("my_node");
 
-  using BadAdaptedResponseType = rclcpp::TypeAdapter<int, rclcpp::msg::String>>;
+  using BadAdaptedResponseType = rclcpp::TypeAdapter<int, rclcpp::msg::String>;
 
-  struct AdaptedTypeStruct {
+  struct BadAdaptedTypeStruct {
     using Request = rclcpp::msg::String;
     using Response = BadAdaptedResponseType;
   };
 
   auto client = node->create_client<BadAdaptedTypeStruct>("client");
+  (void)client;
 }

--- a/rclcpp/test/rclcpp/test_client_with_type_adapter.cpp
+++ b/rclcpp/test/rclcpp/test_client_with_type_adapter.cpp
@@ -41,7 +41,7 @@ static const int g_max_loops = 200;
 static const std::chrono::milliseconds g_sleep_per_loop(10);
 
 
-class TestService: public ::testing::Test
+class TestClient: public ::testing::Test
 {
 public:
   static void SetUpTestCase()
@@ -138,26 +138,24 @@ struct TypeAdapter<int, rclcpp::msg::String>
 }  // namespace rclcpp
 
 /*
- * Testing the basic creation of services with a TypeAdapter for both Request and Response
+ * Testing the basic creation of clients with a TypeAdapter for both Request and Response
  */
-TEST_F(TestService, total_type_adaption_service_creation)
+TEST_F(TestClient, total_type_adaption_client_creation)
 {
-  std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("my_node");
-
   using AdaptedRequestType = rclcpp::TypeAdapter<std::string, rclcpp::msg::String>>;
   using AdaptedResponseType = rclcpp::TypeAdapter<bool, rclcpp::msg::Bool>>;
+
+  std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("my_node");
 
   struct AdaptedTypeStruct {
     using Request = AdaptedRequestType;
     using Response = AdaptedResponseType;
   };
 
-  auto service = rclcpp::create_service<AdaptedTypeStruct>(
-      "service",
-      [](const std::string & req, const bool & res) {});
+  auto client = node->create_client<AdaptedTypeStruct>("client");
 
   /// Now try to adapt the type with the `as` metafunction
-  (void)service;
+  (void)client;
 
   using AdaptedRequestType = rclcpp::adapt_type<std::string>::as<rclcpp::msg::String>;
   using AdaptedResponseType = rclcpp::adapt_type<bool>::as<rclcpp::msg::Bool>;
@@ -167,13 +165,11 @@ TEST_F(TestService, total_type_adaption_service_creation)
     using Response = AdaptedResponseType;
   };
 
-  auto service = rclcpp::create_service<AdaptedTypeStruct>(
-      "service",
-      [](const std::string & req, const bool & res) {});
-  (void)service;
+  auto client = node->create_client<AdaptedTypeStruct>("client");
+  (void)client;
 }
 
-TEST_F(TestService, request_type_adaption_service_creation)
+TEST_F(TestClient, request_type_adaption_client_creation)
 {
   std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("my_node");
 
@@ -184,12 +180,10 @@ TEST_F(TestService, request_type_adaption_service_creation)
     using Response = rclcpp::srv::SetBool::Response;
   };
 
-  auto service = rclcpp::create_service<AdaptedTypeStruct>(
-      "service",
-      [](const std::string & req, rclcpp::srv::SetBool::Response & res) {});
+  auto client = node->create_client<AdaptedTypeStruct>("client");
 
   /// Now try to adapt the type with the `as` metafunction
-  (void)service;
+  (void)client;
 
   using AdaptedRequestType = rclcpp::adapt_type<std::string>::as<rclcpp::msg::String>;
 
@@ -198,13 +192,11 @@ TEST_F(TestService, request_type_adaption_service_creation)
     using Response = rclcpp::srv::SetBool::Response;
   };
 
-  auto service = rclcpp::create_service<AdaptedTypeStruct>(
-      "service",
-      [](const std::string & req, rclcpp::srv::SetBool::Response & res) {});
-  (void)service;
+  auto client = node->create_client<AdaptedTypeStruct>("client");
+  (void)client;
 }
 
-TEST_F(TestService, response_type_adaption_service_creation)
+TEST_F(TestClient, response_type_adaption_client_creation)
 {
   std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("my_node");
 
@@ -215,12 +207,10 @@ TEST_F(TestService, response_type_adaption_service_creation)
     using Response = AdaptedResponseType;
   };
 
-  auto service = rclcpp::create_service<AdaptedTypeStruct>(
-      "service",
-      [](const rclcpp::msg::String & req, const bool & res) {});
+  auto client = node->create_client<AdaptedTypeStruct>("client");
 
   /// Now try to adapt the type with the `as` metafunction
-  (void)service;
+  (void)client;
 
   using AdaptedResponseType = rclcpp::adapt_type<bool>::as<rclcpp::msg::Bool>;
 
@@ -229,14 +219,12 @@ TEST_F(TestService, response_type_adaption_service_creation)
     using Response = AdaptedResponseType;
   };
 
-  auto service = rclcpp::create_service<AdaptedTypeStruct>(
-      "service",
-      [](const rclcpp::msg::String & req, const bool & res) {});
-  (void)service;
+  auto client = node->create_client<AdaptedTypeStruct>("client");
+  (void)client;
 }
 
 /// Testing that conversion errors are passed up
-TEST_F(TestService, conversion_exception_is_passed_up)
+TEST_F(TestClient, conversion_exception_is_passed_up)
 {
   std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("my_node");
 
@@ -247,7 +235,5 @@ TEST_F(TestService, conversion_exception_is_passed_up)
     using Response = BadAdaptedResponseType;
   };
 
-  auto service = rclcpp::create_service<BadAdaptedTypeStruct>(
-      "service",
-      [](const rclcpp::msg::String & req) {});
+  auto client = node->create_client<BadAdaptedTypeStruct>("client");
 }

--- a/rclcpp/test/rclcpp/test_service_with_type_adapter.cpp
+++ b/rclcpp/test/rclcpp/test_service_with_type_adapter.cpp
@@ -1,0 +1,245 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include "../mocking_utils/patch.hpp"
+#include "../utils/rclcpp_gtest_macros.hpp"
+
+#include "test_msgs/msg/empty.hpp"
+#include "rclcpp/msg/string.hpp"
+#include "rclcpp/msg/bool.hpp"
+
+#include "rclcpp/srv/set_bool.hpp"
+
+using namespace std::chrono_literals;
+
+static const int g_max_loops = 200;
+static const std::chrono::milliseconds g_sleep_per_loop(10);
+
+
+class TestService: public ::testing::Test
+{
+public:
+  static void SetUpTestCase()
+  {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+  }
+
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
+};
+
+namespace rclcpp
+{
+template<>
+struct TypeAdapter<bool, rclcpp::msg::Bool>
+{
+  using is_specialized = std::true_type;
+  using custom_type = bool;
+  using ros_message_type = rclcpp::msg::Bool;
+
+  static void
+  convert_to_ros_message(
+    const custom_type & source,
+    ros_message_type & destination)
+  {
+    destination.data = source;
+  }
+
+  static void
+  convert_to_custom(
+    const ros_message_type & source,
+    custom_type & destination)
+  {
+    destination = source.data;
+  }
+};
+
+template<>
+struct TypeAdapter<std::string, rclcpp::msg::String>
+{
+  using is_specialized = std::true_type;
+  using custom_type = std::string;
+  using ros_message_type = rclcpp::msg::String;
+
+  static void
+  convert_to_ros_message(
+    const custom_type & source,
+    ros_message_type & destination)
+  {
+    destination.data = source;
+  }
+
+  static void
+  convert_to_custom(
+    const ros_message_type & source,
+    custom_type & destination)
+  {
+    destination = source.data;
+  }
+};
+
+// Throws in conversion
+template<>
+struct TypeAdapter<int, rclcpp::msg::String>
+{
+  using is_specialized = std::true_type;
+  using custom_type = int;
+  using ros_message_type = rclcpp::msg::String;
+
+  static void
+  convert_to_ros_message(
+    const custom_type & source,
+    ros_message_type & destination)
+  {
+    (void) source;
+    (void) destination;
+    throw std::runtime_error("This should not happen");
+  }
+
+  static void
+  convert_to_custom(
+    const ros_message_type & source,
+    custom_type & destination)
+  {
+    (void) source;
+    (void) destination;
+  }
+};
+
+}  // namespace rclcpp
+
+/*
+ * Testing the basic creation of services with a TypeAdapter for both Request and Response
+ */
+TEST_F(TestService, total_type_adaption_service_creation)
+{
+  using AdaptedRequestType = rclcpp::TypeAdapter<std::string, rclcpp::msg::String>>;
+  using AdaptedResponseType = rclcpp::TypeAdapter<bool, rclcpp::msg::Bool>>;
+
+  struct AdaptedTypeStruct {
+    using Request = AdaptedRequestType;
+    using Response = AdaptedResponseType;
+  };
+
+  auto service = rclcpp::create_service<AdaptedTypeStruct>(
+      "service",
+      [](const std::string & req, const bool & res) {});
+
+  /// Now try to adapt the type with the `as` metafunction
+  (void)service;
+
+  using AdaptedRequestType = rclcpp::adapt_type<std::string>::as<rclcpp::msg::String>;
+  using AdaptedResponseType = rclcpp::adapt_type<bool>::as<rclcpp::msg::Bool>;
+
+  struct AdaptedTypeStruct {
+    using Request = AdaptedRequestType;
+    using Response = AdaptedResponseType;
+  };
+
+  auto service = rclcpp::create_service<AdaptedTypeStruct>(
+      "service",
+      [](const std::string & req, const bool & res) {});
+  (void)service;
+}
+
+TEST_F(TestService, request_type_adaption_service_creation)
+{
+  using AdaptedRequestType = rclcpp::TypeAdapter<std::string, rclcpp::msg::String>>;
+
+  struct AdaptedTypeStruct {
+    using Request = AdaptedRequestType;
+    using Response = rclcpp::srv::SetBool::Response;
+  };
+
+  auto service = rclcpp::create_service<AdaptedTypeStruct>(
+      "service",
+      [](const std::string & req, rclcpp::srv::SetBool::Response & res) {});
+
+  /// Now try to adapt the type with the `as` metafunction
+  (void)service;
+
+  using AdaptedRequestType = rclcpp::adapt_type<std::string>::as<rclcpp::msg::String>;
+
+  struct AdaptedTypeStruct {
+    using Request = AdaptedRequestType;
+    using Response = rclcpp::srv::SetBool::Response;
+  };
+
+  auto service = rclcpp::create_service<AdaptedTypeStruct>(
+      "service",
+      [](const std::string & req, rclcpp::srv::SetBool::Response & res) {});
+  (void)service;
+}
+
+TEST_F(TestService, response_type_adaption_service_creation)
+{
+  using AdaptedResponseType = rclcpp::TypeAdapter<bool, rclcpp::msg::Bool>>;
+
+  struct AdaptedTypeStruct {
+    using Request = rclcpp::msg::String;
+    using Response = AdaptedResponseType;
+  };
+
+  auto service = rclcpp::create_service<AdaptedTypeStruct>(
+      "service",
+      [](const rclcpp::msg::String & req, const bool & res) {});
+
+  /// Now try to adapt the type with the `as` metafunction
+  (void)service;
+
+  using AdaptedResponseType = rclcpp::adapt_type<bool>::as<rclcpp::msg::Bool>;
+
+  struct AdaptedTypeStruct {
+    using Request = rclcpp::msg::String;
+    using Response = AdaptedResponseType;
+  };
+
+  auto service = rclcpp::create_service<AdaptedTypeStruct>(
+      "service",
+      [](const rclcpp::msg::String & req, const bool & res) {});
+  (void)service;
+}
+
+/// Testing that conversion errors are passed up
+TEST_F(TestService, conversion_exception_is_passed_up)
+{
+  using BadAdaptedResponseType = rclcpp::TypeAdapter<int, rclcpp::msg::String>>;
+
+  struct AdaptedTypeStruct {
+    using Request = rclcpp::msg::String;
+    using Response = BadAdaptedResponseType;
+  };
+
+  auto service = rclcpp::create_service<BadAdaptedTypeStruct>(
+      "service",
+      [](const rclcpp::msg::String & req) {});
+}

--- a/rclcpp/test/rclcpp/test_service_with_type_adapter.cpp
+++ b/rclcpp/test/rclcpp/test_service_with_type_adapter.cpp
@@ -26,10 +26,9 @@
 #include "rclcpp/exceptions.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-#include "../mocking_utils/patch.hpp"
 #include "../utils/rclcpp_gtest_macros.hpp"
 
-#include "test_msgs/msg/empty.hpp"
+#include "rclcpp/msg/empty.hpp"
 #include "rclcpp/msg/string.hpp"
 #include "rclcpp/msg/bool.hpp"
 
@@ -73,7 +72,7 @@ struct rclcpp::TypeAdapter<bool, rclcpp::msg::Bool>
     const ros_message_type & source,
     custom_type & destination)
   {
-    destination = source;
+    destination = source.data;
   }
 };
 

--- a/rclcpp/test/rclcpp/test_service_with_type_adapter.cpp
+++ b/rclcpp/test/rclcpp/test_service_with_type_adapter.cpp
@@ -37,10 +37,6 @@
 
 using namespace std::chrono_literals;
 
-static const int g_max_loops = 200;
-static const std::chrono::milliseconds g_sleep_per_loop(10);
-
-
 class TestService: public ::testing::Test
 {
 public:
@@ -57,10 +53,8 @@ public:
   }
 };
 
-namespace rclcpp
-{
 template<>
-struct TypeAdapter<bool, rclcpp::msg::Bool>
+struct rclcpp::TypeAdapter<bool, rclcpp::msg::Bool>
 {
   using is_specialized = std::true_type;
   using custom_type = bool;
@@ -79,12 +73,12 @@ struct TypeAdapter<bool, rclcpp::msg::Bool>
     const ros_message_type & source,
     custom_type & destination)
   {
-    destination = source.data;
+    destination = source;
   }
 };
 
 template<>
-struct TypeAdapter<std::string, rclcpp::msg::String>
+struct rclcpp::TypeAdapter<std::string, rclcpp::msg::String>
 {
   using is_specialized = std::true_type;
   using custom_type = std::string;
@@ -109,7 +103,7 @@ struct TypeAdapter<std::string, rclcpp::msg::String>
 
 // Throws in conversion
 template<>
-struct TypeAdapter<int, rclcpp::msg::String>
+struct rclcpp::TypeAdapter<int, rclcpp::msg::String>
 {
   using is_specialized = std::true_type;
   using custom_type = int;
@@ -134,8 +128,6 @@ struct TypeAdapter<int, rclcpp::msg::String>
     (void) destination;
   }
 };
-
-}  // namespace rclcpp
 
 /*
  * Testing the basic creation of services with a TypeAdapter for both Request and Response

--- a/rclcpp/test/srv/SetBool.srv
+++ b/rclcpp/test/srv/SetBool.srv
@@ -1,0 +1,4 @@
+bool data
+---
+bool success
+string message


### PR DESCRIPTION
This pull request is a larger one in response to issue #1666 which was to add Type Adaptations to Services/Clients, Type Adaptation were originally added to rclcpp with PR #1557 in 2021. Type Adaptations were a whole [design document](https://www.ros.org/reps/rep-2007.html), which is what I tried to follow when implementing this for services and clients, If we're able to do this we can also have a strong resource for the Actions side of things.

At the original time of this PR you can see it doesn't work, I wanted to figure out the direction we needed to take with how we implemented the Type Adaptations. In the documentation, the given example was:
```
using MyAdaptedRequestType = TypeAdapter<std::string, std_msgs::msg::String>;
using MyAdaptedResponseType = TypeAdapter<bool, std_msgs::msg::Bool>;

struct MyServiceTypeAdapter {
   using Request = MyAdaptedRequestType;
   using Response = MyAdaptedResponseType;
};

auto client = node->create_client<MyServiceTypeAdapter>("service");
```
where the original thought was to just make a `struct` that replicates a service with a Request and Response, that's what I applied. There are two spots, currently where this doesn't work -
  - [rosidl_typesupport_cpp's method `get_service_type_support_handle`](https://github.com/CursedRock17/rclcpp/blob/c312b89e3cd2dc7d7b1939e44c237a23386650db/rclcpp/include/rclcpp/get_service_type_support_handle.hpp#L76)
  - [node_type_description's GetTypeDescription__C](https://github.com/CursedRock17/rclcpp/blob/rolling/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp#L27-L32)

These issues highlight the difficulties with using the strategies in the current design docs, which is: the proxy struct that you pass to be a service isn't actually a service. In the case of the rosidl_typesupport, currently [this generated method](https://github.com/ros2/rosidl_typesupport/blob/e5b976b73b4158d0c09d546faac3591cfc90598e/rosidl_typesupport_cpp/resource/srv__type_support.cpp.em#L140-L155) was what I found allowed any services to pass through with this:
- @('::'.join([package_name] + list(interface_path.parents[0].parts)))::@(service.namespaced_type.name)

being passed as the type, afaik there is only one to change this and enable it as a message which where `GetTypeDescription__C` comes into to play, it creates a different method:
```
// Helper function for C typesupport.
namespace rosidl_typesupport_cpp
{
template<>
rosidl_service_type_support_t const *
get_service_type_support_handle<GetTypeDescription__C>()
{
  return ROSIDL_GET_SRV_TYPE_SUPPORT(type_description_interfaces, srv, GetTypeDescription);
}
}  // namespace rosidl_typesupport_cpp
```
calling `ROSIDL_GET_SRV_TYPE_SUPPORT`. Circling back to `get_service_type_support_handle`, we don't where the user is going to get these services from, at least I don't think, so that we could apply this type. Then, GetTypeDescription__C doesn't pass to the Service it's used in because, the `Request` and `Response` aren't technically messages again, they are the generated type that the compiler deciphers, this was all added in the [Type Description](https://github.com/ros2/ros2/issues/1159) design and creation. There is also a similar version of type support in [rosidl_runtime_c](https://github.com/ros2/rosidl/blob/rolling/rosidl_runtime_c/include/rosidl_runtime_c/service_type_support_struct.h#L146)


So I submitted the pr early, to try and gain some sort of insight that I could just be missing and find out the direction we want to go. Technically speaking, we could work by creating another TypeAdaptation [`struct`](https://github.com/CursedRock17/rclcpp/blob/rolling/rclcpp/include/rclcpp/type_adapter.hpp) that could take in some form of `AdaptedStruct` and just do what TypeAdapter does know, but with Response and Request, but this isn't very effective because we're generating way more code, we'll have to do it with 3 things when we add Actions, and I don't even know if it will work entirely. Let me know what direction we want to take on this, anything I missed, and if anything needs to be cleared up
