### PR TITLE
rmw_fastrtps supports service event gid uniqueness test.

### DIFF
--- a/rclcpp/test/rclcpp/test_service_introspection.cpp
+++ b/rclcpp/test/rclcpp/test_service_introspection.cpp
@@ -124,10 +124,10 @@ TEST_F(TestServiceIntrospection, service_introspection_nominal)
   ASSERT_THAT(
     client_gid_arr,
     testing::Eq(event_map[ServiceEventInfo::REQUEST_SENT]->info.client_gid));
-  // TODO(@fujitatomoya): Remove this if statement once other rmw implementations support test.
-  // Only rmw_connextdds can pass this test requirement for now.
+  // TODO(@fujitatomoya): Remove this if statement once rmw implementations support test.
+  // rmw_cyclonedds_cpp does not pass this test requirement for now.
   // See more details for https://github.com/ros2/rmw/issues/357
-  if (std::string(rmw_get_implementation_identifier()).find("rmw_connextdds") == 0) {
+  if (std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds_cpp") != 0) {
     ASSERT_THAT(
       client_gid_arr,
       testing::Eq(event_map[ServiceEventInfo::REQUEST_RECEIVED]->info.client_gid));


### PR DESCRIPTION
part of https://github.com/ros2/rmw/issues/357

this depends on https://github.com/ros2/rmw_fastrtps/pull/781