### PR TITLE
deprecate the static single threaded executor

### DIFF
--- a/rclcpp/include/rclcpp/executors/static_single_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/static_single_threaded_executor.hpp
@@ -31,9 +31,15 @@ namespace executors
 /// Static executor implementation
 /**
  * This executor is a static version of the original single threaded executor.
- * It's static because it doesn't reconstruct the executable list for every iteration.
+ * It contains some performance optimization to avoid unnecessary reconstructions of 
+ * the executable list for every iteration.
  * All nodes, callbackgroups, timers, subscriptions etc. are created before
  * spin() is called, and modified only when an entity is added/removed to/from a node.
+ * This executor is deprecated because these performance improvements have now been
+ * applied to all other executors.
+ * This executor is also considered unstable due to known bugs.
+ * See the unit-tests that are only applied to `StandardExecutors` for information
+ * on the known limitations.
  *
  * To run this executor instead of SingleThreadedExecutor replace:
  * rclcpp::executors::SingleThreadedExecutor exec;
@@ -44,7 +50,8 @@ namespace executors
  * exec.spin();
  * exec.remove_node(node);
  */
-class StaticSingleThreadedExecutor : public rclcpp::Executor
+class [[deprecated("Use rclcpp::executors::SingleThreadedExecutor).")]]
+StaticSingleThreadedExecutor : public rclcpp::Executor
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(StaticSingleThreadedExecutor)

--- a/rclcpp/include/rclcpp/executors/static_single_threaded_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/static_single_threaded_executor.hpp
@@ -31,7 +31,7 @@ namespace executors
 /// Static executor implementation
 /**
  * This executor is a static version of the original single threaded executor.
- * It contains some performance optimization to avoid unnecessary reconstructions of 
+ * It contains some performance optimization to avoid unnecessary reconstructions of
  * the executable list for every iteration.
  * All nodes, callbackgroups, timers, subscriptions etc. are created before
  * spin() is called, and modified only when an entity is added/removed to/from a node.
@@ -50,8 +50,8 @@ namespace executors
  * exec.spin();
  * exec.remove_node(node);
  */
-class [[deprecated("Use rclcpp::executors::SingleThreadedExecutor).")]]
-StaticSingleThreadedExecutor : public rclcpp::Executor
+class [[deprecated("Use rclcpp::executors::SingleThreadedExecutor")]] StaticSingleThreadedExecutor
+  : public rclcpp::Executor
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(StaticSingleThreadedExecutor)

--- a/rclcpp/test/rclcpp/executors/executor_types.hpp
+++ b/rclcpp/test/rclcpp/executors/executor_types.hpp
@@ -25,11 +25,29 @@
 #include "rclcpp/executors/static_single_threaded_executor.hpp"
 #include "rclcpp/executors/multi_threaded_executor.hpp"
 
+// suppress deprecated StaticSingleThreadedExecutor warning
+// we define an alias that explicitly indicates that this class is deprecated, while avoiding
+// polluting a lot of files the gcc pragmas
+#if !defined(_WIN32)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else  // !defined(_WIN32)
+# pragma warning(push)
+# pragma warning(disable: 4996)
+#endif
+using DeprecatedStaticSingleThreadedExecutor = rclcpp::executors::StaticSingleThreadedExecutor;
+// remove warning suppression
+#if !defined(_WIN32)
+# pragma GCC diagnostic pop
+#else  // !defined(_WIN32)
+# pragma warning(pop)
+#endif
+
 using ExecutorTypes =
   ::testing::Types<
   rclcpp::executors::SingleThreadedExecutor,
   rclcpp::executors::MultiThreadedExecutor,
-  rclcpp::executors::StaticSingleThreadedExecutor,
+  DeprecatedStaticSingleThreadedExecutor,
   rclcpp::experimental::executors::EventsExecutor>;
 
 class ExecutorTypeNames
@@ -47,7 +65,7 @@ public:
       return "MultiThreadedExecutor";
     }
 
