### PR TITLE
Disable the loaned messages inside the executor.

### DIFF
--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -623,12 +623,7 @@ Executor::execute_subscription(rclcpp::SubscriptionBase::SharedPtr subscription)
     // Deliver ROS message
     case rclcpp::DeliveredMessageKind::ROS_MESSAGE:
       {
-        // TODO(clalancette): The loaned message interface is currently not safe to use.
-        // If a user takes a reference to the shared_ptr, it can get freed from underneath them
-        // via rcl_return_loaned_message_from_subscription().  The correct solution is to return
-        // the loaned message in a custom deleter, but that needs to be carefully handled with
-        // locking.  Disable the entire interface for now until we sort through the issues.
-        if (false && subscription->can_loan_messages()) {
+        if (subscription->can_loan_messages()) {
           // This is the case where a loaned message is taken from the middleware via
           // inter-process communication, given to the user for their callback,
           // and then returned.

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -623,7 +623,12 @@ Executor::execute_subscription(rclcpp::SubscriptionBase::SharedPtr subscription)
     // Deliver ROS message
     case rclcpp::DeliveredMessageKind::ROS_MESSAGE:
       {
-        if (subscription->can_loan_messages()) {
+        // TODO(clalancette): The loaned message interface is currently not safe to use.
+        // If a user takes a reference to the shared_ptr, it can get freed from underneath them
+        // via rcl_return_loaned_message_from_subscription().  The correct solution is to return
+        // the loaned message in a custom deleter, but that needs to be carefully handled with
+        // locking.  Disable the entire interface for now until we sort through the issues.
+        if (false && subscription->can_loan_messages()) {
           // This is the case where a loaned message is taken from the middleware via
           // inter-process communication, given to the user for their callback,
           // and then returned.
@@ -669,6 +674,11 @@ Executor::execute_subscription(rclcpp::SubscriptionBase::SharedPtr subscription)
             subscription->get_topic_name(),
             [&]() {return subscription->take_type_erased(message.get(), message_info);},
             [&]() {subscription->handle_message(message, message_info);});
+          // TODO(clalancette): In the case that the user is using the MessageMemoryPool,
+          // and they take a shared_ptr reference to the message in the callback, this can
+          // inadvertently return the message to the pool when the user is still using it.
+          // This is a bug that needs to be fixed in the pool, and we should probably have
+          // a custom deleter for the message that actually does the return_message().
           subscription->return_message(message);
         }
         break;

--- a/rclcpp/src/rclcpp/subscription_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_base.cpp
@@ -298,7 +298,20 @@ SubscriptionBase::setup_intra_process(
 bool
 SubscriptionBase::can_loan_messages() const
 {
-  return rcl_subscription_can_loan_messages(subscription_handle_.get());
+  bool retval = rcl_subscription_can_loan_messages(subscription_handle_.get());
+  if (retval) {
+    // TODO(clalancette): The loaned message interface is currently not safe to use with
+    // shared_ptr callbacks.  If a user takes a copy of the shared_ptr, it can get freed from
+    // underneath them via rcl_return_loaned_message_from_subscription().  The correct solution is
+    // to return the loaned message in a custom deleter, but that needs to be carefully handled
+    // with locking.  Warn the user about this until we fix it.
+    RCLCPP_WARN_ONCE(
+      this->node_logger_,
+      "Loaned messages are only safe with const ref subscription callbacks. "
+      "If you are using any other kind of subscriptions, "
+      "set the ROS_DISABLE_LOANED_MESSAGES environment variable to 1 (the default).");
+  }
+  return retval;
 }
 
 rclcpp::Waitable::SharedPtr


### PR DESCRIPTION
They are currently unsafe to use; see the comment in the commit for more information.

This was originally brought up by https://github.com/ros2/rmw_cyclonedds/issues/469 , but we also had another report of it from Nav2 (parts reproduced here for context):

From @SteveMacenski 
```
*    It looks like Fast-DDS returns the same shared pointer memory for multiple subscriber callbacks in a row
*    We take the shared_ptr message from the callback and store it for use. So later on, the community member is identifying that Fast-DDS sets the same underlying memory in msg to the new message, even though we have stored the shared pointer in our code and just reusing it, wiping away our program's state
```

From @wjwwood:
```
This is probably a bug in rclcpp: https://github.com/ros2/rclcpp/blob/rolling/rclcpp/src/rclcpp/executor.cpp#L626-L662
```