### PR TITLE
Fix data race in ~EventHandlerBase

### DIFF
--- a/rclcpp/include/rclcpp/event_handler.hpp
+++ b/rclcpp/include/rclcpp/event_handler.hpp
@@ -260,6 +260,16 @@ public:
     }
   }
 
+  ~EventHandler()
+  {
+    // Since the rmw event listener holds a reference to the
+    // "on ready" callback, we need to clear it on destruction of this class.
+    // This clearing is not needed for other rclcpp entities like pub/subs, since
+    // they do own the underlying rmw entities, which are destroyed
+    // on their rclcpp destructors, thus no risk of dangling pointers.
+    clear_on_ready_callback();
+  }
+
   /// Take data so that the callback cannot be scheduled again
   std::shared_ptr<void>
   take_data() override

--- a/rclcpp/src/rclcpp/event_handler.cpp
+++ b/rclcpp/src/rclcpp/event_handler.cpp
@@ -39,13 +39,6 @@ UnsupportedEventTypeException::UnsupportedEventTypeException(
 
 EventHandlerBase::~EventHandlerBase()
 {
-  // Since the rmw event listener holds a reference to
-  // this callback, we need to clear it on destruction of this class.
-  // This clearing is not needed for other rclcpp entities like pub/subs, since
-  // they do own the underlying rmw entities, which are destroyed
-  // on their rclcpp destructors, thus no risk of dangling pointers.
-  clear_on_ready_callback();
-
   if (rcl_event_fini(&event_handle_) != RCL_RET_OK) {
     RCUTILS_LOG_ERROR_NAMED(
       "rclcpp",


### PR DESCRIPTION
Both the `EventHandler` and its associated pubs/subs share the same underlying rmw event listener:

`EventHandler --> rmw_event_listener <-- Pub/Sub` 

When a pub/sub is destroyed, that listener is destroyed.
There is a data race when the `~EventHandlerBase` calls  `clear_on_ready_callback()`, since it wants to access the listener that could have already been destroyed, thus causing a segfault.

On other hand, the derived `EventHandler` _does_ store a shared_ptr of its associated pub/sub (`parent_handle_`), thus clearing the callbacks on `~EventHandler` instead of `~EventHandlerBase` avoids the race, since the pub/sub are still valid on the `parent_handle_` so the listener is also still valid.

I managed to reproduce the issue on Galactic/Humble/Iron using the example provided here: https://github.com/ros2/rmw_fastrtps/issues/717#issue-1923877969

On rolling, I only managed to reproduce using the EventsExecutor version on its [standalone repo](https://github.com/irobot-ros/events-executor). Even without being able to reproduce properly on rolling, I think this fix may be correct and could avoid future issues. What do you think?