### PR TITLE
Make more of the Waitable API abstract

### DIFF
--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -176,7 +176,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   std::shared_ptr<void>
-  take_data_by_entity_id(size_t id);
+  take_data_by_entity_id(size_t id) = 0;
 
   /// Execute data that is passed in.
   /**
@@ -246,7 +246,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   void
-  set_on_ready_callback(std::function<void(size_t, int)> callback);
+  set_on_ready_callback(std::function<void(size_t, int)> callback) = 0;
 
   /// Unset any callback registered via set_on_ready_callback.
   /**
@@ -256,7 +256,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   void
-  clear_on_ready_callback();
+  clear_on_ready_callback() = 0;
 
 private:
   std::atomic<bool> in_use_by_wait_set_{false};

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -109,7 +109,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   void
-  add_to_wait_set(rcl_wait_set_t & wait_set);
+  add_to_wait_set(rcl_wait_set_t & wait_set) = 0;
 
   /// Check if the Waitable is ready.
   /**
@@ -124,7 +124,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   bool
-  is_ready(const rcl_wait_set_t & wait_set);
+  is_ready(const rcl_wait_set_t & wait_set) = 0;
 
   /// Take the data so that it can be consumed with `execute`.
   /**
@@ -203,7 +203,7 @@ public:
   RCLCPP_PUBLIC
   virtual
   void
-  execute(const std::shared_ptr<void> & data);
+  execute(const std::shared_ptr<void> & data) = 0;
 
   /// Exchange the "in use by wait set" state for this timer.
   /**

--- a/rclcpp/src/rclcpp/waitable.cpp
+++ b/rclcpp/src/rclcpp/waitable.cpp
@@ -54,35 +54,8 @@ Waitable::get_number_of_ready_guard_conditions()
   return 0u;
 }
 
-std::shared_ptr<void>
-Waitable::take_data_by_entity_id(size_t id)
-{
-  (void)id;
-  throw std::runtime_error(
-          "Custom waitables should override take_data_by_entity_id "
-          "if they want to use it.");
-}
-
 bool
 Waitable::exchange_in_use_by_wait_set_state(bool in_use_state)
 {
   return in_use_by_wait_set_.exchange(in_use_state);
-}
-
-void
-Waitable::set_on_ready_callback(std::function<void(size_t, int)> callback)
-{
-  (void)callback;
-
-  throw std::runtime_error(
-          "Custom waitables should override set_on_ready_callback "
-          "if they want to use it.");
-}
-
-void
-Waitable::clear_on_ready_callback()
-{
-  throw std::runtime_error(
-          "Custom waitables should override clear_on_ready_callback if they "
-          "want to use it and make sure to call it on the waitable destructor.");
 }

--- a/rclcpp/src/rclcpp/waitable.cpp
+++ b/rclcpp/src/rclcpp/waitable.cpp
@@ -86,22 +86,3 @@ Waitable::clear_on_ready_callback()
           "Custom waitables should override clear_on_ready_callback if they "
           "want to use it and make sure to call it on the waitable destructor.");
 }
-
-bool
-Waitable::is_ready(const rcl_wait_set_t & wait_set)
-{
-  return this->is_ready(wait_set);
-}
-
-void
-Waitable::add_to_wait_set(rcl_wait_set_t & wait_set)
-{
-  this->add_to_wait_set(wait_set);
-}
-
-void
-Waitable::execute(const std::shared_ptr<void> & data)
-{
-  // note this const cast is only required to support a deprecated function
-  this->execute(const_cast<std::shared_ptr<void> &>(data));
-}

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_waitables.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_waitables.cpp
@@ -31,13 +31,13 @@ public:
   void add_to_wait_set(rcl_wait_set_t &) override {}
   bool is_ready(const rcl_wait_set_t &) override {return false;}
 
-  std::shared_ptr<void>
-  take_data() override
-  {
-    return nullptr;
-  }
-
+  std::shared_ptr<void> take_data() override {return nullptr;}
   void execute(const std::shared_ptr<void> &) override {}
+
+  void set_on_ready_callback(std::function<void(size_t, int)>) override {}
+  void clear_on_ready_callback() override {}
+
+  std::shared_ptr<void> take_data_by_entity_id(size_t) override {return nullptr;}
 };
 
 class TestNodeWaitables : public ::testing::Test

--- a/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
@@ -51,13 +51,13 @@ public:
     return test_waitable_result;
   }
 
-  std::shared_ptr<void>
-  take_data() override
-  {
-    return nullptr;
-  }
-
+  std::shared_ptr<void> take_data() override {return nullptr;}
   void execute(const std::shared_ptr<void> &) override {}
+
+  void set_on_ready_callback(std::function<void(size_t, int)>) override {}
+  void clear_on_ready_callback() override {}
+
+  std::shared_ptr<void> take_data_by_entity_id(size_t) override {return nullptr;}
 };
 
 struct RclWaitSetSizes

--- a/rclcpp/test/rclcpp/test_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/test_memory_strategy.cpp
@@ -40,6 +40,11 @@ public:
 
   std::shared_ptr<void> take_data() override {return nullptr;}
   void execute(const std::shared_ptr<void> &) override {}
+
+  void set_on_ready_callback(std::function<void(size_t, int)>) override {}
+  void clear_on_ready_callback() override {}
+
+  std::shared_ptr<void> take_data_by_entity_id(size_t) override {return nullptr;}
 };
 
 class TestMemoryStrategy : public ::testing::Test

--- a/rclcpp/test/rclcpp/wait_set_policies/test_dynamic_storage.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_dynamic_storage.cpp
@@ -52,15 +52,17 @@ public:
   : is_ready_(false) {}
 
   void add_to_wait_set(rcl_wait_set_t &) override {}
-
   bool is_ready(const rcl_wait_set_t &) override {return is_ready_;}
 
   std::shared_ptr<void> take_data() override {return nullptr;}
-
-  void
-  execute(const std::shared_ptr<void> &) override {}
+  void execute(const std::shared_ptr<void> &) override {}
 
   void set_is_ready(bool value) {is_ready_ = value;}
+
+  void set_on_ready_callback(std::function<void(size_t, int)>) override {}
+  void clear_on_ready_callback() override {}
+
+  std::shared_ptr<void> take_data_by_entity_id(size_t) override {return nullptr;}
 
 private:
   bool is_ready_;

--- a/rclcpp/test/rclcpp/wait_set_policies/test_static_storage.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_static_storage.cpp
@@ -52,15 +52,17 @@ public:
   : is_ready_(false) {}
 
   void add_to_wait_set(rcl_wait_set_t &) override {}
-
   bool is_ready(const rcl_wait_set_t &) override {return is_ready_;}
 
   std::shared_ptr<void> take_data() override {return nullptr;}
-
-  void
-  execute(const std::shared_ptr<void> &) override {}
+  void execute(const std::shared_ptr<void> &) override {}
 
   void set_is_ready(bool value) {is_ready_ = value;}
+
+  void set_on_ready_callback(std::function<void(size_t, int)>) override {}
+  void clear_on_ready_callback() override {}
+
+  std::shared_ptr<void> take_data_by_entity_id(size_t) override {return nullptr;}
 
 private:
   bool is_ready_;

--- a/rclcpp/test/rclcpp/wait_set_policies/test_storage_policy_common.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_storage_policy_common.cpp
@@ -61,13 +61,16 @@ public:
   bool is_ready(const rcl_wait_set_t &) override {return is_ready_;}
 
   std::shared_ptr<void> take_data() override {return nullptr;}
-
-  void
-  execute(const std::shared_ptr<void> & data) override {(void)data;}
+  void execute(const std::shared_ptr<void> &) override {}
 
   void set_is_ready(bool value) {is_ready_ = value;}
 
   void set_add_to_wait_set(bool value) {add_to_wait_set_ = value;}
+
+  void set_on_ready_callback(std::function<void(size_t, int)>) override {}
+  void clear_on_ready_callback() override {}
+
+  std::shared_ptr<void> take_data_by_entity_id(size_t) override {return nullptr;}
 
 private:
   bool is_ready_;

--- a/rclcpp/test/rclcpp/wait_set_policies/test_thread_safe_synchronization.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_thread_safe_synchronization.cpp
@@ -52,15 +52,17 @@ public:
   : is_ready_(false) {}
 
   void add_to_wait_set(rcl_wait_set_t &) override {}
-
   bool is_ready(const rcl_wait_set_t &) override {return is_ready_;}
 
   std::shared_ptr<void> take_data() override {return nullptr;}
-
-  void
-  execute(const std::shared_ptr<void> &) override {}
+  void execute(const std::shared_ptr<void> &) override {}
 
   void set_is_ready(bool value) {is_ready_ = value;}
+
+  void set_on_ready_callback(std::function<void(size_t, int)>) override {}
+  void clear_on_ready_callback() override {}
+
+  std::shared_ptr<void> take_data_by_entity_id(size_t) override {return nullptr;}
 
 private:
   bool is_ready_;


### PR DESCRIPTION
I initially started looking at this because clang was complaining
that "all paths through this function will call itself" (see https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/1966/clang/new/fileName.-934007317/).  And it
is correct; if an implementation does not override these methods,
and they are ever called, they will go into an infinite loop
calling themselves.

However, while looking at it it seemed to me that these were really
part of the API that a concrete implementation of Waitable needed
to implement.  It is fine if an implementation doesn't want to do
anything (like the tests), but all of the "real" users in the codebase
override these.

Thus, remove the implementations here and make these pure virtual
functions that all subclasses must implement.

Note that I've split this into two commits for a particular reason.  5b3f59e030f5b87f4b7b2ec6957be5102ac28519 is the one that will fix the clang warning.  But while I was looking at it, I noticed that there are some other methods in there that really should be pure virtual.  So commit 0194fb774f697a9eac274c306770a3163a87a42e isn't required, but I think it is better C++.

This also requires https://github.com/ros2/system_tests/pull/548 to go in at the same time.