### PR TITLE
Increase the timeout for the cppcheck on rclcpp_action.

### DIFF
--- a/rclcpp_action/CMakeLists.txt
+++ b/rclcpp_action/CMakeLists.txt
@@ -135,3 +135,8 @@ if(BUILD_TESTING)
 endif()
 
 ament_package()
+
+if(TEST cppcheck)
+  # must set the property after ament_package()
+  set_tests_properties(cppcheck PROPERTIES TIMEOUT 600)
+endif()


### PR DESCRIPTION
The default is 300 seconds, but on Windows this is taking between 250 and 300 seconds (I'm seeing it timeout sometimes). Up the timeout to 600 seconds, which should be more than enough.