### PR TITLE
Removing Old Connext Tests

### DIFF
--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -34,13 +34,7 @@ if(TARGET test_exceptions)
   target_link_libraries(test_exceptions ${PROJECT_NAME} mimick)
 endif()
 
-# Increasing timeout because connext can take a long time to destroy nodes
-# TODO(brawner) remove when destroying Node for Connext is resolved. See:
-# https://github.com/ros2/rclcpp/issues/1250
-ament_add_gtest(
-  test_allocator_memory_strategy
-  strategies/test_allocator_memory_strategy.cpp
-  TIMEOUT 360)
+ament_add_gtest(test_allocator_memory_strategy strategies/test_allocator_memory_strategy.cpp)
 if(TARGET test_allocator_memory_strategy)
   ament_target_dependencies(test_allocator_memory_strategy
     "rcl"
@@ -669,13 +663,10 @@ if(TARGET test_interface_traits)
   target_link_libraries(test_interface_traits ${PROJECT_NAME})
 endif()
 
-# TODO(brawner) remove when destroying Node for Connext is resolved. See:
-# https://github.com/ros2/rclcpp/issues/1250
 ament_add_gtest(
   test_executors
   executors/test_executors.cpp
-  APPEND_LIBRARY_DIRS "${append_library_dirs}"
-  TIMEOUT 180)
+  APPEND_LIBRARY_DIRS "${append_library_dirs}")
 if(TARGET test_executors)
   ament_target_dependencies(test_executors
     "rcl"

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -666,7 +666,8 @@ endif()
 ament_add_gtest(
   test_executors
   executors/test_executors.cpp
-  APPEND_LIBRARY_DIRS "${append_library_dirs}")
+  APPEND_LIBRARY_DIRS "${append_library_dirs}"
+  TIMEOUT 180)
 if(TARGET test_executors)
   ament_target_dependencies(test_executors
     "rcl"


### PR DESCRIPTION
So this is a PR in response to some TODOs:
> TODO(brawner) remove when destroying Node for Connext is resolved

This pull requests just removes these older, stale tests which don't have a purpose. The discussion for this takes place in issue #1250, the pull request that these special tests were added was PR #1253. Then, it seems that [this pull request](https://github.com/ros2/rmw_connext/pull/473) in the old rmw_connext repository was responsible for fixing why these tests were added. 

I figured that since that pull request solved the issue, the TODO requirement was met and there is no reason to have special cases on the tests. I assume we should still keep the tests because they're generalized and still provide value.