### PR TITLE
Fix the return type of Rate::period.

### DIFF
--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -163,7 +163,7 @@ public:
   reset();
 
   RCLCPP_PUBLIC
-  Duration
+  std::chrono::nanoseconds
   period() const;
 
 private:

--- a/rclcpp/src/rclcpp/rate.cpp
+++ b/rclcpp/src/rclcpp/rate.cpp
@@ -14,6 +14,7 @@
 
 #include "rclcpp/rate.hpp"
 
+#include <chrono>
 #include <stdexcept>
 
 namespace rclcpp
@@ -87,10 +88,10 @@ Rate::reset()
   last_interval_ = clock_->now();
 }
 
-Duration
+std::chrono::nanoseconds
 Rate::period() const
 {
-  return period_;
+  return std::chrono::nanoseconds(period_.nanoseconds());
 }
 
 WallRate::WallRate(const double rate)


### PR DESCRIPTION
In a recent commit (bc435776a257fcf76c5b0124bec26f6824342e34), we reworked how the Rate class worked so it could be used with ROS time as well.  Unfortunately, we also accidentally broke the API of it by changing the return type of Rate::period to a Duration instead of a
std::chrono::nanoseconds .  Put this back to a std::chrono::nanoseconds; if we want to change it to a Duration, we'll have to add a new method and deprecate this one.

@AlexeyMerzlyakov FYI