### PR TITLE
Correct the incorrect comments in generic_client.hpp

### DIFF
--- a/rclcpp/include/rclcpp/generic_client.hpp
+++ b/rclcpp/include/rclcpp/generic_client.hpp
@@ -36,8 +36,8 @@ namespace rclcpp
 class GenericClient : public ClientBase
 {
 public:
-  using Request = void *;   // Serialized data pointer of request message
-  using Response = void *;  // Serialized data pointer of response message
+  using Request = void *;   // Deserialized data pointer of request message
+  using Response = void *;  // Deserialized data pointer of response message
 
   using SharedResponse = std::shared_ptr<void>;
 


### PR DESCRIPTION
This is a minor fix.  

Since the current rmw does not provide an interface to obtain serialized request and response data, both generic_client and generic_service are currently handling deserialized untyped data.   

In the code comments, it was mistakenly written as serialized data.  