### PR TITLE
Fix typo in function doc

### DIFF
--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -217,13 +217,13 @@ public:
   std::mutex &
   get_clock_mutex() noexcept;
 
-  // Add a callback to invoke if the jump threshold is exceeded.
+  /// Add a callback to invoke if the jump threshold is exceeded.
   /**
    * These callback functions must remain valid as long as the
    * returned shared pointer is valid.
    *
    * Function will register callbacks to the callback queue. On time jump all
-   * callbacks will be executed whose threshold is greater then the time jump;
+   * callbacks will be executed whose threshold is greater than the time jump;
    * The logic will first call selected pre_callbacks and then all selected
    * post_callbacks.
    *
@@ -232,7 +232,7 @@ public:
    * \param pre_callback Must be non-throwing
    * \param post_callback Must be non-throwing.
    * \param threshold Callbacks will be triggered if the time jump is greater
-   * then the threshold.
+   * than the threshold.
    * \throws anything rclcpp::exceptions::throw_from_rcl_error can throw.
    * \throws std::bad_alloc if the allocation of the JumpHandler fails.
    * \warning the instance of the clock must remain valid as long as any created

--- a/rclcpp_action/include/rclcpp_action/create_server.hpp
+++ b/rclcpp_action/include/rclcpp_action/create_server.hpp
@@ -116,7 +116,7 @@ create_server(
  *
  * \sa Server::Server() for more information.
  *
- * \param[in] node] The action server will be added to this node.
+ * \param[in] node The action server will be added to this node.
  * \param[in] name The action name.
  * \param[in] handle_goal A callback that decides if a goal should be accepted or rejected.
  * \param[in] handle_cancel A callback that decides if a goal should be attempted to be canceled.


### PR DESCRIPTION
* "greater then" -> "greater than"
* Use `///` instead of `//` for the function's one-line description
* Remove extra `]`