### PR TITLE
refactor and improve the parameterized spin_some tests for executors

### DIFF
--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -282,16 +282,23 @@ public:
   void
   spin_node_some(std::shared_ptr<rclcpp::Node> node);
 
-  /// Collect work once and execute all available work, optionally within a duration.
+  /// Collect work once and execute all available work, optionally within a max duration.
   /**
-   * This function can be overridden. The default implementation is suitable for a
-   * single-threaded model of execution.
-   * Adding subscriptions, timers, services, etc. with blocking callbacks will cause this function
-   * to block (which may have unintended consequences).
+   * This function can be overridden.
+   * The default implementation is suitable for a single-threaded model of execution.
+   * Adding subscriptions, timers, services, etc. with blocking or long running
+   * callbacks may cause the function exceed the max_duration significantly.
+   *
+   * If there is no work to be done when this called, it will return immediately
+   * because the collecting of available work is non-blocking.
+   * Before each piece of ready work is executed this function checks if the
+   * max_duration has been exceeded, and if it has it returns without starting
+   * the execution of the next piece of work.
+   *
+   * If a max_duration of 0 is given, then all of the collected work will be
+   * executed before the function returns.
    *
    * \param[in] max_duration The maximum amount of time to spend executing work, or 0 for no limit.
-   * Note that spin_some() may take longer than this time as it only returns once max_duration has
-   * been exceeded.
    */
   RCLCPP_PUBLIC
   virtual void

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -596,8 +596,8 @@ TYPED_TEST(TestExecutors, spin_some_max_duration)
   constexpr auto max_duration = 100ms;  // relatively short because we expect to exceed it
   constexpr auto waitable_callback_duration = max_duration * 2;
   auto long_running_callback = [&waitable_callback_duration]() {
-    std::this_thread::sleep_for(waitable_callback_duration);
-  };
+      std::this_thread::sleep_for(waitable_callback_duration);
+    };
 
   auto waitable_interfaces = this->node->get_node_waitables_interface();
 

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -571,6 +571,16 @@ TYPED_TEST(TestExecutors, spin_some_max_duration)
 {
   using ExecutorType = TypeParam;
 
+  // TODO(wjwwood): The `StaticSingleThreadedExecutor` and the `EventsExecutor`
+  //   do not properly implement max_duration (it seems), so disable this test
+  //   for them in the meantime.
+  if (
+    std::is_same<ExecutorType, rclcpp::executors::StaticSingleThreadedExecutor>() ||
+    std::is_same<ExecutorType, rclcpp::experimental::executors::EventsExecutor>())
+  {
+    GTEST_SKIP();
+  }
+
   // Use an isolated callback group to avoid interference from any housekeeping
   // items that may be in the default callback group of the node.
   constexpr bool automatically_add_to_executor_with_node = false;
@@ -583,7 +593,7 @@ TYPED_TEST(TestExecutors, spin_some_max_duration)
   // given to spin_some(), which should result in spin_some() starting to
   // execute one of them, have the max duration elapse, finish executing one
   // of them, then returning before starting on the second.
-  constexpr auto max_duration = 1000ms;  // relatively short because we expect to exceed it
+  constexpr auto max_duration = 100ms;  // relatively short because we expect to exceed it
   constexpr auto waitable_callback_duration = max_duration * 2;
   auto long_running_callback = [&waitable_callback_duration]() {
     std::this_thread::sleep_for(waitable_callback_duration);

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -374,7 +374,20 @@ public:
   {
     (void) data;
     count_++;
-    std::this_thread::sleep_for(3ms);
+    if (nullptr != on_execute_callback_) {
+      on_execute_callback_();
+    } else {
+      // TODO(wjwwood): I don't know why this was here, but probably it should
+      //   not be there, or test cases where that is important should use the
+      //   on_execute_callback?
+      std::this_thread::sleep_for(3ms);
+    }
+  }
+
+  void
+  set_on_execute_callback(std::function<void()> on_execute_callback)
+  {
+    on_execute_callback_ = on_execute_callback;
   }
 
   void
@@ -404,6 +417,7 @@ public:
 private:
   size_t count_ = 0;
   rclcpp::GuardCondition gc_;
+  std::function<void()> on_execute_callback_ = nullptr;
 };
 
 TYPED_TEST(TestExecutors, spinAll)
@@ -448,45 +462,169 @@ TYPED_TEST(TestExecutors, spinAll)
   spinner.join();
 }
 
