### PR TITLE
Increase the cppcheck timeout to 600 seconds.

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -282,7 +282,7 @@ install(
 
 if(TEST cppcheck)
   # must set the property after ament_package()
-  set_tests_properties(cppcheck PROPERTIES TIMEOUT 500)
+  set_tests_properties(cppcheck PROPERTIES TIMEOUT 600)
 endif()
 
 if(TEST cpplint)


### PR DESCRIPTION
This is necessary, most likely because of #2303 .  @alsora @jefferyyjhsu FYI

We've seen test failures from this already, see https://ci.ros2.org/job/ci_windows/20815/