### PR TITLE
Minor naming fixes for ParameterValue to_string() function

### DIFF
--- a/rclcpp/include/rclcpp/parameter_value.hpp
+++ b/rclcpp/include/rclcpp/parameter_value.hpp
@@ -359,7 +359,7 @@ private:
 /// Return the value of a parameter as a string
 RCLCPP_PUBLIC
 std::string
-to_string(const ParameterValue & type);
+to_string(const ParameterValue & value);
 
 }  // namespace rclcpp
 


### PR DESCRIPTION
More appropriate function argument naming that improves readability and coherence.

Refer to: 
https://github.com/ros2/rclcpp/blob/rolling/rclcpp/src/rclcpp/parameter_value.cpp#L83