### PR TITLE
remove unnecessary gtest-skip in test_executors

### DIFF
--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -480,19 +480,13 @@ TYPED_TEST(TestExecutors, spin_some)
 
 // The purpose of this test is to check that the ExecutorT.spin_some() method:
 //   - does not continue executing after max_duration has elapsed
-TYPED_TEST(TestExecutors, spin_some_max_duration)
+// TODO(wjwwood): The `StaticSingleThreadedExecutor`
+//   do not properly implement max_duration (it seems), so disable this test
+//   for them in the meantime.
+//   see: https://github.com/ros2/rclcpp/issues/2462
+TYPED_TEST(TestExecutorsStable, spin_some_max_duration)
 {
   using ExecutorType = TypeParam;
-
-  // TODO(wjwwood): The `StaticSingleThreadedExecutor`
-  //   do not properly implement max_duration (it seems), so disable this test
-  //   for them in the meantime.
-  //   see: https://github.com/ros2/rclcpp/issues/2462
-  if (
-    std::is_same<ExecutorType, rclcpp::executors::StaticSingleThreadedExecutor>())
-  {
-    GTEST_SKIP();
-  }
 
   // Use an isolated callback group to avoid interference from any housekeeping
   // items that may be in the default callback group of the node.
@@ -647,13 +641,6 @@ TYPED_TEST(TestExecutors, testSpinUntilFutureCompleteInterrupted)
 TYPED_TEST(TestExecutors, testRaceConditionAddNode)
 {
   using ExecutorType = TypeParam;
-  // rmw_connextdds doesn't support events-executor
-  if (
-    std::is_same<ExecutorType, rclcpp::experimental::executors::EventsExecutor>() &&
-    std::string(rmw_get_implementation_identifier()).find("rmw_connextdds") == 0)
-  {
-    GTEST_SKIP();
-  }
 
   // Spawn some threads to do some heavy work
   std::atomic<bool> should_cancel = false;


### PR DESCRIPTION
This PR removes a couple of GTEST_SKIP instances from `test_executors.cpp`.

 - Unfortunately, the `spin_some_max_duration` test is still broken for the static single threaded executor (despite https://github.com/ros2/rclcpp/issues/2462#issuecomment-2020753899). Here I replaced the `GTEST_SKIP` with the `TestExecutorsStable` fixture.
 - Verified that the `test_race_condition_add_node` succeeds with connext dds and events-executor (now that the events executor is supported by that RMW). Here I removed the `GTEST_SKIP`.