### PR TITLE
Fix bug in timers lifecycle for events executor

### DIFF
--- a/rclcpp/src/rclcpp/experimental/executors/events_executor/events_executor.cpp
+++ b/rclcpp/src/rclcpp/experimental/executors/events_executor/events_executor.cpp
@@ -341,8 +341,9 @@ EventsExecutor::refresh_current_collection(
   // Acquire lock before modifying the current collection
   std::lock_guard<std::mutex> guard(mutex_);
 
-  // Remove expired timers before updating the timers collection
-  // to ensure any re-initialized timer objects are properly reflected.
+  // Remove expired entities to ensure re-initialized objects
+  // are updated. This fixes issues with stale state entities.
+  // See: https://github.com/ros2/rclcpp/pull/2586
   current_collection_.remove_expired_entities();
 
   current_collection_.timers.update(

--- a/rclcpp/src/rclcpp/experimental/executors/events_executor/events_executor.cpp
+++ b/rclcpp/src/rclcpp/experimental/executors/events_executor/events_executor.cpp
@@ -341,6 +341,10 @@ EventsExecutor::refresh_current_collection(
   // Acquire lock before modifying the current collection
   std::lock_guard<std::mutex> guard(mutex_);
 
+  // Remove expired timers before updating the timers collection
+  // to ensure any re-initialized timer objects are properly reflected.
+  current_collection_.remove_expired_entities();
+
   current_collection_.timers.update(
     new_collection.timers,
     [this](rclcpp::TimerBase::SharedPtr timer) {timers_manager_->add_timer(timer);},

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -451,7 +451,7 @@ if(TARGET test_interface_traits)
 endif()
 
 ament_add_gtest(test_reinitialized_timers
-  test_reinitialized_timers.cpp
+  executors/test_reinitialized_timers.cpp
   TIMEOUT 30)
 if(TARGET test_reinitialized_timers)
   target_link_libraries(test_reinitialized_timers ${PROJECT_NAME})

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -450,6 +450,13 @@ if(TARGET test_interface_traits)
   target_link_libraries(test_interface_traits ${PROJECT_NAME})
 endif()
 
+ament_add_gtest(test_reinitialized_timers
+  test_reinitialized_timers.cpp
+  TIMEOUT 30)
+if(TARGET test_reinitialized_timers)
+  target_link_libraries(test_reinitialized_timers ${PROJECT_NAME})
+endif()
+
 ament_add_gtest(
   test_executors
   executors/test_executors.cpp

--- a/rclcpp/test/rclcpp/executors/test_reinitialized_timers.cpp
+++ b/rclcpp/test/rclcpp/executors/test_reinitialized_timers.cpp
@@ -25,6 +25,7 @@
 #include "rclcpp/experimental/executors/events_executor/events_executor.hpp"
 #include "rclcpp/rclcpp.hpp"
 
+template <typename ExecutorType>
 class TestTimersLifecycle
 : public testing::Test
 {
@@ -40,13 +41,19 @@ public:
   }
 };
 
-TEST_F(TestTimersLifecycle, timers_lifecycle_reinitialized_object)
+using ExecutorTypes = ::testing::Types<
+  rclcpp::executors::SingleThreadedExecutor,
+  rclcpp::executors::MultiThreadedExecutor,
+  rclcpp::executors::StaticSingleThreadedExecutor,
+  rclcpp::experimental::executors::EventsExecutor>;
+
+TYPED_TEST_SUITE(TestTimersLifecycle, ExecutorTypes);
+
+TYPED_TEST(TestTimersLifecycle, timers_lifecycle_reinitialized_object)
 {
   auto timers_period = std::chrono::milliseconds(50);
   auto node = std::make_shared<rclcpp::Node>("test_node");
-  auto single_threaded_executor = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
-  auto multi_threaded_executor = std::make_unique<rclcpp::executors::MultiThreadedExecutor>();
-  auto executor = std::make_unique<rclcpp::experimental::executors::EventsExecutor>();
+  auto executor = std::make_unique<TypeParam>();
 
   executor->add_node(node);
 

--- a/rclcpp/test/rclcpp/executors/test_reinitialized_timers.cpp
+++ b/rclcpp/test/rclcpp/executors/test_reinitialized_timers.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <gtest/gtest.h>
+
 #include <chrono>
 #include <cstddef>
 #include <memory>
 #include <thread>
-
-#include <gtest/gtest.h>
 
 #include "rclcpp/executors/multi_threaded_executor.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
@@ -26,26 +26,17 @@
 #include "rclcpp/rclcpp.hpp"
 
 template <typename ExecutorType>
-class TestTimersLifecycle
-: public testing::Test
+class TestTimersLifecycle : public testing::Test
 {
 public:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    rclcpp::shutdown();
-  }
+  void TearDown() override { rclcpp::shutdown(); }
 };
 
 using ExecutorTypes = ::testing::Types<
-  rclcpp::executors::SingleThreadedExecutor,
-  rclcpp::executors::MultiThreadedExecutor,
-  rclcpp::executors::StaticSingleThreadedExecutor,
-  rclcpp::experimental::executors::EventsExecutor>;
+  rclcpp::executors::SingleThreadedExecutor, rclcpp::executors::MultiThreadedExecutor,
+  rclcpp::executors::StaticSingleThreadedExecutor, rclcpp::experimental::executors::EventsExecutor>;
 
 TYPED_TEST_SUITE(TestTimersLifecycle, ExecutorTypes);
 
@@ -59,26 +50,14 @@ TYPED_TEST(TestTimersLifecycle, timers_lifecycle_reinitialized_object)
 
   size_t count_1 = 0;
   auto timer_1 = rclcpp::create_timer(
-    node,
-    node->get_clock(),
-    rclcpp::Duration(timers_period),
-    [&count_1]() {
-      count_1++;
-    });
+    node, node->get_clock(), rclcpp::Duration(timers_period), [&count_1]() { count_1++; });
 
   size_t count_2 = 0;
   auto timer_2 = rclcpp::create_timer(
-    node,
-    node->get_clock(),
-    rclcpp::Duration(timers_period),
-    [&count_2]() {
-      count_2++;
-    });
+    node, node->get_clock(), rclcpp::Duration(timers_period), [&count_2]() { count_2++; });
 
   {
-    std::thread executor_thread([&executor](){
-      executor->spin();
-    });
+    std::thread executor_thread([&executor]() { executor->spin(); });
 
     while (count_2 < 10u) {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -92,26 +71,14 @@ TYPED_TEST(TestTimersLifecycle, timers_lifecycle_reinitialized_object)
 
   count_1 = 0;
   timer_1 = rclcpp::create_timer(
-    node,
-    node->get_clock(),
-    rclcpp::Duration(timers_period),
-    [&count_1]() {
-      count_1++;
-    });
+    node, node->get_clock(), rclcpp::Duration(timers_period), [&count_1]() { count_1++; });
 
   count_2 = 0;
   timer_2 = rclcpp::create_timer(
-    node,
-    node->get_clock(),
-    rclcpp::Duration(timers_period),
-    [&count_2]() {
-      count_2++;
-    });
+    node, node->get_clock(), rclcpp::Duration(timers_period), [&count_2]() { count_2++; });
 
   {
-    std::thread executor_thread([&executor](){
-      executor->spin();
-    });
+    std::thread executor_thread([&executor]() { executor->spin(); });
 
     while (count_2 < 10u) {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));

--- a/rclcpp/test/rclcpp/executors/test_reinitialized_timers.cpp
+++ b/rclcpp/test/rclcpp/executors/test_reinitialized_timers.cpp
@@ -25,13 +25,13 @@
 #include "rclcpp/experimental/executors/events_executor/events_executor.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-template <typename ExecutorType>
+template<typename ExecutorType>
 class TestTimersLifecycle : public testing::Test
 {
 public:
-  void SetUp() override { rclcpp::init(0, nullptr); }
+  void SetUp() override {rclcpp::init(0, nullptr);}
 
-  void TearDown() override { rclcpp::shutdown(); }
+  void TearDown() override {rclcpp::shutdown();}
 };
 
 using ExecutorTypes = ::testing::Types<
@@ -50,14 +50,14 @@ TYPED_TEST(TestTimersLifecycle, timers_lifecycle_reinitialized_object)
 
   size_t count_1 = 0;
   auto timer_1 = rclcpp::create_timer(
-    node, node->get_clock(), rclcpp::Duration(timers_period), [&count_1]() { count_1++; });
+    node, node->get_clock(), rclcpp::Duration(timers_period), [&count_1]() {count_1++;});
 
   size_t count_2 = 0;
   auto timer_2 = rclcpp::create_timer(
-    node, node->get_clock(), rclcpp::Duration(timers_period), [&count_2]() { count_2++; });
+    node, node->get_clock(), rclcpp::Duration(timers_period), [&count_2]() {count_2++;});
 
   {
-    std::thread executor_thread([&executor]() { executor->spin(); });
+    std::thread executor_thread([&executor]() {executor->spin();});
 
     while (count_2 < 10u) {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -71,14 +71,14 @@ TYPED_TEST(TestTimersLifecycle, timers_lifecycle_reinitialized_object)
 
   count_1 = 0;
   timer_1 = rclcpp::create_timer(
-    node, node->get_clock(), rclcpp::Duration(timers_period), [&count_1]() { count_1++; });
+    node, node->get_clock(), rclcpp::Duration(timers_period), [&count_1]() {count_1++;});
 
   count_2 = 0;
   timer_2 = rclcpp::create_timer(
-    node, node->get_clock(), rclcpp::Duration(timers_period), [&count_2]() { count_2++; });
+    node, node->get_clock(), rclcpp::Duration(timers_period), [&count_2]() {count_2++;});
 
   {
-    std::thread executor_thread([&executor]() { executor->spin(); });
+    std::thread executor_thread([&executor]() {executor->spin();});
 
     while (count_2 < 10u) {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));

