### PR TITLE
Fix TypeAdapted publishing with large messages.

### DIFF
--- a/rclcpp/test/msg/LargeMessage.msg
+++ b/rclcpp/test/msg/LargeMessage.msg
@@ -1,0 +1,3 @@
+# A message with a size larger than the default Linux stack size
+uint8[10485760] data
+uint64 size

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -6,6 +6,7 @@ add_definitions(-DTEST_RESOURCES_DIRECTORY="${TEST_RESOURCES_DIRECTORY}")
 
 rosidl_generate_interfaces(${PROJECT_NAME}_test_msgs
   ../msg/Header.msg
+  ../msg/LargeMessage.msg
   ../msg/MessageWithHeader.msg
   ../msg/String.msg
   DEPENDENCIES builtin_interfaces


### PR DESCRIPTION
Mostly by ensuring we aren't attempting to store
large messages on the stack.  Also add in tests.
I verified that before these changes, the tests failed, while after them they succeed.

This should fix #2417 