### PR TITLE
Fix test_intra_process_manager.cpp with rmw_zenoh_cpp

### DIFF
--- a/rclcpp/test/rclcpp/test_intra_process_manager.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager.cpp
@@ -159,7 +159,7 @@ class PublisherBase
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(PublisherBase)
 
-  explicit PublisherBase(const std::string & topic, rclcpp::QoS qos)
+  explicit PublisherBase(const std::string & topic, const rclcpp::QoS & qos)
   : topic_name(topic),
     qos_profile(qos)
   {}
@@ -226,7 +226,7 @@ public:
 
   RCLCPP_SMART_PTR_DEFINITIONS(Publisher<T, Alloc>)
 
-  explicit Publisher(const std::string & topic, rclcpp::QoS qos)
+  explicit Publisher(const std::string & topic, const rclcpp::QoS & qos)
   : PublisherBase(topic, qos)
   {
     auto allocator = std::make_shared<Alloc>();
@@ -262,7 +262,7 @@ public:
   explicit SubscriptionIntraProcessBase(
     rclcpp::Context::SharedPtr context,
     const std::string & topic,
-    rclcpp::QoS qos)
+    const rclcpp::QoS & qos)
   : topic_name(topic), qos_profile(qos)
   {
     (void)context;
@@ -310,7 +310,7 @@ class SubscriptionIntraProcessBuffer : public SubscriptionIntraProcessBase
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(SubscriptionIntraProcessBuffer)
 
-  explicit SubscriptionIntraProcessBuffer(const std::string & topic, rclcpp::QoS qos)
+  explicit SubscriptionIntraProcessBuffer(const std::string & topic, const rclcpp::QoS & qos)
   : SubscriptionIntraProcessBase(nullptr, topic, qos), take_shared_method(false)
   {
     buffer = std::make_unique<rclcpp::experimental::buffers::mock::IntraProcessBuffer<MessageT>>();
@@ -378,7 +378,7 @@ class SubscriptionIntraProcess : public SubscriptionIntraProcessBuffer<
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(SubscriptionIntraProcess)
 
-  explicit SubscriptionIntraProcess(const std::string & topic, rclcpp::QoS qos)
+  explicit SubscriptionIntraProcess(const std::string & topic, const rclcpp::QoS & qos)
   : SubscriptionIntraProcessBuffer<MessageT, Alloc, Deleter>(topic, qos)
   {
   }

--- a/rclcpp/test/rclcpp/test_intra_process_manager.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager.cpp
@@ -123,6 +123,7 @@ public:
     return result;
   }
 
+private:
   // need to store the messages somewhere otherwise the memory address will be reused
   ConstMessageSharedPtr shared_msg;
   MessageUniquePtr unique_msg;
@@ -158,9 +159,9 @@ class PublisherBase
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(PublisherBase)
 
-  explicit PublisherBase(rclcpp::QoS qos = rclcpp::QoS(10))
-  : qos_profile(qos),
-    topic_name("topic")
+  explicit PublisherBase(const std::string & topic, rclcpp::QoS qos)
+  : topic_name(topic),
+    qos_profile(qos)
   {}
 
   virtual ~PublisherBase()
@@ -205,10 +206,12 @@ public:
     return false;
   }
 
-  rclcpp::QoS qos_profile;
-  std::string topic_name;
   uint64_t intra_process_publisher_id_;
   IntraProcessManagerWeakPtr weak_ipm_;
+
+private:
+  std::string topic_name;
+  rclcpp::QoS qos_profile;
 };
 
 template<typename T, typename Alloc = std::allocator<void>>
@@ -223,8 +226,8 @@ public:
 
   RCLCPP_SMART_PTR_DEFINITIONS(Publisher<T, Alloc>)
 
-  explicit Publisher(rclcpp::QoS qos = rclcpp::QoS(10))
-  : PublisherBase(qos)
+  explicit Publisher(const std::string & topic, rclcpp::QoS qos)
+  : PublisherBase(topic, qos)
   {
     auto allocator = std::make_shared<Alloc>();
     message_allocator_ = std::make_shared<MessageAlloc>(*allocator.get());
@@ -258,9 +261,9 @@ public:
 
   explicit SubscriptionIntraProcessBase(
     rclcpp::Context::SharedPtr context,
-    const std::string & topic = "topic",
-    rclcpp::QoS qos = rclcpp::QoS(10))
-  : qos_profile(qos), topic_name(topic)
+    const std::string & topic,
+    rclcpp::QoS qos)
+  : topic_name(topic), qos_profile(qos)
   {
     (void)context;
   }