-    if (std::is_same<T, rclcpp::executors::StaticSingleThreadedExecutor>()) {
+    if (std::is_same<T, DeprecatedStaticSingleThreadedExecutor>()) {
       return "StaticSingleThreadedExecutor";
     }
 

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -674,20 +674,20 @@ TYPED_TEST(TestExecutors, testRaceConditionAddNode)
   }
 
   // Create an executor
-  auto executor = std::make_shared<ExecutorType>();
+  ExecutorType executor;
   // Start spinning
   auto executor_thread = std::thread(
-    [executor]() {
-      executor->spin();
+    [&executor]() {
+      executor.spin();
     });
   // Add a node to the executor
-  executor->add_node(this->node);
+  executor.add_node(this->node);
 
   // Cancel the executor (make sure that it's already spinning first)
-  while (!executor->is_spinning() && rclcpp::ok()) {
+  while (!executor.is_spinning() && rclcpp::ok()) {
     continue;
   }
-  executor->cancel();
+  executor.cancel();
 
   // Try to join the thread after cancelling the executor
   // This is the "test". We want to make sure that we can still cancel the executor

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -489,7 +489,7 @@ TYPED_TEST(TestExecutors, spin_some_max_duration)
   //   for them in the meantime.
   //   see: https://github.com/ros2/rclcpp/issues/2462
   if (
-    std::is_same<ExecutorType, rclcpp::executors::StaticSingleThreadedExecutor>())
+    std::is_same<ExecutorType, DeprecatedStaticSingleThreadedExecutor>())
   {
     GTEST_SKIP();
   }

--- a/rclcpp/test/rclcpp/executors/test_executors_timer_cancel_behavior.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors_timer_cancel_behavior.cpp
@@ -286,7 +286,7 @@ using MainExecutorTypes =
   ::testing::Types<
   rclcpp::executors::SingleThreadedExecutor,
   rclcpp::executors::MultiThreadedExecutor,
-  rclcpp::executors::StaticSingleThreadedExecutor>;
+  DeprecatedStaticSingleThreadedExecutor>;
 
 // TODO(@fujitatomoya): this test excludes EventExecutor because it does not
 // support simulation time used for this test to relax the racy condition.

--- a/rclcpp/test/rclcpp/executors/test_reinitialized_timers.cpp
+++ b/rclcpp/test/rclcpp/executors/test_reinitialized_timers.cpp
@@ -19,11 +19,9 @@
 #include <memory>
 #include <thread>
 
-#include "rclcpp/executors/multi_threaded_executor.hpp"
-#include "rclcpp/executors/single_threaded_executor.hpp"
-#include "rclcpp/executors/static_single_threaded_executor.hpp"
-#include "rclcpp/experimental/executors/events_executor/events_executor.hpp"
 #include "rclcpp/rclcpp.hpp"
+
+#include "./executor_types.hpp"
 
 template<typename ExecutorType>
 class TestTimersLifecycle : public testing::Test
@@ -33,10 +31,6 @@ public:
 
   void TearDown() override {rclcpp::shutdown();}
 };
-
-using ExecutorTypes = ::testing::Types<
-  rclcpp::executors::SingleThreadedExecutor, rclcpp::executors::MultiThreadedExecutor,
-  rclcpp::executors::StaticSingleThreadedExecutor, rclcpp::experimental::executors::EventsExecutor>;
 
 TYPED_TEST_SUITE(TestTimersLifecycle, ExecutorTypes);
 

