### PR TITLE
fix the execution order of entites in executors to favor insertion order

### DIFF
--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -673,7 +673,11 @@ Executor::collect_entities()
     current_notify_waitable_ = std::make_shared<rclcpp::executors::ExecutorNotifyWaitable>(
       *notify_waitable_);
     auto notify_waitable = std::static_pointer_cast<rclcpp::Waitable>(current_notify_waitable_);
-    collection.waitables.insert({notify_waitable.get(), {notify_waitable, {}}});
+    bool inserted = collection.waitables.insert({notify_waitable.get(), {notify_waitable, {}}});
+    // Should never be false, so this is a defensive check, mark unused too
+    // in order to avoid a warning in release builds.
+    assert(inserted);
+    RCUTILS_UNUSED(inserted);
   }
 
   // We must remove expired entities here, so that we don't continue to use older entities.

--- a/rclcpp/src/rclcpp/executors/executor_entities_collection.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_entities_collection.cpp
@@ -43,10 +43,10 @@ size_t ExecutorEntitiesCollection::remove_expired_entities()
 {
   auto remove_entities = [](auto & collection) -> size_t {
       size_t removed = 0;
-      for (auto it = collection.begin(); it != collection.end(); ) {
+      for (auto it = collection.begin_ordered(); it != collection.end_ordered(); ) {
         if (it->second.entity.expired()) {
           ++removed;
-          it = collection.erase(it);
+          it = collection.erase_ordered(it);
         } else {
           ++it;
         }
@@ -79,39 +79,59 @@ build_entities_collection(
     if (group_ptr->can_be_taken_from().load()) {
       group_ptr->collect_all_ptrs(
         [&collection, weak_group_ptr](const rclcpp::SubscriptionBase::SharedPtr & subscription) {
-          collection.subscriptions.insert(
+          bool inserted = collection.subscriptions.insert(
             {
               subscription->get_subscription_handle().get(),
               {subscription, weak_group_ptr}
             });
+          // Should never be false, so this is a defensive check, mark unused too
+          // in order to avoid a warning in release builds.
+          assert(inserted);
+          RCUTILS_UNUSED(inserted);
         },
         [&collection, weak_group_ptr](const rclcpp::ServiceBase::SharedPtr & service) {
-          collection.services.insert(
+          bool inserted = collection.services.insert(
             {
               service->get_service_handle().get(),
               {service, weak_group_ptr}
             });
+          // Should never be false, so this is a defensive check, mark unused too
+          // in order to avoid a warning in release builds.
+          assert(inserted);
+          RCUTILS_UNUSED(inserted);
         },
         [&collection, weak_group_ptr](const rclcpp::ClientBase::SharedPtr & client) {
-          collection.clients.insert(
+          bool inserted = collection.clients.insert(
             {
               client->get_client_handle().get(),
               {client, weak_group_ptr}
             });
+          // Should never be false, so this is a defensive check, mark unused too
+          // in order to avoid a warning in release builds.
+          assert(inserted);
+          RCUTILS_UNUSED(inserted);
         },
         [&collection, weak_group_ptr](const rclcpp::TimerBase::SharedPtr & timer) {
-          collection.timers.insert(
+          bool inserted = collection.timers.insert(
             {
               timer->get_timer_handle().get(),
               {timer, weak_group_ptr}
             });
+          // Should never be false, so this is a defensive check, mark unused too
+          // in order to avoid a warning in release builds.
+          assert(inserted);
+          RCUTILS_UNUSED(inserted);
         },
         [&collection, weak_group_ptr](const rclcpp::Waitable::SharedPtr & waitable) {
-          collection.waitables.insert(
+          bool inserted = collection.waitables.insert(
             {
               waitable.get(),
               {waitable, weak_group_ptr}
             });
+          // Should never be false, so this is a defensive check, mark unused too
+          // in order to avoid a warning in release builds.
+          assert(inserted);
+          RCUTILS_UNUSED(inserted);
         }
       );
     }

--- a/rclcpp/src/rclcpp/experimental/executors/events_executor/events_executor.cpp
+++ b/rclcpp/src/rclcpp/experimental/executors/events_executor/events_executor.cpp
@@ -511,9 +511,19 @@ EventsExecutor::add_notify_waitable_to_collection(
 {
   // The notify waitable is not associated to any group, so use an invalid one
   rclcpp::CallbackGroup::WeakPtr weak_group_ptr;
-  collection.insert(
+  bool inserted = collection.insert(
   {
     this->notify_waitable_.get(),
     {this->notify_waitable_, weak_group_ptr}
   });
+  // Explicitly ignore if the notify waitable was not inserted because that means
+  // it was already inserted, which happens initially as it is explicitly added
+  // in the constructor as well as every time the collection is reset, so on
+  // the first reset there is a second insertion attempt.
+  // We could check before trying to insert, but that would require a "find" call
+  // on each refresh, which is expensive, and otherwise it would require additional
+  // state in this class to detect the initial case where it is added twice.
+  // Therefore we just insert and ignore it if it fails (the only way it fails
+  // is when a duplicate is inserted).
+  RCUTILS_UNUSED(inserted);
 }


### PR DESCRIPTION
In specific circumstances, multiple entities (of the same kind) in an executor can be ready at the same time and the executor must arbitrarily decide which to execute first, and in Iron and before, this fell back to the order in which they were added, but in Jazzy we (inadvertently) changed this and it became related to the hash order, subtly changing the order of execution that some folks had come to rely on, see: https://github.com/ros2/rclcpp/issues/2532

While this ordering was not guaranteed, this pr aims to restore the previous behavior for consistency and to provide a less surprising result, but the order is still not a guarantee nor is it the same for all executor types (e.g. the EventsExecutor is consistent, but is instead based on the trigger order of the entities, not their insertion/addition order).

The new test is also in a separate pr here: https://github.com/ros2/rclcpp/pull/2536 so it can be more easily back ported to previous versions. I think it should pass on them, but I still need to test it. See that pr for updates.

This approach will not work for backporting as it breaks ABI, but I believe I could make a version that doesn't break ABI (it will be as ugly as past non-ABI breaking changes). I just want to make sure we want to follow through with this before committing resources to that attempt.

This pr does incur some additional overhead, but I believe it should be relatively low, considering what we're storing. It does, however, slow down insertion and erasure from the collections which could be a concern in the tight loop of spin. I will do some more experimentation related to this, but the memory overhead of storing the entity pointers of the collection twice (once as an unordered map for fast random access and once in a vector for maintaining insertion order) should be relatively small. It does increase the memory footprint by 2x, but the footprint was small to begin with (three pointers per entity).

I looked at using existing "ordered maps" but all of them (that I could see) either provided the desired API but lost the fast lookup of the hash or did what I did here and maintained the information twice in two different data structures.

So I think this is a reasonable approach, but I'm up for discussion on alternatives.