### PR TITLE
Only compile the tests once.

### DIFF
--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -99,17 +99,6 @@ ament_add_gtest(test_create_subscription test_create_subscription.cpp)
 if(TARGET test_create_subscription)
   target_link_libraries(test_create_subscription ${PROJECT_NAME} ${test_msgs_TARGETS})
 endif()
-function(test_add_callback_groups_to_executor_for_rmw_implementation)
-  set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
-  ament_add_gmock(test_add_callback_groups_to_executor${target_suffix} test_add_callback_groups_to_executor.cpp
-    ENV ${rmw_implementation_env_var}
-    TIMEOUT 120
-  )
-  if(TARGET test_add_callback_groups_to_executor${target_suffix})
-    target_link_libraries(test_add_callback_groups_to_executor${target_suffix} ${PROJECT_NAME} ${test_msgs_TARGETS})
-  endif()
-endfunction()
-call_for_each_rmw_implementation(test_add_callback_groups_to_executor_for_rmw_implementation)
 ament_add_gtest(test_expand_topic_or_service_name test_expand_topic_or_service_name.cpp)
 ament_add_test_label(test_expand_topic_or_service_name mimick)
 if(TARGET test_expand_topic_or_service_name)
@@ -337,28 +326,6 @@ if(TARGET test_qos)
     rmw::rmw
   )
 endif()
-function(test_generic_pubsub_for_rmw_implementation)
-  set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
-  ament_add_gmock(test_generic_pubsub${target_suffix} test_generic_pubsub.cpp
-    ENV ${rmw_implementation_env_var}
-  )
-  if(TARGET test_generic_pubsub${target_suffix})
-    target_link_libraries(test_generic_pubsub${target_suffix} ${PROJECT_NAME} rcl::rcl ${test_msgs_TARGETS})
-  endif()
-endfunction()
-call_for_each_rmw_implementation(test_generic_pubsub_for_rmw_implementation)
-
-function(test_qos_event_for_rmw_implementation)
-  set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
-  ament_add_gmock(test_qos_event${target_suffix} test_qos_event.cpp
-    ENV ${rmw_implementation_env_var}
-  )
-  ament_add_test_label(test_qos_event${target_suffix} mimick)
-  if(TARGET test_qos_event${target_suffix})
-    target_link_libraries(test_qos_event${target_suffix} ${PROJECT_NAME} mimick rcutils::rcutils rmw::rmw ${test_msgs_TARGETS})
-  endif()
-endfunction()
-call_for_each_rmw_implementation(test_qos_event_for_rmw_implementation)
 
 ament_add_gmock(test_qos_overriding_options test_qos_overriding_options.cpp)
 if(TARGET test_qos_overriding_options)
@@ -650,16 +617,51 @@ if(TARGET test_graph_listener)
   target_link_libraries(test_graph_listener ${PROJECT_NAME} mimick)
 endif()
 
-function(test_subscription_content_filter_for_rmw_implementation)
+ament_add_gmock_executable(test_qos_event test_qos_event.cpp)
+if(TARGET test_qos_event)
+  target_link_libraries(test_qos_event ${PROJECT_NAME} mimick rcutils::rcutils rmw::rmw ${test_msgs_TARGETS})
+endif()
+
+ament_add_gmock_executable(test_generic_pubsub test_generic_pubsub.cpp)
+if(TARGET test_generic_pubsub)
+  target_link_libraries(test_generic_pubsub ${PROJECT_NAME} rcl::rcl ${test_msgs_TARGETS})
+endif()
+
+ament_add_gmock_executable(test_add_callback_groups_to_executor test_add_callback_groups_to_executor.cpp)
+if(TARGET test_add_callback_groups_to_executor)
+  target_link_libraries(test_add_callback_groups_to_executor ${PROJECT_NAME} ${test_msgs_TARGETS})
+endif()
+
+ament_add_gmock_executable(test_subscription_content_filter test_subscription_content_filter.cpp)
+if(TARGET test_subscription_content_filter)
+  target_link_libraries(test_subscription_content_filter ${PROJECT_NAME} mimick ${test_msgs_TARGETS})
+endif()
+
+function(test_on_all_rmws)
   set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
