### PR TITLE
Make the subscriber_triggered_to_receive_message test more reliable.

### DIFF
--- a/rclcpp/test/rclcpp/test_add_callback_groups_to_executor.cpp
+++ b/rclcpp/test/rclcpp/test_add_callback_groups_to_executor.cpp
@@ -355,6 +355,10 @@ TYPED_TEST(TestAddCallbackGroupsToExecutorStable, subscriber_triggered_to_receiv
     node->create_publisher<test_msgs::msg::Empty>("topic_name", qos);
   auto timer_callback =
     [&publisher, &timer_promise]() {
+      if (publisher->get_subscription_count() == 0) {
+        // If discovery hasn't happened yet, get out.
+        return;
+      }
       publisher->publish(test_msgs::msg::Empty());
       timer_promise.set_value();
     };


### PR DESCRIPTION
In the current code, inside of the timer we create the subscription and the publisher, publish immediately, and expect the subscription to get it immediately.  But it may be the case that discovery hasn't even happened between the publisher and the subscription by the time the publish call happens.

To make this more reliable, create the subscription and publish *before* we ever create and spin on the timer.  This at least gives 100 milliseconds for discovery to happen.  That may not be quite enough to make this reliable on all platforms, but in my local testing this helps a lot.  Prior to this change I can make this fail one out of 10 times, and after the change I've run 100 times with no failures.

FYI @iuhilnehc-ynos .

@wjwwood If you have time to look at this, I'd appreciate a review.

@Crola1702 FYI, this should fix the flaky test https://ci.ros2.org/view/nightly/job/nightly_linux_repeated/3515/testReport/junit/rclcpp/TestAddCallbackGroupsToExecutorStable_MultiThreadedExecutor/subscriber_triggered_to_receive_message/