-TYPED_TEST(TestExecutors, spinSome)
+// Helper function to convert chrono durations into a scalar that GoogleTest
+// can more easily compare and print.
+template<typename DurationT>
+auto
+to_nanoseconds_helper(DurationT duration)
+{
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count();
+}
+
+// The purpose of this test is to check that the ExecutorT.spin_some() method:
+//   - works nominally (it can execute entities)
+//   - it can execute multiple items at once
+//   - it does not wait for work to be available before returning
+TYPED_TEST(TestExecutors, spin_some)
 {
   using ExecutorType = TypeParam;
-  ExecutorType executor;
-  auto waitable_interfaces = this->node->get_node_waitables_interface();
-  auto my_waitable = std::make_shared<TestWaitable>();
-  waitable_interfaces->add_waitable(my_waitable, nullptr);
-  executor.add_node(this->node);
 
-  // Long timeout, doesn't block test from finishing because spin_some should exit after the
-  // first one completes.
-  bool spin_exited = false;
-  std::thread spinner([&spin_exited, &executor, this]() {
-      executor.spin_some(1s);
-      executor.remove_node(this->node, true);
-      spin_exited = true;
-    });
+  // Use an isolated callback group to avoid interference from any housekeeping
+  // items that may be in the default callback group of the node.
+  constexpr bool automatically_add_to_executor_with_node = false;
+  auto isolated_callback_group = this->node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive,
+    automatically_add_to_executor_with_node);
 
-  // Do some work until sufficient calls to the waitable occur, but keep going until either
-  // count becomes too large, spin exits, or the 1 second timeout completes.
-  auto start = std::chrono::steady_clock::now();
-  while (
-    my_waitable->get_count() <= 1 &&
-    !spin_exited &&
-    (std::chrono::steady_clock::now() - start < 1s))
+  // Check that spin_some() returns quickly when there is no work to be done.
+  // This can be a false positive if there is somehow some work for the executor
+  // to do that has not been considered, but the isolated callback group should
+  // avoid that.
   {
-    my_waitable->trigger();
-    this->publisher->publish(test_msgs::msg::Empty());
-    std::this_thread::sleep_for(1ms);
-  }
-  // The count of "execute" depends on whether the executor starts spinning before (1) or after (0)
-  // the first iteration of the while loop
-  EXPECT_LE(1u, my_waitable->get_count());
-  waitable_interfaces->remove_waitable(my_waitable, nullptr);
-  EXPECT_TRUE(spin_exited);
-  // Cancel if it hasn't exited already.
-  executor.cancel();
+    ExecutorType executor;
+    executor.add_callback_group(isolated_callback_group, this->node->get_node_base_interface());
 