-  ament_add_gmock(test_subscription_content_filter${target_suffix}
-    test_subscription_content_filter.cpp
+
+  ament_add_gmock_test(test_qos_event
+    TEST_NAME test_qos_event${target_suffix}
+    ENV ${rmw_implementation_env_var}
+  )
+  ament_add_test_label(test_qos_event${target_suffix} mimick)
+
+  ament_add_gmock_test(test_generic_pubsub
+    TEST_NAME test_generic_pubsub${target_suffix}
+    ENV ${rmw_implementation_env_var}
+  )
+
+  ament_add_gmock_test(test_add_callback_groups_to_executor
+    TEST_NAME test_add_callback_groups_to_executor${target_suffix}
+    ENV ${rmw_implementation_env_var}
+    TIMEOUT 120
+  )
+
+  ament_add_gmock_test(test_subscription_content_filter
+    TEST_NAME test_subscription_content_filter${target_suffix}
     ENV ${rmw_implementation_env_var}
     TIMEOUT 120
   )
   ament_add_test_label(test_subscription_content_filter${target_suffix} mimick)
-  if(TARGET test_subscription_content_filter${target_suffix})
-    target_link_libraries(test_subscription_content_filter${target_suffix} ${PROJECT_NAME} mimick ${test_msgs_TARGETS})
-  endif()
 endfunction()
-call_for_each_rmw_implementation(test_subscription_content_filter_for_rmw_implementation)
+call_for_each_rmw_implementation(test_on_all_rmws)

--- a/rclcpp/test/rclcpp/test_subscription_content_filter.cpp
+++ b/rclcpp/test/rclcpp/test_subscription_content_filter.cpp
@@ -30,14 +30,7 @@
 
 #include "test_msgs/msg/basic_types.hpp"
 
-#ifdef RMW_IMPLEMENTATION
-# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
-# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
-#else
-# define CLASSNAME(NAME, SUFFIX) NAME
-#endif
-
-class CLASSNAME (TestContentFilterSubscription, RMW_IMPLEMENTATION) : public ::testing::Test
+class TestContentFilterSubscription : public ::testing::Test
 {
 public:
   static void SetUpTestCase()
@@ -113,7 +106,8 @@ bool operator==(const test_msgs::msg::BasicTypes & m1, const test_msgs::msg::Bas
          m1.uint64_value == m2.uint64_value;
 }
 
-TEST_F(CLASSNAME(TestContentFilterSubscription, RMW_IMPLEMENTATION), is_cft_enabled) {
+TEST_F(TestContentFilterSubscription, is_cft_enabled)
+{
   {
     auto mock = mocking_utils::patch_and_return(
       "lib:rclcpp", rcl_subscription_is_cft_enabled, false);
@@ -127,7 +121,8 @@ TEST_F(CLASSNAME(TestContentFilterSubscription, RMW_IMPLEMENTATION), is_cft_enab
   }
 }
 
-TEST_F(CLASSNAME(TestContentFilterSubscription, RMW_IMPLEMENTATION), get_content_filter_error) {
+TEST_F(TestContentFilterSubscription, get_content_filter_error)
+{
   auto mock = mocking_utils::patch_and_return(
     "lib:rclcpp", rcl_subscription_get_content_filter, RCL_RET_ERROR);
 
@@ -137,7 +132,8 @@ TEST_F(CLASSNAME(TestContentFilterSubscription, RMW_IMPLEMENTATION), get_content
     rclcpp::exceptions::RCLError);
 }
 
-TEST_F(CLASSNAME(TestContentFilterSubscription, RMW_IMPLEMENTATION), set_content_filter_error) {
+TEST_F(TestContentFilterSubscription, set_content_filter_error)
+{
   auto mock = mocking_utils::patch_and_return(
     "lib:rclcpp", rcl_subscription_set_content_filter, RCL_RET_ERROR);
 
@@ -148,7 +144,8 @@ TEST_F(CLASSNAME(TestContentFilterSubscription, RMW_IMPLEMENTATION), set_content
     rclcpp::exceptions::RCLError);
 }
 
-TEST_F(CLASSNAME(TestContentFilterSubscription, RMW_IMPLEMENTATION), get_content_filter) {
+TEST_F(TestContentFilterSubscription, get_content_filter)
+{
   rclcpp::ContentFilterOptions options;
 
   if (sub->is_cft_enabled()) {
@@ -164,7 +161,8 @@ TEST_F(CLASSNAME(TestContentFilterSubscription, RMW_IMPLEMENTATION), get_content
   }
 }
 
-TEST_F(CLASSNAME(TestContentFilterSubscription, RMW_IMPLEMENTATION), set_content_filter) {
+TEST_F(TestContentFilterSubscription, set_content_filter)
+{
   if (sub->is_cft_enabled()) {
     EXPECT_NO_THROW(
       sub->set_content_filter(filter_expression_init, expression_parameters_2));
@@ -175,7 +173,8 @@ TEST_F(CLASSNAME(TestContentFilterSubscription, RMW_IMPLEMENTATION), set_content
   }
 }
 
-TEST_F(CLASSNAME(TestContentFilterSubscription, RMW_IMPLEMENTATION), content_filter_get_begin) {
+TEST_F(TestContentFilterSubscription, content_filter_get_begin)
+{
   using namespace std::chrono_literals;
   {
     test_msgs::msg::BasicTypes msg;
@@ -217,7 +216,8 @@ TEST_F(CLASSNAME(TestContentFilterSubscription, RMW_IMPLEMENTATION), content_fil
   }
 }
 
-TEST_F(CLASSNAME(TestContentFilterSubscription, RMW_IMPLEMENTATION), content_filter_get_later) {
+TEST_F(TestContentFilterSubscription, content_filter_get_later)
+{
   using namespace std::chrono_literals;
   {
     test_msgs::msg::BasicTypes msg;
@@ -264,7 +264,8 @@ TEST_F(CLASSNAME(TestContentFilterSubscription, RMW_IMPLEMENTATION), content_fil
   }
 }
 
-TEST_F(CLASSNAME(TestContentFilterSubscription, RMW_IMPLEMENTATION), content_filter_reset) {
+TEST_F(TestContentFilterSubscription, content_filter_reset)
+{
   using namespace std::chrono_literals;
   {
     test_msgs::msg::BasicTypes msg;
@@ -311,11 +312,8 @@ TEST_F(CLASSNAME(TestContentFilterSubscription, RMW_IMPLEMENTATION), content_fil
   }
 }
 
-TEST_F(
-  CLASSNAME(
-    TestContentFilterSubscription,
-    RMW_IMPLEMENTATION), create_two_content_filters_with_same_topic_name_and_destroy) {
-
+TEST_F(TestContentFilterSubscription, create_two_content_filters_with_same_topic_name_and_destroy)
+{
   // Create another content filter
   auto options = rclcpp::SubscriptionOptions();
 


### PR DESCRIPTION
Even when we want to run them on multiple RMWs, we can do that by compiling once, then setting the environment variable appropriately.

In my local testing, this improved compilation times by about 10%.