### PR TITLE
[documentation] Explain when `MultiThreadedExecutor` is running multiple threads

### DIFF
--- a/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp
@@ -32,6 +32,12 @@ namespace rclcpp
 namespace executors
 {
 
+/**
+ * The Multi-threaded executor uses multiple threads to do work while spinning.
+ *
+ * Note, however, that it will only use multiple threads via its blocking `spin()` method.
+ * When using other methods, like e.g. `rclcpp::Executor:spin_until_future_complete(some_future)`, only the main thread will be used to do work.
+ */
 class MultiThreadedExecutor : public rclcpp::Executor
 {
 public:


### PR DESCRIPTION
This is a tiny PR that adds a class docstring for the `MultiThreadedExecutor`. It includes a note about which methods support multithreaded execution.

Please let me know if this is not the right way to suggest additions to the documentation.
Also, please double check if the note is actually true or can be improved.

**My context:**
I had a unit test with two nodes that communicate with each other and I use the `MultiThreadedExecutor` to spin both of these nodes. One node publishes a TF, the other one regularly waits for that TF.

In the individual test cases, I have been using `multi_threaded_executor_.spin_until_future_complete(some_future);`. This leads to a flaky test that sometimes succeeds and sometimes fails. The reason for that seems to be that the `MultiThreadedExecutor` is only using a single thread when `spin_until_future_complete` is used.
After changing my test setup to use `multi_threaded_executor_.spin();` in a separate thread and just do `some_future.wait_for(...)` in the test cases, everything is working fine.