### PR TITLE
Revert "relax the test simulation rate for timer canceling tests. (#2…

### DIFF
--- a/rclcpp/test/rclcpp/executors/test_executors_timer_cancel_behavior.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors_timer_cancel_behavior.cpp
@@ -102,7 +102,7 @@ private:
 class ClockPublisher : public rclcpp::Node
 {
 public:
-  explicit ClockPublisher(float simulated_clock_step = .001f, float realtime_update_rate = 0.10f)
+  explicit ClockPublisher(float simulated_clock_step = .001f, float realtime_update_rate = 0.25f)
   : Node("clock_publisher"),
     ros_update_duration_(0, 0),
     realtime_clock_step_(0, 0),


### PR DESCRIPTION
…453)"

This reverts commit 1c350d0d7fb9c7158e0a39057112486ddbd38e9a.