### PR TITLE
Update API docs links in package READMEs

### DIFF
--- a/rclcpp/README.md
+++ b/rclcpp/README.md
@@ -2,7 +2,7 @@
 
 The ROS client library in C++.
 
-Visit the [rclcpp API documentation](http://docs.ros2.org/latest/api/rclcpp/) for a complete list of its main components and features.
+The link to the latest rclcpp API documentation, which includes a complete list of its main components and features, can be found on the rclcpp package info page, at the [ROS Index](https://index.ros.org/p/rclcpp/).
 
 ## Quality Declaration
 

--- a/rclcpp_action/README.md
+++ b/rclcpp_action/README.md
@@ -2,7 +2,8 @@
 
 Adds action APIs for C++.
 
-Visit the [rclcpp_action API documentation](http://docs.ros2.org/latest/api/rclcpp_action/) for a complete list of its main components and features. For more information about Actions in ROS 2, see the [design document](http://design.ros2.org/articles/actions.html).
+The link to the latest rclcpp_action API documentation, which includes a complete list of its main components and features, can be found on the rclcpp_action package info page, at the [ROS Index](https://index.ros.org/p/rclcpp_action/).
+For more information about Actions in ROS 2, see the [design document](http://design.ros2.org/articles/actions.html).
 
 ## Quality Declaration
 

--- a/rclcpp_components/README.md
+++ b/rclcpp_components/README.md
@@ -2,7 +2,7 @@
 
 Package containing tools for dynamically loadable components.
 
-Visit the [rclcpp_components API documentation](http://docs.ros2.org/latest/api/rclcpp_components/) for a complete list of its main components and features.
+The link to the latest rclcpp_components API documentation, which includes a complete list of its main components and features, can be found on the rclcpp_components package info page, at the [ROS Index](https://index.ros.org/p/rclcpp_components/).
 
 ## Quality Declaration
 

--- a/rclcpp_lifecycle/README.md
+++ b/rclcpp_lifecycle/README.md
@@ -2,7 +2,8 @@
 
 Package containing a prototype for lifecycle implementation.
 
-Visit the [rclcpp_lifecycle API documentation](http://docs.ros2.org/latest/api/rclcpp_lifecycle/) for a complete list of its main components and features. For more information about LifeCycle in ROS 2, see the [design document](http://design.ros2.org/articles/node_lifecycle.html).
+The link to the latest rclcpp_lifecycle API documentation, which includes a complete list of its main components and features, can be found on the rclcpp_lifecycle package info page, at the [ROS Index](https://index.ros.org/p/rclcpp_lifecycle/).
+For more information about LifeCycle in ROS 2, see the [design document](http://design.ros2.org/articles/node_lifecycle.html).
 
 ## Quality Declaration
 


### PR DESCRIPTION
The root README was updated to point to index.ros.org/p/rclcpp (#1620, #2071), but the individual package READMEs, which are displayed by index.ros.org, still link to docs.ros2.org.