--- a/rclcpp/test/rclcpp/executors/test_reinitialized_timers.cpp
+++ b/rclcpp/test/rclcpp/executors/test_reinitialized_timers.cpp
@@ -36,11 +36,13 @@ TYPED_TEST_SUITE(TestTimersLifecycle, ExecutorTypes);
 
 TYPED_TEST(TestTimersLifecycle, timers_lifecycle_reinitialized_object)
 {
+  using ExecutorType = TypeParam;
+  ExecutorType executor;
+
   auto timers_period = std::chrono::milliseconds(50);
   auto node = std::make_shared<rclcpp::Node>("test_node");
-  auto executor = std::make_unique<TypeParam>();
 
-  executor->add_node(node);
+  executor.add_node(node);
 
   size_t count_1 = 0;
   auto timer_1 = rclcpp::create_timer(
@@ -51,12 +53,12 @@ TYPED_TEST(TestTimersLifecycle, timers_lifecycle_reinitialized_object)
     node, node->get_clock(), rclcpp::Duration(timers_period), [&count_2]() {count_2++;});
 
   {
-    std::thread executor_thread([&executor]() {executor->spin();});
+    std::thread executor_thread([&executor]() {executor.spin();});
 
     while (count_2 < 10u) {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
-    executor->cancel();
+    executor.cancel();
     executor_thread.join();
 
     EXPECT_GE(count_2, 10u);
@@ -72,12 +74,12 @@ TYPED_TEST(TestTimersLifecycle, timers_lifecycle_reinitialized_object)
     node, node->get_clock(), rclcpp::Duration(timers_period), [&count_2]() {count_2++;});
 
   {
-    std::thread executor_thread([&executor]() {executor->spin();});
+    std::thread executor_thread([&executor]() {executor.spin();});
 
     while (count_2 < 10u) {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
-    executor->cancel();
+    executor.cancel();
     executor_thread.join();
 
     EXPECT_GE(count_2, 10u);

--- a/rclcpp/test/rclcpp/executors/test_static_single_threaded_executor.cpp
+++ b/rclcpp/test/rclcpp/executors/test_static_single_threaded_executor.cpp
@@ -20,12 +20,13 @@
 #include <stdexcept>
 
 #include "rclcpp/exceptions.hpp"
+#include "rclcpp/executors.hpp"
 #include "rclcpp/node.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "rclcpp/executors.hpp"
 
 #include "test_msgs/srv/empty.hpp"
 
+#include "./executor_types.hpp"
 #include "../../mocking_utils/patch.hpp"
 #include "../../utils/rclcpp_gtest_macros.hpp"
 
@@ -46,7 +47,7 @@ public:
 };
 
 TEST_F(TestStaticSingleThreadedExecutor, add_callback_group_trigger_guard_failed) {
-  rclcpp::executors::StaticSingleThreadedExecutor executor;
+  DeprecatedStaticSingleThreadedExecutor executor;
   auto node = std::make_shared<rclcpp::Node>("node", "ns");
   rclcpp::CallbackGroup::SharedPtr cb_group = node->create_callback_group(
     rclcpp::CallbackGroupType::MutuallyExclusive);
@@ -61,7 +62,7 @@ TEST_F(TestStaticSingleThreadedExecutor, add_callback_group_trigger_guard_failed
 }
 
 TEST_F(TestStaticSingleThreadedExecutor, add_node_trigger_guard_failed) {
-  rclcpp::executors::StaticSingleThreadedExecutor executor;
+  DeprecatedStaticSingleThreadedExecutor executor;
   auto node = std::make_shared<rclcpp::Node>("node", "ns");
 
   {
@@ -74,7 +75,7 @@ TEST_F(TestStaticSingleThreadedExecutor, add_node_trigger_guard_failed) {
 }
 
 TEST_F(TestStaticSingleThreadedExecutor, remove_callback_group_trigger_guard_failed) {
-  rclcpp::executors::StaticSingleThreadedExecutor executor;
+  DeprecatedStaticSingleThreadedExecutor executor;
   auto node = std::make_shared<rclcpp::Node>("node", "ns");
   rclcpp::CallbackGroup::SharedPtr cb_group = node->create_callback_group(
     rclcpp::CallbackGroupType::MutuallyExclusive);
@@ -92,7 +93,7 @@ TEST_F(TestStaticSingleThreadedExecutor, remove_callback_group_trigger_guard_fai
 }
 
 TEST_F(TestStaticSingleThreadedExecutor, remove_node_failed) {
-  rclcpp::executors::StaticSingleThreadedExecutor executor;
+  DeprecatedStaticSingleThreadedExecutor executor;
   auto node = std::make_shared<rclcpp::Node>("node", "ns");
 
   {
@@ -105,7 +106,7 @@ TEST_F(TestStaticSingleThreadedExecutor, remove_node_failed) {
 }
 
 TEST_F(TestStaticSingleThreadedExecutor, remove_node_trigger_guard_failed) {
-  rclcpp::executors::StaticSingleThreadedExecutor executor;
+  DeprecatedStaticSingleThreadedExecutor executor;
   auto node = std::make_shared<rclcpp::Node>("node", "ns");
 
   executor.add_node(node);
@@ -120,7 +121,7 @@ TEST_F(TestStaticSingleThreadedExecutor, remove_node_trigger_guard_failed) {
 }
 
 TEST_F(TestStaticSingleThreadedExecutor, execute_service) {
-  rclcpp::executors::StaticSingleThreadedExecutor executor;
+  DeprecatedStaticSingleThreadedExecutor executor;
   auto node = std::make_shared<rclcpp::Node>("node", "ns");
   executor.add_node(node);
 

--- a/rclcpp/test/rclcpp/test_add_callback_groups_to_executor.cpp
+++ b/rclcpp/test/rclcpp/test_add_callback_groups_to_executor.cpp
@@ -29,6 +29,8 @@
 #include "rclcpp/executor.hpp"
 #include "rclcpp/rclcpp.hpp"
 
+#include "./executors/executor_types.hpp"
+
 using namespace std::chrono_literals;
 
 template<typename T>
@@ -48,48 +50,8 @@ public:
 template<typename T>
 class TestAddCallbackGroupsToExecutorStable : public TestAddCallbackGroupsToExecutor<T> {};
 
-using ExecutorTypes =
-  ::testing::Types<
-  rclcpp::executors::SingleThreadedExecutor,
-  rclcpp::executors::MultiThreadedExecutor,
-  rclcpp::executors::StaticSingleThreadedExecutor,
-  rclcpp::experimental::executors::EventsExecutor>;
-
-class ExecutorTypeNames
-{
-public:
-  template<typename T>
-  static std::string GetName(int idx)
-  {
-    (void)idx;
-    if (std::is_same<T, rclcpp::executors::SingleThreadedExecutor>()) {
-      return "SingleThreadedExecutor";
-    }
-
-    if (std::is_same<T, rclcpp::executors::MultiThreadedExecutor>()) {
-      return "MultiThreadedExecutor";
-    }
-
-    if (std::is_same<T, rclcpp::executors::StaticSingleThreadedExecutor>()) {
-      return "StaticSingleThreadedExecutor";
-    }
-
-    if (std::is_same<T, rclcpp::experimental::executors::EventsExecutor>()) {
-      return "EventsExecutor";
-    }
-
-    return "";
-  }
-};
-
 TYPED_TEST_SUITE(TestAddCallbackGroupsToExecutor, ExecutorTypes, ExecutorTypeNames);
 
-// StaticSingleThreadedExecutor is not included in these tests for now
-using StandardExecutors =
-  ::testing::Types<
-  rclcpp::executors::SingleThreadedExecutor,
-  rclcpp::executors::MultiThreadedExecutor,
-  rclcpp::experimental::executors::EventsExecutor>;
 TYPED_TEST_SUITE(TestAddCallbackGroupsToExecutorStable, StandardExecutors, ExecutorTypeNames);
 
 /*


### PR DESCRIPTION
This PR marks the `StaticSingleThreadedExecutor` as deprecated.
With the current implementation, all other single threaded executors have better performance than this one and they are more stable.

See https://discourse.ros.org/t/the-ros-2-c-executors/38296 for a recent performance comparison that I run.