### PR TITLE
feat(rclcpp_components): support events executor in node main template

### DIFF
--- a/rclcpp_components/src/node_main.cpp.in
+++ b/rclcpp_components/src/node_main.cpp.in
@@ -23,11 +23,14 @@
 
 #define NODE_MAIN_LOGGER_NAME "@node@"
 
+using namespace rclcpp::executors;
+using namespace rclcpp::experimental::executors;
+
 int main(int argc, char * argv[])
 {
   auto args = rclcpp::init_and_remove_ros_arguments(argc, argv);
   rclcpp::Logger logger = rclcpp::get_logger(NODE_MAIN_LOGGER_NAME);
-  rclcpp::executors::@executor@ exec;
+  @executor@ exec;
   rclcpp::NodeOptions options;
   options.arguments(args);
   std::vector<rclcpp_components::NodeInstanceWrapper> node_wrappers;


### PR DESCRIPTION
Currently, EventsExecutor is in different namespace from other executors, so I modify node_main.cpp.in template to support EventsExecutor.