### PR TITLE
Increase the cppcheck timeout to 1200 seconds

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -298,7 +298,7 @@ install(
 
 if(TEST cppcheck)
   # must set the property after ament_package()
-  set_tests_properties(cppcheck PROPERTIES TIMEOUT 600)
+  set_tests_properties(cppcheck PROPERTIES TIMEOUT 1200)
 endif()
 
 if(TEST cpplint)


### PR DESCRIPTION
I can see a [timeout in rclcpp cppcheck](https://ci.ros2.org/view/nightly/job/nightly_win_deb/3052/consoleText) increasing it a little bit more. [nightly_win_deb build](https://ci.ros2.org/view/nightly/job/nightly_win_deb/3052/#showFailuresLink)

```
2:  - C:/ci/ws/install/Scripts/ament_cppcheck.exe --xunit-file C:/ci/ws/build/rclcpp/test_results/rclcpp/cppcheck.xunit.xml --include_dirs C:/ci/ws/src/ros2/rclcpp/rclcpp/include
  2/124 Test   #2: cppcheck ...................................................***Timeout 600.10 sec
```