### PR TITLE
Use InvalidServiceTypeError for unavailable service type in GenericClient

### DIFF
--- a/rclcpp/test/rclcpp/test_generic_client.cpp
+++ b/rclcpp/test/rclcpp/test_generic_client.cpp
@@ -105,7 +105,7 @@ TEST_F(TestGenericClient, construction_and_destruction) {
     ASSERT_THROW(
     {
       auto client = node->create_generic_client("test_service", "test_msgs/srv/InvalidType");
-    }, std::runtime_error);
+    }, rclcpp::exceptions::InvalidServiceTypeError);
   }
 }
 


### PR DESCRIPTION
Use newly defined exceptions `rclcpp::exceptions::InvalidServiceTypeError` to make errors clearer.
rclcpp::exceptions::InvalidServiceTypeError was introduced in #2617.