--- a/rclcpp/test/rclcpp/executors/test_reinitialized_timers.cpp
+++ b/rclcpp/test/rclcpp/executors/test_reinitialized_timers.cpp
@@ -19,6 +19,9 @@
 
 #include <gtest/gtest.h>
 
+#include "rclcpp/executors/multi_threaded_executor.hpp"
+#include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rclcpp/executors/static_single_threaded_executor.hpp"
 #include "rclcpp/experimental/executors/events_executor/events_executor.hpp"
 #include "rclcpp/rclcpp.hpp"
 
@@ -41,6 +44,8 @@ TEST_F(TestTimersLifecycle, timers_lifecycle_reinitialized_object)
 {
   auto timers_period = std::chrono::milliseconds(50);
   auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto single_threaded_executor = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
+  auto multi_threaded_executor = std::make_unique<rclcpp::executors::MultiThreadedExecutor>();
   auto executor = std::make_unique<rclcpp::experimental::executors::EventsExecutor>();
 
   executor->add_node(node);

--- a/rclcpp/test/rclcpp/test_reinitialized_timers.cpp
+++ b/rclcpp/test/rclcpp/test_reinitialized_timers.cpp
@@ -1,0 +1,108 @@
+// Copyright 2024 iRobot Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rclcpp/experimental/executors/events_executor/events_executor.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+class TestTimersLifecycle
+: public testing::Test
+{
+public:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown() override
+  {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(TestTimersLifecycle, timers_lifecycle_reinitialized_object)
+{
+  auto timers_period = std::chrono::milliseconds(50);
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto executor = std::make_unique<rclcpp::experimental::executors::EventsExecutor>();
+
+  executor->add_node(node);
+
+  size_t count_1 = 0;
+  auto timer_1 = rclcpp::create_timer(
+    node,
+    node->get_clock(),
+    rclcpp::Duration(timers_period),
+    [&count_1]() {
+      count_1++;
+    });
+
+  size_t count_2 = 0;
+  auto timer_2 = rclcpp::create_timer(
+    node,
+    node->get_clock(),
+    rclcpp::Duration(timers_period),
+    [&count_2]() {
+      count_2++;
+    });
+
+  {
+    std::thread executor_thread([&executor](){
+      executor->spin();
+    });
+
+    while (count_2 < 10u) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    executor->cancel();
+    executor_thread.join();
+
+    EXPECT_GE(count_2, 10u);
+    EXPECT_LE(count_2 - count_1, 1u);
+  }
+
+  count_1 = 0;
+  timer_1 = rclcpp::create_timer(
+    node,
+    node->get_clock(),
+    rclcpp::Duration(timers_period),
+    [&count_1]() {
+      count_1++;
+    });
+
+  count_2 = 0;
+  timer_2 = rclcpp::create_timer(
+    node,
+    node->get_clock(),
+    rclcpp::Duration(timers_period),
+    [&count_2]() {
+      count_2++;
+    });
+
+  {
+    std::thread executor_thread([&executor](){
+      executor->spin();
+    });
+
+    while (count_2 < 10u) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    executor->cancel();
+    executor_thread.join();
+
+    EXPECT_GE(count_2, 10u);
+    EXPECT_LE(count_2 - count_1, 1u);
+  }
+}

--- a/rclcpp/test/rclcpp/test_reinitialized_timers.cpp
+++ b/rclcpp/test/rclcpp/test_reinitialized_timers.cpp
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <thread>
+
 #include <gtest/gtest.h>
 
 #include "rclcpp/experimental/executors/events_executor/events_executor.hpp"


### PR DESCRIPTION
This PR addresses a bug in the EventsExecutor related to timers. The issue occurs when multiple timers are present in the entities collection, and at least one of them gets re-initialized. Prior to this fix, the collection failed to detect which timers were re-initialized, leading to the following problems:

- The old timer might continue running, triggering its callback.
- The new timer might never start, preventing its callback from being invoked.

The fix consists in invoking the `remove_expired_entities` right before the timers collection is updated.
A regression test was included among the changes, this test will fail with the current rolling HEAD.