### PR TITLE
Update SignalHandler get_global_signal_handler to avoid complex types in static memory

### DIFF
--- a/rclcpp/src/rclcpp/signal_handler.cpp
+++ b/rclcpp/src/rclcpp/signal_handler.cpp
@@ -113,8 +113,8 @@ SignalHandler::get_logger()
 SignalHandler &
 SignalHandler::get_global_signal_handler()
 {
-  static SignalHandler * signal_handler = new SignalHandler();
-  return *signal_handler;
+  static SignalHandler & signal_handler = *new SignalHandler();
+  return signal_handler;
 }
 
 bool

--- a/rclcpp/src/rclcpp/signal_handler.cpp
+++ b/rclcpp/src/rclcpp/signal_handler.cpp
@@ -113,8 +113,8 @@ SignalHandler::get_logger()
 SignalHandler &
 SignalHandler::get_global_signal_handler()
 {
-  static SignalHandler signal_handler;
-  return signal_handler;
+  static SignalHandler* signal_handler = new SignalHandler();
+  return *signal_handler;
 }
 
 bool

--- a/rclcpp/src/rclcpp/signal_handler.cpp
+++ b/rclcpp/src/rclcpp/signal_handler.cpp
@@ -113,7 +113,7 @@ SignalHandler::get_logger()
 SignalHandler &
 SignalHandler::get_global_signal_handler()
 {
-  static SignalHandler* signal_handler = new SignalHandler();
+  static SignalHandler * signal_handler = new SignalHandler();
   return *signal_handler;
 }
 


### PR DESCRIPTION
This was flagged by msan as a problem. 

There's a description of why this is a potential problem here: https://google.github.io/styleguide/cppguide.html#Static_and_Global_Variables


* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=19557)](http://ci.ros2.org/job/ci_linux/19557/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=14070)](http://ci.ros2.org/job/ci_linux-aarch64/14070/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=20278)](http://ci.ros2.org/job/ci_windows/20278/)