### PR TITLE
use rmw_qos_profile_rosout_default instead of rcl.

### DIFF
--- a/rclcpp/include/rclcpp/qos.hpp
+++ b/rclcpp/include/rclcpp/qos.hpp
@@ -475,7 +475,7 @@ public:
   explicit
   RosoutQoS(
     const QoSInitialization & rosout_qos_initialization = (
-      QoSInitialization::from_rmw(rcl_qos_profile_rosout_default)
+      QoSInitialization::from_rmw(rmw_qos_profile_rosout_default)
   ));
 };
 

--- a/rclcpp/src/rclcpp/qos.cpp
+++ b/rclcpp/src/rclcpp/qos.cpp
@@ -407,7 +407,7 @@ ParameterEventsQoS::ParameterEventsQoS(const QoSInitialization & qos_initializat
 {}
 
 RosoutQoS::RosoutQoS(const QoSInitialization & rosout_initialization)
-: QoS(rosout_initialization, rcl_qos_profile_rosout_default)
+: QoS(rosout_initialization, rmw_qos_profile_rosout_default)
 {}
 
 SystemDefaultsQoS::SystemDefaultsQoS(const QoSInitialization & qos_initialization)

--- a/rclcpp/test/rclcpp/test_qos.cpp
+++ b/rclcpp/test/rclcpp/test_qos.cpp
@@ -184,7 +184,7 @@ TEST(TestQoS, DerivedTypes) {
   EXPECT_EQ(rmw_qos_profile_parameter_events, parameter_events_qos.get_rmw_qos_profile());
 
   rclcpp::RosoutQoS rosout_qos;
-  EXPECT_EQ(rcl_qos_profile_rosout_default, rosout_qos.get_rmw_qos_profile());
+  EXPECT_EQ(rmw_qos_profile_rosout_default, rosout_qos.get_rmw_qos_profile());
 
   rclcpp::SystemDefaultsQoS system_default_qos;
   const rclcpp::KeepLast expected_initialization(RMW_QOS_POLICY_DEPTH_SYSTEM_DEFAULT);

--- a/rclcpp/test/rclcpp/test_rosout_qos.cpp
+++ b/rclcpp/test/rclcpp/test_rosout_qos.cpp
@@ -58,8 +58,8 @@ TEST(TestRosoutQoS, test_rosout_qos_with_default_value) {
   rclcpp::NodeOptions node_options;
   rclcpp::QoS rosout_qos_profile = node_options.rosout_qos();
   rmw_qos_profile_t rmw_qos_profile = rosout_qos_profile.get_rmw_qos_profile();
-  EXPECT_EQ(rcl_qos_profile_rosout_default, rmw_qos_profile);
-  EXPECT_EQ(rcl_qos_profile_rosout_default, node_options.get_rcl_node_options()->rosout_qos);
+  EXPECT_EQ(rmw_qos_profile_rosout_default, rmw_qos_profile);
+  EXPECT_EQ(rmw_qos_profile_rosout_default, node_options.get_rcl_node_options()->rosout_qos);
 }
 
 /*


### PR DESCRIPTION
depends on https://github.com/ros2/rmw/pull/381 and https://github.com/ros2/rcl/pull/1195