@@ -292,8 +295,8 @@ public:
   size_t
   available_capacity() const = 0;
 
-  rclcpp::QoS qos_profile;
   std::string topic_name;
+  rclcpp::QoS qos_profile;
 };
 
 template<
@@ -307,8 +310,8 @@ class SubscriptionIntraProcessBuffer : public SubscriptionIntraProcessBase
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(SubscriptionIntraProcessBuffer)
 
-  explicit SubscriptionIntraProcessBuffer(rclcpp::QoS qos)
-  : SubscriptionIntraProcessBase(nullptr, "topic", qos), take_shared_method(false)
+  explicit SubscriptionIntraProcessBuffer(const std::string & topic, rclcpp::QoS qos)
+  : SubscriptionIntraProcessBase(nullptr, topic, qos), take_shared_method(false)
   {
     buffer = std::make_unique<rclcpp::experimental::buffers::mock::IntraProcessBuffer<MessageT>>();
   }
@@ -375,8 +378,8 @@ class SubscriptionIntraProcess : public SubscriptionIntraProcessBuffer<
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(SubscriptionIntraProcess)
 
-  explicit SubscriptionIntraProcess(rclcpp::QoS qos = rclcpp::QoS(10))
-  : SubscriptionIntraProcessBuffer<MessageT, Alloc, Deleter>(qos)
+  explicit SubscriptionIntraProcess(const std::string & topic, rclcpp::QoS qos)
+  : SubscriptionIntraProcessBuffer<MessageT, Alloc, Deleter>(topic, qos)
   {
   }
 };
@@ -466,12 +469,11 @@ TEST(TestIntraProcessManager, add_pub_sub) {
 
   auto ipm = std::make_shared<IntraProcessManagerT>();
 
-  auto p1 = std::make_shared<PublisherT>(rclcpp::QoS(10).best_effort());
+  auto p1 = std::make_shared<PublisherT>("topic", rclcpp::QoS(10).best_effort());
 
-  auto p2 = std::make_shared<PublisherT>(rclcpp::QoS(10).best_effort());
-  p2->topic_name = "different_topic_name";
+  auto p2 = std::make_shared<PublisherT>("different_topic_name", rclcpp::QoS(10).best_effort());
 
-  auto s1 = std::make_shared<SubscriptionIntraProcessT>(rclcpp::QoS(10).best_effort());
+  auto s1 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10).best_effort());
 
   auto p1_id = ipm->add_publisher(p1);
   auto p2_id = ipm->add_publisher(p2);
@@ -487,9 +489,9 @@ TEST(TestIntraProcessManager, add_pub_sub) {
   ASSERT_EQ(0u, p2_subs);
   ASSERT_EQ(0u, non_existing_pub_subs);
 
-  auto p3 = std::make_shared<PublisherT>(rclcpp::QoS(10).reliable());
+  auto p3 = std::make_shared<PublisherT>("topic", rclcpp::QoS(10).reliable());
 
-  auto s2 = std::make_shared<SubscriptionIntraProcessT>(rclcpp::QoS(10).reliable());
+  auto s2 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10).reliable());
 
   auto s2_id = ipm->template add_subscription<MessageT>(s2);
   auto p3_id = ipm->add_publisher(p3);
