### PR TITLE
Increase timeout for rclcpp_lifecycle to 360

### DIFF
--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -159,3 +159,8 @@ ament_export_targets(${PROJECT_NAME})
 ament_export_dependencies(lifecycle_msgs rcl rclcpp rcl_interfaces rcl_lifecycle rcutils rosidl_typesupport_cpp)
 
 ament_package()
+
+if(TEST cppcheck)
+  # must set the property after ament_package()
+  set_tests_properties(cppcheck PROPERTIES TIMEOUT 360)
+endif()

--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -60,10 +60,11 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # Give cppcheck hints about macro definitions coming from outside this package
   set(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS ${rclcpp_INCLUDE_DIRS})
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE "ament_cmake_cppcheck")
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_cppcheck REQUIRED)
-  # cppcheck is being added elsewhere
+  ament_cppcheck()
   set_tests_properties(cppcheck PROPERTIES TIMEOUT 360)
 
   find_package(performance_test_fixture REQUIRED)

--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -61,6 +61,9 @@ if(BUILD_TESTING)
   # Give cppcheck hints about macro definitions coming from outside this package
   set(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS ${rclcpp_INCLUDE_DIRS})
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_cppcheck REQUIRED)
+  ament_cppcheck()
   set_tests_properties(cppcheck PROPERTIES TIMEOUT 360)
 
   find_package(performance_test_fixture REQUIRED)

--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -164,4 +164,3 @@ ament_export_targets(${PROJECT_NAME})
 ament_export_dependencies(lifecycle_msgs rcl rclcpp rcl_interfaces rcl_lifecycle rcutils rosidl_typesupport_cpp)
 
 ament_package()
-

--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -61,6 +61,7 @@ if(BUILD_TESTING)
   # Give cppcheck hints about macro definitions coming from outside this package
   set(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS ${rclcpp_INCLUDE_DIRS})
   ament_lint_auto_find_test_dependencies()
+  set_tests_properties(cppcheck PROPERTIES TIMEOUT 360)
 
   find_package(performance_test_fixture REQUIRED)
 
@@ -160,7 +161,3 @@ ament_export_dependencies(lifecycle_msgs rcl rclcpp rcl_interfaces rcl_lifecycle
 
 ament_package()
 
-if(TEST cppcheck)
-  # must set the property after ament_package()
-  set_tests_properties(cppcheck PROPERTIES TIMEOUT 360)
-endif()

--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -63,7 +63,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_cppcheck REQUIRED)
-  ament_cppcheck()
+  # cppcheck is being added elsewhere
   set_tests_properties(cppcheck PROPERTIES TIMEOUT 360)
 
   find_package(performance_test_fixture REQUIRED)


### PR DESCRIPTION
Addressing occasional timeouts caused by cppcheck on `nightly_win_deb`,

See: https://github.com/osrf/buildfarm-tools-private/issues/20#issuecomment-1857230574 and https://github.com/ros2/rclcpp/pull/2392

CI job to test:
[![Build Status](https://ci.ros2.org/job/ci_windows/20709/badge/icon)](https://ci.ros2.org/job/ci_windows/20709/)