### PR TITLE
[Backport] set QoS History KEEP_ALL explicitly for statistics publisher. (#2650)

### DIFF
--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -80,7 +80,8 @@ struct SubscriptionOptionsBase
 
     // An optional QoS which can provide topic_statistics with a stable QoS separate from
     // the subscription's current QoS settings which could be unstable.
-    rclcpp::QoS qos = SystemDefaultsQoS();
+    // Explicitly set the enough depth to avoid missing the statistics messages.
+    rclcpp::QoS qos = SystemDefaultsQoS().keep_last(10);
   };
 
   TopicStatisticsOptions topic_stats_options;

--- a/rclcpp/test/rclcpp/test_subscription_options.cpp
+++ b/rclcpp/test/rclcpp/test_subscription_options.cpp
@@ -60,7 +60,7 @@ TEST_F(TestSubscriptionOptions, topic_statistics_options_default_and_set) {
   EXPECT_EQ(options.topic_stats_options.state, rclcpp::TopicStatisticsState::NodeDefault);
   EXPECT_EQ(options.topic_stats_options.publish_topic, defaultPublishTopic);
   EXPECT_EQ(options.topic_stats_options.publish_period, 1s);
-  EXPECT_EQ(options.topic_stats_options.qos, rclcpp::SystemDefaultsQoS());
+  EXPECT_EQ(options.topic_stats_options.qos, rclcpp::SystemDefaultsQoS().keep_last(10));
 
   options.topic_stats_options.state = rclcpp::TopicStatisticsState::Enable;
   options.topic_stats_options.publish_topic = "topic_statistics";


### PR DESCRIPTION
Backport of https://github.com/ros2/rclcpp/pull/2650

closes https://github.com/ros2/rclcpp/issues/2588

* set QoS History KEEP_ALL explicitly for statistics publisher.
* test_subscription_options adjustment.