### PR TITLE
:man_farmer:  Revert "make type support helper supported for service (#2209)"

### DIFF
--- a/rclcpp/include/rclcpp/generic_publisher.hpp
+++ b/rclcpp/include/rclcpp/generic_publisher.hpp
@@ -77,7 +77,7 @@ public:
   : rclcpp::PublisherBase(
       node_base,
       topic_name,
-      *rclcpp::get_message_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *ts_lib),
+      *rclcpp::get_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *ts_lib),
       options.template to_rcl_publisher_options<rclcpp::SerializedMessage>(qos),
       // NOTE(methylDragon): Passing these args separately is necessary for event binding
       options.event_callbacks,

--- a/rclcpp/include/rclcpp/generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/generic_subscription.hpp
@@ -79,7 +79,7 @@ public:
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options)
   : SubscriptionBase(
       node_base,
-      *rclcpp::get_message_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *ts_lib),
+      *rclcpp::get_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *ts_lib),
       topic_name,
       options.to_rcl_subscription_options(qos),
       options.event_callbacks,

--- a/rclcpp/include/rclcpp/typesupport_helpers.hpp
+++ b/rclcpp/include/rclcpp/typesupport_helpers.hpp
@@ -22,7 +22,6 @@
 
 #include "rcpputils/shared_library.hpp"
 #include "rosidl_runtime_cpp/message_type_support_decl.hpp"
-#include "rosidl_runtime_cpp/service_type_support_decl.hpp"
 
 #include "rclcpp/visibility_control.hpp"
 
