### PR TITLE
Fix data race on 'on_parameter_event' callback

### DIFF
--- a/rclcpp/src/rclcpp/time_source.cpp
+++ b/rclcpp/src/rclcpp/time_source.cpp
@@ -246,6 +246,7 @@ public:
     node_parameters_ = node_parameters_interface;
     // TODO(tfoote): Update QOS
 
+    node_name_ = node_base_->get_fully_qualified_name();
     logger_ = node_logging_->get_logger();
 
     // Though this defaults to false, it can be overridden by initial parameter values for the
@@ -323,6 +324,8 @@ private:
   // Dedicated thread for clock subscription.
   bool use_clock_thread_;
   std::thread clock_executor_thread_;
+  // Fully qualified node name
+  const char * node_name_;
 
   // Preserve the node reference
   std::mutex node_base_lock_;
@@ -472,7 +475,7 @@ private:
     }
 
     // Filter out events on 'use_sim_time' parameter instances in other nodes.
-    if (event->node != node_base_->get_fully_qualified_name()) {
+    if (event->node != node_name_) {
       return;
     }
     // Filter for only 'use_sim_time' being added or changed.


### PR DESCRIPTION
The callback `on_parameter_event` was internally accessing `node_base_`, which could be already destroyed.

https://github.com/ros2/rclcpp/blob/13abc1beed02a995863c5c115ef758d35485b46b/rclcpp/src/rclcpp/time_source.cpp#L475

I reproduced this issue also on Galactic, Humble & Iron. It can be reproduced with the example present in this issue:
https://github.com/ros2/rmw_fastrtps/issues/717#issue-1923877969

This PR stores the node name (which is what the callback wants to know), so we don't risk accessing a deleted node.

Segfault backtrace:
```C++
Thread 3 received signal SIGSEGV, Segmentation fault.

rclcpp::TimeSource::NodeState::on_parameter_event (this=0x555555a3c950, event=std::shared_ptr<const rcl_interfaces::msg::ParameterEvent_<std::allocator<void> >> (use count 5, weak count 0) = {...}) at rclcpp/rclcpp/src/rclcpp/time_source.cpp:482
482     if (event->node != node_base_->get_fully_qualified_name()) {

#0  rclcpp::TimeSource::NodeState::on_parameter_event (this=0x555555a3c950, 
    event=std::shared_ptr<const rcl_interfaces::msg::ParameterEvent_<std::allocator<void> >> (use count 5, weak count 0) = {...})
    at rclcpp/rclcpp/src/rclcpp/time_source.cpp:482
#1  0x0.. in rclcpp::TimeSource::NodeState::attachNode(std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>, std::shared_ptr<rclcpp::node_interfaces::NodeTopicsInterface>, std::shared_ptr<rclcpp::node_interfaces::NodeGraphInterface>, std::shared_ptr<rclcpp::node_interfaces::NodeServicesInterface>, std::shared_ptr<rclcpp::node_interfaces::NodeLoggingInterface>, std::shared_ptr<rclcpp::node_interfaces::NodeClockInterface>, std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface>)::{lambda(std::shared_ptr<rcl_interfaces::msg::ParameterEvent_<std::allocator<void> > const>)#1}::operator()(std::shared_ptr<rcl_interfaces::msg::ParameterEvent_<std::allocator<void> > const>) const (__closure=0x555555a2da68, 
    event=std::shared_ptr<const rcl_interfaces::msg::ParameterEvent_<std::allocator<void> >> (use count 5, weak count 0) = {...})
    at rclcpp/rclcpp/src/rclcpp/time_source.cpp:298
...
#6  0x0.. in rclcpp::AnySubscriptionCallback<rcl_interfaces::msg::ParameterEvent_<std::allocator<void> >, std::allocator<void> >::dispatch(std::shared_ptr<rcl_interfaces::msg::ParameterEvent_<std::allocator<void> > >, rclcpp::MessageInfo const&)::{lambda(auto:1&&)#1}::operator()<std::function<void (std::shared_ptr<rcl_interfaces::msg::ParameterEvent_<std::allocator<void> > const>)>&>(std::function<void (std::shared_ptr<rcl_interfaces::msg::ParameterEvent_<std::allocator<void> > const>)>&) const (__closure=0x7ffff4cc0190, callback=...)
    at rclcpp/rclcpp/include/rclcpp/any_subscription_callback.hpp:556
...
#12 0x0.. in rclcpp::AnySubscriptionCallback<rcl_interfaces::msg::ParameterEvent_<std::allocator<void> >, std::allocator<void> >::dispatch (
    this=0x555555a2da68, message=std::shared_ptr<rcl_interfaces::msg::ParameterEvent_<std::allocator<void> >> (use count 5, weak count 0) = {...}, 
    message_info=...) at rclcpp/rclcpp/include/rclcpp/any_subscription_callback.hpp:504
#13 0x0.. in rclcpp::Subscription<rcl_interfaces::msg::ParameterEvent_<std::allocator<void> >, std::allocator<void>, rcl_interfaces::msg::ParameterEvent_<std::allocator<void> >, rcl_interfaces::msg::ParameterEvent_<std::allocator<void> >, rclcpp::message_memory_strategy::MessageMemoryStrategy<rcl_interfaces::msg::ParameterEvent_<std::allocator<void> >, std::allocator<void> > >::handle_message (this=0x555555a2d900, 
    message=std::shared_ptr<void> (use count 5, weak count 0) = {...}, message_info=...)
    at rclcpp/rclcpp/include/rclcpp/subscription.hpp:343
...
#15 0x0.. in take_and_do_error_handling<rclcpp::Executor::execute_subscription(rclcpp::SubscriptionBase::SharedPtr)::<lambda()>, rclcpp::Executor::execute_subscription(rclcpp::SubscriptionBase::SharedPtr)::<lambda()> >(const char *, const char *, struct {...}, struct {...}) (
    action_description=0x7ffff7cf3c50 "taking a message from topic", topic_or_service_name=0x555555aa75d0 "/parameter_events", take_action=..., 
    handle_action=...) at rclcpp/rclcpp/src/rclcpp/executor.cpp:581
#16 0x0.. in rclcpp::Executor::execute_subscription (subscription=std::shared_ptr<rclcpp::SubscriptionBase> (use count 2, weak count 3) = {...})
    at rclcpp/rclcpp/src/rclcpp/executor.cpp:657
```
FYI @alsora 
