### PR TITLE
Add queue for events executor that allows user specified priorities

### DIFF
--- a/rclcpp/include/rclcpp/experimental/executors/events_executor/priority_events_queue.hpp
+++ b/rclcpp/include/rclcpp/experimental/executors/events_executor/priority_events_queue.hpp
@@ -1,0 +1,155 @@
+// Copyright 2023 iRobot Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__EXPERIMENTAL__EXECUTORS__EVENTS_EXECUTOR__SIMPLE_EVENTS_QUEUE_HPP_
+#define RCLCPP__EXPERIMENTAL__EXECUTORS__EVENTS_EXECUTOR__SIMPLE_EVENTS_QUEUE_HPP_
+
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <utility>
+
+#include "rclcpp/experimental/executors/events_executor/events_queue.hpp"
+
+namespace rclcpp
+{
+namespace experimental
+{
+namespace executors
+{
+
+struct PriorityEvent {
+  int priority;
+  rclcpp::experimental::executors::ExecutorEvent event;
+};
+
+/**
+ * @brief This class implements an EventsQueue as a simple wrapper around a std::priority_queue.
+ * It does not perform any checks about the size of queue, which can grow
+ * unbounded without being pruned.
+ */
+class PriorityEventsQueue : public EventsQueue
+{
+public:
+  RCLCPP_PUBLIC
+  PriorityEventsQueue() {
+    // Default callback to extract priority from event
+    extract_priority_ = [](const rclcpp::experimental::executors::ExecutorEvent & event) {
+      return 0;
+    };
+  }
+
+  RCLCPP_PUBLIC
+  explicit PriorityEventsQueue(
+    std::function<int(const rclcpp::experimental::executors::ExecutorEvent &)> extract_priority)
+  : extract_priority_(extract_priority) {}
+
+  RCLCPP_PUBLIC
+  ~PriorityEventsQueue() override = default;
+
+  /**
+   * @brief enqueue event into the queue
+   * Thread safe
+   * @param event The event to enqueue into the queue
+   */
+  RCLCPP_PUBLIC
+  void
+  enqueue(const rclcpp::experimental::executors::ExecutorEvent & event) override
+  {
+    int priority = extract_priority_(event);
+    rclcpp::experimental::executors::PriorityEvent single_event = {priority, event};
+    single_event.event.num_events = 1;
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+      for (size_t ev = 0; ev < event.num_events; ev++) {
+        event_queue_.push(single_event);
+      }
+    }
+    events_queue_cv_.notify_one();
+  }
+
+  /**
+   * @brief waits for an event until timeout, gets a single event
+   * Thread safe
+   * @return true if event, false if timeout
+   */
+  RCLCPP_PUBLIC
+  bool
+  dequeue(
+    rclcpp::experimental::executors::ExecutorEvent & event,
+    std::chrono::nanoseconds timeout = std::chrono::nanoseconds::max()) override
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    // Initialize to true because it's only needed if we have a valid timeout
+    bool has_data = true;
+    if (timeout != std::chrono::nanoseconds::max()) {
+      has_data =
+        events_queue_cv_.wait_for(lock, timeout, [this]() {return !event_queue_.empty();});
+    } else {
+      events_queue_cv_.wait(lock, [this]() {return !event_queue_.empty();});
+    }
+
+    if (has_data) {
+      event = event_queue_.top().event;
+      event_queue_.pop();
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * @brief Test whether queue is empty
+   * Thread safe
+   * @return true if the queue's size is 0, false otherwise.
+   */
+  RCLCPP_PUBLIC
+  bool
+  empty() const override
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return event_queue_.empty();
+  }
+
+  /**
+   * @brief Returns the number of elements in the queue.
+   * Thread safe
+   * @return the number of elements in the queue.
+   */
+  RCLCPP_PUBLIC
+  size_t
+  size() const override
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return event_queue_.size();
+  }
+
+private:
+  // Callback to extract priority from event
+  std::function<int(const rclcpp::experimental::executors::ExecutorEvent &)> extract_priority_;
+  // The underlying queue implementation
+  std::priority_queue<rclcpp::experimental::executors::PriorityEvent> event_queue_;
+  // Mutex to protect read/write access to the queue
+  mutable std::mutex mutex_;
+  // Variable used to notify when an event is added to the queue
+  std::condition_variable events_queue_cv_;
+};
+
+}  // namespace executors
+}  // namespace experimental
+}  // namespace rclcpp
+
+#endif  // RCLCPP__EXPERIMENTAL__EXECUTORS__EVENTS_EXECUTOR__SIMPLE_EVENTS_QUEUE_HPP_

