### PR TITLE
Fix exception message for uninitialized parameter

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -528,7 +528,7 @@ declare_parameter_helper(
     if (rclcpp::PARAMETER_NOT_SET == type) {
       throw rclcpp::exceptions::InvalidParameterTypeException{
               name,
-              "cannot declare a statically typed parameter with an uninitialized value"
+              "cannot declare a statically typed parameter with an uninitialized type"
       };
     }
     parameter_descriptor.type = static_cast<uint8_t>(type);


### PR DESCRIPTION
A small nit but to my understanding declaring a statically typed parameter with an uninitialized value is allowed, what is not allowed is having an uninitialized type, as the exception `InvalidParameterTypeException` also explains.
Updated the exception message to reflect this.