### PR TITLE
fix spin_some_max_duration unit-test for events-executor

### DIFF
--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -571,13 +571,12 @@ TYPED_TEST(TestExecutors, spin_some_max_duration)
 {
   using ExecutorType = TypeParam;
 
-  // TODO(wjwwood): The `StaticSingleThreadedExecutor` and the `EventsExecutor`
+  // TODO(wjwwood): The `StaticSingleThreadedExecutor`
   //   do not properly implement max_duration (it seems), so disable this test
   //   for them in the meantime.
   //   see: https://github.com/ros2/rclcpp/issues/2462
   if (
-    std::is_same<ExecutorType, rclcpp::executors::StaticSingleThreadedExecutor>() ||
-    std::is_same<ExecutorType, rclcpp::experimental::executors::EventsExecutor>())
+    std::is_same<ExecutorType, rclcpp::executors::StaticSingleThreadedExecutor>())
   {
     GTEST_SKIP();
   }
@@ -609,6 +608,9 @@ TYPED_TEST(TestExecutors, spin_some_max_duration)
   auto my_waitable2 = std::make_shared<TestWaitable>();
   my_waitable2->set_on_execute_callback(long_running_callback);
   waitable_interfaces->add_waitable(my_waitable2, isolated_callback_group);
+
+  my_waitable1->trigger();
+  my_waitable2->trigger();
 
   ExecutorType executor;
   executor.add_callback_group(isolated_callback_group, this->node->get_node_base_interface());

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -352,8 +352,13 @@ public:
   bool
   is_ready(rcl_wait_set_t * wait_set) override
   {
-    (void)wait_set;
-    return true;
+    for (size_t i = 0; i < wait_set->size_of_guard_conditions; ++i) {
+      auto rcl_guard_condition = wait_set->guard_conditions[i];
+      if (&gc_.get_rcl_guard_condition() == rcl_guard_condition) {
+        return true;
+      }
+    }
+    return false;
   }
 
   std::shared_ptr<void>


### PR DESCRIPTION
This PR partially fixes https://github.com/ros2/rclcpp/issues/2462

The EventsExecutor and the StaticSingleThreadedExecutor were failing a unit-test.
This PR fixes the test for the EventsExecutor.

The waitables were not triggered, so the events executor was not executing them.

This poses the question... Why do the other executors "execute" a waitable that was not triggered?
EDIT: the other executors worked because there was a bug in the `is_ready` method of the `TestWaitable` class. This was returning "true" regardless of whether the waitable was triggered.
Fixed it as a separate commit [0e6c78d](https://github.com/ros2/rclcpp/pull/2465/commits/0e6c78dba83e817d26d2cd8649d46a2513b5cc92)

FYI @wjwwood 