### PR TITLE
Add a custom deleter when constructing rcl_service_t

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
@@ -86,18 +86,18 @@ public:
     if (enabled) {
       auto * rcl_node = node_base->get_rcl_node_handle();
       std::shared_ptr<rcl_service_t> rcl_srv(
-          new rcl_service_t,
-          [rcl_node, logger = this->logger_](rcl_service_t * service)
-          {
-            if (rcl_service_fini(service, rcl_node) != RCL_RET_OK)
-            {
-              RCLCPP_ERROR(logger,
-                "Error in destruction of rcl service handle [~/get_type_description]: %s",
-                rcl_get_error_string().str);
-              rcl_reset_error();
-            }
-            delete service;
-          });
+        new rcl_service_t,
+        [rcl_node, logger = this->logger_](rcl_service_t * service)
+        {
+          if (rcl_service_fini(service, rcl_node) != RCL_RET_OK) {
+            RCLCPP_ERROR(
+              logger,
+              "Error in destruction of rcl service handle [~/get_type_description]: %s",
+              rcl_get_error_string().str);
+            rcl_reset_error();
+          }
+          delete service;
+        });
       *rcl_srv = rcl_get_zero_initialized_service();
       rcl_ret_t rcl_ret = rcl_node_type_description_service_init(rcl_srv.get(), rcl_node);
 

--- a/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
@@ -98,6 +98,7 @@ public:
             }
             delete service;
           });
+      *rcl_srv = rcl_get_zero_initialized_service();
       rcl_ret_t rcl_ret = rcl_node_type_description_service_init(rcl_srv.get(), rcl_node);
 
       if (rcl_ret != RCL_RET_OK) {

--- a/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
@@ -85,12 +85,24 @@ public:
 
     if (enabled) {
       auto * rcl_node = node_base->get_rcl_node_handle();
-      auto rcl_srv = std::make_shared<rcl_service_t>();
+      std::shared_ptr<rcl_service_t> rcl_srv(
+          new rcl_service_t,
+          [rcl_node, logger = this->logger_](rcl_service_t * service)
+          {
+            if (rcl_service_fini(service, rcl_node) != RCL_RET_OK)
+            {
+              RCLCPP_ERROR(logger,
+                "Error in destruction of rcl service handle [~/get_type_description]: %s",
+                rcl_get_error_string().str);
+              rcl_reset_error();
+            }
+            delete service;
+          });
       rcl_ret_t rcl_ret = rcl_node_type_description_service_init(rcl_srv.get(), rcl_node);
 
       if (rcl_ret != RCL_RET_OK) {
         RCLCPP_ERROR(
-          logger_, "Failed to initialize ~/get_type_description_service: %s",
+          logger_, "Failed to initialize ~/get_type_description service: %s",
           rcl_get_error_string().str);
         throw std::runtime_error(
                 "Failed to initialize ~/get_type_description service.");


### PR DESCRIPTION
In the type description service construction, we were previously passing the shared_ptr to the rcl_service_t with the assumption that rclcpp::Service would do the clean up.  This was an incorrect assumption, and so I have added a custom deleter to fini the service and delete when the shared_ptr is cleaned up.

Fixes leak introduced in #2344