### PR TITLE
Load params

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -586,6 +586,14 @@ public:
   void
   undeclare_parameter(const std::string & name);
 
+  /// Load a list of parameters from a yaml parameter file..
+  /**
+   * \param[in] yaml_name The name of the yaml file that needs to be loaded.
+   */
+  RCLCPP_PUBLIC
+  void
+  load_parameters(const std::string & yaml_filepath);
+
   /// Return true if a given parameter is declared.
   /**
    * \param[in] name The name of the parameter to check for being declared.

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -591,8 +591,8 @@ public:
    * \param[in] yaml_name The name of the yaml file that needs to be loaded.
    */
   RCLCPP_PUBLIC
-  void
-  load_parameters(const std::string & yaml_filepath);
+  std::vector<rcl_interfaces::msg::SetParametersResult>
+  load_parameters(const std::string & yaml_filepath, const std::string & node_name_);
 
   /// Return true if a given parameter is declared.
   /**

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
@@ -137,8 +137,9 @@ public:
   undeclare_parameter(const std::string & name) override;
 
   RCLCPP_PUBLIC
-  void
-  load_parameters(const std::string & yaml_filepath) override;
+  std::vector<rcl_interfaces::msg::SetParametersResult>
+  load_parameters(
+  const std::string & yaml_filepath, const std::string & node_name_) override;
 
   RCLCPP_PUBLIC
   bool

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
@@ -137,6 +137,10 @@ public:
   undeclare_parameter(const std::string & name) override;
 
   RCLCPP_PUBLIC
+  void
+  load_parameters(const std::string & yaml_filepath) override;
+
+  RCLCPP_PUBLIC
   bool
   has_parameter(const std::string & name) const override;
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -115,6 +115,15 @@ public:
   void
   undeclare_parameter(const std::string & name) = 0;
 
+  /// Load a list parameters from a yaml parameter file
+  /**
+   * \sa rclcpp::Node::load_parameters
+   */
+  RCLCPP_PUBLIC
+  virtual
+  void
+  load_parameters(const std::string & yaml_filepath) = 0;
+
   /// Return true if the parameter has been declared, otherwise false.
   /**
    * \sa rclcpp::Node::has_parameter

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -121,8 +121,9 @@ public:
    */
   RCLCPP_PUBLIC
   virtual
-  void
-  load_parameters(const std::string & yaml_filepath) = 0;
+  std::vector<rcl_interfaces::msg::SetParametersResult>
+  load_parameters(
+  const std::string & yaml_filepath, const std::string & node_name_) = 0;
 
   /// Return true if the parameter has been declared, otherwise false.
   /**

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -373,6 +373,12 @@ Node::undeclare_parameter(const std::string & name)
   this->node_parameters_->undeclare_parameter(name);
 }
 
+void
+Node::load_parameters(const std::string & yaml_filepath)
+{
+  this->node_parameters_->load_parameters(yaml_filepath);
+}
+
 bool
 Node::has_parameter(const std::string & name) const
 {

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -373,10 +373,10 @@ Node::undeclare_parameter(const std::string & name)
   this->node_parameters_->undeclare_parameter(name);
 }
 
-void
-Node::load_parameters(const std::string & yaml_filepath)
+std::vector<rcl_interfaces::msg::SetParametersResult>
+Node::load_parameters(const std::string & yaml_filepath, const std::string & node_name_)
 {
-  this->node_parameters_->load_parameters(yaml_filepath);
+  return this->node_parameters_->load_parameters(yaml_filepath, node_name_);
 }
 
 bool

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -657,6 +657,14 @@ NodeParameters::undeclare_parameter(const std::string & name)
   parameters_.erase(parameter_info);
 }
 
+void
+NodeParameters::load_parameters(const std::string & yaml_filepath)
+{
+  auto parameters_client = std::make_shared<rclcpp::AsyncParametersClient>(node_, "package_name");
+  parameters_client->load_parameters(yaml_filepath);
+
+}
+
 bool
 NodeParameters::has_parameter(const std::string & name) const
 {

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -14,6 +14,7 @@
 
 #include "rclcpp/node_interfaces/node_parameters.hpp"
 
+#include <cwctype>
 #include <rcl_yaml_param_parser/parser.h>
 
 #include <array>
@@ -657,12 +658,20 @@ NodeParameters::undeclare_parameter(const std::string & name)
   parameters_.erase(parameter_info);
 }
 
-void
-NodeParameters::load_parameters(const std::string & yaml_filepath)
+std::vector<rcl_interfaces::msg::SetParametersResult>
+NodeParameters::load_parameters(
+const std::string & yaml_filepath, const std::string & node_name_)
 {
-  auto parameters_client = std::make_shared<rclcpp::AsyncParametersClient>(node_, "package_name");
-  parameters_client->load_parameters(yaml_filepath);
+  rclcpp::ParameterMap parameter_map =
+    rclcpp::parameter_map_from_yaml_file(yaml_filepath, node_name_.c_str());
 
+  auto iter = parameter_map.find(node_name_);
+  if (iter == parameter_map.end() || iter->second.size() == 0) {
+    throw rclcpp::exceptions::InvalidParametersException("No valid parameter");
+  }
+  auto params_result = set_parameters(iter->second);
+
+  return params_result;
 }
 
 bool

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_parameters.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_parameters.cpp
@@ -125,6 +125,20 @@ TEST_F(TestNodeParameters, list_parameters)
     list_result5.names.end());
 }
 
+TEST_F(TestNodeParameters, load_parameters) {
+  const uint64_t expected_param_count = 4;
+  auto load_node = std::make_shared<rclcpp::Node>(
+    "load_node",
+    "namespace",
+    rclcpp::NodeOptions().allow_undeclared_parameters(true));
+  // load parameters
+  rcpputils::fs::path test_resources_path{TEST_RESOURCES_DIRECTORY};
+  const std::string parameters_filepath = (
+    test_resources_path / "test_node" / "load_parameters.yaml").string();
+  auto load_vector = node_parameters->load_parameters(parameters_filepath, "/namespace/load_node");
+  ASSERT_EQ(load_vector.size(), expected_param_count);
+}
+
 TEST_F(TestNodeParameters, parameter_overrides)
 {
   rclcpp::NodeOptions node_options;


### PR DESCRIPTION
This is a pull request meant to address #1029 and may start as a draft depending on the issue actually needing to be addressed. It adds the `load_parameters` function to `NodeParametersInterface` and all of its children; a way to add parameters during runtime through a yaml file.