### PR TITLE
Removed deprecated methods and classes

### DIFF
--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -89,46 +89,6 @@ public:
    * added to the executor in either case.
    *
    * \param[in] group_type The type of the callback group.
-   * \param[in] automatically_add_to_executor_with_node A boolean that
-   *   determines whether a callback group is automatically added to an executor
-   *   with the node with which it is associated.
-   */
-  [[deprecated("Use CallbackGroup constructor with context function argument")]]
-  RCLCPP_PUBLIC
-  explicit CallbackGroup(
-    CallbackGroupType group_type,
-    bool automatically_add_to_executor_with_node = true);
-
-  /// Constructor for CallbackGroup.
-  /**
-   * Callback Groups have a type, either 'Mutually Exclusive' or 'Reentrant'
-   * and when creating one the type must be specified.
-   *
-   * Callbacks in Reentrant Callback Groups must be able to:
-   *   - run at the same time as themselves (reentrant)
-   *   - run at the same time as other callbacks in their group
-   *   - run at the same time as other callbacks in other groups
-   *
-   * Callbacks in Mutually Exclusive Callback Groups:
-   *   - will not be run multiple times simultaneously (non-reentrant)
-   *   - will not be run at the same time as other callbacks in their group
-   *   - but must run at the same time as callbacks in other groups
-   *
-   * Additionally, callback groups have a property which determines whether or
-   * not they are added to an executor with their associated node automatically.
-   * When creating a callback group the automatically_add_to_executor_with_node
-   * argument determines this behavior, and if true it will cause the newly
-   * created callback group to be added to an executor with the node when the
-   * Executor::add_node method is used.
-   * If false, this callback group will not be added automatically and would
-   * have to be added to an executor manually using the
-   * Executor::add_callback_group method.
-   *
-   * Whether the node was added to the executor before creating the callback
-   * group, or after, is irrelevant; the callback group will be automatically
-   * added to the executor in either case.
-   *
-   * \param[in] group_type The type of the callback group.
    * \param[in] context A weak pointer to the context associated with this callback group.
    * \param[in] automatically_add_to_executor_with_node A boolean that
    *   determines whether a callback group is automatically added to an executor

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -415,7 +415,6 @@ public:
 
   RCLCPP_SMART_PTR_DEFINITIONS(Client)
 
-
   /// A convenient Client::Future and request id pair.
   /**
    * Public members:

--- a/rclcpp/include/rclcpp/client.hpp
+++ b/rclcpp/include/rclcpp/client.hpp
@@ -70,14 +70,6 @@ struct FutureAndRequestId
   /// Allow implicit conversions to `std::future` by reference.
   operator FutureT &() {return this->future;}
 
-  /// Deprecated, use the `future` member variable instead.
-  /**
-   * Allow implicit conversions to `std::future` by value.
-   * \deprecated
-   */
-  [[deprecated("FutureAndRequestId: use .future instead of an implicit conversion")]]
-  operator FutureT() {return this->future;}
-
   // delegate future like methods in the std::future impl_
 
   /// See std::future::get().
@@ -423,6 +415,7 @@ public:
 
   RCLCPP_SMART_PTR_DEFINITIONS(Client)
 
+
   /// A convenient Client::Future and request id pair.
   /**
    * Public members:
@@ -435,15 +428,6 @@ public:
     : detail::FutureAndRequestId<std::future<SharedResponse>>
   {
     using detail::FutureAndRequestId<std::future<SharedResponse>>::FutureAndRequestId;
-
-    /// Deprecated, use `.future.share()` instead.
-    /**
-     * Allow implicit conversions to `std::shared_future` by value.
-     * \deprecated
-     */
-    [[deprecated(
-      "FutureAndRequestId: use .future.share() instead of an implicit conversion")]]
-    operator SharedFuture() {return this->future.share();}
 
     // delegate future like methods in the std::future impl_
 

--- a/rclcpp/include/rclcpp/create_client.hpp
+++ b/rclcpp/include/rclcpp/create_client.hpp
@@ -48,27 +48,8 @@ create_client(
   const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
   rclcpp::CallbackGroup::SharedPtr group = nullptr)
 {
-  return create_client<ServiceT>(
-    node_base, node_graph, node_services,
-    service_name,
-    qos.get_rmw_qos_profile(),
-    group);
-}
-
-/// Create a service client with a given type.
-/// \internal
-template<typename ServiceT>
-typename rclcpp::Client<ServiceT>::SharedPtr
-create_client(
-  std::shared_ptr<node_interfaces::NodeBaseInterface> node_base,
-  std::shared_ptr<node_interfaces::NodeGraphInterface> node_graph,
-  std::shared_ptr<node_interfaces::NodeServicesInterface> node_services,
-  const std::string & service_name,
-  const rmw_qos_profile_t & qos_profile,
-  rclcpp::CallbackGroup::SharedPtr group)
-{
   rcl_client_options_t options = rcl_client_get_default_options();
-  options.qos = qos_profile;
+  options.qos = qos.get_rmw_qos_profile();
 
   auto cli = rclcpp::Client<ServiceT>::make_shared(
     node_base.get(),
@@ -80,7 +61,6 @@ create_client(
   node_services->add_client(cli_base_ptr, group);
   return cli;
 }
-
 }  // namespace rclcpp
 
 #endif  // RCLCPP__CREATE_CLIENT_HPP_

--- a/rclcpp/include/rclcpp/event_handler.hpp
+++ b/rclcpp/include/rclcpp/event_handler.hpp
@@ -233,8 +233,6 @@ protected:
   size_t wait_set_event_index_;
 };
 
-using QOSEventHandlerBase [[deprecated("Use rclcpp::EventHandlerBase")]] = EventHandlerBase;
-
 template<typename EventCallbackT, typename ParentHandleT>
 class EventHandler : public EventHandlerBase
 {
@@ -311,11 +309,6 @@ private:
   ParentHandleT parent_handle_;
   EventCallbackT event_callback_;
 };
-
-template<typename EventCallbackT, typename ParentHandleT>
-using QOSEventHandler [[deprecated("Use rclcpp::EventHandler")]] = EventHandler<EventCallbackT,
-    ParentHandleT>;
-
 }  // namespace rclcpp
 
 #endif  // RCLCPP__EVENT_HANDLER_HPP_

--- a/rclcpp/include/rclcpp/loaned_message.hpp
+++ b/rclcpp/include/rclcpp/loaned_message.hpp
@@ -82,36 +82,6 @@ public:
     }
   }
 
