### PR TITLE
Fix name of ParameterEventHandler class in doc

### DIFF
--- a/rclcpp/include/rclcpp/parameter_event_handler.hpp
+++ b/rclcpp/include/rclcpp/parameter_event_handler.hpp
@@ -126,7 +126,7 @@ struct ParameterEventCallbackHandle
  *         // Now that we know the event matches the regular expression we scanned for, we can
  *         // use 'get_parameter_from_event' to get a specific parameter name that we're looking for
  *         rclcpp::Parameter p;
- *         if (rclcpp::ParameterEventsSubscriber::get_parameter_from_event(
+ *         if (rclcpp::ParameterEventHandler::get_parameter_from_event(
  *             event, p, remote_param_name, fqn))
  *         {
  *           RCLCPP_INFO(
@@ -139,7 +139,7 @@ struct ParameterEventCallbackHandle
  *
  *         // You can also use 'get_parameter*s*_from_event' to enumerate all changes that came
  *         // in on this event
- *         auto params = rclcpp::ParameterEventsSubscriber::get_parameters_from_event(event);
+ *         auto params = rclcpp::ParameterEventHandler::get_parameters_from_event(event);
  *         for (auto & p : params) {
  *           RCLCPP_INFO(
  *             node->get_logger(),


### PR DESCRIPTION
This was added in #1573, which is a fixed version of #829 (which was reverted in #1572).

The title of #1573/#829 mentions "ParameterEventsSubscriber" but there is no such class. `ParameterEventsSubscriber` was renamed to `ParameterEventHandler`: https://github.com/ros2/rclcpp/pull/829/commits/60533db8d353dd2b3780793f5a12fb7bb245bb92 + https://github.com/ros2/rclcpp/pull/829/commits/894da98dbaafddf427c7baa71f41c6d70ec8ad08. These docs (and PR title) were just not updated. `rclcpp::ParameterEventsSubscriber::get_parameter_from_event()` doesn't exist, but `rclcpp::ParameterEventHandler::get_parameter_from_event()` does.