@@ -41,52 +40,14 @@ get_typesupport_library(const std::string & type, const std::string & typesuppor
 /// Extract the type support handle from the library.
 /**
  * The library needs to match the topic type. The shared library must stay loaded for the lifetime of the result.
- *
- * \deprecated Use get_message_typesupport_handle() instead
- *
  * \param[in] type The topic type, e.g. "std_msgs/msg/String"
  * \param[in] typesupport_identifier Type support identifier, typically "rosidl_typesupport_cpp"
  * \param[in] library The shared type support library
  * \return A type support handle
  */
-[[deprecated("Use `get_message_typesupport_handle` instead")]]
 RCLCPP_PUBLIC
 const rosidl_message_type_support_t *
 get_typesupport_handle(
-  const std::string & type,
-  const std::string & typesupport_identifier,
-  rcpputils::SharedLibrary & library);
-
-/// Extract the message type support handle from the library.
-/**
- * The library needs to match the topic type. The shared library must stay loaded for the lifetime of the result.
- *
- * \param[in] type The topic type, e.g. "std_msgs/msg/String"
- * \param[in] typesupport_identifier Type support identifier, typically "rosidl_typesupport_cpp"
- * \param[in] library The shared type support library
- * \throws std::runtime_error if the symbol of type not found in the library.
- * \return A message type support handle
- */
-RCLCPP_PUBLIC
-const rosidl_message_type_support_t *
-get_message_typesupport_handle(
-  const std::string & type,
-  const std::string & typesupport_identifier,
-  rcpputils::SharedLibrary & library);
-
-/// Extract the service type support handle from the library.
-/**
- * The library needs to match the topic type. The shared library must stay loaded for the lifetime of the result.
- *
- * \param[in] type The service type, e.g. "std_srvs/srv/Empty"
- * \param[in] typesupport_identifier Type support identifier, typically "rosidl_typesupport_cpp"
- * \param[in] library The shared type support library
- * \throws std::runtime_error if the symbol of type not found in the library.
- * \return A service type support handle
- */
-RCLCPP_PUBLIC
-const rosidl_service_type_support_t *
-get_service_typesupport_handle(
   const std::string & type,
   const std::string & typesupport_identifier,
   rcpputils::SharedLibrary & library);

--- a/rclcpp/test/rclcpp/test_typesupport_helpers.cpp
+++ b/rclcpp/test/rclcpp/test_typesupport_helpers.cpp
@@ -50,7 +50,7 @@ TEST(TypesupportHelpersTest, returns_c_type_info_for_valid_legacy_library) {
   try {
     auto library = rclcpp::get_typesupport_library(
       "test_msgs/BasicTypes", "rosidl_typesupport_cpp");
-    auto string_typesupport = rclcpp::get_message_typesupport_handle(
+    auto string_typesupport = rclcpp::get_typesupport_handle(
       "test_msgs/BasicTypes", "rosidl_typesupport_cpp", *library);
 
     EXPECT_THAT(
@@ -65,7 +65,7 @@ TEST(TypesupportHelpersTest, returns_c_type_info_for_valid_library) {
   try {
     auto library = rclcpp::get_typesupport_library(
       "test_msgs/msg/BasicTypes", "rosidl_typesupport_cpp");
-    auto string_typesupport = rclcpp::get_message_typesupport_handle(
+    auto string_typesupport = rclcpp::get_typesupport_handle(
       "test_msgs/msg/BasicTypes", "rosidl_typesupport_cpp", *library);
 
     EXPECT_THAT(
@@ -74,53 +74,4 @@ TEST(TypesupportHelpersTest, returns_c_type_info_for_valid_library) {
   } catch (const std::runtime_error & e) {
     FAIL() << e.what();
   }
-}
-
-TEST(TypesupportHelpersTest, returns_service_type_info_for_valid_legacy_library) {
-  try {
-    auto library = rclcpp::get_typesupport_library(
-      "test_msgs/Empty", "rosidl_typesupport_cpp");
-    auto empty_typesupport = rclcpp::get_service_typesupport_handle(
-      "test_msgs/Empty", "rosidl_typesupport_cpp", *library);
-
-    EXPECT_THAT(
-      std::string(empty_typesupport->typesupport_identifier),
-      ContainsRegex("rosidl_typesupport"));
-  } catch (const std::runtime_error & e) {
-    FAIL() << e.what();
-  }
-}
-
-TEST(TypesupportHelpersTest, returns_service_type_info_for_valid_library) {
-  try {
-    auto library = rclcpp::get_typesupport_library(
-      "test_msgs/srv/Empty", "rosidl_typesupport_cpp");
-    auto empty_typesupport = rclcpp::get_service_typesupport_handle(
-      "test_msgs/srv/Empty", "rosidl_typesupport_cpp", *library);
-
-    EXPECT_THAT(
-      std::string(empty_typesupport->typesupport_identifier),
-      ContainsRegex("rosidl_typesupport"));
-  } catch (const std::runtime_error & e) {
-    FAIL() << e.what();
-  }
-}
-
-TEST(TypesupportHelpersTest, test_throw_exception_with_invalid_type) {
-  // message
-  std::string invalid_type = "test_msgs/msg/InvalidType";
-  auto library = rclcpp::get_typesupport_library(invalid_type, "rosidl_typesupport_cpp");
-  EXPECT_THROW(
-    rclcpp::get_message_typesupport_handle(invalid_type, "rosidl_typesupport_cpp", *library),
-    std::runtime_error);
-  EXPECT_THROW(
-    rclcpp::get_service_typesupport_handle(invalid_type, "rosidl_typesupport_cpp", *library),
-    std::runtime_error);
-
-  // service
-  invalid_type = "test_msgs/srv/InvalidType";
-  library = rclcpp::get_typesupport_library(invalid_type, "rosidl_typesupport_cpp");
-  EXPECT_THROW(
-    rclcpp::get_service_typesupport_handle(invalid_type, "rosidl_typesupport_cpp", *library),
-    std::runtime_error);
 }


### PR DESCRIPTION
This reverts commit d9b2744057b8fd230f2c71c739fcdf7e27219d85.

The PR I'm proposing to revert seems to be breaking the cppcheck, causing a timeout in `nightly_win_deb`.

I'm opening this PR in draft to test with CI if this was actually the cause of the problem.

Reference failure we'll try to replicate: https://ci.ros2.org/view/nightly/job/nightly_win_deb/2942/ 

CI test, CI_Windows, debug, packages-up-to rclcpp_lifecycle
[![Build Status](https://ci.ros2.org/job/ci_windows/20691/badge/icon)](https://ci.ros2.org/job/ci_windows/20691/)