--- a/rclcpp/include/rclcpp/experimental/executors/events_executor/priority_events_queue.hpp
+++ b/rclcpp/include/rclcpp/experimental/executors/events_executor/priority_events_queue.hpp
@@ -41,7 +41,7 @@ struct ComparePriorities : public std::binary_function<PriorityEvent, PriorityEv
   _GLIBCXX14_CONSTEXPR
   bool
   operator()(const PriorityEvent & __x, const PriorityEvent & __y) const
-  {return __x.priority < __y.priority;}
+  {return __x.priority > __y.priority;}
 };
 
 /**

--- a/rclcpp/include/rclcpp/experimental/executors/events_executor/priority_events_queue.hpp
+++ b/rclcpp/include/rclcpp/experimental/executors/events_executor/priority_events_queue.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 iRobot Corporation.
+// Copyright 2023 Washington University in St. Louis.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,6 @@ struct PriorityEvent
 
 struct ComparePriorities : public std::binary_function<PriorityEvent, PriorityEvent, bool>
 {
-  _GLIBCXX14_CONSTEXPR
   bool
   operator()(const PriorityEvent & __x, const PriorityEvent & __y) const
   {return __x.priority > __y.priority;}

--- a/rclcpp/include/rclcpp/experimental/executors/events_executor/priority_events_queue.hpp
+++ b/rclcpp/include/rclcpp/experimental/executors/events_executor/priority_events_queue.hpp
@@ -20,6 +20,7 @@
 #include <mutex>
 #include <queue>
 #include <utility>
+#include <vector>
 
 #include "rclcpp/experimental/executors/events_executor/events_queue.hpp"
 

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -482,6 +482,13 @@ if(TARGET test_events_queue)
   target_link_libraries(test_events_queue ${PROJECT_NAME})
 endif()
 
+ament_add_gtest(test_priority_events_executor executors/test_priority_events_executor.cpp TIMEOUT 5)
+if(TARGET test_priority_events_executor)
+  ament_target_dependencies(test_priority_events_executor
+    "test_msgs")
+  target_link_libraries(test_priority_events_executor ${PROJECT_NAME})
+endif()
+
 ament_add_gtest(test_guard_condition test_guard_condition.cpp
   APPEND_LIBRARY_DIRS "${append_library_dirs}")
 if(TARGET test_guard_condition)

--- a/rclcpp/test/rclcpp/executors/test_priority_events_executor.cpp
+++ b/rclcpp/test/rclcpp/executors/test_priority_events_executor.cpp
@@ -100,31 +100,11 @@ TEST_F(TestPriorityEventsExecutor, priority_subs)
 
   // Create executor
   auto extract_priority = [](const rclcpp::experimental::executors::ExecutorEvent & event) {
-      const rcl_client_t * client;
-      const rcl_service_t * service;
-      const rclcpp::TimerBase * timer;
-      const rclcpp::Waitable * waitable;
-      const rcl_subscription_t * subscription;
-      switch (event.type) {
-        case rclcpp::experimental::executors::ExecutorEventType::CLIENT_EVENT:
-          client = static_cast<const rcl_client_t *>(event.entity_key);
-          break;
-        case rclcpp::experimental::executors::ExecutorEventType::SERVICE_EVENT:
-          service = static_cast<const rcl_service_t *>(event.entity_key);
-          break;
-        case rclcpp::experimental::executors::ExecutorEventType::TIMER_EVENT:
-          timer = static_cast<const rclcpp::TimerBase *>(event.entity_key);
-          return 0UL;
-          break;
-        case rclcpp::experimental::executors::ExecutorEventType::SUBSCRIPTION_EVENT:
-          subscription = static_cast<const rcl_subscription_t *>(event.entity_key);
-          return rcl_subscription_get_options(subscription)->qos.deadline.sec;
-          break;
-        case rclcpp::experimental::executors::ExecutorEventType::WAITABLE_EVENT:
-          waitable = static_cast<const rclcpp::Waitable *>(event.entity_key);
-          break;
+      if (event.type != rclcpp::experimental::executors::ExecutorEventType::SUBSCRIPTION_EVENT) {
+        return 0UL;
       }
-      return 0UL;
+      auto subscription = static_cast<const rcl_subscription_t *>(event.entity_key);
+      return rcl_subscription_get_options(subscription)->qos.deadline.sec;
     };
   EventsExecutor executor(std::make_unique<PriorityEventsQueue>(extract_priority));
   executor.add_node(node);

--- a/rclcpp/test/rclcpp/executors/test_priority_events_executor.cpp
+++ b/rclcpp/test/rclcpp/executors/test_priority_events_executor.cpp
@@ -1,0 +1,132 @@
+// Copyright 2023 Washington University in St. Louis.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include "rclcpp/experimental/executors/events_executor/events_executor.hpp"
+#include "rclcpp/experimental/executors/events_executor/priority_events_queue.hpp"
+
+#include "test_msgs/srv/empty.hpp"
+#include "test_msgs/msg/empty.hpp"
+
+using namespace std::chrono_literals;
+
+using rclcpp::experimental::executors::EventsExecutor;
+using rclcpp::experimental::executors::PriorityEventsQueue;
+
+class TestPriorityEventsExecutor : public ::testing::Test
+{
+public:
+  void SetUp()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown()
+  {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(TestPriorityEventsExecutor, priority_subs)
+{
+  // rmw_connextdds doesn't support events-executor
+  if (std::string(rmw_get_implementation_identifier()).find("rmw_connextdds") == 0) {
+    GTEST_SKIP();
+  }
+
+  // Create timer publishing to 3 subscriptions
+  auto node = std::make_shared<rclcpp::Node>("node");
+
+  int subscriptions_executed = 0;
+
+  bool msg_received_low = false;
+  auto sub_low = node->create_subscription<test_msgs::msg::Empty>(
+    "topic", rclcpp::SensorDataQoS(),
+    [&msg_received_low, &subscriptions_executed](test_msgs::msg::Empty::ConstSharedPtr msg)
+    {
+      (void)msg;
+      msg_received_low = true;
+      EXPECT_EQ(subscriptions_executed, 2);
+      subscriptions_executed++;
+    });
+
+  bool msg_received_medium = false;
+  auto sub_medium = node->create_subscription<test_msgs::msg::Empty>(
+    "topic", rclcpp::SensorDataQoS(),
+    [&msg_received_medium, &subscriptions_executed](test_msgs::msg::Empty::ConstSharedPtr msg)
+    {
+      (void)msg;
+      msg_received_medium = true;
+      EXPECT_EQ(subscriptions_executed, 1);
+      subscriptions_executed++;
+    });
+
+  bool msg_received_high = false;
+  auto sub_high = node->create_subscription<test_msgs::msg::Empty>(
+    "topic", rclcpp::SensorDataQoS(),
+    [&msg_received_high, &subscriptions_executed](test_msgs::msg::Empty::ConstSharedPtr msg)
+    {
+      (void)msg;
+      msg_received_high = true;
+      EXPECT_EQ(subscriptions_executed, 0);
+      subscriptions_executed++;
+    });
+
+  auto publisher = node->create_publisher<test_msgs::msg::Empty>("topic", rclcpp::SensorDataQoS());
+
+  // Create executor
+  auto extract_priority = [](const rclcpp::experimental::executors::ExecutorEvent & event) {
+      return event.type == rclcpp::experimental::executors::ExecutorEventType::TIMER_EVENT ?
+             0 : 1;
+    };
+  EventsExecutor executor(std::make_unique<PriorityEventsQueue>(extract_priority));
+  executor.add_node(node);
+
+
+  bool spin_exited = false;
+  std::thread spinner([&spin_exited, &executor, this]() {
+      executor.spin();
+      spin_exited = true;
+    });
+
+  auto msg = std::make_unique<test_msgs::msg::Empty>();
+  publisher->publish(std::move(msg));
+
+  // Wait some time for the subscription to receive the message
+  auto start = std::chrono::high_resolution_clock::now();
+  while (
+    !msg_received_low &&
+    !spin_exited &&
+    (std::chrono::high_resolution_clock::now() - start < 1s))
+  {
+    auto time = std::chrono::high_resolution_clock::now() - start;
+    auto time_msec = std::chrono::duration_cast<std::chrono::milliseconds>(time);
+    std::this_thread::sleep_for(25ms);
+  }
+
+  executor.cancel();
+  spinner.join();
+  executor.remove_node(node);
+
+  EXPECT_TRUE(msg_received_low);
+  EXPECT_TRUE(msg_received_medium);
+  EXPECT_TRUE(msg_received_high);
+  EXPECT_EQ(subscriptions_executed, 3);
+  EXPECT_TRUE(spin_exited);
+}


### PR DESCRIPTION
This allows the user to assign arbitrary fixed-priorities to events according to a user-defined function. It can be used like so:

    auto extract_priority = [](const rclcpp::experimental::executors::ExecutorEvent & event) {
         //Compute priority by examining event.entity_key
         return priority;
      };
    EventsExecutor executor(std::make_unique<PriorityEventsQueue>(extract_priority));

The PriorityEventsQueue allows arbitrary scheduling policies to be built on the EventsExecutor. For instance, rate-monotonic scheduling can be done by examining the deadline parameter in an Executable's QoS settings and prioritizing smaller values. Adding these deadlines to the release time makes an earliest-deadline-first scheduler.

pinging @alsora 
I pitched this idea to you at ROSCon last year.