### PR TITLE
Fixes pointed out by the clang analyzer.

### DIFF
--- a/rclcpp/include/rclcpp/logger.hpp
+++ b/rclcpp/include/rclcpp/logger.hpp
@@ -126,9 +126,6 @@ private:
   std::shared_ptr<std::pair<std::string, std::string>> logger_sublogger_pairname_ = nullptr;
 
 public:
-  RCLCPP_PUBLIC
-  Logger(const Logger &) = default;
-
   /// Get the name of this logger.
   /**
    * \return the full name of the logger including any prefixes, or

--- a/rclcpp/src/rclcpp/context.cpp
+++ b/rclcpp/src/rclcpp/context.cpp
@@ -462,7 +462,7 @@ template<Context::ShutdownType shutdown_type>
 std::vector<rclcpp::Context::ShutdownCallback>
 Context::get_shutdown_callback() const
 {
-  const auto get_callback_vector = [this](auto & mutex, auto & callback_set) {
+  const auto get_callback_vector = [](auto & mutex, auto & callback_set) {
       const std::lock_guard<std::mutex> lock(mutex);
       std::vector<rclcpp::Context::ShutdownCallback> callbacks;
       for (auto & callback : callback_set) {

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -644,6 +644,7 @@ TYPED_TEST(TestExecutors, testRaceConditionAddNode)
             break;
           }
           total += k * (i + 42);
+          (void)total;
         }
       });
   }

--- a/rclcpp/test/rclcpp/test_intra_process_manager.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager.cpp
@@ -289,7 +289,7 @@ public:
   }
 
   bool
-  use_take_shared_method() const
+  use_take_shared_method() const override
   {
     return take_shared_method;
   }


### PR DESCRIPTION
1. Remove the default Logger copy constructor without copy assignment (rule of three -> rule of zero).
2. Remove an unnecessary capture in a lambda.
3. Mark a variable unused.
4. Mark a method as override.