### PR TITLE
Add tracepoint for generic publisher/subscriber

### DIFF
--- a/rclcpp/include/rclcpp/generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/generic_subscription.hpp
@@ -87,7 +87,6 @@ public:
     any_callback_(callback),
     ts_lib_(ts_lib)
   {
-    auto callback_ptr = static_cast<const void *>(&any_callback_);
     TRACETOOLS_TRACEPOINT(
       rclcpp_subscription_init,
       static_cast<const void *>(get_subscription_handle().get()),
@@ -95,7 +94,7 @@ public:
     TRACETOOLS_TRACEPOINT(
       rclcpp_subscription_callback_added,
       static_cast<const void *>(this),
-      callback_ptr);
+      static_cast<const void *>(&any_callback_));
 
 #ifndef TRACETOOLS_DISABLED
     any_callback_.register_callback_for_tracing();

--- a/rclcpp/include/rclcpp/generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/generic_subscription.hpp
@@ -163,7 +163,6 @@ public:
 
 private:
   RCLCPP_DISABLE_COPY(GenericSubscription)
-  
   AnySubscriptionCallback<rclcpp::SerializedMessage, std::allocator<void>> any_callback_;
   // The type support library should stay loaded, so it is stored in the GenericSubscription
   std::shared_ptr<rcpputils::SharedLibrary> ts_lib_;

--- a/rclcpp/include/rclcpp/generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/generic_subscription.hpp
@@ -84,13 +84,23 @@ public:
       options.event_callbacks,
       options.use_default_callbacks,
       DeliveredMessageKind::SERIALIZED_MESSAGE),
-    callback_([callback](
-        std::shared_ptr<const rclcpp::SerializedMessage> serialized_message,
-        const rclcpp::MessageInfo & message_info) mutable {
-        callback.dispatch(serialized_message, message_info);
-      }),
+    any_callback_(callback),
     ts_lib_(ts_lib)
-  {}
+  {
+    auto callback_ptr = static_cast<const void *>(&any_callback_);
+    TRACETOOLS_TRACEPOINT(
+      rclcpp_subscription_init,
+      static_cast<const void *>(get_subscription_handle().get()),
+      static_cast<const void *>(this));
+    TRACETOOLS_TRACEPOINT(
+      rclcpp_subscription_callback_added,
+      static_cast<const void *>(this),
+      callback_ptr);
+
+#ifndef TRACETOOLS_DISABLED
+    any_callback_.register_callback_for_tracing();
+#endif
+  }
 
   RCLCPP_PUBLIC
   virtual ~GenericSubscription() = default;
@@ -153,10 +163,8 @@ public:
 
 private:
   RCLCPP_DISABLE_COPY(GenericSubscription)
-
-  std::function<void(
-      std::shared_ptr<const rclcpp::SerializedMessage>,
-      const rclcpp::MessageInfo)> callback_;
+  
+  AnySubscriptionCallback<rclcpp::SerializedMessage, std::allocator<void>> any_callback_;
   // The type support library should stay loaded, so it is stored in the GenericSubscription
   std::shared_ptr<rcpputils::SharedLibrary> ts_lib_;
 };