-  spinner.join();
+    auto start = std::chrono::steady_clock::now();
+    // spin_some with some non-trival "max_duration" and check that it does not
+    // take anywhere near that long to execute.
+    constexpr auto max_duration = 10s;
+    executor.spin_some(max_duration);
+    EXPECT_LT(
+      to_nanoseconds_helper(std::chrono::steady_clock::now() - start),
+      to_nanoseconds_helper(max_duration / 2))
+      << "spin_some() took a long time to execute when it should have done "
+      << "nothing and should not have blocked either, but this could be a "
+      << "false negative if the computer is really slow";
+  }
+
+  // Check that having one thing ready gets executed by spin_some().
+  auto waitable_interfaces = this->node->get_node_waitables_interface();
+  auto my_waitable1 = std::make_shared<TestWaitable>();
+  waitable_interfaces->add_waitable(my_waitable1, isolated_callback_group);
+  {
+    ExecutorType executor;
+    executor.add_callback_group(isolated_callback_group, this->node->get_node_base_interface());
+
+    my_waitable1->trigger();
+
+    // The long duration should not matter, as executing the waitable is
+    // non-blocking, and spin_some() should exit after completing the available
+    // work.
+    auto start = std::chrono::steady_clock::now();
+    constexpr auto max_duration = 10s;
+    executor.spin_some(max_duration);
+    EXPECT_LT(
+      to_nanoseconds_helper(std::chrono::steady_clock::now() - start),
+      to_nanoseconds_helper(max_duration / 2))
+      << "spin_some() took a long time to execute when it should have very "
+      << "little to do and should not have blocked either, but this could be a "
+      << "false negative if the computer is really slow";
+
+    EXPECT_GT(my_waitable1->get_count(), 0u)
+      << "spin_some() failed to execute a waitable that was triggered";
+  }
+
+  // Check that multiple things being ready are executed by spin_some().
+  auto my_waitable2 = std::make_shared<TestWaitable>();
+  waitable_interfaces->add_waitable(my_waitable2, isolated_callback_group);
+  {
+    ExecutorType executor;
+    executor.add_callback_group(isolated_callback_group, this->node->get_node_base_interface());
+
+    const size_t original_my_waitable1_count = my_waitable1->get_count();
+    my_waitable1->trigger();
+    my_waitable2->trigger();
+
+    // The long duration should not matter, as executing the waitable is
+    // non-blocking, and spin_some() should exit after completing the available
+    // work.
+    auto start = std::chrono::steady_clock::now();
+    constexpr auto max_duration = 10s;
+    executor.spin_some(max_duration);
+    EXPECT_LT(
+      to_nanoseconds_helper(std::chrono::steady_clock::now() - start),
+      to_nanoseconds_helper(max_duration / 2))
+      << "spin_some() took a long time to execute when it should have very "
+      << "little to do and should not have blocked either, but this could be a "
+      << "false negative if the computer is really slow";
+
+    EXPECT_GT(my_waitable1->get_count(), original_my_waitable1_count)
+      << "spin_some() failed to execute a waitable that was triggered";
+    EXPECT_GT(my_waitable2->get_count(), 0u)
+      << "spin_some() failed to execute a waitable that was triggered";
+  }
+}
+
+// The purpose of this test is to check that the ExecutorT.spin_some() method:
+//   - does not continue executing after max_duration has elapsed
+TYPED_TEST(TestExecutors, spin_some_max_duration)
+{
+  using ExecutorType = TypeParam;
+
+  // Use an isolated callback group to avoid interference from any housekeeping
+  // items that may be in the default callback group of the node.
+  constexpr bool automatically_add_to_executor_with_node = false;
+  auto isolated_callback_group = this->node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive,
+    automatically_add_to_executor_with_node);
+
+  // Set up a situation with two waitables that take time to execute, such that
+  // the time it takes to execute two waitables far exceeds the max_duration
+  // given to spin_some(), which should result in spin_some() starting to
+  // execute one of them, have the max duration elapse, finish executing one
+  // of them, then returning before starting on the second.
+  constexpr auto max_duration = 1000ms;  // relatively short because we expect to exceed it
+  constexpr auto waitable_callback_duration = max_duration * 2;
+  auto long_running_callback = [&waitable_callback_duration]() {
+    std::this_thread::sleep_for(waitable_callback_duration);
+  };
+
+  auto waitable_interfaces = this->node->get_node_waitables_interface();
+
+  auto my_waitable1 = std::make_shared<TestWaitable>();
+  my_waitable1->set_on_execute_callback(long_running_callback);
+  waitable_interfaces->add_waitable(my_waitable1, isolated_callback_group);
+
+  auto my_waitable2 = std::make_shared<TestWaitable>();
+  my_waitable2->set_on_execute_callback(long_running_callback);
+  waitable_interfaces->add_waitable(my_waitable2, isolated_callback_group);
+
+  ExecutorType executor;
+  executor.add_callback_group(isolated_callback_group, this->node->get_node_base_interface());
+
+  auto start = std::chrono::steady_clock::now();
+  // spin_some and check that it does not take longer than two of waitable_callback_duration,
+  // nor significantly less than a single waitable_callback_duration.
+  executor.spin_some(max_duration);
+  auto spin_some_run_time = std::chrono::steady_clock::now() - start;
+  EXPECT_GT(
+    to_nanoseconds_helper(spin_some_run_time),
+    to_nanoseconds_helper(waitable_callback_duration / 2))
+    << "spin_some() took less than half the expected time to execute a single "
+    << "waitable, which implies it did not actually execute one when it was "
+    << "expected to";
+  EXPECT_LT(
+    to_nanoseconds_helper(spin_some_run_time),
+    to_nanoseconds_helper(waitable_callback_duration * 2))
+    << "spin_some() took longer than expected to execute by a significant margin, but "
+    << "this could be a false positive on a very slow computer";
+
+  // check that exactly one of the waitables were executed (do not depend on a specific order)
+  size_t number_of_waitables_executed = my_waitable1->get_count() + my_waitable2->get_count();
+  EXPECT_EQ(number_of_waitables_executed, 1u)
+    << "expected exactly one of the two waitables to be executed, but "
+    << "my_waitable1->get_count(): " << my_waitable1->get_count() << " and "
+    << "my_waitable2->get_count(): " << my_waitable2->get_count();
 }
 
 // Check spin_node_until_future_complete with node base pointer

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -530,7 +530,7 @@ TYPED_TEST(TestExecutors, spin_some)
       << "little to do and should not have blocked either, but this could be a "
       << "false negative if the computer is really slow";
 
