### PR TITLE
Topic correct typeadapter deduction

### DIFF
--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -486,13 +486,13 @@ private:
                 "subscription use different allocator types, which is not supported");
       }
 
-      if constexpr (rclcpp::TypeAdapter<MessageT>::is_specialized::value) {
+      if constexpr (rclcpp::TypeAdapter<MessageT, ROSMessageType>::is_specialized::value) {
         ROSMessageTypeAllocator ros_message_alloc(allocator);
         auto ptr = ros_message_alloc.allocate(1);
         ros_message_alloc.construct(ptr);
         ROSMessageTypeDeleter deleter;
         allocator::set_allocator_for_deleter(&deleter, &allocator);
-        rclcpp::TypeAdapter<MessageT>::convert_to_ros_message(*message, *ptr);
+        rclcpp::TypeAdapter<MessageT, ROSMessageType>::convert_to_ros_message(*message, *ptr);
         auto ros_msg = std::unique_ptr<ROSMessageType, ROSMessageTypeDeleter>(ptr, deleter);
         ros_message_subscription->provide_intra_process_message(std::move(ros_msg));
       } else {


### PR DESCRIPTION
to fix https://github.com/ros2/rclcpp/issues/2291

Based on the document of [TypeAdapter](https://github.com/ros2/rclcpp/blob/bc435776a257fcf76c5b0124bec26f6824342e34/rclcpp/include/rclcpp/type_adapter.hpp#L23-L37), I'd like to update from `TypeAdapter<MessageT>` to `TypeAdapter<MessageT, ROSMessageType>`, rather than adding another if-block to deal with `TypeAdapter<MessageT, ROSMessageType>` as there are no cases in the existing test that could be failed.

BTW: I think https://github.com/ros2/rclcpp/blob/bc435776a257fcf76c5b0124bec26f6824342e34/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp#L397-L416 can be updated as well because of some unuseful code. (Maybe update it in the following PR.)

I'd like to hear your opinions.