--- a/rclcpp/src/rclcpp/generic_publisher.cpp
+++ b/rclcpp/src/rclcpp/generic_publisher.cpp
@@ -23,7 +23,8 @@ namespace rclcpp
 
 void GenericPublisher::publish(const rclcpp::SerializedMessage & message)
 {
-  TRACETOOLS_TRACEPOINT(rclcpp_publish,
+  TRACETOOLS_TRACEPOINT(
+    rclcpp_publish,
     nullptr,
     static_cast<const void *>(&message.get_rcl_serialized_message()));
   auto return_code = rcl_publish_serialized_message(

--- a/rclcpp/src/rclcpp/generic_publisher.cpp
+++ b/rclcpp/src/rclcpp/generic_publisher.cpp
@@ -24,7 +24,7 @@ namespace rclcpp
 void GenericPublisher::publish(const rclcpp::SerializedMessage & message)
 {
   TRACETOOLS_TRACEPOINT(rclcpp_publish,
-    static_cast<const void *>(publisher_handle_.get()),
+    nullptr,
     static_cast<const void *>(&message.get_rcl_serialized_message()));
   auto return_code = rcl_publish_serialized_message(
     get_publisher_handle().get(), &message.get_rcl_serialized_message(), NULL);

--- a/rclcpp/src/rclcpp/generic_publisher.cpp
+++ b/rclcpp/src/rclcpp/generic_publisher.cpp
@@ -23,6 +23,9 @@ namespace rclcpp
 
 void GenericPublisher::publish(const rclcpp::SerializedMessage & message)
 {
+  TRACETOOLS_TRACEPOINT(rclcpp_publish,
+    static_cast<const void *>(publisher_handle_.get()),
+    static_cast<const void *>(&message.get_rcl_serialized_message()));
   auto return_code = rcl_publish_serialized_message(
     get_publisher_handle().get(), &message.get_rcl_serialized_message(), NULL);
 
@@ -68,6 +71,7 @@ void GenericPublisher::deserialize_message(
 
 void GenericPublisher::publish_loaned_message(void * loaned_message)
 {
+  TRACETOOLS_TRACEPOINT(rclcpp_publish, nullptr, static_cast<const void *>(loaned_message));
   auto return_code = rcl_publish_loaned_message(
     get_publisher_handle().get(), loaned_message, NULL);
 

--- a/rclcpp/src/rclcpp/generic_subscription.cpp
+++ b/rclcpp/src/rclcpp/generic_subscription.cpp
@@ -51,7 +51,7 @@ GenericSubscription::handle_serialized_message(
   const std::shared_ptr<rclcpp::SerializedMessage> & message,
   const rclcpp::MessageInfo & message_info)
 {
-  any_callback_.dispatch(message,message_info);
+  any_callback_.dispatch(message, message_info);
 }
 
 void

--- a/rclcpp/src/rclcpp/generic_subscription.cpp
+++ b/rclcpp/src/rclcpp/generic_subscription.cpp
@@ -51,7 +51,7 @@ GenericSubscription::handle_serialized_message(
   const std::shared_ptr<rclcpp::SerializedMessage> & message,
   const rclcpp::MessageInfo & message_info)
 {
-  callback_(message, message_info);
+  any_callback_.dispatch(message,message_info);
 }
 
 void

--- a/rclcpp/src/rclcpp/subscription_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_base.cpp
@@ -244,6 +244,7 @@ SubscriptionBase::take_serialized(
     &message_out.get_rcl_serialized_message(),
     &message_info_out.get_rmw_message_info(),
     nullptr);
+  TRACETOOLS_TRACEPOINT(rclcpp_take, static_cast<const void *>(&message_out.get_rcl_serialized_message()));
   if (RCL_RET_SUBSCRIPTION_TAKE_FAILED == ret) {
     return false;
   } else if (RCL_RET_OK != ret) {

--- a/rclcpp/src/rclcpp/subscription_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_base.cpp
@@ -244,7 +244,9 @@ SubscriptionBase::take_serialized(
     &message_out.get_rcl_serialized_message(),
     &message_info_out.get_rmw_message_info(),
     nullptr);
-  TRACETOOLS_TRACEPOINT(rclcpp_take, static_cast<const void *>(&message_out.get_rcl_serialized_message()));
+  TRACETOOLS_TRACEPOINT(
+    rclcpp_take,
+    static_cast<const void *>(&message_out.get_rcl_serialized_message()));
   if (RCL_RET_SUBSCRIPTION_TAKE_FAILED == ret) {
     return false;
   } else if (RCL_RET_OK != ret) {


### PR DESCRIPTION
Hi, I'm  developed member of [CARET](https://github.com/tier4/caret) for real-time analysis using [ros2tracing](https://github.com/ros2/ros2_tracing). 

In communication through GenericPublisher/Subscription, message tracking was not possible due to a lack of trace data.
In this PR, added trace points to the GenericPublisher and GenericSubscription.

- GenericPublisher
I have added the following trace points.
   - tracepoint : [rclcpp_publish](https://github.com/ros2/ros2_tracing/blob/327e8dfbf0cab3ab3472be409b5d184e4c1eacb9/tracetools/src/tracetools.c#L130-L136)

- GenericSubscription
[There was a recent PR that made `create_generic_subscription` go through AnySubscriptionCallback](https://github.com/ros2/rclcpp/pull/1928). This change caused [`callback`](https://github.com/ros2/rclcpp/blob/b007204fd83828c11f80bf4712d237bfb2431f6e/rclcpp/include/rclcpp/generic_subscription.hpp#L87-L91) to be captured by the lambda, resulting in it being copied and `callback` address was changed. In this case, the addresses of trace points outputed  at initialization and runtime were different.  Therefore, I modified to ensure that they have the same `callback` address .
And, I have added the following trace points.
   - tracepoint : [rclcpp_subscription_init](https://github.com/ros2/ros2_tracing/blob/327e8dfbf0cab3ab3472be409b5d184e4c1eacb9/tracetools/src/tracetools.c#L191-L198)
   - tracepoint : [rclcpp_subscription_callback_added](https://github.com/ros2/ros2_tracing/blob/327e8dfbf0cab3ab3472be409b5d184e4c1eacb9/tracetools/src/tracetools.c#L200-L207)


Additionally, with these changes, I submitted a PR to the following repository.
- rcl
https://github.com/ros2/rcl/pull/1136
- rmw_cyclonedds
https://github.com/ros2/rmw_cyclonedds/pull/485
- rmw_fastrtps
https://github.com/ros2/rmw_fastrtps/pull/748
- rmw_connextdds
https://github.com/ros2/rmw_connextdds/pull/145
- ros2_tracing
https://github.com/ros2/ros2_tracing/pull/97