### PR TITLE
Fix  warning: possible null dereference

### DIFF
--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -430,7 +430,7 @@ public:
     const std::shared_ptr<const ROSMessageType> & message)
   {
     auto ptr = ROSMessageTypeAllocatorTraits::allocate(ros_message_type_allocator_, 1);
-    if (ptr == nullptr){
+    if (ptr == nullptr) {
       throw std::bad_alloc();
     }
     ROSMessageTypeAllocatorTraits::construct(ros_message_type_allocator_, ptr, *message);
@@ -442,7 +442,7 @@ public:
     const std::shared_ptr<const rclcpp::SerializedMessage> & serialized_message)
   {
     auto ptr = SerializedMessageAllocatorTraits::allocate(serialized_message_allocator_, 1);
-    if (ptr == nullptr){
+    if (ptr == nullptr) {
       throw std::bad_alloc();
     }
     SerializedMessageAllocatorTraits::construct(
@@ -458,7 +458,7 @@ public:
     const std::shared_ptr<const SubscribedType> & message)
   {
     auto ptr = SubscribedTypeAllocatorTraits::allocate(subscribed_type_allocator_, 1);
-    if (ptr == nullptr){
+    if (ptr == nullptr) {
       	throw std::bad_alloc();
       }
     SubscribedTypeAllocatorTraits::construct(subscribed_type_allocator_, ptr, *message);
@@ -470,7 +470,7 @@ public:
   {
     if constexpr (rclcpp::TypeAdapter<MessageT>::is_specialized::value) {
       auto ptr = SubscribedTypeAllocatorTraits::allocate(subscribed_type_allocator_, 1);
-      if (ptr == nullptr){
+      if (ptr == nullptr) {
       	throw std::bad_alloc();
       }
       SubscribedTypeAllocatorTraits::construct(subscribed_type_allocator_, ptr);
@@ -488,7 +488,7 @@ public:
   {
     if constexpr (rclcpp::TypeAdapter<MessageT>::is_specialized::value) {
       auto ptr = ROSMessageTypeAllocatorTraits::allocate(ros_message_type_allocator_, 1);
-      if (ptr == nullptr){
+      if (ptr == nullptr) {
       	throw std::bad_alloc();
       }
       ROSMessageTypeAllocatorTraits::construct(ros_message_type_allocator_, ptr);

--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -459,7 +459,7 @@ public:
   {
     auto ptr = SubscribedTypeAllocatorTraits::allocate(subscribed_type_allocator_, 1);
     if (ptr == nullptr) {
-      	throw std::bad_alloc();
+        throw std::bad_alloc();
       }
     SubscribedTypeAllocatorTraits::construct(subscribed_type_allocator_, ptr, *message);
     return std::unique_ptr<SubscribedType, SubscribedTypeDeleter>(ptr, subscribed_type_deleter_);
@@ -471,7 +471,7 @@ public:
     if constexpr (rclcpp::TypeAdapter<MessageT>::is_specialized::value) {
       auto ptr = SubscribedTypeAllocatorTraits::allocate(subscribed_type_allocator_, 1);
       if (ptr == nullptr) {
-      	throw std::bad_alloc();
+        throw std::bad_alloc();
       }
       SubscribedTypeAllocatorTraits::construct(subscribed_type_allocator_, ptr);
       rclcpp::TypeAdapter<MessageT>::convert_to_custom(msg, *ptr);
@@ -489,7 +489,7 @@ public:
     if constexpr (rclcpp::TypeAdapter<MessageT>::is_specialized::value) {
       auto ptr = ROSMessageTypeAllocatorTraits::allocate(ros_message_type_allocator_, 1);
       if (ptr == nullptr) {
-      	throw std::bad_alloc();
+        throw std::bad_alloc();
       }
       ROSMessageTypeAllocatorTraits::construct(ros_message_type_allocator_, ptr);
       rclcpp::TypeAdapter<MessageT>::convert_to_ros_message(msg, *ptr);

--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -17,6 +17,7 @@
 
 #include <functional>
 #include <memory>
+#include <new>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
@@ -429,6 +430,9 @@ public:
     const std::shared_ptr<const ROSMessageType> & message)
   {
     auto ptr = ROSMessageTypeAllocatorTraits::allocate(ros_message_type_allocator_, 1);
+    if (ptr == nullptr){
+      throw std::bad_alloc();
+    }
     ROSMessageTypeAllocatorTraits::construct(ros_message_type_allocator_, ptr, *message);
     return std::unique_ptr<ROSMessageType, ROSMessageTypeDeleter>(ptr, ros_message_type_deleter_);
   }
@@ -438,6 +442,9 @@ public:
     const std::shared_ptr<const rclcpp::SerializedMessage> & serialized_message)
   {
     auto ptr = SerializedMessageAllocatorTraits::allocate(serialized_message_allocator_, 1);
+    if (ptr == nullptr){
+      throw std::bad_alloc();
+    }
     SerializedMessageAllocatorTraits::construct(
       serialized_message_allocator_, ptr, *serialized_message);
     return std::unique_ptr<
@@ -451,6 +458,9 @@ public:
     const std::shared_ptr<const SubscribedType> & message)
   {
     auto ptr = SubscribedTypeAllocatorTraits::allocate(subscribed_type_allocator_, 1);
+    if (ptr == nullptr){
+      	throw std::bad_alloc();
+      }
     SubscribedTypeAllocatorTraits::construct(subscribed_type_allocator_, ptr, *message);
     return std::unique_ptr<SubscribedType, SubscribedTypeDeleter>(ptr, subscribed_type_deleter_);
   }
@@ -460,6 +470,9 @@ public:
   {
     if constexpr (rclcpp::TypeAdapter<MessageT>::is_specialized::value) {
       auto ptr = SubscribedTypeAllocatorTraits::allocate(subscribed_type_allocator_, 1);
+      if (ptr == nullptr){
+      	throw std::bad_alloc();
+      }
       SubscribedTypeAllocatorTraits::construct(subscribed_type_allocator_, ptr);
       rclcpp::TypeAdapter<MessageT>::convert_to_custom(msg, *ptr);
       return std::unique_ptr<SubscribedType, SubscribedTypeDeleter>(ptr, subscribed_type_deleter_);
@@ -475,6 +488,9 @@ public:
   {
     if constexpr (rclcpp::TypeAdapter<MessageT>::is_specialized::value) {
       auto ptr = ROSMessageTypeAllocatorTraits::allocate(ros_message_type_allocator_, 1);
+      if (ptr == nullptr){
+      	throw std::bad_alloc();
+      }
       ROSMessageTypeAllocatorTraits::construct(ros_message_type_allocator_, ptr);
       rclcpp::TypeAdapter<MessageT>::convert_to_ros_message(msg, *ptr);
       return std::unique_ptr<ROSMessageType, ROSMessageTypeDeleter>(ptr, ros_message_type_deleter_);

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_buffer.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_buffer.hpp
@@ -112,7 +112,7 @@ public:
     if constexpr (!std::is_same<SubscribedType, ROSMessageType>::value) {
       auto ptr = SubscribedTypeAllocatorTraits::allocate(subscribed_type_allocator_, 1);
       if (ptr == nullptr) {
-      	throw std::bad_alloc();
+        throw std::bad_alloc();
       }
       SubscribedTypeAllocatorTraits::construct(subscribed_type_allocator_, ptr);
       rclcpp::TypeAdapter<SubscribedType, ROSMessageType>::convert_to_custom(msg, *ptr);

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_buffer.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_buffer.hpp
@@ -111,7 +111,7 @@ public:
   {
     if constexpr (!std::is_same<SubscribedType, ROSMessageType>::value) {
       auto ptr = SubscribedTypeAllocatorTraits::allocate(subscribed_type_allocator_, 1);
-      if (ptr == nullptr){
+      if (ptr == nullptr) {
       	throw std::bad_alloc();
       }
       SubscribedTypeAllocatorTraits::construct(subscribed_type_allocator_, ptr);

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_buffer.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_buffer.hpp
@@ -111,6 +111,9 @@ public:
   {
     if constexpr (!std::is_same<SubscribedType, ROSMessageType>::value) {
       auto ptr = SubscribedTypeAllocatorTraits::allocate(subscribed_type_allocator_, 1);
+      if (ptr == nullptr){
+      	throw std::bad_alloc();
+      }
       SubscribedTypeAllocatorTraits::construct(subscribed_type_allocator_, ptr);
       rclcpp::TypeAdapter<SubscribedType, ROSMessageType>::convert_to_custom(msg, *ptr);
       return SubscribedTypeUniquePtr(ptr, subscribed_type_deleter_);


### PR DESCRIPTION
Closes #2493 
CC @clalancette 

At least for now I drafted a `bad_alloc` exception, but in the same files it is used `std::runtime_error` carrying always an explanatory message. `bad_alloc` by design is not allowed to allocate memory, so it is not designed with error messages in mind.

So I open this as draft so we can devise the best strategy / the one more consistent with `rclcpp` development in general. 