### PR TITLE
Removed test_timers_manager clang warning

### DIFF
--- a/rclcpp/test/rclcpp/test_timers_manager.cpp
+++ b/rclcpp/test/rclcpp/test_timers_manager.cpp
@@ -375,7 +375,7 @@ TEST_F(TestTimersManager, check_one_timer_cancel_doesnt_affect_other_timers)
   // since typical users aren't going to mess around with the timer manager.
   t1 = TimerT::make_shared(
     1ms,
-    [=, &t1_runs, &t1]() {
+    [ =, &t1_runs, &t1]() {
       t1_runs++;
       if (t1_runs == cancel_iter) {
         t1->cancel();

--- a/rclcpp/test/rclcpp/test_timers_manager.cpp
+++ b/rclcpp/test/rclcpp/test_timers_manager.cpp
@@ -375,7 +375,7 @@ TEST_F(TestTimersManager, check_one_timer_cancel_doesnt_affect_other_timers)
   // since typical users aren't going to mess around with the timer manager.
   t1 = TimerT::make_shared(
     1ms,
-    [&t1_runs, &t1]() {
+    [=, &t1_runs, &t1]() {
       t1_runs++;
       if (t1_runs == cancel_iter) {
         t1->cancel();

--- a/rclcpp/test/rclcpp/test_timers_manager.cpp
+++ b/rclcpp/test/rclcpp/test_timers_manager.cpp
@@ -375,7 +375,7 @@ TEST_F(TestTimersManager, check_one_timer_cancel_doesnt_affect_other_timers)
   // since typical users aren't going to mess around with the timer manager.
   t1 = TimerT::make_shared(
     1ms,
-    [&t1_runs, &t1, cancel_iter]() {
+    [&t1_runs, &t1]() {
       t1_runs++;
       if (t1_runs == cancel_iter) {
         t1->cancel();


### PR DESCRIPTION
Related with this warning https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/1846/gcc/new/folder.-1481343024/