-    EXPECT_GT(my_waitable1->get_count(), 0u)
+    EXPECT_EQ(my_waitable1->get_count(), 1u)
       << "spin_some() failed to execute a waitable that was triggered";
   }
 
@@ -558,9 +558,9 @@ TYPED_TEST(TestExecutors, spin_some)
       << "little to do and should not have blocked either, but this could be a "
       << "false negative if the computer is really slow";
 
-    EXPECT_GT(my_waitable1->get_count(), original_my_waitable1_count)
+    EXPECT_EQ(my_waitable1->get_count(), original_my_waitable1_count + 1)
       << "spin_some() failed to execute a waitable that was triggered";
-    EXPECT_GT(my_waitable2->get_count(), 0u)
+    EXPECT_EQ(my_waitable2->get_count(), 1u)
       << "spin_some() failed to execute a waitable that was triggered";
   }
 }
@@ -574,6 +574,7 @@ TYPED_TEST(TestExecutors, spin_some_max_duration)
   // TODO(wjwwood): The `StaticSingleThreadedExecutor` and the `EventsExecutor`
   //   do not properly implement max_duration (it seems), so disable this test
   //   for them in the meantime.
+  //   see: https://github.com/ros2/rclcpp/issues/2462
   if (
     std::is_same<ExecutorType, rclcpp::executors::StaticSingleThreadedExecutor>() ||
     std::is_same<ExecutorType, rclcpp::experimental::executors::EventsExecutor>())


### PR DESCRIPTION
After working on https://github.com/ros2/rclcpp/pull/2142 I came to realize that the parameterized `spinSome` (always should have been `spin_some` to match our style and the name of the method being tested) tests were testing some false assumptions and in general were very fragile.

I reworked the nominal test to check that it does not block when there's no work, that it works with one ready item, and that it also executes multiple ready items when they are available.

```
$ ./build/rclcpp/test/rclcpp/test_executors --gtest_filter=*spin_some
Running main() from /home/william/ros2_ws/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
Note: Google Test filter = *spin_some
[==========] Running 4 tests from 4 test suites.
[----------] Global test environment set-up.
[----------] 1 test from TestExecutors/SingleThreadedExecutor, where TypeParam = rclcpp::executors::SingleThreadedExecutor
[ RUN      ] TestExecutors/SingleThreadedExecutor.spin_some
[       OK ] TestExecutors/SingleThreadedExecutor.spin_some (53 ms)
[----------] 1 test from TestExecutors/SingleThreadedExecutor (53 ms total)

[----------] 1 test from TestExecutors/MultiThreadedExecutor, where TypeParam = rclcpp::executors::MultiThreadedExecutor
[ RUN      ] TestExecutors/MultiThreadedExecutor.spin_some
[       OK ] TestExecutors/MultiThreadedExecutor.spin_some (19 ms)
[----------] 1 test from TestExecutors/MultiThreadedExecutor (19 ms total)

[----------] 1 test from TestExecutors/StaticSingleThreadedExecutor, where TypeParam = rclcpp::executors::StaticSingleThreadedExecutor
[ RUN      ] TestExecutors/StaticSingleThreadedExecutor.spin_some
[       OK ] TestExecutors/StaticSingleThreadedExecutor.spin_some (19 ms)
[----------] 1 test from TestExecutors/StaticSingleThreadedExecutor (19 ms total)

[----------] 1 test from TestExecutors/EventsExecutor, where TypeParam = rclcpp::experimental::executors::EventsExecutor
[ RUN      ] TestExecutors/EventsExecutor.spin_some
[       OK ] TestExecutors/EventsExecutor.spin_some (19 ms)
[----------] 1 test from TestExecutors/EventsExecutor (19 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 4 test suites ran. (110 ms total)
[  PASSED  ] 4 tests.
```

I also added a test which checks the `max_duration` option is being respected, and I found that the `StaticSingleThreadedExecutor` and the `EventsExecutor` do not implement this correctly. I think at least the `StaticSingleThreadedExecutor` should be fixed in https://github.com/ros2/rclcpp/pull/2142, but I've disabled that new test for both of them for now, with a TODO. I will also open issues about it.

