### PR TITLE
Add transient local durability support to publisher and subscriptions when using intra-process communication

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -46,6 +46,7 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/context.cpp
   src/rclcpp/contexts/default_context.cpp
   src/rclcpp/detail/add_guard_condition_to_rcl_wait_set.cpp
+  src/rclcpp/detail/resolve_intra_process_buffer_type.cpp
   src/rclcpp/detail/resolve_parameter_overrides.cpp
   src/rclcpp/detail/rmw_implementation_specific_payload.cpp
   src/rclcpp/detail/rmw_implementation_specific_publisher_payload.cpp

--- a/rclcpp/include/rclcpp/detail/resolve_intra_process_buffer_type.hpp
+++ b/rclcpp/include/rclcpp/detail/resolve_intra_process_buffer_type.hpp
@@ -47,6 +47,10 @@ resolve_intra_process_buffer_type(
   return resolved_buffer_type;
 }
 
+rclcpp::IntraProcessBufferType
+resolve_intra_process_buffer_type(
+  const rclcpp::IntraProcessBufferType buffer_type);
+
 }  // namespace detail
 
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/detail/resolve_intra_process_buffer_type.hpp
+++ b/rclcpp/include/rclcpp/detail/resolve_intra_process_buffer_type.hpp
@@ -47,6 +47,7 @@ resolve_intra_process_buffer_type(
   return resolved_buffer_type;
 }
 
+RCLCPP_PUBLIC
 rclcpp::IntraProcessBufferType
 resolve_intra_process_buffer_type(
   const rclcpp::IntraProcessBufferType buffer_type);

--- a/rclcpp/include/rclcpp/experimental/buffers/buffer_implementation_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/buffers/buffer_implementation_base.hpp
@@ -15,6 +15,8 @@
 #ifndef RCLCPP__EXPERIMENTAL__BUFFERS__BUFFER_IMPLEMENTATION_BASE_HPP_
 #define RCLCPP__EXPERIMENTAL__BUFFERS__BUFFER_IMPLEMENTATION_BASE_HPP_
 
+#include <vector>
+
 namespace rclcpp
 {
 namespace experimental
@@ -30,6 +32,8 @@ public:
 
   virtual BufferT dequeue() = 0;
   virtual void enqueue(BufferT request) = 0;
+
+  virtual std::vector<BufferT> get_all_data() = 0;
 
   virtual void clear() = 0;
   virtual bool has_data() const = 0;

--- a/rclcpp/include/rclcpp/experimental/buffers/ring_buffer_implementation.hpp
+++ b/rclcpp/include/rclcpp/experimental/buffers/ring_buffer_implementation.hpp
@@ -15,6 +15,7 @@
 #ifndef RCLCPP__EXPERIMENTAL__BUFFERS__RING_BUFFER_IMPLEMENTATION_HPP_
 #define RCLCPP__EXPERIMENTAL__BUFFERS__RING_BUFFER_IMPLEMENTATION_HPP_
 
+#include <memory>
 #include <mutex>
 #include <stdexcept>
 #include <utility>
@@ -111,6 +112,17 @@ public:
     size_--;
 
     return request;
+  }
+
+  /// Get all the elements from the ring buffer
+  /**
+   * This member function is thread-safe.
+   *
+   * \return a vector containing all the elements from the ring buffer
+   */
+  std::vector<BufferT> get_all_data() override
+  {
+    return get_all_data_impl();
   }
 
   /// Get the next index value for the ring buffer
@@ -213,6 +225,49 @@ private:
   inline size_t available_capacity_() const
   {
     return capacity_ - size_;
+  }
+
+  /// Traits for checking if a type is std::unique_ptr
+  template<typename ...>
+  struct is_std_unique_ptr final : std::false_type {};
+  template<class T, typename ... Args>
+  struct is_std_unique_ptr<std::unique_ptr<T, Args...>> final : std::true_type
+  {
+    typedef T Ptr_type;
+  };
+
+  /// Get all the elements from the ring buffer
+  /**
+   * This member function is thread-safe.
+   * Two versions for the implementation of the function.
+   * One for buffer containing unique_ptr and the other for other typess
+   *
+   * \return a vector containing all the elements from the ring buffer
+   */
+  template<typename T = BufferT, std::enable_if_t<is_std_unique_ptr<T>::value, void> * = nullptr>
+  std::vector<BufferT> get_all_data_impl()
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<BufferT> result_vtr;
+    result_vtr.reserve(size_);
+    for (size_t id = 0; id < size_; ++id) {
+      result_vtr.emplace_back(
+        new typename is_std_unique_ptr<T>::Ptr_type(
+          *(ring_buffer_[(read_index_ + id) % capacity_])));
+    }
+    return result_vtr;
+  }
+
+  template<typename T = BufferT, std::enable_if_t<!is_std_unique_ptr<T>::value, void> * = nullptr>
+  std::vector<BufferT> get_all_data_impl()
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<BufferT> result_vtr;
+    result_vtr.reserve(size_);
+    for (size_t id = 0; id < size_; ++id) {
+      result_vtr.emplace_back(ring_buffer_[(read_index_ + id) % capacity_]);
+    }
+    return result_vtr;
   }
 
   size_t capacity_;

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -28,6 +28,7 @@
 #include <typeinfo>
 
 #include "rclcpp/allocator/allocator_deleter.hpp"
+#include "rclcpp/experimental/buffers/intra_process_buffer.hpp"
 #include "rclcpp/experimental/ros_message_intra_process_buffer.hpp"
 #include "rclcpp/experimental/subscription_intra_process.hpp"
 #include "rclcpp/experimental/subscription_intra_process_base.hpp"
@@ -112,9 +113,76 @@ public:
    * \param subscription the SubscriptionIntraProcess to register.
    * \return an unsigned 64-bit integer which is the subscription's unique id.
    */
+  template<
+    typename ROSMessageType,
+    typename Alloc = std::allocator<ROSMessageType>
+  >
   RCLCPP_PUBLIC
   uint64_t
-  add_subscription(rclcpp::experimental::SubscriptionIntraProcessBase::SharedPtr subscription);
+  add_subscription(rclcpp::experimental::SubscriptionIntraProcessBase::SharedPtr subscription)
+  {
+    using ROSMessageTypeAllocatorTraits = allocator::AllocRebind<ROSMessageType, Alloc>;
+    using ROSMessageTypeAllocator = typename ROSMessageTypeAllocatorTraits::allocator_type;
+    using ROSMessageTypeDeleter = allocator::Deleter<ROSMessageTypeAllocator, ROSMessageType>;
+
+    std::unique_lock<std::shared_timed_mutex> lock(mutex_);
+
+    uint64_t sub_id = IntraProcessManager::get_next_unique_id();
+
+    subscriptions_[sub_id] = subscription;
+
+    // adds the subscription id to all the matchable publishers
+    for (auto & pair : publishers_) {
+      auto publisher = pair.second.lock();
+      if (!publisher) {
+        continue;
+      }
+      if (can_communicate(publisher, subscription)) {
+        uint64_t pub_id = pair.first;
+        insert_sub_id_for_pub(sub_id, pub_id, subscription->use_take_shared_method());
+        if (publisher->is_durability_transient_local() &&
+          subscription->is_durability_transient_local())
+        {
+          auto publisher_buffer = publisher_buffers_[pub_id].lock();
+          if (!publisher_buffer) {
+            throw std::runtime_error("publisher buffer has unexpectedly gone out of scope");
+          }
+          auto buffer = std::dynamic_pointer_cast<
+            rclcpp::experimental::buffers::IntraProcessBuffer<
+              ROSMessageType,
+              ROSMessageTypeAllocator,
+              ROSMessageTypeDeleter
+            >
+            >(publisher_buffer);
+          if (!buffer) {
+            throw std::runtime_error(
+                    "failed to dynamic cast publisher's IntraProcessBufferBase to "
+                    "IntraProcessBuffer<ROSMessageType,ROSMessageTypeAllocator,"
+                    "ROSMessageTypeDeleter> which can happen when the publisher and "
+                    "subscription use different allocator types, which is not supported");
+          }
+          if (subscription->use_take_shared_method()) {
+            auto data_vec = buffer->get_all_data_shared();
+            for (auto shared_data : data_vec) {
+              this->template add_shared_msg_to_buffer<
+                ROSMessageType, ROSMessageTypeAllocator, ROSMessageTypeDeleter, ROSMessageType>(
+                shared_data, sub_id);
+            }
+          } else {
+            auto data_vec = buffer->get_all_data_unique();
+            for (auto & owned_data : data_vec) {
+              auto allocator = ROSMessageTypeAllocator();
+              this->template add_owned_msg_to_buffer<
+                ROSMessageType, ROSMessageTypeAllocator, ROSMessageTypeDeleter, ROSMessageType>(
+                std::move(owned_data), sub_id, allocator);
+            }
+          }
+        }
+      }
+    }
+
+    return sub_id;
+  }
 
   /// Unregister a subscription using the subscription's unique id.
   /**
@@ -138,7 +206,10 @@ public:
    */
   RCLCPP_PUBLIC
   uint64_t
