### PR TITLE
LifecycleNode shutdown on dtor only with valid context.

### DIFF
--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -155,15 +155,23 @@ LifecycleNode::~LifecycleNode()
   auto current_state = LifecycleNode::get_current_state().id();
   // shutdown if necessary to avoid leaving the device in any other primary state
   if (current_state < lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED) {
-    auto ret = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
-    auto finalized = LifecycleNode::shutdown(ret);
-    if (finalized.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED ||
-      ret != rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS)
-    {
-      RCLCPP_WARN(
+    if (node_base_->get_context()->is_valid()) {
+      auto ret = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
+      auto finalized = LifecycleNode::shutdown(ret);
+      if (finalized.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED ||
+        ret != rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS)
+      {
+        RCLCPP_WARN(
+          rclcpp::get_logger("rclcpp_lifecycle"),
+          "Shutdown error in destruction of LifecycleNode: final state(%s)",
+          finalized.label().c_str());
+      }
+    } else {
+      // TODO(fujitatomoya): consider when context is gracefully shutdown before.
+      RCLCPP_DEBUG(
         rclcpp::get_logger("rclcpp_lifecycle"),
-        "Shutdown error in destruction of LifecycleNode: final state(%s)",
-        finalized.label().c_str());
+        "Context invalid error in destruction of LifecycleNode: Node still in transition state(%u)",
+        current_state);
     }
   } else if (current_state > lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED) {
     RCLCPP_WARN(
@@ -174,6 +182,7 @@ LifecycleNode::~LifecycleNode()
 
   // release sub-interfaces in an order that allows them to consult with node_base during tear-down
   node_waitables_.reset();
+  node_type_descriptions_.reset();
   node_time_source_.reset();
   node_parameters_.reset();
   node_clock_.reset();
@@ -182,6 +191,7 @@ LifecycleNode::~LifecycleNode()
   node_timers_.reset();
   node_logging_.reset();
   node_graph_.reset();
+  node_base_.reset();
 }
 
 const char *


### PR DESCRIPTION
https://github.com/ros2/rclcpp/pull/2528 generates the following error when the context is gracefully shutdown. (e.g deferred signal handler of rclcpp.)

```bash
root@tomoyafujita:~/ros2_ws/colcon_ws# ros2 run lifecycle lifecycle_talker
^C[INFO] [1717052032.575390927] [rclcpp]: signal_handler(signum=2)
[ERROR] [1717052032.577706294] [lc_talker]: Unable to start transition 5 from current state shuttingdown: Could not publish transition: publisher's context is invalid, at /root/ros2_ws/colcon_ws/src/ros2/rcl/rcl/src/rcl/publisher.c:423, at /root/ros2_ws/colcon_ws/src/ros2/rcl/rcl_lifecycle/src/rcl_lifecycle.c:368
[WARN] [1717052032.577764887] [rclcpp_lifecycle]: Shutdown error in destruction of LifecycleNode: final state(unconfigured)
```

this is because the shutdown in the dtor is called but failed to publish the transition since the context is not valid.

i thought of a couple of things, but at this moment, i would like to label it with `TODO`.

- add the context shutdown callback with weak_ptr lifecyclenode. so that even with graceful shutdown, context shutdown callback will be calling the lifecyclenode::shutdown properly.
- add `shutdown` without publishing the transition. lifecycnode itself needs to be shutdown to avoid leaving the device or sensor in unknown state. we can call this method when the context is invalid.

This also addresses https://github.com/ros2/rclcpp/issues/2547 (Nav2 CI finds this behavior)