### PR TITLE
Init QOSEventHandlerBase::wait_set_event_index_

### DIFF
--- a/rclcpp/include/rclcpp/qos_event.hpp
+++ b/rclcpp/include/rclcpp/qos_event.hpp
@@ -214,7 +214,7 @@ protected:
   set_on_new_event_callback(rcl_event_callback_t callback, const void * user_data);
 
   rcl_event_t event_handle_;
-  size_t wait_set_event_index_;
+  size_t wait_set_event_index_ = 0;
   std::recursive_mutex callback_mutex_;
   std::function<void(size_t)> on_new_event_callback_{nullptr};
 };


### PR DESCRIPTION
This prevents a call to is_ready() using an uninitalised index to access wait_set->events that may occur before the event has been setup in add_to_wait_set().

Backported to humble from https://github.com/ros2/rclcpp/pull/2376