-  add_publisher(rclcpp::PublisherBase::SharedPtr publisher);
+  add_publisher(
+    rclcpp::PublisherBase::SharedPtr publisher,
+    rclcpp::experimental::buffers::IntraProcessBufferBase::SharedPtr buffer =
+    rclcpp::experimental::buffers::IntraProcessBufferBase::SharedPtr());
 
   /// Unregister a publisher using the publisher's unique id.
   /**
@@ -352,6 +423,9 @@ private:
   using PublisherMap =
     std::unordered_map<uint64_t, rclcpp::PublisherBase::WeakPtr>;
 
+  using PublisherBufferMap =
+    std::unordered_map<uint64_t, rclcpp::experimental::buffers::IntraProcessBufferBase::WeakPtr>;
+
   using PublisherToSubscriptionIdsMap =
     std::unordered_map<uint64_t, SplittedSubscriptions>;
 
@@ -548,6 +622,7 @@ private:
   PublisherToSubscriptionIdsMap pub_to_subs_;
   SubscriptionMap subscriptions_;
   PublisherMap publishers_;
+  PublisherBufferMap publisher_buffers_;
 
   mutable std::shared_timed_mutex mutex_;
 };

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -292,6 +292,34 @@ public:
     }
   }
 
+  template<
+    typename MessageT,
+    typename Alloc,
+    typename Deleter,
+    typename ROSMessageType>
+  void
+  add_shared_msg_to_buffer(
+    std::shared_ptr<const MessageT> message,
+    uint64_t subscription_id)
+  {
+    add_shared_msg_to_buffers<MessageT, Alloc, Deleter, ROSMessageType>(message, {subscription_id});
+  }
+
+  template<
+    typename MessageT,
+    typename Alloc,
+    typename Deleter,
+    typename ROSMessageType>
+  void
+  add_owned_msg_to_buffer(
+    std::unique_ptr<MessageT, Deleter> message,
+    uint64_t subscription_id,
+    typename allocator::AllocRebind<MessageT, Alloc>::allocator_type & allocator)
+  {
+    add_owned_msg_to_buffers<MessageT, Alloc, Deleter, ROSMessageType>(
+      std::move(message), {subscription_id}, allocator);
+  }
+
   /// Return true if the given rmw_gid_t matches any stored Publishers.
   RCLCPP_PUBLIC
   bool

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -117,7 +117,6 @@ public:
     typename ROSMessageType,
     typename Alloc = std::allocator<ROSMessageType>
   >
-  RCLCPP_PUBLIC
   uint64_t
   add_subscription(rclcpp::experimental::SubscriptionIntraProcessBase::SharedPtr subscription)
   {
@@ -413,7 +412,6 @@ private:
     typename ROSMessageType,
     typename Alloc = std::allocator<ROSMessageType>
   >
-  RCLCPP_PUBLIC
   void do_transient_local_publish(
     const uint64_t pub_id, const uint64_t sub_id,
     const bool use_take_shared_method)

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -163,9 +163,13 @@ public:
    * This method stores the publisher intra process object, together with
    * the information of its wrapped publisher (i.e. topic name and QoS).
    *
+   * If the publisher's durability is transient local, its buffer pointer should
+   * be passed and the method will store it as well.
+   *
    * In addition this generates a unique intra process id for the publisher.
    *
    * \param publisher publisher to be registered with the manager.
+   * \param buffer publisher's buffer to be stored if its duability is transient local.
    * \return an unsigned 64-bit integer which is the publisher's unique id.
    */
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -67,6 +67,10 @@ public:
   size_t
   available_capacity() const = 0;
 
+  RCLCPP_PUBLIC
+  bool
+  is_durability_transient_local() const;
+
   bool
   is_ready(rcl_wait_set_t * wait_set) override = 0;
 

--- a/rclcpp/include/rclcpp/publisher_base.hpp
+++ b/rclcpp/include/rclcpp/publisher_base.hpp
@@ -390,7 +390,6 @@ protected:
   using IntraProcessManagerWeakPtr =
     std::weak_ptr<rclcpp::experimental::IntraProcessManager>;
   bool intra_process_is_enabled_;
-  const bool durability_is_transient_local_;
   IntraProcessManagerWeakPtr weak_ipm_;
   uint64_t intra_process_publisher_id_;
 

--- a/rclcpp/include/rclcpp/publisher_base.hpp
+++ b/rclcpp/include/rclcpp/publisher_base.hpp
@@ -139,6 +139,12 @@ public:
   size_t
   get_intra_process_subscription_count() const;
 
+  /// Get if durability is transient local
+  /** \return If durability is transient local*/
+  RCLCPP_PUBLIC
+  bool
+  is_durability_transient_local() const;
+
   /// Manually assert that this Publisher is alive (for RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC).
   /**
    * If the rmw Liveliness policy is set to RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC, the creator
@@ -331,6 +337,27 @@ public:
     event_handlers_[event_type]->clear_on_ready_callback();
   }
 
+
+  /// Publish shared messages from intra process buffer for late joiner
+  /**
+   * This signature allows the user to give a sub_id from intra process manager.
+   * The function will publish messages currently held in buffer_ to the subscription
+   * as shared pointers.
+   *
+   * \param[in] sud_id subscription id in ipm to publish data to
+   */
+  virtual void do_shared_intra_process_publish_for_late_joiner(const uint64_t sub_id);
+
+  /// Publish owned messages from intra process buffer for late joiner
+  /**
+   * This signature allows the user to give a sub_id from intra process manager.
+   * The function will publish messages currently held in buffer_ to the subscription
+   * as unique pointers.
+   *
+   * \param[in] sud_id subscription id in ipm to publish data to
+   */
+  virtual void do_unique_intra_process_publish_for_late_joiner(const uint64_t sub_id);
+
 protected:
   template<typename EventCallbackT>
   void
@@ -363,6 +390,7 @@ protected:
   using IntraProcessManagerWeakPtr =
     std::weak_ptr<rclcpp::experimental::IntraProcessManager>;
   bool intra_process_is_enabled_;
+  const bool durability_is_transient_local_;
   IntraProcessManagerWeakPtr weak_ipm_;
   uint64_t intra_process_publisher_id_;
 

--- a/rclcpp/include/rclcpp/publisher_base.hpp
+++ b/rclcpp/include/rclcpp/publisher_base.hpp
@@ -337,27 +337,6 @@ public:
     event_handlers_[event_type]->clear_on_ready_callback();
   }
 
-
-  /// Publish shared messages from intra process buffer for late joiner
-  /**
-   * This signature allows the user to give a sub_id from intra process manager.
-   * The function will publish messages currently held in buffer_ to the subscription
-   * as shared pointers.
-   *
-   * \param[in] sud_id subscription id in ipm to publish data to
-   */
-  virtual void do_shared_intra_process_publish_for_late_joiner(const uint64_t sub_id);
-
-  /// Publish owned messages from intra process buffer for late joiner
-  /**
-   * This signature allows the user to give a sub_id from intra process manager.
-   * The function will publish messages currently held in buffer_ to the subscription
-   * as unique pointers.
-   *
-   * \param[in] sud_id subscription id in ipm to publish data to
-   */
-  virtual void do_unique_intra_process_publish_for_late_joiner(const uint64_t sub_id);
-
 protected:
   template<typename EventCallbackT>
   void

--- a/rclcpp/include/rclcpp/publisher_options.hpp
+++ b/rclcpp/include/rclcpp/publisher_options.hpp
@@ -24,6 +24,7 @@
 
 #include "rclcpp/allocator/allocator_common.hpp"
 #include "rclcpp/detail/rmw_implementation_specific_publisher_payload.hpp"
+#include "rclcpp/intra_process_buffer_type.hpp"
 #include "rclcpp/intra_process_setting.hpp"
 #include "rclcpp/qos.hpp"
 #include "rclcpp/event_handler.hpp"
@@ -39,6 +40,9 @@ struct PublisherOptionsBase
 {
   /// Setting to explicitly set intraprocess communications.
   IntraProcessSetting use_intra_process_comm = IntraProcessSetting::NodeDefault;
+
+  /// Setting the data-type stored in the intraprocess buffer
+  IntraProcessBufferType intra_process_buffer_type = IntraProcessBufferType::SharedPtr;
 
   /// Callbacks for various events related to publishers.
   PublisherEventCallbacks event_callbacks;

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -163,10 +163,6 @@ public:
         throw std::invalid_argument(
                 "intraprocess communication is not allowed with 0 depth qos policy");
       }