-  /// Constructor of the LoanedMessage class.
-  /**
-   * The constructor of this class allocates memory for a given message type
-   * and associates this with a given publisher.
-   *
-   * Given the publisher instance, a case differentiation is being performaned
-   * which decides whether the underlying middleware is able to allocate the appropriate
-   * memory for this message type or not.
-   * In the case that the middleware can not loan messages, the passed in allocator instance
-   * is being used to allocate the message within the scope of this class.
-   * Otherwise, the allocator is being ignored and the allocation is solely performaned
-   * in the underlying middleware with its appropriate allocation strategy.
-   * The need for this arises as the user code can be written explicitly targeting a middleware
-   * capable of loaning messages.
-   * However, this user code is ought to be usable even when dynamically linked against
-   * a middleware which doesn't support message loaning in which case the allocator will be used.
-   *
-   * \param[in] pub rclcpp::Publisher instance to which the memory belongs
-   * \param[in] allocator Allocator instance in case middleware can not allocate messages
-   * \throws anything rclcpp::exceptions::throw_from_rcl_error can throw.
-   */
-  [[
-    deprecated("used the LoanedMessage constructor that does not use a shared_ptr to the allocator")
-  ]]
-  LoanedMessage(
-    const rclcpp::PublisherBase * pub,
-    std::shared_ptr<std::allocator<MessageT>> allocator)
-  : LoanedMessage(*pub, *allocator)
-  {}
-
   /// Move semantic for RVO
   LoanedMessage(LoanedMessage<MessageT> && other)
   : pub_(std::move(other.pub_)),

--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -259,22 +259,6 @@ public:
 
   /// Create and return a Client.
   /**
-   * \param[in] service_name The topic to service on.
-   * \param[in] qos_profile rmw_qos_profile_t Quality of service profile for client.
-   * \param[in] group Callback group to call the service.
-   * \return Shared pointer to the created client.
-   * \deprecated use rclcpp::QoS instead of rmw_qos_profile_t
-   */
-  template<typename ServiceT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  typename rclcpp::Client<ServiceT>::SharedPtr
-  create_client(
-    const std::string & service_name,
-    const rmw_qos_profile_t & qos_profile,
-    rclcpp::CallbackGroup::SharedPtr group = nullptr);
-
-  /// Create and return a Client.
-  /**
    * \param[in] service_name The name on which the service is accessible.
    * \param[in] qos Quality of service profile for client.
    * \param[in] group Callback group to handle the reply to service calls.
@@ -285,24 +269,6 @@ public:
   create_client(
     const std::string & service_name,
     const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
-    rclcpp::CallbackGroup::SharedPtr group = nullptr);
-
-  /// Create and return a Service.
-  /**
-   * \param[in] service_name The topic to service on.
-   * \param[in] callback User-defined callback function.
-   * \param[in] qos_profile rmw_qos_profile_t Quality of service profile for client.
-   * \param[in] group Callback group to call the service.
-   * \return Shared pointer to the created service.
-   * \deprecated use rclcpp::QoS instead of rmw_qos_profile_t
-   */
-  template<typename ServiceT, typename CallbackT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  typename rclcpp::Service<ServiceT>::SharedPtr
-  create_service(
-    const std::string & service_name,
-    CallbackT && callback,
-    const rmw_qos_profile_t & qos_profile,
     rclcpp::CallbackGroup::SharedPtr group = nullptr);
 
   /// Create and return a Service.
@@ -1015,8 +981,6 @@ public:
     rclcpp::node_interfaces::OnSetParametersCallbackHandle;
   using OnSetParametersCallbackType =
     rclcpp::node_interfaces::NodeParametersInterface::OnSetParametersCallbackType;
-  using OnParametersSetCallbackType [[deprecated("use OnSetParametersCallbackType instead")]] =
-    OnSetParametersCallbackType;
 
   using PostSetParametersCallbackHandle =
     rclcpp::node_interfaces::PostSetParametersCallbackHandle;

--- a/rclcpp/include/rclcpp/node_impl.hpp
+++ b/rclcpp/include/rclcpp/node_impl.hpp
@@ -154,22 +154,6 @@ Node::create_client(
     group);
 }
 
-template<typename ServiceT>
-typename Client<ServiceT>::SharedPtr
-Node::create_client(
-  const std::string & service_name,
-  const rmw_qos_profile_t & qos_profile,
-  rclcpp::CallbackGroup::SharedPtr group)
-{
-  return rclcpp::create_client<ServiceT>(
-    node_base_,
-    node_graph_,
-    node_services_,
-    extend_name_with_sub_namespace(service_name, this->get_sub_namespace()),
-    qos_profile,
-    group);
-}
-
 template<typename ServiceT, typename CallbackT>
 typename rclcpp::Service<ServiceT>::SharedPtr
 Node::create_service(
@@ -184,23 +168,6 @@ Node::create_service(
     extend_name_with_sub_namespace(service_name, this->get_sub_namespace()),
     std::forward<CallbackT>(callback),
     qos,
-    group);
-}
-
-template<typename ServiceT, typename CallbackT>
-typename rclcpp::Service<ServiceT>::SharedPtr
-Node::create_service(
-  const std::string & service_name,
-  CallbackT && callback,
-  const rmw_qos_profile_t & qos_profile,
-  rclcpp::CallbackGroup::SharedPtr group)
-{
-  return rclcpp::create_service<ServiceT, CallbackT>(
-    node_base_,
-    node_services_,
-    extend_name_with_sub_namespace(service_name, this->get_sub_namespace()),
-    std::forward<CallbackT>(callback),
-    qos_profile,
     group);
 }
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -52,8 +52,6 @@ struct OnSetParametersCallbackHandle
     std::function<
     rcl_interfaces::msg::SetParametersResult(
       const std::vector<rclcpp::Parameter> &)>;
-  using OnParametersSetCallbackType [[deprecated("use OnSetParametersCallbackType instead")]] =
-    OnSetParametersCallbackType;
 
   OnSetParametersCallbackType callback;
 };

--- a/rclcpp/include/rclcpp/parameter_client.hpp
+++ b/rclcpp/include/rclcpp/parameter_client.hpp
@@ -58,37 +58,6 @@ public:
    * \param[in] node_topics_interface Node topic base interface.
    * \param[in] node_graph_interface The node graph interface of the corresponding node.
    * \param[in] node_services_interface Node service interface.
