### PR TITLE
[events executor] - Fix Behavior with Timer Cancel

### DIFF
--- a/rclcpp/include/rclcpp/experimental/timers_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/timers_manager.hpp
@@ -495,14 +495,7 @@ private:
     static bool timer_greater(TimerPtr a, TimerPtr b)
     {
       // TODO(alsora): this can cause an error if timers are using different clocks
-      bool both_canceled_or_active = a->is_canceled() == b->is_canceled();
-      if (both_canceled_or_active) {
-        return a->time_until_trigger() > b->time_until_trigger();
-      }
-      else if (a->is_canceled()) {
-        return true;
-      }
-      return false;
+      return a->time_until_trigger() > b->time_until_trigger();
     }
 
     std::vector<TimerPtr> owned_heap_;

--- a/rclcpp/include/rclcpp/experimental/timers_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/timers_manager.hpp
@@ -273,15 +273,6 @@ public:
     }
 
     /**
-     * @brief Returns the size of the heap.
-     * @return the number of valid timers in the heap.
-     */
-    size_t size() const
-    {
-      return weak_heap_.size();
-    }
-
-    /**
      * @brief This function restores the current object as a valid heap
      * and it returns a locked version of it.
      * Timers that went out of scope are removed from the container.

--- a/rclcpp/src/rclcpp/experimental/executors/events_executor/events_executor.cpp
+++ b/rclcpp/src/rclcpp/experimental/executors/events_executor/events_executor.cpp
@@ -206,11 +206,12 @@ EventsExecutor::spin_once_impl(std::chrono::nanoseconds timeout)
     timeout = std::chrono::nanoseconds::max();
   }
 
-  // Select the smallest between input timeout and timer timeout
+  // Select the smallest between input timeout and timer timeout.
+  // Cancelled timers are not considered.
   bool is_timer_timeout = false;
   auto next_timer_timeout = timers_manager_->get_head_timeout();
-  if (next_timer_timeout < timeout) {
-    timeout = next_timer_timeout;
+  if (next_timer_timeout.has_value() && next_timer_timeout.value() < timeout) {
+    timeout = next_timer_timeout.value();
     is_timer_timeout = true;
   }
 

--- a/rclcpp/src/rclcpp/experimental/timers_manager.cpp
+++ b/rclcpp/src/rclcpp/experimental/timers_manager.cpp
@@ -268,11 +268,10 @@ void TimersManager::run_timers()
       TimersHeap locked_heap = weak_timers_heap_.validate_and_lock();
       locked_heap.heapify();
       weak_timers_heap_.store(locked_heap);
-    }
-    else if (time_to_sleep.value() != std::chrono::nanoseconds::zero()) {
-        // If time_to_sleep is zero, we immediately execute. Otherwise, wait
-        // until timeout or notification that timers have been updated
-        timers_cv_.wait_for(lock, time_to_sleep.value(), [this]() {return timers_updated_;});
+    } else if (time_to_sleep.value() != std::chrono::nanoseconds::zero()) {
+      // If time_to_sleep is zero, we immediately execute. Otherwise, wait
+      // until timeout or notification that timers have been updated
+      timers_cv_.wait_for(lock, time_to_sleep.value(), [this]() {return timers_updated_;});
     }
 
     // Reset timers updated flag

--- a/rclcpp/src/rclcpp/experimental/timers_manager.cpp
+++ b/rclcpp/src/rclcpp/experimental/timers_manager.cpp
@@ -291,6 +291,12 @@ void TimersManager::run_timers()
       else {
         // Wait until notification that timers have been updated
         timers_cv_.wait(lock, [this]() {return timers_updated_;});
+
+        // Re-heap in case ordering changed due to a cancelled timer
+        // re-activating.
+        TimersHeap locked_heap = weak_timers_heap_.validate_and_lock();
+        locked_heap.heapify();
+        weak_timers_heap_.store(locked_heap);
       }
     }
 

--- a/rclcpp/src/rclcpp/experimental/timers_manager.cpp
+++ b/rclcpp/src/rclcpp/experimental/timers_manager.cpp
@@ -246,28 +246,48 @@ void TimersManager::run_timers()
 
     std::optional<std::chrono::nanoseconds> time_to_sleep = get_head_timeout_unsafe();
 
-    if (!time_to_sleep.has_value()) {
-        // If head was cancelled, and there is more than 1 timer, we need to re-heapify. This
-        // is a case where the next up timer should really be used, so the next loop iteration
-        // will pick up the correct head.
-        if (weak_timers_heap_.size() > 1) {
-          TimersHeap locked_heap = weak_timers_heap_.validate_and_lock();
-          locked_heap.heapify();
-          weak_timers_heap_.store(locked_heap);
+    // Head timer is not cancelled
+    if (time_to_sleep.has_value()) {
+      // No need to wait if a timer is already available
+      if (time_to_sleep.value() > std::chrono::nanoseconds::zero()) {
+        // Heap is not empty
+        if (time_to_sleep.value() != std::chrono::nanoseconds::max()) {
+          // Check if head timer is in cancelled_timers_
+          TimerPtr head_timer = weak_timers_heap_.front().lock();
+          auto itr = std::find(cancelled_timers_.begin(), cancelled_timers_.end(), head_timer);
+
+          if (itr != cancelled_timers_.end()) {
+            // Remove if present bc recieved valid time_to_sleep so no longer cancelled
+            cancelled_timers_.erase(itr);
+          }
+
+          // Wait until timeout or notification that timers have been updated
+          timers_cv_.wait_for(lock, time_to_sleep.value(), [this]() {return timers_updated_;});
         }
-        // Otherwise, we can just wait indefinitely for a new timer to be added, since the only
-        // timer is invalid.
+        // Heap is empty
         else {
           // Wait until notification that timers have been updated
           timers_cv_.wait(lock, [this]() {return timers_updated_;});
         }
-    }
-    // No need to wait if a timer is already available
-    else if (time_to_sleep.value() > std::chrono::nanoseconds::zero()) {
-      if (time_to_sleep.value() != std::chrono::nanoseconds::max()) {
-        // Wait until timeout or notification that timers have been updated
-        timers_cv_.wait_for(lock, time_to_sleep.value(), [this]() {return timers_updated_;});
       }
+    }
+    // Head timer is cancelled
+    else {
+      // Check if head timer is in cancelled_timers_ already
+      TimerPtr head_timer = weak_timers_heap_.front().lock();
+      auto itr = std::find(cancelled_timers_.begin(), cancelled_timers_.end(), head_timer);
+
+      if (itr == cancelled_timers_.end()) {
+        // Append to vector if not present so it will be treated as a cancelled timer
+        cancelled_timers_.push_back(head_timer);
+
+        // Re-heap to move cancelled timer from head of heap
+        TimersHeap locked_heap = weak_timers_heap_.validate_and_lock();
+        locked_heap.heapify();
+        weak_timers_heap_.store(locked_heap);
+      }
+      // Head timer has already been recongized as cancelled
+      // This handles the case where all timers in the heap are cancelled
       else {
         // Wait until notification that timers have been updated
         timers_cv_.wait(lock, [this]() {return timers_updated_;});

--- a/rclcpp/src/rclcpp/experimental/timers_manager.cpp
+++ b/rclcpp/src/rclcpp/experimental/timers_manager.cpp
@@ -246,58 +246,33 @@ void TimersManager::run_timers()
 
     std::optional<std::chrono::nanoseconds> time_to_sleep = get_head_timeout_unsafe();
 
-    // Head timer is not cancelled
-    if (time_to_sleep.has_value()) {
-      // No need to wait if a timer is already available
-      if (time_to_sleep.value() > std::chrono::nanoseconds::zero()) {
-        // Heap is not empty
-        if (time_to_sleep.value() != std::chrono::nanoseconds::max()) {
-          // Check if head timer is in cancelled_timers_
-          TimerPtr head_timer = weak_timers_heap_.front().lock();
-          auto itr = std::find(cancelled_timers_.begin(), cancelled_timers_.end(), head_timer);
-
-          if (itr != cancelled_timers_.end()) {
-            // Remove if present bc recieved valid time_to_sleep so no longer cancelled
-            cancelled_timers_.erase(itr);
-          }
-
-          // Wait until timeout or notification that timers have been updated
-          timers_cv_.wait_for(lock, time_to_sleep.value(), [this]() {return timers_updated_;});
-        }
-        // Heap is empty
-        else {
-          // Wait until notification that timers have been updated
-          timers_cv_.wait(lock, [this]() {return timers_updated_;});
-        }
-      }
+    // If head timer was cancelled, try to reheap and get a new head.
+    // This avoids an edge condition where head timer is cancelled, but other
+    // valid timers remain in the heap.
+    if (!time_to_sleep.has_value()) {
+      // Re-heap to (possibly) move cancelled timer from head of heap. If
+      // entire heap is cancelled, this will still result in a nullopt.
+      TimersHeap locked_heap = weak_timers_heap_.validate_and_lock();
+      locked_heap.heapify();
+      weak_timers_heap_.store(locked_heap);
+      time_to_sleep = get_head_timeout_unsafe();
     }
-    // Head timer is cancelled
-    else {
-      // Check if head timer is in cancelled_timers_ already
-      TimerPtr head_timer = weak_timers_heap_.front().lock();
-      auto itr = std::find(cancelled_timers_.begin(), cancelled_timers_.end(), head_timer);
 
-      if (itr == cancelled_timers_.end()) {
-        // Append to vector if not present so it will be treated as a cancelled timer
-        cancelled_timers_.push_back(head_timer);
+    // If no timers, or all timers cancelled, wait for an update.
+    if (!time_to_sleep.has_value() || (time_to_sleep.value() == std::chrono::nanoseconds::max()) ) {
+      // Wait until notification that timers have been updated
+      timers_cv_.wait(lock, [this]() {return timers_updated_;});
 
-        // Re-heap to move cancelled timer from head of heap
-        TimersHeap locked_heap = weak_timers_heap_.validate_and_lock();
-        locked_heap.heapify();
-        weak_timers_heap_.store(locked_heap);
-      }
-      // Head timer has already been recongized as cancelled
-      // This handles the case where all timers in the heap are cancelled
-      else {
-        // Wait until notification that timers have been updated
-        timers_cv_.wait(lock, [this]() {return timers_updated_;});
-
-        // Re-heap in case ordering changed due to a cancelled timer
-        // re-activating.
-        TimersHeap locked_heap = weak_timers_heap_.validate_and_lock();
-        locked_heap.heapify();
-        weak_timers_heap_.store(locked_heap);
-      }
+      // Re-heap in case ordering changed due to a cancelled timer
+      // re-activating.
+      TimersHeap locked_heap = weak_timers_heap_.validate_and_lock();
+      locked_heap.heapify();
+      weak_timers_heap_.store(locked_heap);
+    }
+    else if (time_to_sleep.value() != std::chrono::nanoseconds::zero()) {
+        // If time_to_sleep is zero, we immediately execute. Otherwise, wait
+        // until timeout or notification that timers have been updated
+        timers_cv_.wait_for(lock, time_to_sleep.value(), [this]() {return timers_updated_;});
     }
 
     // Reset timers updated flag

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -936,7 +936,7 @@ TYPED_TEST(TestTimerCancelBehavior, testTimer1CancelledWithExecutorSpin) {
   // Cancel to stop the spin after some time.
   std::this_thread::sleep_for(5ms);
   this->node->CancelTimer1();
-  std::this_thread::sleep_for(10ms);
+  std::this_thread::sleep_for(20ms);
   this->executor.cancel();
 
   int t1_runs = this->node->GetTimer1Cnt();
@@ -954,7 +954,7 @@ TYPED_TEST(TestTimerCancelBehavior, testTimer2CancelledWithExecutorSpin) {
   // Cancel to stop the spin after some time.
   std::this_thread::sleep_for(5ms);
   this->node->CancelTimer2();
-  std::this_thread::sleep_for(10ms);
+  std::this_thread::sleep_for(20ms);
   this->executor.cancel();
 
   int t1_runs = this->node->GetTimer1Cnt();
@@ -971,14 +971,14 @@ TYPED_TEST(TestTimerCancelBehavior, testHeadTimerCancelThenResetBehavior) {
   // Cancel to stop the spin after some time.
   std::this_thread::sleep_for(5ms);
   this->node->CancelTimer1();
-  std::this_thread::sleep_for(10ms);
+  std::this_thread::sleep_for(20ms);
   int t1_runs_initial = this->node->GetTimer1Cnt();
   int t2_runs_initial = this->node->GetTimer2Cnt();
 
   // Manually reset timer 1, then sleep again
   // Counts should update.
   this->node->ResetTimer1();
-  std::this_thread::sleep_for(15ms);
+  std::this_thread::sleep_for(25ms);
   int t1_runs_final = this->node->GetTimer1Cnt();
   int t2_runs_final = this->node->GetTimer2Cnt();
 
@@ -1000,14 +1000,14 @@ TYPED_TEST(TestTimerCancelBehavior, testBackTimerCancelThenResetBehavior) {
   // Cancel to stop the spin after some time.
   std::this_thread::sleep_for(5ms);
   this->node->CancelTimer2();
-  std::this_thread::sleep_for(10ms);
+  std::this_thread::sleep_for(20ms);
   int t1_runs_initial = this->node->GetTimer1Cnt();
   int t2_runs_initial = this->node->GetTimer2Cnt();
 
   // Manually reset timer 1, then sleep again
   // Counts should update.
   this->node->ResetTimer2();
-  std::this_thread::sleep_for(15ms);
+  std::this_thread::sleep_for(25ms);
   int t1_runs_final = this->node->GetTimer1Cnt();
   int t2_runs_final = this->node->GetTimer2Cnt();
 
@@ -1030,19 +1030,19 @@ TYPED_TEST(TestTimerCancelBehavior, testBothTimerCancelThenResetT1Behavior) {
   std::this_thread::sleep_for(5ms);
   this->node->CancelTimer1();
   this->node->CancelTimer2();
-  std::this_thread::sleep_for(10ms);
+  std::this_thread::sleep_for(20ms);
   int t1_runs_initial = this->node->GetTimer1Cnt();
   int t2_runs_initial = this->node->GetTimer2Cnt();
 
   // Manually reset timer 1, then sleep again
   // Counts should update.
   this->node->ResetTimer1();
-  std::this_thread::sleep_for(15ms);
+  std::this_thread::sleep_for(25ms);
   int t1_runs_intermediate = this->node->GetTimer1Cnt();
   int t2_runs_intermediate = this->node->GetTimer2Cnt();
 
   this->node->ResetTimer2();
-  std::this_thread::sleep_for(15ms);
+  std::this_thread::sleep_for(25ms);
   int t1_runs_final = this->node->GetTimer1Cnt();
   int t2_runs_final = this->node->GetTimer2Cnt();
 
@@ -1069,19 +1069,19 @@ TYPED_TEST(TestTimerCancelBehavior, testBothTimerCancelThenResetT2Behavior) {
   std::this_thread::sleep_for(5ms);
   this->node->CancelTimer1();
   this->node->CancelTimer2();
-  std::this_thread::sleep_for(10ms);
+  std::this_thread::sleep_for(20ms);
   int t1_runs_initial = this->node->GetTimer1Cnt();
   int t2_runs_initial = this->node->GetTimer2Cnt();
 
   // Manually reset timer 1, then sleep again
   // Counts should update.
   this->node->ResetTimer2();
-  std::this_thread::sleep_for(15ms);
+  std::this_thread::sleep_for(25ms);
   int t1_runs_intermediate = this->node->GetTimer1Cnt();
   int t2_runs_intermediate = this->node->GetTimer2Cnt();
 
   this->node->ResetTimer1();
-  std::this_thread::sleep_for(15ms);
+  std::this_thread::sleep_for(25ms);
   int t1_runs_final = this->node->GetTimer1Cnt();
   int t2_runs_final = this->node->GetTimer2Cnt();
 

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -934,16 +934,16 @@ TYPED_TEST(TestTimerCancelBehavior, testTimer1CancelledWithExecutorSpin) {
   // executor, which is the most common usecase.
 
   // Cancel to stop the spin after some time.
-  std::this_thread::sleep_for(5ms);
+  std::this_thread::sleep_for(100ms);
   this->node->CancelTimer1();
-  std::this_thread::sleep_for(20ms);
+  std::this_thread::sleep_for(300ms);
   this->executor.cancel();
 
   int t1_runs = this->node->GetTimer1Cnt();
   int t2_runs = this->node->GetTimer2Cnt();
   EXPECT_NE(t1_runs, t2_runs);
   // Check that t2 has significantly more calls
-  EXPECT_LT(t1_runs + 5, t2_runs);
+  EXPECT_LT(t1_runs + 150, t2_runs);
 }
 
 TYPED_TEST(TestTimerCancelBehavior, testTimer2CancelledWithExecutorSpin) {
@@ -952,16 +952,16 @@ TYPED_TEST(TestTimerCancelBehavior, testTimer2CancelledWithExecutorSpin) {
   // executor, which is the most common usecase.
 
   // Cancel to stop the spin after some time.
-  std::this_thread::sleep_for(5ms);
+  std::this_thread::sleep_for(100ms);
   this->node->CancelTimer2();
-  std::this_thread::sleep_for(20ms);
+  std::this_thread::sleep_for(300ms);
   this->executor.cancel();
 
   int t1_runs = this->node->GetTimer1Cnt();
   int t2_runs = this->node->GetTimer2Cnt();
   EXPECT_NE(t1_runs, t2_runs);
   // Check that t1 has significantly more calls
-  EXPECT_LT(t2_runs + 5, t1_runs);
+  EXPECT_LT(t2_runs + 150, t1_runs);
 }
 
 TYPED_TEST(TestTimerCancelBehavior, testHeadTimerCancelThenResetBehavior) {
@@ -969,16 +969,16 @@ TYPED_TEST(TestTimerCancelBehavior, testHeadTimerCancelThenResetBehavior) {
   // and that the cancelled timer starts executing normally once reset manually.
 
   // Cancel to stop the spin after some time.
-  std::this_thread::sleep_for(5ms);
+  std::this_thread::sleep_for(100ms);
   this->node->CancelTimer1();
-  std::this_thread::sleep_for(20ms);
+  std::this_thread::sleep_for(300ms);
   int t1_runs_initial = this->node->GetTimer1Cnt();
   int t2_runs_initial = this->node->GetTimer2Cnt();
 
   // Manually reset timer 1, then sleep again
   // Counts should update.
   this->node->ResetTimer1();
-  std::this_thread::sleep_for(25ms);
+  std::this_thread::sleep_for(300ms);
   int t1_runs_final = this->node->GetTimer1Cnt();
   int t2_runs_final = this->node->GetTimer2Cnt();
 
@@ -986,11 +986,11 @@ TYPED_TEST(TestTimerCancelBehavior, testHeadTimerCancelThenResetBehavior) {
 
   // T1 should have been restarted, and execute about 15 additional times.
   // Check 10 greater than initial, to account for some timing jitter.
-  EXPECT_LT(t1_runs_initial + 10, t1_runs_final);
+  EXPECT_LT(t1_runs_initial + 150, t1_runs_final);
 
-  EXPECT_LT(t1_runs_initial + 5, t2_runs_initial);
+  EXPECT_LT(t1_runs_initial + 150, t2_runs_initial);
   // Check that t2 has significantly more calls, and keeps getting called.
-  EXPECT_LT(t2_runs_initial + 13, t2_runs_final);
+  EXPECT_LT(t2_runs_initial + 150, t2_runs_final);
 }
 
 TYPED_TEST(TestTimerCancelBehavior, testBackTimerCancelThenResetBehavior) {
@@ -998,16 +998,16 @@ TYPED_TEST(TestTimerCancelBehavior, testBackTimerCancelThenResetBehavior) {
   // and that the cancelled timer starts executing normally once reset manually.
 
   // Cancel to stop the spin after some time.
-  std::this_thread::sleep_for(5ms);
+  std::this_thread::sleep_for(100ms);
   this->node->CancelTimer2();
-  std::this_thread::sleep_for(20ms);
+  std::this_thread::sleep_for(300ms);
   int t1_runs_initial = this->node->GetTimer1Cnt();
   int t2_runs_initial = this->node->GetTimer2Cnt();
 
   // Manually reset timer 1, then sleep again
   // Counts should update.
   this->node->ResetTimer2();
-  std::this_thread::sleep_for(25ms);
+  std::this_thread::sleep_for(300ms);
   int t1_runs_final = this->node->GetTimer1Cnt();
   int t2_runs_final = this->node->GetTimer2Cnt();
 
@@ -1015,11 +1015,11 @@ TYPED_TEST(TestTimerCancelBehavior, testBackTimerCancelThenResetBehavior) {
 
   // T2 should have been restarted, and execute about 15 additional times.
   // Check 10 greater than initial, to account for some timing jitter.
-  EXPECT_LT(t2_runs_initial + 10, t2_runs_final);
+  EXPECT_LT(t2_runs_initial + 150, t2_runs_final);
 
-  EXPECT_LT(t2_runs_initial + 5, t1_runs_initial);
+  EXPECT_LT(t2_runs_initial + 150, t1_runs_initial);
   // Check that t1 has significantly more calls, and keeps getting called.
-  EXPECT_LT(t1_runs_initial + 13, t1_runs_final);
+  EXPECT_LT(t1_runs_initial + 150, t1_runs_final);
 }
 
 TYPED_TEST(TestTimerCancelBehavior, testBothTimerCancelThenResetT1Behavior) {
@@ -1027,22 +1027,22 @@ TYPED_TEST(TestTimerCancelBehavior, testBothTimerCancelThenResetT1Behavior) {
   // Ensure that only the reset timer is executed.
 
   // Cancel to stop the spin after some time.
-  std::this_thread::sleep_for(5ms);
+  std::this_thread::sleep_for(100ms);
   this->node->CancelTimer1();
   this->node->CancelTimer2();
-  std::this_thread::sleep_for(20ms);
+  std::this_thread::sleep_for(300ms);
   int t1_runs_initial = this->node->GetTimer1Cnt();
   int t2_runs_initial = this->node->GetTimer2Cnt();
 
   // Manually reset timer 1, then sleep again
   // Counts should update.
   this->node->ResetTimer1();
-  std::this_thread::sleep_for(25ms);
+  std::this_thread::sleep_for(300ms);
   int t1_runs_intermediate = this->node->GetTimer1Cnt();
   int t2_runs_intermediate = this->node->GetTimer2Cnt();
 
   this->node->ResetTimer2();
-  std::this_thread::sleep_for(25ms);
+  std::this_thread::sleep_for(300ms);
   int t1_runs_final = this->node->GetTimer1Cnt();
   int t2_runs_final = this->node->GetTimer2Cnt();
 
@@ -1054,11 +1054,11 @@ TYPED_TEST(TestTimerCancelBehavior, testBothTimerCancelThenResetT1Behavior) {
   // Expect that T1 has up to 15 more calls than t2. Add some buffer
   // to account for jitter.
   EXPECT_EQ(t2_runs_initial, t2_runs_intermediate);
-  EXPECT_LT(t1_runs_initial + 11, t1_runs_intermediate);
+  EXPECT_LT(t1_runs_initial + 150, t1_runs_intermediate);
 
   // Expect that by end of test, both are running properly again.
-  EXPECT_LT(t1_runs_intermediate + 11, t1_runs_final);
-  EXPECT_LT(t2_runs_intermediate + 11, t2_runs_final);
+  EXPECT_LT(t1_runs_intermediate + 150, t1_runs_final);
+  EXPECT_LT(t2_runs_intermediate + 150, t2_runs_final);
 }
 
 TYPED_TEST(TestTimerCancelBehavior, testBothTimerCancelThenResetT2Behavior) {
@@ -1066,22 +1066,22 @@ TYPED_TEST(TestTimerCancelBehavior, testBothTimerCancelThenResetT2Behavior) {
   // Ensure that only the reset timer is executed.
 
   // Cancel to stop the spin after some time.
-  std::this_thread::sleep_for(5ms);
+  std::this_thread::sleep_for(100ms);
   this->node->CancelTimer1();
   this->node->CancelTimer2();
-  std::this_thread::sleep_for(20ms);
+  std::this_thread::sleep_for(300ms);
   int t1_runs_initial = this->node->GetTimer1Cnt();
   int t2_runs_initial = this->node->GetTimer2Cnt();
 
   // Manually reset timer 1, then sleep again
   // Counts should update.
   this->node->ResetTimer2();
-  std::this_thread::sleep_for(25ms);
+  std::this_thread::sleep_for(300ms);
   int t1_runs_intermediate = this->node->GetTimer1Cnt();
   int t2_runs_intermediate = this->node->GetTimer2Cnt();
 
   this->node->ResetTimer1();
-  std::this_thread::sleep_for(25ms);
+  std::this_thread::sleep_for(300ms);
   int t1_runs_final = this->node->GetTimer1Cnt();
   int t2_runs_final = this->node->GetTimer2Cnt();
 
@@ -1093,9 +1093,9 @@ TYPED_TEST(TestTimerCancelBehavior, testBothTimerCancelThenResetT2Behavior) {
   // Expect that T1 has up to 15 more calls than t2. Add some buffer
   // to account for jitter.
   EXPECT_EQ(t1_runs_initial, t1_runs_intermediate);
-  EXPECT_LT(t2_runs_initial + 11, t2_runs_intermediate);
+  EXPECT_LT(t2_runs_initial + 150, t2_runs_intermediate);
 
   // Expect that by end of test, both are running properly again.
-  EXPECT_LT(t1_runs_intermediate + 11, t1_runs_final);
-  EXPECT_LT(t2_runs_intermediate + 11, t2_runs_final);
+  EXPECT_LT(t1_runs_intermediate + 150, t1_runs_final);
+  EXPECT_LT(t2_runs_intermediate + 150, t2_runs_final);
 }

--- a/rclcpp/test/rclcpp/test_timers_manager.cpp
+++ b/rclcpp/test/rclcpp/test_timers_manager.cpp
@@ -21,8 +21,6 @@
 
 #include "rclcpp/contexts/default_context.hpp"
 #include "rclcpp/experimental/timers_manager.hpp"
-#include "rclcpp/node.hpp"
-#include <rclcpp/experimental/executors/events_executor/events_executor.hpp>
 
 using namespace std::chrono_literals;
 

--- a/rclcpp/test/rclcpp/test_timers_manager.cpp
+++ b/rclcpp/test/rclcpp/test_timers_manager.cpp
@@ -21,6 +21,8 @@
 
 #include "rclcpp/contexts/default_context.hpp"
 #include "rclcpp/experimental/timers_manager.hpp"
+#include "rclcpp/node.hpp"
+#include <rclcpp/experimental/executors/events_executor/events_executor.hpp>
 
 using namespace std::chrono_literals;
 
@@ -358,4 +360,50 @@ TEST_F(TestTimersManager, infinite_loop)
 
   EXPECT_LT(0u, t1_runs);
   EXPECT_LT(0u, t2_runs);
+}
+
+// Validate that cancelling one timer yields no change in behavior for other
+// timers.
+TEST_F(TestTimersManager, check_one_timer_cancel_doesnt_affect_other_timers)
+{
+  auto timers_manager = std::make_shared<TimersManager>(
+    rclcpp::contexts::get_global_default_context());
+
+  size_t t1_runs = 0;
+  std::shared_ptr<TimerT> t1;
+  // After a while cancel t1. Don't remove it though.
+  // Simulates typical usage in a Node where a timer is cancelled but not removed,
+  // since typical users aren't going to mess around with the timer manager.
+  t1 = TimerT::make_shared(
+    1ms,
+    [&t1_runs, &t1]() {
+      t1_runs++;
+      if (t1_runs == 5) {
+        t1->cancel();
+      }
+    },
+    rclcpp::contexts::get_global_default_context());
+
+  size_t t2_runs = 0;
+  auto t2 = TimerT::make_shared(
+    1ms,
+    [&t2_runs]() {
+      t2_runs++;
+    },
+    rclcpp::contexts::get_global_default_context());
+
+  // Add timers
+  timers_manager->add_timer(t1);
+  timers_manager->add_timer(t2);
+
+  // Start timers thread
+  timers_manager->start();
+
+  std::this_thread::sleep_for(15ms);
+
+  // t1 has stopped running
+  EXPECT_NE(t1_runs, t2_runs);
+  // Check that t2 has significantly more calls
+  EXPECT_LT(t1_runs + 5, t2_runs);
+  timers_manager->stop();
 }


### PR DESCRIPTION
## Background
It appears that with the experimental events executor, some usages of the rclcpp API cause broken behavior. Specifically, if multiple timers are configured in a node, and during runtime one of the timers is cancelled via the `TimerBase::cancel` method, this will result in all other timers failing to execute.

A minimal working example of the bug is found here --
[example_package.tar.gz](https://github.com/ros2/rclcpp/files/13494070/example_package.tar.gz)

To reproduce, build the package using `colcon build`, then run `USE_EVENTS_EXECUTOR=1 ros2 run example_package timer_node`. It is observable that both timers get cancelled after the first timer cancels itself:
```
root@753c2035d766:/app/src# USE_EVENTS_EXECUTOR=1 ros2 run example_package timer_node
[INFO] [1701211973.238745755] [timer_node]: Using EventsExecutor
[INFO] [1701211974.239147118] [timer_node]: Timer 1!
[INFO] [1701211974.239268496] [timer_node]: Timer 2!
[INFO] [1701211975.239086741] [timer_node]: Timer 1!
[INFO] [1701211975.239251090] [timer_node]: Timer 2!
[INFO] [1701211976.239241288] [timer_node]: Timer 1!
[INFO] [1701211976.239417539] [timer_node]: Timer 2!
[INFO] [1701211977.239107783] [timer_node]: Timer 1!
[INFO] [1701211977.239260069] [timer_node]: Timer 2!
[INFO] [1701211978.239079416] [timer_node]: Timer 1!
[INFO] [1701211978.239232915] [timer_node]: Timer 2!
[INFO] [1701211979.239045079] [timer_node]: Timer 1!
[INFO] [1701211979.239198617] [timer_node]: Timer cancelling itself!
[INFO] [1701211979.239225057] [timer_node]: Timer 2!
```

Myself and @gusbrigantino  have tested this on latest `rolling` as well as `iron`.

## Solution
The root cause is that there’s an edgecase within the `TimersManager` class which causes the thread to hang indefinitely if the ‘head’ timer in an internal data structure gets cancelled. As a result, the method will block until timers are reset (the `timers_updated_` flag is set, which only occurs if the timers are reset. The underlying issue is that the `TimersManager` class is not properly checking for if a timer to be executed has actually been cancelled.

The implemented fix adds logic to the comparison used for the heap such that cancelled timers are always at the bottom of the heap. Furthermore,  `get_head_timeout_unsafe` is modified to return whether or not the current timer is invalid. This bool is then used to break out of the loop in `run_timers`.