```
$ ./build/rclcpp/test/rclcpp/test_executors --gtest_filter=*spin_some_max_duration
Running main() from /home/william/ros2_ws/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
Note: Google Test filter = *spin_some_max_duration
[==========] Running 4 tests from 4 test suites.
[----------] Global test environment set-up.
[----------] 1 test from TestExecutors/SingleThreadedExecutor, where TypeParam = rclcpp::executors::SingleThreadedExecutor
[ RUN      ] TestExecutors/SingleThreadedExecutor.spin_some_max_duration
[       OK ] TestExecutors/SingleThreadedExecutor.spin_some_max_duration (2065 ms)
[----------] 1 test from TestExecutors/SingleThreadedExecutor (2066 ms total)

[----------] 1 test from TestExecutors/MultiThreadedExecutor, where TypeParam = rclcpp::executors::MultiThreadedExecutor
[ RUN      ] TestExecutors/MultiThreadedExecutor.spin_some_max_duration
[       OK ] TestExecutors/MultiThreadedExecutor.spin_some_max_duration (2038 ms)
[----------] 1 test from TestExecutors/MultiThreadedExecutor (2038 ms total)

[----------] 1 test from TestExecutors/StaticSingleThreadedExecutor, where TypeParam = rclcpp::executors::StaticSingleThreadedExecutor
[ RUN      ] TestExecutors/StaticSingleThreadedExecutor.spin_some_max_duration
/home/william/ros2_ws/src/ros2/rclcpp/rclcpp/test/rclcpp/executors/test_executors.cpp:616: Failure
Expected: (to_nanoseconds_helper(spin_some_run_time)) < (to_nanoseconds_helper(waitable_callback_duration * 2)), actual: 4004709489 vs 4000000000
spin_some() took longer than expected to execute by a significant margin, but this could be a false positive on a very slow computer
/home/william/ros2_ws/src/ros2/rclcpp/rclcpp/test/rclcpp/executors/test_executors.cpp:624: Failure
Expected equality of these values:
  number_of_waitables_executed
    Which is: 2
  1u
    Which is: 1
expected exactly one of the two waitables to be executed, but my_waitable1->get_count(): 1 and my_waitable2->get_count(): 1
[  FAILED  ] TestExecutors/StaticSingleThreadedExecutor.spin_some_max_duration, where TypeParam = rclcpp::executors::StaticSingleThreadedExecutor (4042 ms)
[----------] 1 test from TestExecutors/StaticSingleThreadedExecutor (4042 ms total)

[----------] 1 test from TestExecutors/EventsExecutor, where TypeParam = rclcpp::experimental::executors::EventsExecutor
[ RUN      ] TestExecutors/EventsExecutor.spin_some_max_duration
/home/william/ros2_ws/src/ros2/rclcpp/rclcpp/test/rclcpp/executors/test_executors.cpp:610: Failure
Expected: (to_nanoseconds_helper(spin_some_run_time)) > (to_nanoseconds_helper(waitable_callback_duration / 2)), actual: 55376 vs 1000000000
spin_some() took less than half the expected time to execute a single waitable, which implies it did not actually execute one when it was expected to
/home/william/ros2_ws/src/ros2/rclcpp/rclcpp/test/rclcpp/executors/test_executors.cpp:624: Failure
Expected equality of these values:
  number_of_waitables_executed
    Which is: 0
  1u
    Which is: 1
expected exactly one of the two waitables to be executed, but my_waitable1->get_count(): 0 and my_waitable2->get_count(): 0
[  FAILED  ] TestExecutors/EventsExecutor.spin_some_max_duration, where TypeParam = rclcpp::experimental::executors::EventsExecutor (22 ms)
[----------] 1 test from TestExecutors/EventsExecutor (22 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 4 test suites ran. (8169 ms total)
[  PASSED  ] 2 tests.
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] TestExecutors/StaticSingleThreadedExecutor.spin_some_max_duration, where TypeParam = rclcpp::executors::StaticSingleThreadedExecutor
[  FAILED  ] TestExecutors/EventsExecutor.spin_some_max_duration, where TypeParam = rclcpp::experimental::executors::EventsExecutor

 2 FAILED TESTS
```

Note that I will also reduce the `max_duration` being tested, but in the above output I had increased it to 1s to see if it's a data race issue, but it doesn't appear to be the case.

I also took the opportunity to clarify the docstring for `spin_some` even though the text that was there previously already agreed with these tests, but I just made it extra clear what the expectation was (so clarified, but not a change in expected behavior).