-      if (qos_profile.durability() != rclcpp::DurabilityPolicy::Volatile) {
-        throw std::invalid_argument(
-                "intraprocess communication allowed only with volatile durability");
-      }
 
       using SubscriptionIntraProcessT = rclcpp::experimental::SubscriptionIntraProcess<
         MessageT,

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -189,7 +189,8 @@ public:
       // Add it to the intra process manager.
       using rclcpp::experimental::IntraProcessManager;
       auto ipm = context->get_sub_context<IntraProcessManager>();
-      uint64_t intra_process_subscription_id = ipm->add_subscription(subscription_intra_process_);
+      uint64_t intra_process_subscription_id = ipm->template add_subscription<
+        ROSMessageType, ROSMessageTypeAllocator>(subscription_intra_process_);
       this->setup_intra_process(intra_process_subscription_id, ipm);
     }
 

--- a/rclcpp/src/rclcpp/detail/resolve_intra_process_buffer_type.cpp
+++ b/rclcpp/src/rclcpp/detail/resolve_intra_process_buffer_type.cpp
@@ -1,0 +1,37 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rclcpp/detail/resolve_intra_process_buffer_type.hpp>
+
+namespace rclcpp
+{
+
+namespace detail
+{
+rclcpp::IntraProcessBufferType
+resolve_intra_process_buffer_type(
+  const rclcpp::IntraProcessBufferType buffer_type)
+{
+  if (buffer_type == IntraProcessBufferType::CallbackDefault) {
+    throw std::invalid_argument(
+            "IntraProcessBufferType::CallbackDefault is not allowed "
+            "when there is no callback function");
+  }
+
+  return buffer_type;
+}
+
+}  // namespace detail
+
+}  // namespace rclcpp

--- a/rclcpp/src/rclcpp/intra_process_manager.cpp
+++ b/rclcpp/src/rclcpp/intra_process_manager.cpp
@@ -76,6 +76,15 @@ IntraProcessManager::add_subscription(SubscriptionIntraProcessBase::SharedPtr su
     if (can_communicate(publisher, subscription)) {
       uint64_t pub_id = pair.first;
       insert_sub_id_for_pub(sub_id, pub_id, subscription->use_take_shared_method());
+      if (publisher->is_durability_transient_local() &&
+        subscription->is_durability_transient_local())
+      {
+        if (subscription->use_take_shared_method()) {
+          publisher->do_shared_intra_process_publish_for_late_joiner(sub_id);
+        } else {
+          publisher->do_unique_intra_process_publish_for_late_joiner(sub_id);
+        }
+      }
     }
   }
 

--- a/rclcpp/src/rclcpp/intra_process_manager.cpp
+++ b/rclcpp/src/rclcpp/intra_process_manager.cpp
@@ -32,13 +32,24 @@ IntraProcessManager::~IntraProcessManager()
 {}
 
 uint64_t
-IntraProcessManager::add_publisher(rclcpp::PublisherBase::SharedPtr publisher)
+IntraProcessManager::add_publisher(
+  rclcpp::PublisherBase::SharedPtr publisher,
+  rclcpp::experimental::buffers::IntraProcessBufferBase::SharedPtr buffer)
 {
   std::unique_lock<std::shared_timed_mutex> lock(mutex_);
 
   uint64_t pub_id = IntraProcessManager::get_next_unique_id();
 
   publishers_[pub_id] = publisher;
+  if (publisher->is_durability_transient_local()) {
+    if (buffer) {
+      publisher_buffers_[pub_id] = buffer;
+    } else {
+      throw std::runtime_error(
+              "transient_local publisher needs to pass"
+              "a valid publisher buffer ptr when calling add_publisher()");
+    }
+  }
 
   // Initialize the subscriptions storage for this publisher.
   pub_to_subs_[pub_id] = SplittedSubscriptions();
@@ -56,39 +67,6 @@ IntraProcessManager::add_publisher(rclcpp::PublisherBase::SharedPtr publisher)
   }
 
   return pub_id;
-}
-
-uint64_t
-IntraProcessManager::add_subscription(SubscriptionIntraProcessBase::SharedPtr subscription)
-{
-  std::unique_lock<std::shared_timed_mutex> lock(mutex_);
-
-  uint64_t sub_id = IntraProcessManager::get_next_unique_id();
-
-  subscriptions_[sub_id] = subscription;
-
-  // adds the subscription id to all the matchable publishers
-  for (auto & pair : publishers_) {
-    auto publisher = pair.second.lock();
-    if (!publisher) {
-      continue;
-    }
-    if (can_communicate(publisher, subscription)) {
-      uint64_t pub_id = pair.first;
-      insert_sub_id_for_pub(sub_id, pub_id, subscription->use_take_shared_method());
-      if (publisher->is_durability_transient_local() &&
-        subscription->is_durability_transient_local())
-      {
-        if (subscription->use_take_shared_method()) {
-          publisher->do_shared_intra_process_publish_for_late_joiner(sub_id);
-        } else {
-          publisher->do_unique_intra_process_publish_for_late_joiner(sub_id);
-        }
-      }
-    }
-  }
-
-  return sub_id;
 }
 
 void

--- a/rclcpp/src/rclcpp/intra_process_manager.cpp
+++ b/rclcpp/src/rclcpp/intra_process_manager.cpp
@@ -99,6 +99,7 @@ IntraProcessManager::remove_publisher(uint64_t intra_process_publisher_id)
   std::unique_lock<std::shared_timed_mutex> lock(mutex_);
 
   publishers_.erase(intra_process_publisher_id);
+  publisher_buffers_.erase(intra_process_publisher_id);
   pub_to_subs_.erase(intra_process_publisher_id);
 }
 

--- a/rclcpp/src/rclcpp/publisher_base.cpp
+++ b/rclcpp/src/rclcpp/publisher_base.cpp
@@ -50,8 +50,6 @@ PublisherBase::PublisherBase(
   bool use_default_callbacks)
 : rcl_node_handle_(node_base->get_shared_rcl_node_handle()),
   intra_process_is_enabled_(false),
-  durability_is_transient_local_(
-    publisher_options.qos.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL),
   intra_process_publisher_id_(0),
   type_support_(type_support),
   event_callbacks_(event_callbacks)
@@ -275,7 +273,8 @@ PublisherBase::get_intra_process_subscription_count() const
 bool
 PublisherBase::is_durability_transient_local() const
 {
-  return durability_is_transient_local_;
+  return rcl_publisher_get_actual_qos(publisher_handle_.get())->durability ==
+         RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
 }
 
 rclcpp::QoS

--- a/rclcpp/src/rclcpp/publisher_base.cpp
+++ b/rclcpp/src/rclcpp/publisher_base.cpp
@@ -50,6 +50,8 @@ PublisherBase::PublisherBase(
   bool use_default_callbacks)
 : rcl_node_handle_(node_base->get_shared_rcl_node_handle()),
   intra_process_is_enabled_(false),
+  durability_is_transient_local_(
+    publisher_options.qos.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL),
   intra_process_publisher_id_(0),
   type_support_(type_support),
   event_callbacks_(event_callbacks)
@@ -270,6 +272,12 @@ PublisherBase::get_intra_process_subscription_count() const
   return ipm->get_subscription_count(intra_process_publisher_id_);
 }
 
+bool
+PublisherBase::is_durability_transient_local() const
+{
+  return durability_is_transient_local_;
+}
+
 rclcpp::QoS
 PublisherBase::get_actual_qos() const
 {
@@ -402,4 +410,13 @@ size_t PublisherBase::lowest_available_ipm_capacity() const
   }
 
   return ipm->lowest_available_capacity(intra_process_publisher_id_);
+}
+
+void PublisherBase::do_shared_intra_process_publish_for_late_joiner(const uint64_t)
+{
+  throw std::runtime_error("intra process publish for late joiner is not implemented");
+}
+void PublisherBase::do_unique_intra_process_publish_for_late_joiner(const uint64_t)
+{
+  throw std::runtime_error("intra process publish for late joiner is not implemented");
 }

--- a/rclcpp/src/rclcpp/publisher_base.cpp
+++ b/rclcpp/src/rclcpp/publisher_base.cpp
@@ -410,12 +410,3 @@ size_t PublisherBase::lowest_available_ipm_capacity() const
 
   return ipm->lowest_available_capacity(intra_process_publisher_id_);
 }
-
-void PublisherBase::do_shared_intra_process_publish_for_late_joiner(const uint64_t)
-{
-  throw std::runtime_error("intra process publish for late joiner is not implemented");
-}
-void PublisherBase::do_unique_intra_process_publish_for_late_joiner(const uint64_t)
-{
-  throw std::runtime_error("intra process publish for late joiner is not implemented");
-}

