### PR TITLE
Enabled Logger based on Severity

### DIFF
--- a/rclcpp/include/rclcpp/logger.hpp
+++ b/rclcpp/include/rclcpp/logger.hpp
@@ -24,6 +24,7 @@
 #include "rcl/node.h"
 #include "rcutils/logging.h"
 #include "rcpputils/filesystem_helper.hpp"
+#include "rclcpp/logging.hpp"
 
 /**
  * \def RCLCPP_LOGGING_ENABLED
@@ -34,8 +35,7 @@
  * This should be used in combination with `RCLCPP_LOG_MIN_SEVERITY` to compile
  * out logging macros.
  */
-// TODO(dhood): determine this automatically from `RCLCPP_LOG_MIN_SEVERITY`
-#ifndef RCLCPP_LOGGING_ENABLED
+#ifdef RCLCPP_LOGG_MIN_SEVERITY_NONE
 #define RCLCPP_LOGGING_ENABLED 1
 #endif
 


### PR DESCRIPTION
Originally added in pull request #411 there is the following TODO:

> TODO(dhood): determine this automatically from `RCLCPP_LOG_MIN_SEVERITY`

referencing the enabled of normal [loggers](https://github.com/ros2/rclcpp/blob/rolling/rclcpp/include/rclcpp/logger.hpp#L39). This pull request is meant to solve that TODO, or at least get a grasp on what determining loggers based on severity should look like. This could be useful for giving the user more control over how loggers turn to dummies based on the extent of failure.