### PR TITLE
remove deprecated APIs from component_manager.hpp

### DIFF
--- a/rclcpp_components/include/rclcpp_components/component_manager.hpp
+++ b/rclcpp_components/include/rclcpp_components/component_manager.hpp
@@ -185,20 +185,6 @@ protected:
     const std::shared_ptr<LoadNode::Request> request,
     std::shared_ptr<LoadNode::Response> response);
 
-  /**
-   * \deprecated Use on_load_node() instead
-   */
-  [[deprecated("Use on_load_node() instead")]]
-  RCLCPP_COMPONENTS_PUBLIC
-  virtual void
-  OnLoadNode(
-    const std::shared_ptr<rmw_request_id_t> request_header,
-    const std::shared_ptr<LoadNode::Request> request,
-    std::shared_ptr<LoadNode::Response> response)
-  {
-    on_load_node(request_header, request, response);
-  }
-
   /// Service callback to unload a node in the component
   /**
    * \param request_header unused
@@ -212,20 +198,6 @@ protected:
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<UnloadNode::Request> request,
     std::shared_ptr<UnloadNode::Response> response);
-
-  /**
-   * \deprecated Use on_unload_node() instead
-   */
-  [[deprecated("Use on_unload_node() instead")]]
-  RCLCPP_COMPONENTS_PUBLIC
-  virtual void
-  OnUnloadNode(
-    const std::shared_ptr<rmw_request_id_t> request_header,
-    const std::shared_ptr<UnloadNode::Request> request,
-    std::shared_ptr<UnloadNode::Response> response)
-  {
-    on_unload_node(request_header, request, response);
-  }
 
   /// Service callback to get the list of nodes in the component
   /**
@@ -241,20 +213,6 @@ protected:
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<ListNodes::Request> request,
     std::shared_ptr<ListNodes::Response> response);
-
-  /**
-   * \deprecated Use on_list_nodes() instead
-   */
-  [[deprecated("Use on_list_nodes() instead")]]
-  RCLCPP_COMPONENTS_PUBLIC
-  virtual void
-  OnListNodes(
-    const std::shared_ptr<rmw_request_id_t> request_header,
-    const std::shared_ptr<ListNodes::Request> request,
-    std::shared_ptr<ListNodes::Response> response)
-  {
-    on_list_nodes(request_header, request, response);
-  }
 
 protected:
   std::weak_ptr<rclcpp::Executor> executor_;


### PR DESCRIPTION
These methods were marked as deprecated in 2021 (https://github.com/ros2/rclcpp/pull/1716), it's time to let them go.