### PR TITLE
Remove the set_deprecated signatures in any_subscription_callback.

### DIFF
--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -34,7 +34,6 @@
 #include "rclcpp/serialized_message.hpp"
 #include "rclcpp/type_adapter.hpp"
 
-
 namespace rclcpp
 {
 
@@ -394,56 +393,10 @@ public:
     // converted to one another, e.g. shared_ptr and unique_ptr.
     using scbth = detail::SubscriptionCallbackTypeHelper<MessageT, CallbackT>;
 
-    // Determine if the given CallbackT is a deprecated signature or not.
-    constexpr auto is_deprecated =
-      rclcpp::function_traits::same_arguments<
-      typename scbth::callback_type,
-      std::function<void(std::shared_ptr<MessageT>)>
-      >::value
-      ||
-      rclcpp::function_traits::same_arguments<
-      typename scbth::callback_type,
-      std::function<void(std::shared_ptr<MessageT>, const rclcpp::MessageInfo &)>
-      >::value;
-
-    // Use the discovered type to force the type of callback when assigning
-    // into the variant.
-    if constexpr (is_deprecated) {
-      // If deprecated, call sub-routine that is deprecated.
-      set_deprecated(static_cast<typename scbth::callback_type>(callback));
-    } else {
-      // Otherwise just assign it.
-      callback_variant_ = static_cast<typename scbth::callback_type>(callback);
-    }
+    callback_variant_ = static_cast<typename scbth::callback_type>(callback);
 
     // Return copy of self for easier testing, normally will be compiled out.
     return *this;
-  }
-
-  /// Function for shared_ptr to non-const MessageT, which is deprecated.
-  template<typename SetT>
-#if !defined(RCLCPP_AVOID_DEPRECATIONS_FOR_UNIT_TESTS)
-  // suppress deprecation warnings in `test_any_subscription_callback.cpp`
-  [[deprecated("use 'void(std::shared_ptr<const MessageT>)' instead")]]
-#endif
-  void
-  set_deprecated(std::function<void(std::shared_ptr<SetT>)> callback)
-  {
-    callback_variant_ = callback;
-  }
-
-  /// Function for shared_ptr to non-const MessageT with MessageInfo, which is deprecated.
-  template<typename SetT>
-#if !defined(RCLCPP_AVOID_DEPRECATIONS_FOR_UNIT_TESTS)
-  // suppress deprecation warnings in `test_any_subscription_callback.cpp`
-  [[deprecated(
-          "use 'void(std::shared_ptr<const MessageT>, const rclcpp::MessageInfo &)' instead"
-  )]]
-#endif
-  void
-  set_deprecated(std::function<void(std::shared_ptr<SetT>, const rclcpp::MessageInfo &)> callback)
-  {
-    callback_variant_ = callback;
   }
 
   std::unique_ptr<ROSMessageType, ROSMessageTypeDeleter>

--- a/rclcpp/test/rclcpp/test_any_subscription_callback.cpp
+++ b/rclcpp/test/rclcpp/test_any_subscription_callback.cpp
@@ -19,8 +19,6 @@
 #include <string>
 #include <utility>
 
-// TODO(aprotyas): Figure out better way to suppress deprecation warnings.
-#define RCLCPP_AVOID_DEPRECATIONS_FOR_UNIT_TESTS 1
 #include "rclcpp/any_subscription_callback.hpp"
 #include "test_msgs/msg/empty.hpp"
 #include "test_msgs/msg/empty.h"


### PR DESCRIPTION
These have been deprecated since April 2021, so it is safe to remove them now.