### PR TITLE
Added test cased for missing events & double call to take_data

### DIFF
--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -392,6 +392,12 @@ public:
   bool
   is_ready(rcl_wait_set_t * wait_set) override
   {
+    for (size_t i = 0; i < wait_set->size_of_guard_conditions; ++i) {
+      if (&gc_.get_rcl_guard_condition() == wait_set->guard_conditions[i]) {
+        return true;
+      }
+    }
+    return false;
     (void)wait_set;
     return true;
   }


### PR DESCRIPTION
Added a test, if a trigger event for a waitable was missed. 
Added a test, if take_data was called two times in a row, without calling is_ready in between.
This is related to #2250.