### PR TITLE
Multithreaded executor behavior

### DIFF
--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -634,6 +634,33 @@ protected:
     AnyExecutable & any_executable,
     std::chrono::nanoseconds timeout = std::chrono::nanoseconds(-1));
 
+  /// Update wait set
+  /**
+   * This function can be called by any thread
+   * 
+   * \param[in] timeout duration of time to wait for work, a negative value
+   *   (the defualt behavior), will make this function block indefinitely
+   */
+  RCLCPP_PUBLIC
+  void
+  wait_set_update(std::chrono::nanoseconds timeout = std::chrono::nanoseconds(-1));
+
+  /// Wait for executable in ready state and populate union structure.
+  /**
+   * If an executable is ready, it will return immediately, otherwise
+   * block based on the timeout for work to become ready.
+   *
+   * \param[out] any_executable populated union structure of ready executable
+   * \return true if an executable was ready and any_executable was populated,
+   *   otherwise false
+   */
+  RCLCPP_PUBLIC
+  bool
+  get_next_executable_multi(
+    AnyExecutable & any_executable
+    );
+
+
   /// Add all callback groups that can be automatically added from associated nodes.
   /**
    * The executor, before collecting entities, verifies if any callback group from

--- a/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
@@ -85,6 +85,7 @@ private:
   size_t number_of_threads_;
   bool yield_before_execute_;
   std::chrono::nanoseconds next_exec_timeout_;
+  std::atomic<int> wait_count_;
 };
 
 }  // namespace executors

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -968,6 +968,20 @@ Executor::get_next_ready_executable_from_map(
   return success;
 }
 
+void
+Executor::wait_set_update(std::chrono::nanoseconds timeout)
+{
+  wait_for_work(timeout);
+}
+
+bool
+Executor::get_next_executable_multi(AnyExecutable & any_executable)
+{
+  bool success = false;
+  success = get_next_ready_executable(any_executable);
+  return success;
+}
+
 bool
 Executor::get_next_executable(AnyExecutable & any_executable, std::chrono::nanoseconds timeout)
 {


### PR DESCRIPTION
Hello,

while working on the multithreaded executor, I encountered a problem.

Take the following configuration:
One node, with two timers, each timer with a period of 1000ms, and an execution time of 1000ms per timer. Both timers are in a mutually exclusive callback group.
Due to the current structure of the multithreaded executor, only one timer will be executed, while the other one will never be executed.
I suppose this is due to one thread updating the wait set, while the other one is blocked by the execution. By the time the thread that occupies the callback group is finished, the task of the just finished timer is ready again, and the second timer task is never executed.

In my changes, I updated the behavior of the multithreaded executor, so that the wait set is only updated once all the work that is available is done. This guarantees that all callbacks in a mutually exclusive callback group will be executed, even if some of them are ready again. This change should align the behavior of the multithreaded executor more with the behavior of the single threaded executor.

If you have any suggestions or feedback for this idea, please let me know.