### PR TITLE
[rclcpp_components] Add missing parameter to `rclcpp_components_register_node` API documentation

### DIFF
--- a/rclcpp_components/cmake/rclcpp_components_register_node.cmake
+++ b/rclcpp_components/cmake/rclcpp_components_register_node.cmake
@@ -24,6 +24,8 @@
 # :type PLUGIN: string
 # :param EXECUTABLE: the node's executable name
 # :type EXECUTABLE: string
+# :param EXECUTOR: the C++ class name of the executor to use (blank uses SingleThreadedExecutor)
+# :type EXECUTOR: string
 # :param RESOURCE_INDEX: the ament resource index to register the components
 # :type RESOURCE_INDEX: string
 #


### PR DESCRIPTION
`EXECUTOR` was missing.