### PR TITLE
Adjust rclcpp usage of get_type_description_service

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
@@ -84,21 +84,16 @@ public:
     }
 
     if (enabled) {
-      auto rcl_node = node_base->get_rcl_node_handle();
-      rcl_ret_t rcl_ret = rcl_node_type_description_service_init(rcl_node);
+      auto * rcl_node = node_base->get_rcl_node_handle();
+      auto rcl_srv = std::make_shared<rcl_service_t>();
+      rcl_ret_t rcl_ret = rcl_node_type_description_service_init(rcl_srv.get(), rcl_node);
+
       if (rcl_ret != RCL_RET_OK) {
         RCLCPP_ERROR(
           logger_, "Failed to initialize ~/get_type_description_service: %s",
           rcl_get_error_string().str);
         throw std::runtime_error(
                 "Failed to initialize ~/get_type_description service.");
-      }
-
-      rcl_service_t * rcl_srv = nullptr;
-      rcl_ret = rcl_node_get_type_description_service(rcl_node, &rcl_srv);
-      if (rcl_ret != RCL_RET_OK) {
-        throw std::runtime_error(
-                "Failed to get initialized ~/get_type_description service from rcl.");
       }
 
       rclcpp::AnyServiceCallback<ServiceT> cb;
@@ -122,18 +117,6 @@ public:
       node_services->add_service(
         std::dynamic_pointer_cast<ServiceBase>(type_description_srv_),
         nullptr);
-    }
-  }
-
-  ~NodeTypeDescriptionsImpl()
-  {
-    if (
-      type_description_srv_ &&
-      RCL_RET_OK != rcl_node_type_description_service_fini(node_base_->get_rcl_node_handle()))
-    {
-      RCLCPP_ERROR(
-        logger_,
-        "Error in shutdown of get_type_description service: %s", rcl_get_error_string().str);
     }
   }
 };

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_type_descriptions.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_type_descriptions.cpp
@@ -43,10 +43,9 @@ TEST_F(TestNodeTypeDescriptions, disabled_no_service)
   node_options.append_parameter_override("start_type_description_service", false);
   rclcpp::Node node{"node", "ns", node_options};
 
-  rcl_node_t * rcl_node = node.get_node_base_interface()->get_rcl_node_handle();
-  rcl_service_t * srv = nullptr;
-  rcl_ret_t ret = rcl_node_get_type_description_service(rcl_node, &srv);
-  ASSERT_EQ(RCL_RET_NOT_INIT, ret);
+  auto services = node.get_node_graph_interface()->get_service_names_and_types_by_node(
+    "node", "/ns");
+  EXPECT_TRUE(services.find("/ns/node/get_type_description") == services.end());
 }
 
 TEST_F(TestNodeTypeDescriptions, enabled_creates_service)
@@ -55,9 +54,8 @@ TEST_F(TestNodeTypeDescriptions, enabled_creates_service)
   node_options.append_parameter_override("start_type_description_service", true);
   rclcpp::Node node{"node", "ns", node_options};
 
-  rcl_node_t * rcl_node = node.get_node_base_interface()->get_rcl_node_handle();
-  rcl_service_t * srv = nullptr;
-  rcl_ret_t ret = rcl_node_get_type_description_service(rcl_node, &srv);
-  ASSERT_EQ(RCL_RET_OK, ret);
-  ASSERT_NE(nullptr, srv);
+  auto services = node.get_node_graph_interface()->get_service_names_and_types_by_node(
+    "node", "/ns");
+
+  EXPECT_TRUE(services.find("/ns/node/get_type_description") != services.end());
 }


### PR DESCRIPTION
In https://github.com/ros2/rcl/pull/1112, the API is updated to populate the service structure, rather than `init`, `get`, and `fini`.  This updates rclcpp to use the new API pattern.