@@ -528,11 +530,11 @@ TEST(TestIntraProcessManager, single_subscription) {
 
   auto ipm = std::make_shared<IntraProcessManagerT>();
 
-  auto p1 = std::make_shared<PublisherT>();
+  auto p1 = std::make_shared<PublisherT>("topic", rclcpp::QoS(10));
   auto p1_id = ipm->add_publisher(p1);
   p1->set_intra_process_manager(p1_id, ipm);
 
-  auto s1 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s1 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s1->take_shared_method = false;
   auto s1_id = ipm->template add_subscription<MessageT>(s1);
 
@@ -543,7 +545,7 @@ TEST(TestIntraProcessManager, single_subscription) {
   ASSERT_EQ(original_message_pointer, received_message_pointer_1);
 
   ipm->remove_subscription(s1_id);
-  auto s2 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s2 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s2->take_shared_method = true;
   auto s2_id = ipm->template add_subscription<MessageT>(s2);
   (void)s2_id;
@@ -582,15 +584,15 @@ TEST(TestIntraProcessManager, multiple_subscriptions_same_type) {
 
   auto ipm = std::make_shared<IntraProcessManagerT>();
 
-  auto p1 = std::make_shared<PublisherT>();
+  auto p1 = std::make_shared<PublisherT>("topic", rclcpp::QoS(10));
   auto p1_id = ipm->add_publisher(p1);
   p1->set_intra_process_manager(p1_id, ipm);
 
-  auto s1 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s1 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s1->take_shared_method = false;
   auto s1_id = ipm->template add_subscription<MessageT>(s1);
 
-  auto s2 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s2 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s2->take_shared_method = false;
   auto s2_id = ipm->template add_subscription<MessageT>(s2);
 
@@ -606,11 +608,11 @@ TEST(TestIntraProcessManager, multiple_subscriptions_same_type) {
   ipm->remove_subscription(s1_id);
   ipm->remove_subscription(s2_id);
 
-  auto s3 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s3 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s3->take_shared_method = true;
   auto s3_id = ipm->template add_subscription<MessageT>(s3);
 
-  auto s4 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s4 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s4->take_shared_method = true;
   auto s4_id = ipm->template add_subscription<MessageT>(s4);
 
@@ -625,11 +627,11 @@ TEST(TestIntraProcessManager, multiple_subscriptions_same_type) {
   ipm->remove_subscription(s3_id);
   ipm->remove_subscription(s4_id);
 
-  auto s5 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s5 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s5->take_shared_method = false;
   auto s5_id = ipm->template add_subscription<MessageT>(s5);
 
-  auto s6 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s6 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s6->take_shared_method = false;
   auto s6_id = ipm->template add_subscription<MessageT>(s6);
 
@@ -645,12 +647,12 @@ TEST(TestIntraProcessManager, multiple_subscriptions_same_type) {
   ipm->remove_subscription(s5_id);
   ipm->remove_subscription(s6_id);
 
-  auto s7 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s7 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s7->take_shared_method = true;
   auto s7_id = ipm->template add_subscription<MessageT>(s7);
   (void)s7_id;
 
-  auto s8 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s8 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s8->take_shared_method = true;
   auto s8_id = ipm->template add_subscription<MessageT>(s8);
   (void)s8_id;
@@ -688,15 +690,15 @@ TEST(TestIntraProcessManager, multiple_subscriptions_different_type) {
 
   auto ipm = std::make_shared<IntraProcessManagerT>();
 
-  auto p1 = std::make_shared<PublisherT>();
+  auto p1 = std::make_shared<PublisherT>("topic", rclcpp::QoS(10));
   auto p1_id = ipm->add_publisher(p1);
   p1->set_intra_process_manager(p1_id, ipm);
 
-  auto s1 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s1 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s1->take_shared_method = true;
   auto s1_id = ipm->template add_subscription<MessageT>(s1);
 
-  auto s2 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s2 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s2->take_shared_method = false;
   auto s2_id = ipm->template add_subscription<MessageT>(s2);
 
@@ -711,15 +713,15 @@ TEST(TestIntraProcessManager, multiple_subscriptions_different_type) {
   ipm->remove_subscription(s1_id);
   ipm->remove_subscription(s2_id);
 
-  auto s3 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s3 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s3->take_shared_method = false;
   auto s3_id = ipm->template add_subscription<MessageT>(s3);
 
-  auto s4 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s4 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s4->take_shared_method = false;
   auto s4_id = ipm->template add_subscription<MessageT>(s4);
 
-  auto s5 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s5 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s5->take_shared_method = true;
   auto s5_id = ipm->template add_subscription<MessageT>(s5);
 
@@ -743,19 +745,19 @@ TEST(TestIntraProcessManager, multiple_subscriptions_different_type) {
   ipm->remove_subscription(s4_id);
   ipm->remove_subscription(s5_id);
 
-  auto s6 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s6 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s6->take_shared_method = true;
   auto s6_id = ipm->template add_subscription<MessageT>(s6);
 
-  auto s7 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s7 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s7->take_shared_method = true;
   auto s7_id = ipm->template add_subscription<MessageT>(s7);
 
-  auto s8 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s8 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s8->take_shared_method = false;
   auto s8_id = ipm->template add_subscription<MessageT>(s8);
 
-  auto s9 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s9 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s9->take_shared_method = false;
   auto s9_id = ipm->template add_subscription<MessageT>(s9);
 
@@ -781,12 +783,12 @@ TEST(TestIntraProcessManager, multiple_subscriptions_different_type) {
   ipm->remove_subscription(s8_id);
   ipm->remove_subscription(s9_id);
 
-  auto s10 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s10 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s10->take_shared_method = false;
   auto s10_id = ipm->template add_subscription<MessageT>(s10);
   (void)s10_id;
 
-  auto s11 = std::make_shared<SubscriptionIntraProcessT>();
+  auto s11 = std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(10));
   s11->take_shared_method = true;
   auto s11_id = ipm->template add_subscription<MessageT>(s11);
   (void)s11_id;
@@ -831,10 +833,12 @@ TEST(TestIntraProcessManager, lowest_available_capacity) {
 
   auto ipm = std::make_shared<IntraProcessManagerT>();
 
-  auto p1 = std::make_shared<PublisherT>(rclcpp::QoS(history_depth).best_effort());
+  auto p1 = std::make_shared<PublisherT>("topic", rclcpp::QoS(history_depth).best_effort());
 
-  auto s1 = std::make_shared<SubscriptionIntraProcessT>(rclcpp::QoS(history_depth).best_effort());
-  auto s2 = std::make_shared<SubscriptionIntraProcessT>(rclcpp::QoS(history_depth).best_effort());
+  auto s1 =
+    std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(history_depth).best_effort());
+  auto s2 =
+    std::make_shared<SubscriptionIntraProcessT>("topic", rclcpp::QoS(history_depth).best_effort());
 
   auto p1_id = ipm->add_publisher(p1);
   p1->set_intra_process_manager(p1_id, ipm);
@@ -902,7 +906,7 @@ TEST(TestIntraProcessManager, transient_local_invalid_buffer) {
 
   auto ipm = std::make_shared<IntraProcessManagerT>();
 
-  auto p1 = std::make_shared<PublisherT>(rclcpp::QoS(history_depth).transient_local());
+  auto p1 = std::make_shared<PublisherT>("topic", rclcpp::QoS(history_depth).transient_local());
 
   ASSERT_THROW(
   {
@@ -926,14 +930,14 @@ TEST(TestIntraProcessManager, transient_local) {
 
   auto ipm = std::make_shared<IntraProcessManagerT>();
 
-  auto p1 = std::make_shared<PublisherT>(rclcpp::QoS(history_depth).transient_local());
+  auto p1 = std::make_shared<PublisherT>("topic", rclcpp::QoS(history_depth).transient_local());
 
-  auto s1 =
-    std::make_shared<SubscriptionIntraProcessT>(rclcpp::QoS(history_depth).transient_local());
-  auto s2 =
-    std::make_shared<SubscriptionIntraProcessT>(rclcpp::QoS(history_depth).transient_local());
-  auto s3 =
-    std::make_shared<SubscriptionIntraProcessT>(rclcpp::QoS(history_depth).transient_local());
+  auto s1 = std::make_shared<SubscriptionIntraProcessT>(
+    "topic", rclcpp::QoS(history_depth).transient_local());
+  auto s2 = std::make_shared<SubscriptionIntraProcessT>(
+    "topic", rclcpp::QoS(history_depth).transient_local());
+  auto s3 = std::make_shared<SubscriptionIntraProcessT>(
+    "topic", rclcpp::QoS(history_depth).transient_local());
 
   s1->take_shared_method = false;
   s2->take_shared_method = true;


### PR DESCRIPTION
There are 2 patches here:

1.  Make every pub and sub in test_intra_process_manager.cpp have to pass in both a topic name and a QoS when they are constructing mock pubs and subs for the intra-process manager test.  This just makes it easier to tell whether the pubs and subs should be matched or not.
2.  The intra_process_manager will attempt to match QoS between publishers and subscriptions as they are added to the IPM. This is exactly correct, but the tests were not following the same pattern. Thus, when running these tests under Zenoh, the tests would fail because more things would match than the tests were expecting. Update the test to take the differences in QoS into account, which fixes the test under rmw_zenoh_cpp (and keeps it working for the existing DDS RMWs).