### PR TITLE
Fix documentation typo in server_goal_handle.hpp

### DIFF
--- a/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
+++ b/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
@@ -43,7 +43,7 @@ class ServerGoalHandleBase
 {
 public:
   /// Indicate if client has requested this goal be cancelled.
-  /// \return true if a cancelation request has been accepted for this goal.
+  /// \return true if a cancellation request has been accepted for this goal.
   RCLCPP_ACTION_PUBLIC
   bool
   is_canceling() const;


### PR DESCRIPTION
Changes from pull request #2668 to re-target the branch.

Both typos from the previous PR need to be fixed in the downstream ([`humble`](https://github.com/ros2/rclcpp/tree/humble)).