### PR TITLE
address rate related flaky tests.

### DIFF
--- a/rclcpp/src/rclcpp/context.cpp
+++ b/rclcpp/src/rclcpp/context.cpp
@@ -496,7 +496,7 @@ Context::sleep_for(const std::chrono::nanoseconds & nanoseconds)
       std::unique_lock<std::mutex> lock(interrupt_mutex_);
       auto start = std::chrono::steady_clock::now();
       // this will release the lock while waiting
-      interrupt_condition_variable_.wait_for(lock, nanoseconds);
+      interrupt_condition_variable_.wait_for(lock, time_left);
       time_left -= std::chrono::steady_clock::now() - start;
     }
   } while (time_left > std::chrono::nanoseconds::zero() && this->is_valid());

--- a/rclcpp/src/rclcpp/rate.cpp
+++ b/rclcpp/src/rclcpp/rate.cpp
@@ -67,7 +67,8 @@ Rate::sleep()
   // Calculate the time to sleep
   auto time_to_sleep = next_interval - now;
   // Sleep (will get interrupted by ctrl-c, may not sleep full time)
-  return clock_->sleep_for(time_to_sleep);
+  clock_->sleep_for(time_to_sleep);
+  return true;
 }
 
 bool

--- a/rclcpp/test/rclcpp/test_rate.cpp
+++ b/rclcpp/test/rclcpp/test_rate.cpp
@@ -40,7 +40,7 @@ public:
  */
 TEST_F(TestRate, rate_basics) {
   auto period = std::chrono::milliseconds(1000);
-  auto offset = std::chrono::milliseconds(500);
+  auto offset = std::chrono::milliseconds(300);
   auto epsilon = std::chrono::milliseconds(100);
   double overrun_ratio = 1.5;
 
@@ -95,7 +95,7 @@ TEST_F(TestRate, rate_basics) {
 
 TEST_F(TestRate, wall_rate_basics) {
   auto period = std::chrono::milliseconds(100);
-  auto offset = std::chrono::milliseconds(50);
+  auto offset = std::chrono::milliseconds(30);
   auto epsilon = std::chrono::milliseconds(1);
   double overrun_ratio = 1.5;
 
@@ -155,7 +155,7 @@ TEST_F(TestRate, wall_rate_basics) {
  */
 TEST_F(TestRate, generic_rate) {
   auto period = std::chrono::milliseconds(100);
-  auto offset = std::chrono::milliseconds(50);
+  auto offset = std::chrono::milliseconds(30);
   auto epsilon = std::chrono::milliseconds(1);
   double overrun_ratio = 1.5;
 

--- a/rclcpp/test/rclcpp/test_rate.cpp
+++ b/rclcpp/test/rclcpp/test_rate.cpp
@@ -40,7 +40,7 @@ public:
  */
 TEST_F(TestRate, rate_basics) {
   auto period = std::chrono::milliseconds(1000);
-  auto offset = std::chrono::milliseconds(300);
+  auto offset = std::chrono::milliseconds(500);
   auto epsilon = std::chrono::milliseconds(100);
   double overrun_ratio = 1.5;
 
@@ -95,7 +95,7 @@ TEST_F(TestRate, rate_basics) {
 
 TEST_F(TestRate, wall_rate_basics) {
   auto period = std::chrono::milliseconds(100);
-  auto offset = std::chrono::milliseconds(30);
+  auto offset = std::chrono::milliseconds(50);
   auto epsilon = std::chrono::milliseconds(1);
   double overrun_ratio = 1.5;
 
@@ -155,7 +155,7 @@ TEST_F(TestRate, wall_rate_basics) {
  */
 TEST_F(TestRate, generic_rate) {
   auto period = std::chrono::milliseconds(100);
-  auto offset = std::chrono::milliseconds(30);
+  auto offset = std::chrono::milliseconds(50);
   auto epsilon = std::chrono::milliseconds(1);
   double overrun_ratio = 1.5;
 

--- a/rclcpp/test/rclcpp/test_rate.cpp
+++ b/rclcpp/test/rclcpp/test_rate.cpp
@@ -21,12 +21,24 @@
 
 #include "../utils/rclcpp_gtest_macros.hpp"
 
+class TestRate : public ::testing::Test
+{
+public:
+  void SetUp()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown()
+  {
+    rclcpp::shutdown();
+  }
+};
+
 /*
    Basic tests for the Rate and WallRate classes.
  */
-TEST(TestRate, rate_basics) {
-  rclcpp::init(0, nullptr);
-
+TEST_F(TestRate, rate_basics) {
   auto period = std::chrono::milliseconds(1000);
   auto offset = std::chrono::milliseconds(500);
   auto epsilon = std::chrono::milliseconds(100);
@@ -79,13 +91,9 @@ TEST(TestRate, rate_basics) {
   auto five = std::chrono::system_clock::now();
   delta = five - four;
   ASSERT_TRUE(epsilon > delta);
-
-  rclcpp::shutdown();
 }
 
-TEST(TestRate, wall_rate_basics) {
-  rclcpp::init(0, nullptr);
-
+TEST_F(TestRate, wall_rate_basics) {
   auto period = std::chrono::milliseconds(100);
   auto offset = std::chrono::milliseconds(50);
   auto epsilon = std::chrono::milliseconds(1);
@@ -140,14 +148,12 @@ TEST(TestRate, wall_rate_basics) {
   auto five = std::chrono::steady_clock::now();
   delta = five - four;
   EXPECT_GT(epsilon, delta);
-
-  rclcpp::shutdown();
 }
 
 /*
    Basic test for the deprecated GenericRate class.
  */
-TEST(TestRate, generic_rate) {
+TEST_F(TestRate, generic_rate) {
   auto period = std::chrono::milliseconds(100);
   auto offset = std::chrono::milliseconds(50);
   auto epsilon = std::chrono::milliseconds(1);
@@ -262,7 +268,7 @@ TEST(TestRate, generic_rate) {
   }
 }
 
-TEST(TestRate, from_double) {
+TEST_F(TestRate, from_double) {
   {
     rclcpp::Rate rate(1.0);
     EXPECT_EQ(rclcpp::Duration(std::chrono::seconds(1)), rate.period());
@@ -281,7 +287,7 @@ TEST(TestRate, from_double) {
   }
 }
 
-TEST(TestRate, clock_types) {
+TEST_F(TestRate, clock_types) {
   {
     rclcpp::Rate rate(1.0, std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME));
 // suppress deprecated warnings
@@ -341,7 +347,7 @@ TEST(TestRate, clock_types) {
   }
 }
 
-TEST(TestRate, incorrect_constuctor) {
+TEST_F(TestRate, incorrect_constuctor) {
   // Constructor with 0-frequency
   RCLCPP_EXPECT_THROW_EQ(
     rclcpp::Rate rate(0.0),


### PR DESCRIPTION
https://ci.ros2.org/view/nightly/job/nightly_win_rep/3129/testReport/projectroot.test/rclcpp/test_rate/

> C:\ci\ws\src\ros2\rclcpp\rclcpp\test\rclcpp\test_rate.cpp(61): error: Value of: r.sleep()

we did not really change the test here.

https://github.com/ros2/rclcpp/blob/rolling/rclcpp/test/rclcpp/test_rate.cpp#L61

originally if it did not miss the cycle, no matter it actually sleeps or not, it will return true.
i think this is intention, since time goes by during calling `sleep` method. if that is racy, it actually does not sleep in here.

> unknown file: error: C++ exception with description "context is already initialized" thrown in the test body.

i think this is just a secondary problem because `ASSERT_TRUE(r.sleep());` will not get to `rclcpp::shutdown();`.
i believe we should use texture to avoid these possible confusions...