-   * \param[in] remote_node_name Name of the remote node
-   * \param[in] qos_profile The rmw qos profile to use to subscribe
-   * \param[in] group (optional) The async parameter client will be added to this callback group.
-   * \deprecated use rclcpp::QoS instead of rmw_qos_profile_t
-   */
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  RCLCPP_PUBLIC
-  AsyncParametersClient(
-    const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
-    const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface,
-    const rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_interface,
-    const rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_interface,
-    const std::string & remote_node_name,
-    const rmw_qos_profile_t & qos_profile,
-    rclcpp::CallbackGroup::SharedPtr group = nullptr)
-  : AsyncParametersClient(
-      node_base_interface,
-      node_topics_interface,
-      node_graph_interface,
-      node_services_interface,
-      remote_node_name,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)),
-      group)
-  {}
-
-  /// Create an async parameters client.
-  /**
-   * \param[in] node_base_interface The node base interface of the corresponding node.
-   * \param[in] node_topics_interface Node topic base interface.
-   * \param[in] node_graph_interface The node graph interface of the corresponding node.
-   * \param[in] node_services_interface Node service interface.
    * \param[in] remote_node_name (optional) name of the remote node
    * \param[in] qos_profile (optional) The qos profile to use to subscribe
    * \param[in] group (optional) The async parameter client will be added to this callback group.
@@ -102,31 +71,6 @@ public:
     const std::string & remote_node_name = "",
     const rclcpp::QoS & qos_profile = rclcpp::ParametersQoS(),
     rclcpp::CallbackGroup::SharedPtr group = nullptr);
-
-  /// Constructor
-  /**
-   * \param[in] node The async parameters client will be added to this node.
-   * \param[in] remote_node_name name of the remote node
-   * \param[in] qos_profile The rmw qos profile to use to subscribe
-   * \param[in] group (optional) The async parameter client will be added to this callback group.
-   * \deprecated use rclcpp::QoS instead of rmw_qos_profile_t
-   */
-  template<typename NodeT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  AsyncParametersClient(
-    const std::shared_ptr<NodeT> node,
-    const std::string & remote_node_name,
-    const rmw_qos_profile_t & qos_profile,
-    rclcpp::CallbackGroup::SharedPtr group = nullptr)
-  : AsyncParametersClient(
-      node->get_node_base_interface(),
-      node->get_node_topics_interface(),
-      node->get_node_graph_interface(),
-      node->get_node_services_interface(),
-      remote_node_name,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)),
-      group)
-  {}
 
   /**
    * \param[in] node The async parameters client will be added to this node.
@@ -147,31 +91,6 @@ public:
       node->get_node_services_interface(),
       remote_node_name,
       qos_profile,
-      group)
-  {}
-
-  /// Constructor
-  /**
-   * \param[in] node The async parameters client will be added to this node.
-   * \param[in] remote_node_name Name of the remote node
-   * \param[in] qos_profile The rmw qos profile to use to subscribe
-   * \param[in] group (optional) The async parameter client will be added to this callback group.
-   * \deprecated use rclcpp::QoS instead of rmw_qos_profile_t
-   */
-  template<typename NodeT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  AsyncParametersClient(
-    NodeT * node,
-    const std::string & remote_node_name,
-    const rmw_qos_profile_t & qos_profile,
-    rclcpp::CallbackGroup::SharedPtr group = nullptr)
-  : AsyncParametersClient(
-      node->get_node_base_interface(),
-      node->get_node_topics_interface(),
-      node->get_node_graph_interface(),
-      node->get_node_services_interface(),
-      remote_node_name,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)),
       group)
   {}
 
@@ -384,19 +303,6 @@ public:
   RCLCPP_SMART_PTR_DEFINITIONS(SyncParametersClient)
 
   template<typename NodeT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  SyncParametersClient(
-    std::shared_ptr<NodeT> node,
-    const std::string & remote_node_name,
-    const rmw_qos_profile_t & qos_profile)
-  : SyncParametersClient(
-      std::make_shared<rclcpp::executors::SingleThreadedExecutor>(),
-      node,
-      remote_node_name,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)))
-  {}
-
-  template<typename NodeT>
   explicit SyncParametersClient(
     std::shared_ptr<NodeT> node,
     const std::string & remote_node_name = "",
@@ -409,23 +315,6 @@ public:
   {}
 
   template<typename NodeT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  SyncParametersClient(
-    rclcpp::Executor::SharedPtr executor,
-    std::shared_ptr<NodeT> node,
-    const std::string & remote_node_name,
-    const rmw_qos_profile_t & qos_profile)
-  : SyncParametersClient(
-      executor,
-      node->get_node_base_interface(),
-      node->get_node_topics_interface(),
-      node->get_node_graph_interface(),
-      node->get_node_services_interface(),
-      remote_node_name,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)))
-  {}
-
-  template<typename NodeT>
   SyncParametersClient(
     rclcpp::Executor::SharedPtr executor,
     std::shared_ptr<NodeT> node,
@@ -439,19 +328,6 @@ public:
       node->get_node_services_interface(),
       remote_node_name,
       qos_profile)
-  {}
-
-  template<typename NodeT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  SyncParametersClient(
-    NodeT * node,
-    const std::string & remote_node_name,
-    const rmw_qos_profile_t & qos_profile)
-  : SyncParametersClient(
-      std::make_shared<rclcpp::executors::SingleThreadedExecutor>(),
-      node,
-      remote_node_name,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)))
   {}
 
   template<typename NodeT>
@@ -467,23 +343,6 @@ public:
   {}
 
   template<typename NodeT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  SyncParametersClient(
-    rclcpp::Executor::SharedPtr executor,
-    NodeT * node,
-    const std::string & remote_node_name,
-    const rmw_qos_profile_t & qos_profile)
-  : SyncParametersClient(
-      executor,
-      node->get_node_base_interface(),
-      node->get_node_topics_interface(),
-      node->get_node_graph_interface(),
-      node->get_node_services_interface(),
-      remote_node_name,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)))
-  {}
-
-  template<typename NodeT>
   SyncParametersClient(
     rclcpp::Executor::SharedPtr executor,
     NodeT * node,
@@ -498,28 +357,6 @@ public:
       remote_node_name,
       qos_profile)
   {}
-
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  RCLCPP_PUBLIC
-  SyncParametersClient(
-    rclcpp::Executor::SharedPtr executor,
-    const rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
-    const rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface,
-    const rclcpp::node_interfaces::NodeGraphInterface::SharedPtr node_graph_interface,
-    const rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_interface,
-    const std::string & remote_node_name,
-    const rmw_qos_profile_t & qos_profile)
-  : executor_(executor), node_base_interface_(node_base_interface)
-  {
-    async_parameters_client_ =
-      std::make_shared<AsyncParametersClient>(
-      node_base_interface,
-      node_topics_interface,
-      node_graph_interface,
-      node_services_interface,
-      remote_node_name,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)));
-  }
 
   RCLCPP_PUBLIC
   SyncParametersClient(

--- a/rclcpp/include/rclcpp/parameter_service.hpp
+++ b/rclcpp/include/rclcpp/parameter_service.hpp
@@ -40,20 +40,6 @@ class ParameterService
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(ParameterService)
 
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  RCLCPP_PUBLIC
-  ParameterService(
-    const std::shared_ptr<node_interfaces::NodeBaseInterface> node_base,
-    const std::shared_ptr<node_interfaces::NodeServicesInterface> node_services,
-    rclcpp::node_interfaces::NodeParametersInterface * node_params,
-    const rmw_qos_profile_t & qos_profile)
-  : ParameterService(
-      node_base,
-      node_services,
-      node_params,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(qos_profile)))
-  {}
-
   RCLCPP_PUBLIC
   ParameterService(
     const std::shared_ptr<node_interfaces::NodeBaseInterface> node_base,

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -96,22 +96,6 @@ public:
   using ROSMessageTypeAllocator = typename ROSMessageTypeAllocatorTraits::allocator_type;
   using ROSMessageTypeDeleter = allocator::Deleter<ROSMessageTypeAllocator, ROSMessageType>;
 
-  using MessageAllocatorTraits
-  [[deprecated("use PublishedTypeAllocatorTraits")]] =
-    PublishedTypeAllocatorTraits;
-  using MessageAllocator
-  [[deprecated("use PublishedTypeAllocator")]] =
-    PublishedTypeAllocator;
-  using MessageDeleter
-  [[deprecated("use PublishedTypeDeleter")]] =
-    PublishedTypeDeleter;
-  using MessageUniquePtr
-  [[deprecated("use std::unique_ptr<PublishedType, PublishedTypeDeleter>")]] =
-    std::unique_ptr<PublishedType, PublishedTypeDeleter>;
-  using MessageSharedPtr
-  [[deprecated("use std::shared_ptr<const PublishedType>")]] =
-    std::shared_ptr<const PublishedType>;
-
   using BufferSharedPtr = typename rclcpp::experimental::buffers::IntraProcessBuffer<
     ROSMessageType,
     ROSMessageTypeAllocator,
@@ -421,13 +405,6 @@ public:
       // and thus the destructor of rclcpp::LoanedMessage cleans up the memory.
       this->publish(loaned_msg.get());
     }
