### PR TITLE
use QoS Reliable and History Depth 10 for stable test result.

### DIFF
--- a/rclcpp/test/rclcpp/test_service_introspection.cpp
+++ b/rclcpp/test/rclcpp/test_service_introspection.cpp
@@ -68,7 +68,8 @@ protected:
 
     client = node->create_client<BasicTypes>("service");
     service = node->create_service<BasicTypes>("service", srv_callback);
-    sub = node->create_subscription<BasicTypes::Event>("service/_service_event", 10, callback);
+    sub = node->create_subscription<BasicTypes::Event>(
+      "service/_service_event", qos_profile_, callback);
     events.clear();
   }
 
@@ -80,6 +81,7 @@ protected:
   rclcpp::Node::SharedPtr node;
   rclcpp::Client<BasicTypes>::SharedPtr client;
   rclcpp::Service<BasicTypes>::SharedPtr service;
+  rclcpp::QoS qos_profile_ = rclcpp::QoS(10).reliable();
   rclcpp::Subscription<BasicTypes::Event>::SharedPtr sub;
   std::vector<std::shared_ptr<const BasicTypes::Event>> events;
   std::chrono::milliseconds timeout = std::chrono::milliseconds(1000);
@@ -92,9 +94,9 @@ TEST_F(TestServiceIntrospection, service_introspection_nominal)
   request->set__int64_value(42);
 
   client->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
+    node->get_clock(), qos_profile_, RCL_SERVICE_INTROSPECTION_CONTENTS);
   service->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
+    node->get_clock(), qos_profile_, RCL_SERVICE_INTROSPECTION_CONTENTS);
 
   auto future = client->async_send_request(request);
   ASSERT_EQ(
@@ -163,9 +165,9 @@ TEST_F(TestServiceIntrospection, service_introspection_nominal)
 TEST_F(TestServiceIntrospection, service_introspection_enable_disable_events)
 {
   client->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_OFF);
+    node->get_clock(), qos_profile_, RCL_SERVICE_INTROSPECTION_OFF);
   service->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_OFF);
+    node->get_clock(), qos_profile_, RCL_SERVICE_INTROSPECTION_OFF);
 
   auto request = std::make_shared<BasicTypes::Request>();
   request->set__bool_value(true);
@@ -183,9 +185,9 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_events)
   events.clear();
 
   client->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
+    node->get_clock(), qos_profile_, RCL_SERVICE_INTROSPECTION_METADATA);
   service->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_OFF);
+    node->get_clock(), qos_profile_, RCL_SERVICE_INTROSPECTION_OFF);
 
   future = client->async_send_request(request);
   ASSERT_EQ(
@@ -200,9 +202,9 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_events)
   events.clear();
 
   client->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_OFF);
+    node->get_clock(), qos_profile_, RCL_SERVICE_INTROSPECTION_OFF);
   service->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
+    node->get_clock(), qos_profile_, RCL_SERVICE_INTROSPECTION_METADATA);
 
   future = client->async_send_request(request);
   ASSERT_EQ(
@@ -217,9 +219,9 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_events)
   events.clear();
 
   client->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
+    node->get_clock(), qos_profile_, RCL_SERVICE_INTROSPECTION_METADATA);
   service->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
+    node->get_clock(), qos_profile_, RCL_SERVICE_INTROSPECTION_METADATA);
 
   future = client->async_send_request(request);
   ASSERT_EQ(
@@ -235,9 +237,9 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_events)
 TEST_F(TestServiceIntrospection, service_introspection_enable_disable_event_content)
 {
   client->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
+    node->get_clock(), qos_profile_, RCL_SERVICE_INTROSPECTION_METADATA);
   service->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
+    node->get_clock(), qos_profile_, RCL_SERVICE_INTROSPECTION_METADATA);
 
   auto request = std::make_shared<BasicTypes::Request>();
   request->set__bool_value(true);
@@ -259,9 +261,9 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_event_cont
   events.clear();
 
   client->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
+    node->get_clock(), qos_profile_, RCL_SERVICE_INTROSPECTION_CONTENTS);
   service->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
+    node->get_clock(), qos_profile_, RCL_SERVICE_INTROSPECTION_METADATA);
 
   future = client->async_send_request(request);
   ASSERT_EQ(
@@ -292,9 +294,9 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_event_cont
   events.clear();
 
   client->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
+    node->get_clock(), qos_profile_, RCL_SERVICE_INTROSPECTION_METADATA);
   service->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
+    node->get_clock(), qos_profile_, RCL_SERVICE_INTROSPECTION_CONTENTS);
 
   future = client->async_send_request(request);
   ASSERT_EQ(
@@ -325,9 +327,9 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_event_cont
   events.clear();
 
   client->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
+    node->get_clock(), qos_profile_, RCL_SERVICE_INTROSPECTION_CONTENTS);
   service->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
+    node->get_clock(), qos_profile_, RCL_SERVICE_INTROSPECTION_CONTENTS);
 
   future = client->async_send_request(request);
   ASSERT_EQ(


### PR DESCRIPTION
address https://github.com/ros2/rclcpp/issues/2613

> [!NOTE]  
> This is still draft PR since the test still sometimes fails with rmw_connextdds.