### PR TITLE
[fix] Init EventHandlerBase::wait_set_event_index_

### DIFF
--- a/rclcpp/include/rclcpp/event_handler.hpp
+++ b/rclcpp/include/rclcpp/event_handler.hpp
@@ -230,7 +230,7 @@ protected:
   std::function<void(size_t)> on_new_event_callback_{nullptr};
 
   rcl_event_t event_handle_;
-  size_t wait_set_event_index_;
+  size_t wait_set_event_index_ = 0;
 };
 
 using QOSEventHandlerBase [[deprecated("Use rclcpp::EventHandlerBase")]] = EventHandlerBase;


### PR DESCRIPTION
This prevents a call to is_ready() using an uninitalised index to access wait_set->events that may occur before the event has been setup in add_to_wait_set().