--- a/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
@@ -34,3 +34,9 @@ SubscriptionIntraProcessBase::get_actual_qos() const
 {
   return qos_profile_;
 }
+
+bool
+SubscriptionIntraProcessBase::is_durability_transient_local() const
+{
+  return qos_profile_.durability() == rclcpp::DurabilityPolicy::TransientLocal;
+}

--- a/rclcpp/test/rclcpp/test_intra_process_buffer.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_buffer.cpp
@@ -190,6 +190,33 @@ TEST(TestIntraProcessBuffer, shared_buffer_consume) {
   EXPECT_EQ(1L, original_shared_msg.use_count());
   EXPECT_EQ(*original_shared_msg, *popped_unique_msg);
   EXPECT_NE(original_message_pointer, popped_message_pointer);
+
+  original_shared_msg = std::make_shared<char>('c');
+  original_message_pointer = reinterpret_cast<std::uintptr_t>(original_shared_msg.get());
+  auto original_shared_msg_2 = std::make_shared<char>('d');
+  auto original_message_pointer_2 = reinterpret_cast<std::uintptr_t>(original_shared_msg_2.get());
+  intra_process_buffer.add_shared(original_shared_msg);
+  intra_process_buffer.add_shared(original_shared_msg_2);
+
+  auto shared_data_vec = intra_process_buffer.get_all_data_shared();
+  EXPECT_EQ(2L, shared_data_vec.size());
+  EXPECT_EQ(3L, original_shared_msg.use_count());
+  EXPECT_EQ(original_shared_msg.use_count(), shared_data_vec[0].use_count());
+  EXPECT_EQ(*original_shared_msg, *shared_data_vec[0]);
+  EXPECT_EQ(original_message_pointer, reinterpret_cast<std::uintptr_t>(shared_data_vec[0].get()));
+  EXPECT_EQ(3L, original_shared_msg_2.use_count());
+  EXPECT_EQ(original_shared_msg_2.use_count(), shared_data_vec[1].use_count());
+  EXPECT_EQ(*original_shared_msg_2, *shared_data_vec[1]);
+  EXPECT_EQ(original_message_pointer_2, reinterpret_cast<std::uintptr_t>(shared_data_vec[1].get()));
+
+  auto unique_data_vec = intra_process_buffer.get_all_data_unique();
+  EXPECT_EQ(2L, unique_data_vec.size());
+  EXPECT_EQ(3L, original_shared_msg.use_count());
+  EXPECT_EQ(*original_shared_msg, *unique_data_vec[0]);
+  EXPECT_NE(original_message_pointer, reinterpret_cast<std::uintptr_t>(unique_data_vec[0].get()));
+  EXPECT_EQ(3L, original_shared_msg_2.use_count());
+  EXPECT_EQ(*original_shared_msg_2, *unique_data_vec[1]);
+  EXPECT_NE(original_message_pointer_2, reinterpret_cast<std::uintptr_t>(unique_data_vec[1].get()));
 }
 
 /*
@@ -237,6 +264,33 @@ TEST(TestIntraProcessBuffer, unique_buffer_consume) {
 
   EXPECT_EQ(original_value, *popped_unique_msg);
   EXPECT_EQ(original_message_pointer, popped_message_pointer);
+
+  original_unique_msg = std::make_unique<char>('c');
+  original_message_pointer = reinterpret_cast<std::uintptr_t>(original_unique_msg.get());
+  original_value = *original_unique_msg;
+  auto original_unique_msg_2 = std::make_unique<char>('d');
+  auto original_message_pointer_2 = reinterpret_cast<std::uintptr_t>(original_unique_msg.get());
+  auto original_value_2 = *original_unique_msg_2;
+  intra_process_buffer.add_unique(std::move(original_unique_msg));
+  intra_process_buffer.add_unique(std::move(original_unique_msg_2));
+
+  auto shared_data_vec = intra_process_buffer.get_all_data_shared();
+  EXPECT_EQ(2L, shared_data_vec.size());
+  EXPECT_EQ(1L, shared_data_vec[0].use_count());
+  EXPECT_EQ(original_value, *shared_data_vec[0]);
+  EXPECT_NE(original_message_pointer, reinterpret_cast<std::uintptr_t>(shared_data_vec[0].get()));
+  EXPECT_EQ(1L, shared_data_vec[1].use_count());
+  EXPECT_EQ(original_value_2, *shared_data_vec[1]);
+  EXPECT_NE(original_message_pointer_2, reinterpret_cast<std::uintptr_t>(shared_data_vec[1].get()));
+
+  auto unique_data_vec = intra_process_buffer.get_all_data_unique();
+  EXPECT_EQ(2L, unique_data_vec.size());
+  EXPECT_EQ(1L, shared_data_vec[0].use_count());
+  EXPECT_EQ(original_value, *unique_data_vec[0]);
+  EXPECT_NE(original_message_pointer, reinterpret_cast<std::uintptr_t>(unique_data_vec[0].get()));
+  EXPECT_EQ(1L, shared_data_vec[1].use_count());
+  EXPECT_EQ(original_value_2, *unique_data_vec[1]);
+  EXPECT_NE(original_message_pointer_2, reinterpret_cast<std::uintptr_t>(unique_data_vec[1].get()));
 }
 
 /*

--- a/rclcpp/test/rclcpp/test_intra_process_manager.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager.cpp
@@ -81,6 +81,12 @@ public:
   }
 
   bool
+  is_durability_transient_local() const
+  {
+    return qos_profile.durability() == rclcpp::DurabilityPolicy::TransientLocal;
+  }
+
+  bool
   operator==(const rmw_gid_t & gid) const
   {
     (void)gid;
@@ -92,6 +98,13 @@ public:
   {
     (void)gid;
     return false;
+  }
+
+  virtual void do_shared_intra_process_publish_for_late_joiner(const uint64_t)
+  {
+  }
+  virtual void do_unique_intra_process_publish_for_late_joiner(const uint64_t)
+  {
   }
 
   rclcpp::QoS qos_profile;
@@ -229,6 +242,12 @@ public:
   get_topic_name()
   {
     return topic_name.c_str();
+  }
+
+  bool
+  is_durability_transient_local() const
+  {
+    return qos_profile.durability() == rclcpp::DurabilityPolicy::TransientLocal;
   }
 
   virtual

--- a/rclcpp/test/rclcpp/test_intra_process_manager.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager.cpp
@@ -445,18 +445,18 @@ void Publisher<T, Alloc>::publish(MessageUniquePtr msg)
 }  // namespace rclcpp
 
 /*
-   This tests how the class connects and disconnects publishers and subscriptions:
-   - Creates 2 publishers on different topics and a subscription to one of them.
-     Add everything to the intra-process manager.
-   - All the entities are expected to have different ids.
-   - Check the subscriptions count for each publisher.
-   - One of the publishers is expected to have 1 subscription, while the other 0.
-   - Check the subscription count for a non existing publisher id, should return 0.
-   - Add a new publisher and a new subscription both with reliable QoS.
-   - The subscriptions count of the previous publisher is expected to remain unchanged,
-     while the new publisher is expected to have 2 subscriptions (it's compatible with both QoS).
-   - Remove the just added subscriptions.
-   - The count for the last publisher is expected to decrease to 1.
+ * This tests how the class connects and disconnects publishers and subscriptions:
+ * - Creates 2 publishers on different topics and a subscription to one of them.
+ *   Add everything to the intra-process manager.
+ * - All the entities are expected to have different ids.
+ * - Check the subscriptions count for each publisher.
+ * - One of the publishers is expected to have 1 subscription, while the other 0.
+ * - Check the subscription count for a non existing publisher id, should return 0.
+ * - Add a new publisher and a new subscription both with reliable QoS.
+ * - The subscriptions count of the previous publisher is expected to remain unchanged,
+ *   while the new publisher is expected to have 2 subscriptions (it's compatible with both QoS).
+ * - Remove the just added subscriptions.
+ * - The count for the last publisher is expected to decrease to 1.
  */
 TEST(TestIntraProcessManager, add_pub_sub) {
   using IntraProcessManagerT = rclcpp::experimental::IntraProcessManager;
@@ -511,14 +511,14 @@ TEST(TestIntraProcessManager, add_pub_sub) {
 }
 
 /*
-   This tests the minimal usage of the class where there is a single subscription per publisher:
-   - Publishes a unique_ptr message with a subscription requesting ownership.
-   - The received message is expected to be the same.
-   - Remove the first subscription from ipm and add a new one.
-   - Publishes a unique_ptr message with a subscription not requesting ownership.
-   - The received message is expected to be the same, the first subscription do not receive it.
-   - Publishes a shared_ptr message with a subscription not requesting ownership.
-   - The received message is expected to be the same.
+ * This tests the minimal usage of the class where there is a single subscription per publisher:
+ * - Publishes a unique_ptr message with a subscription requesting ownership.
+ * - The received message is expected to be the same.
+ * - Remove the first subscription from ipm and add a new one.
+ * - Publishes a unique_ptr message with a subscription not requesting ownership.
+ * - The received message is expected to be the same, the first subscription do not receive it.
+ * - Publishes a shared_ptr message with a subscription not requesting ownership.
+ * - The received message is expected to be the same.
  */
 TEST(TestIntraProcessManager, single_subscription) {
   using IntraProcessManagerT = rclcpp::experimental::IntraProcessManager;
@@ -564,15 +564,15 @@ TEST(TestIntraProcessManager, single_subscription) {
 }
 
 /*
-   This tests the usage of the class where there are multiple subscriptions of the same type:
-   - Publishes a unique_ptr message with 2 subscriptions requesting ownership.
-   - One is expected to receive the published message, while the other will receive a copy.
-   - Publishes a unique_ptr message with 2 subscriptions not requesting ownership.
-   - Both received messages are expected to be the same as the published one.
-   - Publishes a shared_ptr message with 2 subscriptions requesting ownership.
-   - Both received messages are expected to be a copy of the published one.
-   - Publishes a shared_ptr message with 2 subscriptions not requesting ownership.
-   - Both received messages are expected to be the same as the published one.
+ * This tests the usage of the class where there are multiple subscriptions of the same type:
+ * - Publishes a unique_ptr message with 2 subscriptions requesting ownership.
+ * - One is expected to receive the published message, while the other will receive a copy.
+ * - Publishes a unique_ptr message with 2 subscriptions not requesting ownership.
+ * - Both received messages are expected to be the same as the published one.
+ * - Publishes a shared_ptr message with 2 subscriptions requesting ownership.
+ * - Both received messages are expected to be a copy of the published one.
+ * - Publishes a shared_ptr message with 2 subscriptions not requesting ownership.
+ * - Both received messages are expected to be the same as the published one.
  */
 TEST(TestIntraProcessManager, multiple_subscriptions_same_type) {
   using IntraProcessManagerT = rclcpp::experimental::IntraProcessManager;
@@ -665,20 +665,20 @@ TEST(TestIntraProcessManager, multiple_subscriptions_same_type) {
 }
 
 /*
-   This tests the usage of the class where there are multiple subscriptions of different types:
-   - Publishes a unique_ptr message with 1 subscription requesting ownership and 1 not.
-   - The one requesting ownership is expected to receive the published message,
-     while the other is expected to receive a copy.
-   - Publishes a unique_ptr message with 2 subscriptions requesting ownership and 1 not.
-   - One of the subscriptions requesting ownership is expected to receive the published message,
-     while both other subscriptions are expected to receive different copies.
-   - Publishes a unique_ptr message with 2 subscriptions requesting ownership and 2 not.
-   - The 2 subscriptions not requesting ownership are expected to both receive the same copy
-     of the message, one of the subscription requesting ownership is expected to receive a
-     different copy, while the last is expected to receive the published message.
-   - Publishes a shared_ptr message with 1 subscription requesting ownership and 1 not.
-   - The subscription requesting ownership is expected to receive a copy of the message, while
-     the other is expected to receive the published message
+ * This tests the usage of the class where there are multiple subscriptions of different types:
+ * - Publishes a unique_ptr message with 1 subscription requesting ownership and 1 not.
+ * - The one requesting ownership is expected to receive the published message,
+ *   while the other is expected to receive a copy.
+ * - Publishes a unique_ptr message with 2 subscriptions requesting ownership and 1 not.
+ * - One of the subscriptions requesting ownership is expected to receive the published message,
+ *   while both other subscriptions are expected to receive different copies.
+ * - Publishes a unique_ptr message with 2 subscriptions requesting ownership and 2 not.
+ * - The 2 subscriptions not requesting ownership are expected to both receive the same copy
+ *   of the message, one of the subscription requesting ownership is expected to receive a
+ *   different copy, while the last is expected to receive the published message.
+ * - Publishes a shared_ptr message with 1 subscription requesting ownership and 1 not.
+ * - The subscription requesting ownership is expected to receive a copy of the message, while
+ *   the other is expected to receive the published message
  */
 TEST(TestIntraProcessManager, multiple_subscriptions_different_type) {
   using IntraProcessManagerT = rclcpp::experimental::IntraProcessManager;
@@ -801,25 +801,25 @@ TEST(TestIntraProcessManager, multiple_subscriptions_different_type) {
 }
 
 /*
-   This tests the method "lowest_available_capacity":
-   - Creates 1 publisher.
-   - The available buffer capacity should be at least history size.
-   - Add 2 subscribers.
-   - Add everything to the intra-process manager.
-   - All the entities are expected to have different ids.
-   - Check the subscriptions count for the publisher.
-   - The available buffer capacity should be the history size.
-   - Publish one message (without receiving it).
-   - The available buffer capacity should decrease by 1.
-   - Publish another message (without receiving it).
-   - The available buffer capacity should decrease by 1.
-   - One subscriber receives one message.
-   - The available buffer capacity should stay the same,
-     as the other subscriber still has not freed its buffer.
-   - The other subscriber receives one message.
-   - The available buffer capacity should increase by 1.
-   - One subscription goes out of scope.
-   - The available buffer capacity should not change.
+ * This tests the method "lowest_available_capacity":
+ * - Creates 1 publisher.
+ * - The available buffer capacity should be at least history size.
+ * - Add 2 subscribers.
+ * - Add everything to the intra-process manager.
+ * - All the entities are expected to have different ids.
+ * - Check the subscriptions count for the publisher.
+ * - The available buffer capacity should be the history size.
+ * - Publish one message (without receiving it).
+ * - The available buffer capacity should decrease by 1.
+ * - Publish another message (without receiving it).
+ * - The available buffer capacity should decrease by 1.
+ * - One subscriber receives one message.
+ * - The available buffer capacity should stay the same,
+ *   as the other subscriber still has not freed its buffer.
+ * - The other subscriber receives one message.
+ * - The available buffer capacity should increase by 1.
+ * - One subscription goes out of scope.
+ * - The available buffer capacity should not change.
  */
 TEST(TestIntraProcessManager, lowest_available_capacity) {
   using IntraProcessManagerT = rclcpp::experimental::IntraProcessManager;
@@ -889,10 +889,10 @@ TEST(TestIntraProcessManager, lowest_available_capacity) {
 }
 
 /*
-   This tests the check inside add_publisher for transient_local
-   durability publishers
-   - add_publisher should throw runtime_error when no valid buffer ptr
-   is passed with a transient_local publisher
+ * This tests the check inside add_publisher for transient_local
+ * durability publishers
+ * - add_publisher should throw runtime_error when no valid buffer ptr
+ * is passed with a transient_local publisher
  */
 TEST(TestIntraProcessManager, transient_local_invalid_buffer) {
   using IntraProcessManagerT = rclcpp::experimental::IntraProcessManager;
@@ -911,10 +911,10 @@ TEST(TestIntraProcessManager, transient_local_invalid_buffer) {
 }
 
 /*
-   This tests publishing function for transient_local durability publihers
-   - A message is published before three transient_local subscriptions are added to
-   ipm. Two of the subscriptions use take_shared method. Delivery of the message is verified
-   along with the contents and pointer addresses from the subscriptions.
+ * This tests publishing function for transient_local durability publihers
+ * - A message is published before three transient_local subscriptions are added to
+ * ipm. Two of the subscriptions use take_shared method. Delivery of the message is verified
+ * along with the contents and pointer addresses from the subscriptions.
  */
 TEST(TestIntraProcessManager, transient_local) {
   using IntraProcessManagerT = rclcpp::experimental::IntraProcessManager;

--- a/rclcpp/test/rclcpp/test_intra_process_manager.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager.cpp
@@ -33,6 +33,111 @@
 
 namespace rclcpp
 {
+namespace experimental
+{
+namespace buffers
+{
+namespace mock
+{
+
+class IntraProcessBufferBase
+{
+public:
+  RCLCPP_SMART_PTR_ALIASES_ONLY(IntraProcessBufferBase)
+
+  virtual ~IntraProcessBufferBase() {}
+};
+
+}  // namespace mock
+}  // namespace buffers
+}  // namespace experimental
+}  // namespace rclcpp
+
+namespace rclcpp
+{
+namespace experimental
+{
+namespace buffers
+{
+namespace mock
+{
+template<
+  typename MessageT,
+  typename Alloc = std::allocator<MessageT>,
+  typename MessageDeleter = std::default_delete<MessageT>>
+class IntraProcessBuffer : public IntraProcessBufferBase
+{
+public:
+  using ConstMessageSharedPtr = std::shared_ptr<const MessageT>;
+  using MessageUniquePtr = std::unique_ptr<MessageT>;
+
+  RCLCPP_SMART_PTR_DEFINITIONS(IntraProcessBuffer)
+
+  IntraProcessBuffer()
+  {}
+
+  void add(ConstMessageSharedPtr msg)
+  {
+    message_ptr = reinterpret_cast<std::uintptr_t>(msg.get());
+    shared_msg = msg;
+    ++num_msgs;
+  }
+
+  void add(MessageUniquePtr msg)
+  {
+    message_ptr = reinterpret_cast<std::uintptr_t>(msg.get());
+    unique_msg = std::move(msg);
+    ++num_msgs;
+  }
+
+  void pop(std::uintptr_t & msg_ptr)
+  {
+    msg_ptr = message_ptr;
+    message_ptr = 0;
+    --num_msgs;
+  }
+
+  size_t size() const
+  {
+    return num_msgs;
+  }
+
+  std::vector<ConstMessageSharedPtr> get_all_data_shared()
+  {
+    if (shared_msg) {
+      return {shared_msg};
+    } else if (unique_msg) {
+      return {std::make_shared<const MessageT>(*unique_msg)};
+    }
+    return {};
+  }
+
+  std::vector<MessageUniquePtr> get_all_data_unique()
+  {
+    std::vector<MessageUniquePtr> result;
+    if (shared_msg) {
+      result.push_back(std::make_unique<MessageT>(*shared_msg));
+    } else if (unique_msg) {
+      result.push_back(std::make_unique<MessageT>(*unique_msg));
+    }
+    return result;
+  }
+
+  // need to store the messages somewhere otherwise the memory address will be reused
+  ConstMessageSharedPtr shared_msg;
+  MessageUniquePtr unique_msg;
+
+  std::uintptr_t message_ptr;
+  // count add and pop
+  size_t num_msgs = 0u;
+};
+
+}  // namespace mock
+}  // namespace buffers
+}  // namespace experimental
+}  // namespace rclcpp
+namespace rclcpp
+{
 // forward declaration
 namespace experimental
 {
@@ -100,13 +205,6 @@ public:
     return false;
   }
 
-  virtual void do_shared_intra_process_publish_for_late_joiner(const uint64_t)
-  {
-  }
-  virtual void do_unique_intra_process_publish_for_late_joiner(const uint64_t)
-  {
-  }
-
   rclcpp::QoS qos_profile;
   std::string topic_name;
   uint64_t intra_process_publisher_id_;
@@ -130,6 +228,9 @@ public:
   {
     auto allocator = std::make_shared<Alloc>();
     message_allocator_ = std::make_shared<MessageAlloc>(*allocator.get());
+    if (qos.durability() == rclcpp::DurabilityPolicy::TransientLocal) {
+      buffer = std::make_shared<rclcpp::experimental::buffers::mock::IntraProcessBuffer<T>>();
+    }
   }
 
   // The following functions use the IntraProcessManager
@@ -137,74 +238,11 @@ public:
   void publish(MessageUniquePtr msg);
 
   std::shared_ptr<MessageAlloc> message_allocator_;
+  typename rclcpp::experimental::buffers::mock::IntraProcessBuffer<T>::SharedPtr buffer{nullptr};
 };
 
 }  // namespace mock
 }  // namespace rclcpp
-
-namespace rclcpp
-{
-namespace experimental
-{
-namespace buffers
-{
-namespace mock
-{
-template<
-  typename MessageT,
-  typename Alloc = std::allocator<void>,
-  typename MessageDeleter = std::default_delete<MessageT>>
-class IntraProcessBuffer
-{
-public:
-  using ConstMessageSharedPtr = std::shared_ptr<const MessageT>;
-  using MessageUniquePtr = std::unique_ptr<MessageT>;
-
-  RCLCPP_SMART_PTR_DEFINITIONS(IntraProcessBuffer)
-
-  IntraProcessBuffer()
-  {}
-
-  void add(ConstMessageSharedPtr msg)
-  {
-    message_ptr = reinterpret_cast<std::uintptr_t>(msg.get());
-    shared_msg = msg;
-    ++num_msgs;
-  }
-
-  void add(MessageUniquePtr msg)
-  {
-    message_ptr = reinterpret_cast<std::uintptr_t>(msg.get());
-    unique_msg = std::move(msg);
-    ++num_msgs;
-  }
-
-  void pop(std::uintptr_t & msg_ptr)
-  {
-    msg_ptr = message_ptr;
-    message_ptr = 0;
-    --num_msgs;
-  }
-
-  size_t size() const
-  {
-    return num_msgs;
-  }
-
-  // need to store the messages somewhere otherwise the memory address will be reused
-  ConstMessageSharedPtr shared_msg;
-  MessageUniquePtr unique_msg;
-
-  std::uintptr_t message_ptr;
-  // count add and pop
-  size_t num_msgs = 0u;
-};
-
-}  // namespace mock
-}  // namespace buffers
-}  // namespace experimental
-}  // namespace rclcpp
-
 
 namespace rclcpp
 {
@@ -350,12 +388,14 @@ public:
 // Prevent the header files of the mocked classes to be included
 #define RCLCPP__PUBLISHER_HPP_
 #define RCLCPP__PUBLISHER_BASE_HPP_
+#define RCLCPP__EXPERIMENTAL__BUFFERS__INTRA_PROCESS_BUFFER_HPP_
 #define RCLCPP__EXPERIMENTAL__SUBSCRIPTION_INTRA_PROCESS_HPP_
 #define RCLCPP__EXPERIMENTAL__SUBSCRIPTION_INTRA_PROCESS_BUFFER_HPP_
 #define RCLCPP__EXPERIMENTAL__SUBSCRIPTION_INTRA_PROCESS_BASE_HPP_
 // Force ipm to use our mock publisher class.
 #define Publisher mock::Publisher
 #define PublisherBase mock::PublisherBase
+#define IntraProcessBufferBase mock::IntraProcessBufferBase
 #define IntraProcessBuffer mock::IntraProcessBuffer
 #define SubscriptionIntraProcessBase mock::SubscriptionIntraProcessBase
 #define SubscriptionIntraProcessBuffer mock::SubscriptionIntraProcessBuffer
@@ -387,10 +427,18 @@ void Publisher<T, Alloc>::publish(MessageUniquePtr msg)
     throw std::runtime_error("cannot publish msg which is a null pointer");
   }
 
-  ipm->template do_intra_process_publish<T, T, Alloc>(
-    intra_process_publisher_id_,
-    std::move(msg),
-    *message_allocator_);
+  if (buffer) {
+    auto shared_msg = ipm->template do_intra_process_publish_and_return_shared<T, T, Alloc>(
+      intra_process_publisher_id_,
+      std::move(msg),
+      *message_allocator_);
+    buffer->add(shared_msg);
+  } else {
+    ipm->template do_intra_process_publish<T, T, Alloc>(
+      intra_process_publisher_id_,
+      std::move(msg),
+      *message_allocator_);
+  }
 }
 
 }  // namespace mock
@@ -427,7 +475,7 @@ TEST(TestIntraProcessManager, add_pub_sub) {
 
   auto p1_id = ipm->add_publisher(p1);
   auto p2_id = ipm->add_publisher(p2);
-  auto s1_id = ipm->add_subscription(s1);
+  auto s1_id = ipm->template add_subscription<MessageT>(s1);
 
   bool unique_ids = p1_id != p2_id && p2_id != s1_id;
   ASSERT_TRUE(unique_ids);
@@ -443,7 +491,7 @@ TEST(TestIntraProcessManager, add_pub_sub) {
 
   auto s2 = std::make_shared<SubscriptionIntraProcessT>(rclcpp::QoS(10).reliable());
 
-  auto s2_id = ipm->add_subscription(s2);
+  auto s2_id = ipm->template add_subscription<MessageT>(s2);
   auto p3_id = ipm->add_publisher(p3);
 
   p1_subs = ipm->get_subscription_count(p1_id);
@@ -486,7 +534,7 @@ TEST(TestIntraProcessManager, single_subscription) {
 
   auto s1 = std::make_shared<SubscriptionIntraProcessT>();
   s1->take_shared_method = false;
-  auto s1_id = ipm->add_subscription(s1);
+  auto s1_id = ipm->template add_subscription<MessageT>(s1);
 
   auto unique_msg = std::make_unique<MessageT>();
   auto original_message_pointer = reinterpret_cast<std::uintptr_t>(unique_msg.get());
@@ -497,7 +545,7 @@ TEST(TestIntraProcessManager, single_subscription) {
   ipm->remove_subscription(s1_id);
   auto s2 = std::make_shared<SubscriptionIntraProcessT>();
   s2->take_shared_method = true;
-  auto s2_id = ipm->add_subscription(s2);
+  auto s2_id = ipm->template add_subscription<MessageT>(s2);
   (void)s2_id;
 
   unique_msg = std::make_unique<MessageT>();
@@ -540,11 +588,11 @@ TEST(TestIntraProcessManager, multiple_subscriptions_same_type) {
 
   auto s1 = std::make_shared<SubscriptionIntraProcessT>();
   s1->take_shared_method = false;
-  auto s1_id = ipm->add_subscription(s1);
+  auto s1_id = ipm->template add_subscription<MessageT>(s1);
 
   auto s2 = std::make_shared<SubscriptionIntraProcessT>();
   s2->take_shared_method = false;
-  auto s2_id = ipm->add_subscription(s2);
+  auto s2_id = ipm->template add_subscription<MessageT>(s2);
 
   auto unique_msg = std::make_unique<MessageT>();
   auto original_message_pointer = reinterpret_cast<std::uintptr_t>(unique_msg.get());
@@ -560,11 +608,11 @@ TEST(TestIntraProcessManager, multiple_subscriptions_same_type) {
 
   auto s3 = std::make_shared<SubscriptionIntraProcessT>();
   s3->take_shared_method = true;
-  auto s3_id = ipm->add_subscription(s3);
+  auto s3_id = ipm->template add_subscription<MessageT>(s3);
 
   auto s4 = std::make_shared<SubscriptionIntraProcessT>();
   s4->take_shared_method = true;
-  auto s4_id = ipm->add_subscription(s4);
+  auto s4_id = ipm->template add_subscription<MessageT>(s4);
 
   unique_msg = std::make_unique<MessageT>();
   original_message_pointer = reinterpret_cast<std::uintptr_t>(unique_msg.get());
@@ -579,11 +627,11 @@ TEST(TestIntraProcessManager, multiple_subscriptions_same_type) {
 
   auto s5 = std::make_shared<SubscriptionIntraProcessT>();
   s5->take_shared_method = false;
-  auto s5_id = ipm->add_subscription(s5);
+  auto s5_id = ipm->template add_subscription<MessageT>(s5);
 
   auto s6 = std::make_shared<SubscriptionIntraProcessT>();
   s6->take_shared_method = false;
-  auto s6_id = ipm->add_subscription(s6);
+  auto s6_id = ipm->template add_subscription<MessageT>(s6);
 
   unique_msg = std::make_unique<MessageT>();
   original_message_pointer = reinterpret_cast<std::uintptr_t>(unique_msg.get());
@@ -599,12 +647,12 @@ TEST(TestIntraProcessManager, multiple_subscriptions_same_type) {
 
   auto s7 = std::make_shared<SubscriptionIntraProcessT>();
   s7->take_shared_method = true;
-  auto s7_id = ipm->add_subscription(s7);
+  auto s7_id = ipm->template add_subscription<MessageT>(s7);
   (void)s7_id;
 
   auto s8 = std::make_shared<SubscriptionIntraProcessT>();
   s8->take_shared_method = true;
-  auto s8_id = ipm->add_subscription(s8);
+  auto s8_id = ipm->template add_subscription<MessageT>(s8);
   (void)s8_id;
 
   unique_msg = std::make_unique<MessageT>();
@@ -646,11 +694,11 @@ TEST(TestIntraProcessManager, multiple_subscriptions_different_type) {
 
   auto s1 = std::make_shared<SubscriptionIntraProcessT>();
   s1->take_shared_method = true;
-  auto s1_id = ipm->add_subscription(s1);
+  auto s1_id = ipm->template add_subscription<MessageT>(s1);
 
   auto s2 = std::make_shared<SubscriptionIntraProcessT>();
   s2->take_shared_method = false;
-  auto s2_id = ipm->add_subscription(s2);
+  auto s2_id = ipm->template add_subscription<MessageT>(s2);
 
   auto unique_msg = std::make_unique<MessageT>();
   auto original_message_pointer = reinterpret_cast<std::uintptr_t>(unique_msg.get());
@@ -665,15 +713,15 @@ TEST(TestIntraProcessManager, multiple_subscriptions_different_type) {
 
   auto s3 = std::make_shared<SubscriptionIntraProcessT>();
   s3->take_shared_method = false;
-  auto s3_id = ipm->add_subscription(s3);
+  auto s3_id = ipm->template add_subscription<MessageT>(s3);
 
   auto s4 = std::make_shared<SubscriptionIntraProcessT>();
   s4->take_shared_method = false;
-  auto s4_id = ipm->add_subscription(s4);
+  auto s4_id = ipm->template add_subscription<MessageT>(s4);
 
   auto s5 = std::make_shared<SubscriptionIntraProcessT>();
   s5->take_shared_method = true;
-  auto s5_id = ipm->add_subscription(s5);
+  auto s5_id = ipm->template add_subscription<MessageT>(s5);
 
   unique_msg = std::make_unique<MessageT>();
   original_message_pointer = reinterpret_cast<std::uintptr_t>(unique_msg.get());
@@ -697,19 +745,19 @@ TEST(TestIntraProcessManager, multiple_subscriptions_different_type) {
 
   auto s6 = std::make_shared<SubscriptionIntraProcessT>();
   s6->take_shared_method = true;
-  auto s6_id = ipm->add_subscription(s6);
+  auto s6_id = ipm->template add_subscription<MessageT>(s6);
 
   auto s7 = std::make_shared<SubscriptionIntraProcessT>();
   s7->take_shared_method = true;
-  auto s7_id = ipm->add_subscription(s7);
+  auto s7_id = ipm->template add_subscription<MessageT>(s7);
 
   auto s8 = std::make_shared<SubscriptionIntraProcessT>();
   s8->take_shared_method = false;
-  auto s8_id = ipm->add_subscription(s8);
+  auto s8_id = ipm->template add_subscription<MessageT>(s8);
 
   auto s9 = std::make_shared<SubscriptionIntraProcessT>();
   s9->take_shared_method = false;
-  auto s9_id = ipm->add_subscription(s9);
+  auto s9_id = ipm->template add_subscription<MessageT>(s9);
 
   unique_msg = std::make_unique<MessageT>();
   original_message_pointer = reinterpret_cast<std::uintptr_t>(unique_msg.get());
@@ -735,12 +783,12 @@ TEST(TestIntraProcessManager, multiple_subscriptions_different_type) {
 
   auto s10 = std::make_shared<SubscriptionIntraProcessT>();
   s10->take_shared_method = false;
-  auto s10_id = ipm->add_subscription(s10);
+  auto s10_id = ipm->template add_subscription<MessageT>(s10);
   (void)s10_id;
 
   auto s11 = std::make_shared<SubscriptionIntraProcessT>();
   s11->take_shared_method = true;
-  auto s11_id = ipm->add_subscription(s11);
+  auto s11_id = ipm->template add_subscription<MessageT>(s11);
   (void)s11_id;
 
   unique_msg = std::make_unique<MessageT>();
@@ -795,8 +843,8 @@ TEST(TestIntraProcessManager, lowest_available_capacity) {
 
   ASSERT_LE(0u, c1);
 
-  auto s1_id = ipm->add_subscription(s1);
-  auto s2_id = ipm->add_subscription(s2);
+  auto s1_id = ipm->template add_subscription<MessageT>(s1);
+  auto s2_id = ipm->template add_subscription<MessageT>(s2);
 
   bool unique_ids = s1_id != s2_id && p1_id != s1_id;
   ASSERT_TRUE(unique_ids);
@@ -838,4 +886,83 @@ TEST(TestIntraProcessManager, lowest_available_capacity) {
 
   c1 = ipm->lowest_available_capacity(p1_id);
   ASSERT_EQ(history_depth - 1u, c1);
+}
+
+/*
+   This tests the check inside add_publisher for transient_local
+   durability publishers
+   - add_publisher should throw runtime_error when no valid buffer ptr
+   is passed with a transient_local publisher
+ */
+TEST(TestIntraProcessManager, transient_local_invalid_buffer) {
+  using IntraProcessManagerT = rclcpp::experimental::IntraProcessManager;
+  using MessageT = rcl_interfaces::msg::Log;
+  using PublisherT = rclcpp::mock::Publisher<MessageT>;
+  constexpr auto history_depth = 10u;
+
+  auto ipm = std::make_shared<IntraProcessManagerT>();
+
+  auto p1 = std::make_shared<PublisherT>(rclcpp::QoS(history_depth).transient_local());
+
+  ASSERT_THROW(
+  {
+    ipm->add_publisher(p1, nullptr);
+  }, std::runtime_error);
+}
+
+/*
+   This tests publishing function for transient_local durability publihers
+   - A message is published before three transient_local subscriptions are added to
+   ipm. Two of the subscriptions use take_shared method. Delivery of the message is verified
+   along with the contents and pointer addresses from the subscriptions.
+ */
+TEST(TestIntraProcessManager, transient_local) {
+  using IntraProcessManagerT = rclcpp::experimental::IntraProcessManager;
+  using MessageT = rcl_interfaces::msg::Log;
+  using PublisherT = rclcpp::mock::Publisher<MessageT>;
+  using SubscriptionIntraProcessT = rclcpp::experimental::mock::SubscriptionIntraProcess<MessageT>;
+
+  constexpr auto history_depth = 10u;
+
+  auto ipm = std::make_shared<IntraProcessManagerT>();
+
+  auto p1 = std::make_shared<PublisherT>(rclcpp::QoS(history_depth).transient_local());
+
+  auto s1 =
+    std::make_shared<SubscriptionIntraProcessT>(rclcpp::QoS(history_depth).transient_local());
+  auto s2 =
+    std::make_shared<SubscriptionIntraProcessT>(rclcpp::QoS(history_depth).transient_local());
+  auto s3 =
+    std::make_shared<SubscriptionIntraProcessT>(rclcpp::QoS(history_depth).transient_local());
+
+  s1->take_shared_method = false;
+  s2->take_shared_method = true;
+  s3->take_shared_method = true;
+
+  auto p1_id = ipm->add_publisher(p1, p1->buffer);
+
+  p1->set_intra_process_manager(p1_id, ipm);
+
+  auto unique_msg = std::make_unique<MessageT>();
+  unique_msg->msg = "Test";
+  p1->publish(std::move(unique_msg));
+
+  ipm->template add_subscription<MessageT>(s1);
+  ipm->template add_subscription<MessageT>(s2);
+  ipm->template add_subscription<MessageT>(s3);
+
+  auto received_message_pointer_1 = s1->pop();
+  auto received_message_pointer_2 = s2->pop();
+  auto received_message_pointer_3 = s3->pop();
+  ASSERT_NE(0u, received_message_pointer_1);
+  ASSERT_NE(0u, received_message_pointer_2);
+  ASSERT_NE(0u, received_message_pointer_3);
+  ASSERT_EQ(received_message_pointer_3, received_message_pointer_2);
+  ASSERT_EQ(
+    reinterpret_cast<MessageT *>(received_message_pointer_1)->msg,
+    reinterpret_cast<MessageT *>(received_message_pointer_2)->msg);
+  ASSERT_EQ(
+    reinterpret_cast<MessageT *>(received_message_pointer_1)->msg,
+    reinterpret_cast<MessageT *>(received_message_pointer_3)->msg);
+  ASSERT_EQ("Test", reinterpret_cast<MessageT *>(received_message_pointer_1)->msg);
 }

--- a/rclcpp/test/rclcpp/test_ring_buffer_implementation.cpp
+++ b/rclcpp/test/rclcpp/test_ring_buffer_implementation.cpp
@@ -39,6 +39,7 @@ TEST(TestRingBufferImplementation, constructor) {
 /*
    Basic usage
    - insert data and check that it has data
+   - get all data
    - extract data
    - overwrite old data writing over the buffer capacity
  */
@@ -64,6 +65,12 @@ TEST(TestRingBufferImplementation, basic_usage) {
 
   rb.enqueue('d');
 
+  const auto all_data_vec = rb.get_all_data();
+
+  EXPECT_EQ(2u, all_data_vec.size());
+  EXPECT_EQ('c', all_data_vec[0]);
+  EXPECT_EQ('d', all_data_vec[1]);
+
   EXPECT_EQ(true, rb.has_data());
   EXPECT_EQ(true, rb.is_full());
 
@@ -76,6 +83,59 @@ TEST(TestRingBufferImplementation, basic_usage) {
   v = rb.dequeue();
 
   EXPECT_EQ('d', v);
+  EXPECT_EQ(false, rb.has_data());
+  EXPECT_EQ(false, rb.is_full());
+}
+
+/*
+   Basic usage with unique_ptr
+   - insert unique_ptr data and check that it has data
+   - get all data
+   - extract data
+   - overwrite old data writing over the buffer capacity
+ */
+TEST(TestRingBufferImplementation, basic_usage_unique_ptr) {
+  rclcpp::experimental::buffers::RingBufferImplementation<std::unique_ptr<char>> rb(2);
+
+  auto a = std::make_unique<char>('a');
+  auto b = std::make_unique<char>('b');
+  auto original_b_pointer = reinterpret_cast<std::uintptr_t>(b.get());
+  auto c = std::make_unique<char>('c');
+  auto original_c_pointer = reinterpret_cast<std::uintptr_t>(c.get());
+
+  rb.enqueue(std::move(a));
+
+  EXPECT_EQ(true, rb.has_data());
+  EXPECT_EQ(false, rb.is_full());
+
+  rb.enqueue(std::move(b));
+  rb.enqueue(std::move(c));
+
+  EXPECT_EQ(true, rb.has_data());
+  EXPECT_EQ(true, rb.is_full());
+
+  const auto all_data_vec = rb.get_all_data();
+
+  EXPECT_EQ(2u, all_data_vec.size());
+  EXPECT_EQ('b', *all_data_vec[0]);
+  EXPECT_EQ('c', *all_data_vec[1]);
+  EXPECT_NE(original_b_pointer, reinterpret_cast<std::uintptr_t>(all_data_vec[0].get()));
+  EXPECT_NE(original_c_pointer, reinterpret_cast<std::uintptr_t>(all_data_vec[1].get()));
+
+  EXPECT_EQ(true, rb.has_data());
+  EXPECT_EQ(true, rb.is_full());
+
+  auto uni_ptr = rb.dequeue();
+
+  EXPECT_EQ('b', *uni_ptr);
+  EXPECT_EQ(original_b_pointer, reinterpret_cast<std::uintptr_t>(uni_ptr.get()));
+  EXPECT_EQ(true, rb.has_data());
+  EXPECT_EQ(false, rb.is_full());
+
+  uni_ptr = rb.dequeue();
+
+  EXPECT_EQ('c', *uni_ptr);
+  EXPECT_EQ(original_c_pointer, reinterpret_cast<std::uintptr_t>(uni_ptr.get()));
   EXPECT_EQ(false, rb.has_data());
   EXPECT_EQ(false, rb.is_full());
 }

--- a/rclcpp/test/rclcpp/test_ring_buffer_implementation.cpp
+++ b/rclcpp/test/rclcpp/test_ring_buffer_implementation.cpp
@@ -22,7 +22,7 @@
 #include "rclcpp/experimental/buffers/ring_buffer_implementation.hpp"
 
 /*
-   Construtctor
+ * Construtctor
  */
 TEST(TestRingBufferImplementation, constructor) {
   // Cannot create a buffer of size zero.
@@ -37,11 +37,11 @@ TEST(TestRingBufferImplementation, constructor) {
 }
 
 /*
-   Basic usage
-   - insert data and check that it has data
-   - get all data
-   - extract data
-   - overwrite old data writing over the buffer capacity
+ * Basic usage
+ * - insert data and check that it has data
+ * - get all data
+ * - extract data
+ * - overwrite old data writing over the buffer capacity
  */
 TEST(TestRingBufferImplementation, basic_usage) {
   rclcpp::experimental::buffers::RingBufferImplementation<char> rb(2);
@@ -88,11 +88,11 @@ TEST(TestRingBufferImplementation, basic_usage) {
 }
 
 /*
-   Basic usage with unique_ptr
-   - insert unique_ptr data and check that it has data
-   - get all data
-   - extract data
-   - overwrite old data writing over the buffer capacity
+ * Basic usage with unique_ptr
+ * - insert unique_ptr data and check that it has data
+ * - get all data
+ * - extract data
+ * - overwrite old data writing over the buffer capacity
  */
 TEST(TestRingBufferImplementation, basic_usage_unique_ptr) {
   rclcpp::experimental::buffers::RingBufferImplementation<std::unique_ptr<char>> rb(2);

--- a/rclcpp/test/rclcpp/test_subscription.cpp
+++ b/rclcpp/test/rclcpp/test_subscription.cpp
@@ -611,11 +611,7 @@ static std::vector<TestParameters> invalid_qos_profiles()
 {
   std::vector<TestParameters> parameters;
 
-  parameters.reserve(3);
-  parameters.push_back(
-    TestParameters(
-      rclcpp::QoS(rclcpp::KeepLast(10)).transient_local(),
-      "transient_local_qos"));
+  parameters.reserve(1);
   parameters.push_back(
     TestParameters(
       rclcpp::QoS(rclcpp::KeepAll()),


### PR DESCRIPTION
Signed-off-by: Jeffery Hsu [jefferyyjhsu@gmail.com](mailto:jefferyyjhsu@gmail.com)
This PR adds transient local durability support to publishers and subscriptions when intra-process communication is used.
An intra-process buffer already existed on the subscription side. The PR adds the same style buffer to the publisher side and other supporting functions allowing intra process manager to publish saved messages for late joining subscriptions.