-  }
-
-  [[deprecated("use get_published_type_allocator() or get_ros_message_type_allocator() instead")]]
-  std::shared_ptr<PublishedTypeAllocator>
-  get_allocator() const
-  {
-    return std::make_shared<PublishedTypeAllocator>(published_type_allocator_);
   }
 
   PublishedTypeAllocator

--- a/rclcpp/include/rclcpp/rate.hpp
+++ b/rclcpp/include/rclcpp/rate.hpp
@@ -39,10 +39,6 @@ public:
   RCLCPP_PUBLIC
   virtual bool sleep() = 0;
 
-  [[deprecated("use get_type() instead")]]
-  RCLCPP_PUBLIC
-  virtual bool is_steady() const = 0;
-
   RCLCPP_PUBLIC
   virtual rcl_clock_type_t get_type() const = 0;
 
@@ -53,82 +49,6 @@ public:
 using std::chrono::duration;
 using std::chrono::duration_cast;
 using std::chrono::nanoseconds;
-
-template<class Clock = std::chrono::high_resolution_clock>
-class [[deprecated("use rclcpp::Rate class instead of GenericRate")]] GenericRate : public RateBase
-{
-public:
-  RCLCPP_SMART_PTR_DEFINITIONS(GenericRate)
-
-  explicit GenericRate(double rate)
-  : period_(duration_cast<nanoseconds>(duration<double>(1.0 / rate))), last_interval_(Clock::now())
-  {}
-  explicit GenericRate(std::chrono::nanoseconds period)
-  : period_(period), last_interval_(Clock::now())
-  {}
-
-  virtual bool
-  sleep()
-  {
-    // Time coming into sleep
-    auto now = Clock::now();
-    // Time of next interval
-    auto next_interval = last_interval_ + period_;
-    // Detect backwards time flow
-    if (now < last_interval_) {
-      // Best thing to do is to set the next_interval to now + period
-      next_interval = now + period_;
-    }
-    // Calculate the time to sleep
-    auto time_to_sleep = next_interval - now;
-    // Update the interval
-    last_interval_ += period_;
-    // If the time_to_sleep is negative or zero, don't sleep
-    if (time_to_sleep <= std::chrono::seconds(0)) {
-      // If an entire cycle was missed then reset next interval.
-      // This might happen if the loop took more than a cycle.
-      // Or if time jumps forward.
-      if (now > next_interval + period_) {
-        last_interval_ = now + period_;
-      }
-      // Either way do not sleep and return false
-      return false;
-    }
-    // Sleep (will get interrupted by ctrl-c, may not sleep full time)
-    rclcpp::sleep_for(time_to_sleep);
-    return true;
-  }
-
-  [[deprecated("use get_type() instead")]]
-  virtual bool
-  is_steady() const
-  {
-    return Clock::is_steady;
-  }
-
-  virtual rcl_clock_type_t get_type() const
-  {
-    return Clock::is_steady ? RCL_STEADY_TIME : RCL_SYSTEM_TIME;
-  }
-
-  virtual void
-  reset()
-  {
-    last_interval_ = Clock::now();
-  }
-
-  std::chrono::nanoseconds period() const
-  {
-    return period_;
-  }
-
-private:
-  RCLCPP_DISABLE_COPY(GenericRate)
-
-  std::chrono::nanoseconds period_;
-  using ClockDurationNano = std::chrono::duration<typename Clock::rep, std::nano>;
-  std::chrono::time_point<Clock, ClockDurationNano> last_interval_;
-};
 
 class Rate : public RateBase
 {
@@ -148,11 +68,6 @@ public:
   RCLCPP_PUBLIC
   virtual bool
   sleep();
-
-  [[deprecated("use get_type() instead")]]
-  RCLCPP_PUBLIC
-  virtual bool
-  is_steady() const;
 
   RCLCPP_PUBLIC
   virtual rcl_clock_type_t

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -90,18 +90,6 @@ public:
   using ROSMessageTypeAllocator = typename ROSMessageTypeAllocatorTraits::allocator_type;
   using ROSMessageTypeDeleter = allocator::Deleter<ROSMessageTypeAllocator, ROSMessageType>;
 
-  using MessageAllocatorTraits [[deprecated("use ROSMessageTypeAllocatorTraits")]] =
-    ROSMessageTypeAllocatorTraits;
-  using MessageAllocator [[deprecated("use ROSMessageTypeAllocator")]] =
-    ROSMessageTypeAllocator;
-  using MessageDeleter [[deprecated("use ROSMessageTypeDeleter")]] =
-    ROSMessageTypeDeleter;
-
-  using ConstMessageSharedPtr [[deprecated]] = std::shared_ptr<const ROSMessageType>;
-  using MessageUniquePtr
-  [[deprecated("use std::unique_ptr<ROSMessageType, ROSMessageTypeDeleter> instead")]] =
-    std::unique_ptr<ROSMessageType, ROSMessageTypeDeleter>;
-
 private:
   using SubscriptionTopicStatisticsSharedPtr =
     std::shared_ptr<rclcpp::topic_statistics::SubscriptionTopicStatistics>;

--- a/rclcpp/include/rclcpp/typesupport_helpers.hpp
+++ b/rclcpp/include/rclcpp/typesupport_helpers.hpp
@@ -38,25 +38,6 @@ RCLCPP_PUBLIC
 std::shared_ptr<rcpputils::SharedLibrary>
 get_typesupport_library(const std::string & type, const std::string & typesupport_identifier);
 
-/// Extract the type support handle from the library.
-/**
- * The library needs to match the topic type. The shared library must stay loaded for the lifetime of the result.
- *
- * \deprecated Use get_message_typesupport_handle() instead
- *
- * \param[in] type The topic type, e.g. "std_msgs/msg/String"
- * \param[in] typesupport_identifier Type support identifier, typically "rosidl_typesupport_cpp"
- * \param[in] library The shared type support library
- * \return A type support handle
- */
-[[deprecated("Use `get_message_typesupport_handle` instead")]]
-RCLCPP_PUBLIC
-const rosidl_message_type_support_t *
-get_typesupport_handle(
-  const std::string & type,
-  const std::string & typesupport_identifier,
-  rcpputils::SharedLibrary & library);
-
 /// Extract the message type support handle from the library.
 /**
  * The library needs to match the topic type. The shared library must stay loaded for the lifetime of the result.

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -101,23 +101,6 @@ public:
   size_t
   get_number_of_ready_guard_conditions();
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Woverloaded-virtual"
-#endif
-  /// Deprecated.
-  /**
-   * \sa add_to_wait_set(rcl_wait_set_t &)
-   */
-  [[deprecated("Use add_to_wait_set(rcl_wait_set_t & wait_set) signature")]]
-  RCLCPP_PUBLIC
-  virtual
-  void
-  add_to_wait_set(rcl_wait_set_t * wait_set);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
-
   /// Add the Waitable to a wait set.
   /**
    * \param[in] wait_set A handle to the wait set to add the Waitable to.
@@ -127,23 +110,6 @@ public:
   virtual
   void
   add_to_wait_set(rcl_wait_set_t & wait_set);
-
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Woverloaded-virtual"
-#endif
-  /// Deprecated.
-  /**
-   * \sa is_ready(const rcl_wait_set_t &)
-   */
-  [[deprecated("Use is_ready(const rcl_wait_set_t & wait_set) signature")]]
-  RCLCPP_PUBLIC
-  virtual
-  bool
-  is_ready(rcl_wait_set_t * wait_set);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
 
   /// Check if the Waitable is ready.
   /**
@@ -211,23 +177,6 @@ public:
   virtual
   std::shared_ptr<void>
   take_data_by_entity_id(size_t id);
-
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Woverloaded-virtual"
-#endif
-  /// Deprecated.
-  /**
-   * \sa execute(const std::shared_ptr<void> &)
-   */
-  [[deprecated("Use execute(const std::shared_ptr<void> & data) signature")]]
-  RCLCPP_PUBLIC
-  virtual
-  void
-  execute(std::shared_ptr<void> & data);
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
 
   /// Execute data that is passed in.
   /**

--- a/rclcpp/src/rclcpp/rate.cpp
+++ b/rclcpp/src/rclcpp/rate.cpp
@@ -71,12 +71,6 @@ Rate::sleep()
   return true;
 }
 
-bool
-Rate::is_steady() const
-{
-  return clock_->get_clock_type() == RCL_STEADY_TIME;
-}
-
 rcl_clock_type_t
 Rate::get_type() const
 {

--- a/rclcpp/src/rclcpp/waitable.cpp
+++ b/rclcpp/src/rclcpp/waitable.cpp
@@ -96,38 +96,12 @@ Waitable::is_ready(const rcl_wait_set_t & wait_set)
 void
 Waitable::add_to_wait_set(rcl_wait_set_t & wait_set)
 {
-#if !defined(_WIN32)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#else  // !defined(_WIN32)
-# pragma warning(push)
-# pragma warning(disable: 4996)
-#endif
   this->add_to_wait_set(wait_set);
-// remove warning suppression
-#if !defined(_WIN32)
-# pragma GCC diagnostic pop
-#else  // !defined(_WIN32)
-# pragma warning(pop)
-#endif
 }
 
 void
 Waitable::execute(const std::shared_ptr<void> & data)
 {
-#if !defined(_WIN32)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#else  // !defined(_WIN32)
-# pragma warning(push)
-# pragma warning(disable: 4996)
-#endif
   // note this const cast is only required to support a deprecated function
   this->execute(const_cast<std::shared_ptr<void> &>(data));
-// remove warning suppression
-#if !defined(_WIN32)
-# pragma GCC diagnostic pop
-#else  // !defined(_WIN32)
-# pragma warning(pop)
-#endif
 }

--- a/rclcpp/src/rclcpp/waitable.cpp
+++ b/rclcpp/src/rclcpp/waitable.cpp
@@ -87,10 +87,10 @@ Waitable::clear_on_ready_callback()
           "want to use it and make sure to call it on the waitable destructor.");
 }
 
-void
-Waitable::add_to_wait_set(rcl_wait_set_t * wait_set)
+bool
+Waitable::is_ready(const rcl_wait_set_t & wait_set)
 {
-  this->add_to_wait_set(*wait_set);
+  return this->is_ready(wait_set);
 }
 
 void
@@ -103,47 +103,13 @@ Waitable::add_to_wait_set(rcl_wait_set_t & wait_set)
 # pragma warning(push)
 # pragma warning(disable: 4996)
 #endif
-  this->add_to_wait_set(&wait_set);
+  this->add_to_wait_set(wait_set);
 // remove warning suppression
 #if !defined(_WIN32)
 # pragma GCC diagnostic pop
 #else  // !defined(_WIN32)
 # pragma warning(pop)
 #endif
-}
-
-bool
-Waitable::is_ready(rcl_wait_set_t * wait_set)
-{
-  const rcl_wait_set_t & const_wait_set_ref = *wait_set;
-  return this->is_ready(const_wait_set_ref);
-}
-
-bool
-Waitable::is_ready(const rcl_wait_set_t & wait_set)
-{
-#if !defined(_WIN32)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#else  // !defined(_WIN32)
-# pragma warning(push)
-# pragma warning(disable: 4996)
-#endif
-  // note this const cast is only required to support a deprecated function
-  return this->is_ready(&const_cast<rcl_wait_set_t &>(wait_set));
-// remove warning suppression
-#if !defined(_WIN32)
-# pragma GCC diagnostic pop
-#else  // !defined(_WIN32)
-# pragma warning(pop)
-#endif
-}
-
-void
-Waitable::execute(std::shared_ptr<void> & data)
-{
-  const std::shared_ptr<void> & const_data = data;
-  this->execute(const_data);
 }
 
 void

--- a/rclcpp/test/rclcpp/test_client.cpp
+++ b/rclcpp/test/rclcpp/test_client.cpp
@@ -90,30 +90,9 @@ TEST_F(TestClient, construction_and_destruction) {
     auto client = node->create_client<ListParameters>("service");
   }
   {
-    // suppress deprecated function warning
-    #if !defined(_WIN32)
-    # pragma GCC diagnostic push
-    # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    #else  // !defined(_WIN32)
-    # pragma warning(push)
-    # pragma warning(disable: 4996)
-    #endif
-
-    auto client = node->create_client<ListParameters>(
-      "service", rmw_qos_profile_services_default);
-
-    // remove warning suppression
-    #if !defined(_WIN32)
-    # pragma GCC diagnostic pop
-    #else  // !defined(_WIN32)
-    # pragma warning(pop)
-    #endif
-  }
-  {
     auto client = node->create_client<ListParameters>(
       "service", rclcpp::ServicesQoS());
   }
-
   {
     ASSERT_THROW(
     {
@@ -123,27 +102,6 @@ TEST_F(TestClient, construction_and_destruction) {
 }
 
 TEST_F(TestClient, construction_with_free_function) {
-  {
-    auto client = rclcpp::create_client<rcl_interfaces::srv::ListParameters>(
-      node->get_node_base_interface(),
-      node->get_node_graph_interface(),
-      node->get_node_services_interface(),
-      "service",
-      rmw_qos_profile_services_default,
-      nullptr);
-  }
-  {
-    ASSERT_THROW(
-    {
-      auto client = rclcpp::create_client<rcl_interfaces::srv::ListParameters>(
-        node->get_node_base_interface(),
-        node->get_node_graph_interface(),
-        node->get_node_services_interface(),
-        "invalid_?service",
-        rmw_qos_profile_services_default,
-        nullptr);
-    }, rclcpp::exceptions::InvalidServiceNameError);
-  }
   {
     auto client = rclcpp::create_client<rcl_interfaces::srv::ListParameters>(
       node->get_node_base_interface(),

--- a/rclcpp/test/rclcpp/test_loaned_message.cpp
+++ b/rclcpp/test/rclcpp/test_loaned_message.cpp
@@ -40,53 +40,6 @@ protected:
   }
 };
 
-TEST_F(TestLoanedMessage, initialize) {
-  auto node = std::make_shared<rclcpp::Node>("loaned_message_test_node");
-  auto pub = node->create_publisher<MessageT>("loaned_message_test_topic", 1);
-
-// suppress deprecated function warning
-#if !defined(_WIN32)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#else  // !defined(_WIN32)
-# pragma warning(push)
-# pragma warning(disable: 4996)
-#endif
-
-  auto pub_allocator = pub->get_allocator();
-
-// remove warning suppression
-#if !defined(_WIN32)
-# pragma GCC diagnostic pop
-#else  // !defined(_WIN32)
-# pragma warning(pop)
-#endif
-
-// suppress deprecated function warning
-#if !defined(_WIN32)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#else  // !defined(_WIN32)
-# pragma warning(push)
-# pragma warning(disable: 4996)
-#endif
-
-  auto loaned_msg = rclcpp::LoanedMessage<MessageT>(pub.get(), pub_allocator);
-
-// remove warning suppression
-#if !defined(_WIN32)
-# pragma GCC diagnostic pop
-#else  // !defined(_WIN32)
-# pragma warning(pop)
-#endif
-
-  ASSERT_TRUE(loaned_msg.is_valid());
-  loaned_msg.get().float32_value = 42.0f;
-  ASSERT_EQ(42.0f, loaned_msg.get().float32_value);
-
-  SUCCEED();
-}
-
 TEST_F(TestLoanedMessage, loan_from_pub) {
   auto node = std::make_shared<rclcpp::Node>("loaned_message_test_node");
   auto pub = node->create_publisher<MessageT>("loaned_message_test_topic", 1);

--- a/rclcpp/test/rclcpp/test_rate.cpp
+++ b/rclcpp/test/rclcpp/test_rate.cpp
@@ -47,21 +47,6 @@ TEST_F(TestRate, rate_basics) {
   auto start = std::chrono::system_clock::now();
   rclcpp::Rate r(period);
   EXPECT_EQ(rclcpp::Duration(period), r.period());
-// suppress deprecated warnings
-#if !defined(_WIN32)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#else  // !defined(_WIN32)
-# pragma warning(push)
-# pragma warning(disable: 4996)
-#endif
-  ASSERT_FALSE(r.is_steady());
-// remove warning suppression
-#if !defined(_WIN32)
-# pragma GCC diagnostic pop
-#else  // !defined(_WIN32)
-# pragma warning(pop)
-#endif
   ASSERT_EQ(RCL_SYSTEM_TIME, r.get_type());
   ASSERT_TRUE(r.sleep());
   auto one = std::chrono::system_clock::now();
@@ -102,23 +87,6 @@ TEST_F(TestRate, wall_rate_basics) {
   auto start = std::chrono::steady_clock::now();
   rclcpp::WallRate r(period);
   EXPECT_EQ(rclcpp::Duration(period), r.period());
-// suppress deprecated warnings
-#if !defined(_WIN32)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#else  // !defined(_WIN32)
-# pragma warning(push)
-# pragma warning(disable: 4996)
-#endif
-  ASSERT_TRUE(r.is_steady());
-// suppress deprecated warnings
-#if !defined(_WIN32)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#else  // !defined(_WIN32)
-# pragma warning(push)
-# pragma warning(disable: 4996)
-#endif
   ASSERT_EQ(RCL_STEADY_TIME, r.get_type());
   ASSERT_TRUE(r.sleep());
   auto one = std::chrono::steady_clock::now();
@@ -150,124 +118,6 @@ TEST_F(TestRate, wall_rate_basics) {
   EXPECT_GT(epsilon, delta);
 }
 
-/*
-   Basic test for the deprecated GenericRate class.
- */
-TEST_F(TestRate, generic_rate) {
-  auto period = std::chrono::milliseconds(100);
-  auto offset = std::chrono::milliseconds(50);
-  auto epsilon = std::chrono::milliseconds(1);
-  double overrun_ratio = 1.5;
-
-  {
-    auto start = std::chrono::system_clock::now();
-
-// suppress deprecated warnings
-#if !defined(_WIN32)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#else  // !defined(_WIN32)
-# pragma warning(push)
-# pragma warning(disable: 4996)
-#endif
-
-    rclcpp::GenericRate<std::chrono::system_clock> gr(period);
-    ASSERT_FALSE(gr.is_steady());
-
-// remove warning suppression
-#if !defined(_WIN32)
-# pragma GCC diagnostic pop
-#else  // !defined(_WIN32)
-# pragma warning(pop)
-#endif
-
-    ASSERT_EQ(gr.get_type(), RCL_SYSTEM_TIME);
-    EXPECT_EQ(period, gr.period());
-    ASSERT_TRUE(gr.sleep());
-    auto one = std::chrono::system_clock::now();
-    auto delta = one - start;
-    EXPECT_LT(period, delta + epsilon);
-    EXPECT_GT(period * overrun_ratio, delta);
-
-    rclcpp::sleep_for(offset);
-    ASSERT_TRUE(gr.sleep());
-    auto two = std::chrono::system_clock::now();
-    delta = two - start;
-    EXPECT_LT(2 * period, delta);
-    EXPECT_GT(2 * period * overrun_ratio, delta);
-
-    rclcpp::sleep_for(offset);
-    auto two_offset = std::chrono::system_clock::now();
-    gr.reset();
-    ASSERT_TRUE(gr.sleep());
-    auto three = std::chrono::system_clock::now();
-    delta = three - two_offset;
-    EXPECT_LT(period, delta + epsilon);
-    EXPECT_GT(period * overrun_ratio, delta);
-
-    rclcpp::sleep_for(offset + period);
-    auto four = std::chrono::system_clock::now();
-    ASSERT_FALSE(gr.sleep());
-    auto five = std::chrono::system_clock::now();
-    delta = five - four;
-    ASSERT_TRUE(epsilon > delta);
-  }
-
-  {
-    auto start = std::chrono::steady_clock::now();
-
-// suppress deprecated warnings
-#if !defined(_WIN32)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#else  // !defined(_WIN32)
-# pragma warning(push)
-# pragma warning(disable: 4996)
-#endif
-
-    rclcpp::GenericRate<std::chrono::steady_clock> gr(period);
-    ASSERT_TRUE(gr.is_steady());
-
-// remove warning suppression
-#if !defined(_WIN32)
-# pragma GCC diagnostic pop
-#else  // !defined(_WIN32)
-# pragma warning(pop)
-#endif
-
-    ASSERT_EQ(gr.get_type(), RCL_STEADY_TIME);
-    EXPECT_EQ(period, gr.period());
-    ASSERT_TRUE(gr.sleep());
-    auto one = std::chrono::steady_clock::now();
-    auto delta = one - start;
-    EXPECT_LT(period, delta);
-    EXPECT_GT(period * overrun_ratio, delta);
-
-    rclcpp::sleep_for(offset);
-    ASSERT_TRUE(gr.sleep());
-    auto two = std::chrono::steady_clock::now();
-    delta = two - start;
-    EXPECT_LT(2 * period, delta + epsilon);
-    EXPECT_GT(2 * period * overrun_ratio, delta);
-
-    rclcpp::sleep_for(offset);
-    auto two_offset = std::chrono::steady_clock::now();
-    gr.reset();
-    ASSERT_TRUE(gr.sleep());
-    auto three = std::chrono::steady_clock::now();
-    delta = three - two_offset;
-    EXPECT_LT(period, delta);
-    EXPECT_GT(period * overrun_ratio, delta);
-
-    rclcpp::sleep_for(offset + period);
-    auto four = std::chrono::steady_clock::now();
-    ASSERT_FALSE(gr.sleep());
-    auto five = std::chrono::steady_clock::now();
-    delta = five - four;
-    EXPECT_GT(epsilon, delta);
-  }
-}
-
 TEST_F(TestRate, from_double) {
   {
     rclcpp::Rate rate(1.0);
@@ -290,59 +140,14 @@ TEST_F(TestRate, from_double) {
 TEST_F(TestRate, clock_types) {
   {
     rclcpp::Rate rate(1.0, std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME));
-// suppress deprecated warnings
-#if !defined(_WIN32)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#else  // !defined(_WIN32)
-# pragma warning(push)
-# pragma warning(disable: 4996)
-#endif
-    EXPECT_FALSE(rate.is_steady());
-// remove warning suppression
-#if !defined(_WIN32)
-# pragma GCC diagnostic pop
-#else  // !defined(_WIN32)
-# pragma warning(pop)
-#endif
     EXPECT_EQ(RCL_SYSTEM_TIME, rate.get_type());
   }
   {
     rclcpp::Rate rate(1.0, std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME));
-// suppress deprecated warnings
-#if !defined(_WIN32)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#else  // !defined(_WIN32)
-# pragma warning(push)
-# pragma warning(disable: 4996)
-#endif
-    EXPECT_TRUE(rate.is_steady());
-// remove warning suppression
-#if !defined(_WIN32)
-# pragma GCC diagnostic pop
-#else  // !defined(_WIN32)
-# pragma warning(pop)
-#endif
     EXPECT_EQ(RCL_STEADY_TIME, rate.get_type());
   }
   {
     rclcpp::Rate rate(1.0, std::make_shared<rclcpp::Clock>(RCL_ROS_TIME));
-// suppress deprecated warnings
-#if !defined(_WIN32)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#else  // !defined(_WIN32)
-# pragma warning(push)
-# pragma warning(disable: 4996)
-#endif
-    EXPECT_FALSE(rate.is_steady());
-// remove warning suppression
-#if !defined(_WIN32)
-# pragma GCC diagnostic pop
-#else  // !defined(_WIN32)
-# pragma warning(pop)
-#endif
     EXPECT_EQ(RCL_ROS_TIME, rate.get_type());
   }
 }

--- a/rclcpp_components/include/rclcpp_components/component_manager.hpp
+++ b/rclcpp_components/include/rclcpp_components/component_manager.hpp
@@ -185,20 +185,6 @@ protected:
     const std::shared_ptr<LoadNode::Request> request,
     std::shared_ptr<LoadNode::Response> response);
 
-  /**
-   * \deprecated Use on_load_node() instead
-   */
-  [[deprecated("Use on_load_node() instead")]]
-  RCLCPP_COMPONENTS_PUBLIC
-  virtual void
-  OnLoadNode(
-    const std::shared_ptr<rmw_request_id_t> request_header,
-    const std::shared_ptr<LoadNode::Request> request,
-    std::shared_ptr<LoadNode::Response> response)
-  {
-    on_load_node(request_header, request, response);
-  }
-
   /// Service callback to unload a node in the component
   /**
    * \param request_header unused
@@ -212,20 +198,6 @@ protected:
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<UnloadNode::Request> request,
     std::shared_ptr<UnloadNode::Response> response);
-
-  /**
-   * \deprecated Use on_unload_node() instead
-   */
-  [[deprecated("Use on_unload_node() instead")]]
-  RCLCPP_COMPONENTS_PUBLIC
-  virtual void
-  OnUnloadNode(
-    const std::shared_ptr<rmw_request_id_t> request_header,
-    const std::shared_ptr<UnloadNode::Request> request,
-    std::shared_ptr<UnloadNode::Response> response)
-  {
-    on_unload_node(request_header, request, response);
-  }
 
   /// Service callback to get the list of nodes in the component
   /**
@@ -241,20 +213,6 @@ protected:
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<ListNodes::Request> request,
     std::shared_ptr<ListNodes::Response> response);
-
-  /**
-   * \deprecated Use on_list_nodes() instead
-   */
-  [[deprecated("Use on_list_nodes() instead")]]
-  RCLCPP_COMPONENTS_PUBLIC
-  virtual void
-  OnListNodes(
-    const std::shared_ptr<rmw_request_id_t> request_header,
-    const std::shared_ptr<ListNodes::Request> request,
-    std::shared_ptr<ListNodes::Response> response)
-  {
-    on_list_nodes(request_header, request, response);
-  }
 
 protected:
   std::weak_ptr<rclcpp::Executor> executor_;

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -282,19 +282,6 @@ public:
 
   /// Create and return a Client.
   /**
-   * \sa rclcpp::Node::create_client
-   * \deprecated use rclcpp::QoS instead of rmw_qos_profile_t
-   */
-  template<typename ServiceT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  typename rclcpp::Client<ServiceT>::SharedPtr
-  create_client(
-    const std::string & service_name,
-    const rmw_qos_profile_t & qos_profile,
-    rclcpp::CallbackGroup::SharedPtr group = nullptr);
-
-  /// Create and return a Client.
-  /**
    * \param[in] service_name The name on which the service is accessible.
    * \param[in] qos Quality of service profile for client.
    * \param[in] group Callback group to handle the reply to service calls.
@@ -305,20 +292,6 @@ public:
   create_client(
     const std::string & service_name,
     const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
-    rclcpp::CallbackGroup::SharedPtr group = nullptr);
-
-  /// Create and return a Service.
-  /**
-   * \sa rclcpp::Node::create_service
-   * \deprecated use rclcpp::QoS instead of rmw_qos_profile_t
-   */
-  template<typename ServiceT, typename CallbackT>
-  [[deprecated("use rclcpp::QoS instead of rmw_qos_profile_t")]]
-  typename rclcpp::Service<ServiceT>::SharedPtr
-  create_service(
-    const std::string & service_name,
-    CallbackT && callback,
-    const rmw_qos_profile_t & qos_profile,
     rclcpp::CallbackGroup::SharedPtr group = nullptr);
 
   /// Create and return a Service.
@@ -572,8 +545,6 @@ public:
     rclcpp::node_interfaces::OnSetParametersCallbackHandle;
   using OnSetParametersCallbackType =
     rclcpp::node_interfaces::NodeParametersInterface::OnSetParametersCallbackType;
-  using OnParametersSetCallbackType [[deprecated("use OnSetParametersCallbackType instead")]] =
-    OnSetParametersCallbackType;
 
   using PostSetParametersCallbackHandle =
     rclcpp::node_interfaces::PostSetParametersCallbackHandle;

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node_impl.hpp
@@ -124,37 +124,12 @@ template<typename ServiceT>
 typename rclcpp::Client<ServiceT>::SharedPtr
 LifecycleNode::create_client(
   const std::string & service_name,
-  const rmw_qos_profile_t & qos_profile,
-  rclcpp::CallbackGroup::SharedPtr group)
-{
-  return rclcpp::create_client<ServiceT>(
-    node_base_, node_graph_, node_services_,
-    service_name, qos_profile, group);
-}
-
-template<typename ServiceT>
-typename rclcpp::Client<ServiceT>::SharedPtr
-LifecycleNode::create_client(
-  const std::string & service_name,
   const rclcpp::QoS & qos,
   rclcpp::CallbackGroup::SharedPtr group)
 {
   return rclcpp::create_client<ServiceT>(
     node_base_, node_graph_, node_services_,
     service_name, qos, group);
-}
-
-template<typename ServiceT, typename CallbackT>
-typename rclcpp::Service<ServiceT>::SharedPtr
-LifecycleNode::create_service(
-  const std::string & service_name,
-  CallbackT && callback,
-  const rmw_qos_profile_t & qos_profile,
-  rclcpp::CallbackGroup::SharedPtr group)
-{
-  return rclcpp::create_service<ServiceT, CallbackT>(
-    node_base_, node_services_,
-    service_name, std::forward<CallbackT>(callback), qos_profile, group);
 }
 
 template<typename ServiceT, typename CallbackT>

--- a/rclcpp_lifecycle/test/test_client.cpp
+++ b/rclcpp_lifecycle/test/test_client.cpp
@@ -62,27 +62,6 @@ TEST_F(TestClient, construction_and_destruction) {
     EXPECT_TRUE(client);
   }
   {
-    // suppress deprecated function warning
-    #if !defined(_WIN32)
-    # pragma GCC diagnostic push
-    # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    #else  // !defined(_WIN32)
-    # pragma warning(push)
-    # pragma warning(disable: 4996)
-    #endif
-
-    auto client = node_->create_client<ListParameters>(
-      "service", rmw_qos_profile_services_default);
-    EXPECT_TRUE(client);
-
-    // remove warning suppression
-    #if !defined(_WIN32)
-    # pragma GCC diagnostic pop
-    #else  // !defined(_WIN32)
-    # pragma warning(pop)
-    #endif
-  }
-  {
     auto client = node_->create_client<ListParameters>(
       "service", rclcpp::ServicesQoS());
     EXPECT_TRUE(client);
@@ -97,28 +76,6 @@ TEST_F(TestClient, construction_and_destruction) {
 }
 
 TEST_F(TestClient, construction_with_free_function) {
-  {
-    auto client = rclcpp::create_client<rcl_interfaces::srv::ListParameters>(
-      node_->get_node_base_interface(),
-      node_->get_node_graph_interface(),
-      node_->get_node_services_interface(),
-      "service",
-      rmw_qos_profile_services_default,
-      nullptr);
-    EXPECT_TRUE(client);
-  }
-  {
-    ASSERT_THROW(
-    {
-      auto client = rclcpp::create_client<rcl_interfaces::srv::ListParameters>(
-        node_->get_node_base_interface(),
-        node_->get_node_graph_interface(),
-        node_->get_node_services_interface(),
-        "invalid_?service",
-        rmw_qos_profile_services_default,
-        nullptr);
-    }, rclcpp::exceptions::InvalidServiceNameError);
-  }
   {
     auto client = rclcpp::create_client<rcl_interfaces::srv::ListParameters>(
       node_->get_node_base_interface(),

--- a/rclcpp_lifecycle/test/test_service.cpp
+++ b/rclcpp_lifecycle/test/test_service.cpp
@@ -69,31 +69,6 @@ TEST_F(TestService, construction_and_destruction) {
     EXPECT_NE(nullptr, const_service_base->get_service_handle());
   }
   {
-    // suppress deprecated function warning
-    #if !defined(_WIN32)
-    # pragma GCC diagnostic push
-    # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    #else  // !defined(_WIN32)
-    # pragma warning(push)
-    # pragma warning(disable: 4996)
-    #endif
-
-    auto service = node->create_service<Empty>(
-      "service", callback, rmw_qos_profile_services_default);
-
-    // remove warning suppression
-    #if !defined(_WIN32)
-    # pragma GCC diagnostic pop
-    #else  // !defined(_WIN32)
-    # pragma warning(pop)
-    #endif
-
-    EXPECT_NE(nullptr, service->get_service_handle());
-    const rclcpp::ServiceBase * const_service_base = service.get();
-    EXPECT_NE(nullptr, const_service_base->get_service_handle());
-  }
-
-  {
     ASSERT_THROW(
     {
       auto service = node->create_service<Empty>("invalid_service?", callback);


### PR DESCRIPTION
Most of the deprecated happened since `iron`.

Since Jazzy:

 - rate
 - typesupport_helpers
 - waitable