### PR TITLE
remove invalid sized allocation test for SerializedMessage.

### DIFF
--- a/rclcpp/test/rclcpp/test_serialized_message.cpp
+++ b/rclcpp/test/rclcpp/test_serialized_message.cpp
@@ -145,11 +145,6 @@ TEST(TestSerializedMessage, reserve) {
   // Resize using reserve method
   serialized_msg.reserve(15);
   EXPECT_EQ(15u, serialized_msg.capacity());
-
-  // Use invalid value throws exception
-  EXPECT_THROW(
-    {serialized_msg.reserve(-1);},
-    rclcpp::exceptions::RCLBadAlloc);
 }
 
 TEST(TestSerializedMessage, serialization) {


### PR DESCRIPTION
address https://github.com/ros2/rcutils/issues/431