### PR TITLE
Omnibus fixes for running tests with Connext.

### DIFF
--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -714,6 +714,12 @@ TYPED_TEST(TestExecutors, notifyTwiceWhileSpinning)
       sub1_msg_count++;
     });
 
+  // Wait for the subscription to be matched
+  size_t tries = 1000;
+  while (this->publisher->get_subscription_count() < 1 && tries-- > 0) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
   // Publish a message and verify it's received
   this->publisher->publish(test_msgs::msg::Empty());
   auto start = std::chrono::steady_clock::now();
@@ -730,6 +736,12 @@ TYPED_TEST(TestExecutors, notifyTwiceWhileSpinning)
     [&sub2_msg_count](test_msgs::msg::Empty::ConstSharedPtr) {
       sub2_msg_count++;
     });
+
+  // Wait for the subscription to be matched
+  tries = 1000;
+  while (this->publisher->get_subscription_count() < 2 && tries-- > 0) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
 
   // Publish a message and verify it's received by both subscriptions
   this->publisher->publish(test_msgs::msg::Empty());

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -715,10 +715,11 @@ TYPED_TEST(TestExecutors, notifyTwiceWhileSpinning)
     });
 
   // Wait for the subscription to be matched
-  size_t tries = 1000;
-  while (this->publisher->get_subscription_count() < 1 && tries-- > 0) {
+  size_t tries = 10000;
+  while (this->publisher->get_subscription_count() < 2 && tries-- > 0) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
+  ASSERT_EQ(this->publisher->get_subscription_count(), 2);
 
   // Publish a message and verify it's received
   this->publisher->publish(test_msgs::msg::Empty());
@@ -738,10 +739,11 @@ TYPED_TEST(TestExecutors, notifyTwiceWhileSpinning)
     });
 
   // Wait for the subscription to be matched
-  tries = 1000;
-  while (this->publisher->get_subscription_count() < 2 && tries-- > 0) {
+  tries = 10000;
+  while (this->publisher->get_subscription_count() < 3 && tries-- > 0) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
+  ASSERT_EQ(this->publisher->get_subscription_count(), 3);
 
   // Publish a message and verify it's received by both subscriptions
   this->publisher->publish(test_msgs::msg::Empty());

--- a/rclcpp/test/rclcpp/test_client_common.cpp
+++ b/rclcpp/test/rclcpp/test_client_common.cpp
@@ -431,7 +431,7 @@ TYPED_TEST(TestAllClientTypesWithServer, client_qos)
 
   rclcpp::ServicesQoS qos_profile;
   qos_profile.liveliness(rclcpp::LivelinessPolicy::Automatic);
-  rclcpp::Duration duration(std::chrono::nanoseconds(1));
+  rclcpp::Duration duration(std::chrono::milliseconds(1));
   qos_profile.deadline(duration);
   qos_profile.lifespan(duration);
   qos_profile.liveliness_lease_duration(duration);

--- a/rclcpp/test/rclcpp/test_generic_service.cpp
+++ b/rclcpp/test/rclcpp/test_generic_service.cpp
@@ -320,7 +320,7 @@ TEST_F(TestGenericService, rcl_service_request_subscription_get_actual_qos_error
 TEST_F(TestGenericService, generic_service_qos) {
   rclcpp::ServicesQoS qos_profile;
   qos_profile.liveliness(rclcpp::LivelinessPolicy::Automatic);
-  rclcpp::Duration duration(std::chrono::nanoseconds(1));
+  rclcpp::Duration duration(std::chrono::milliseconds(1));
   qos_profile.deadline(duration);
   qos_profile.lifespan(duration);
   qos_profile.liveliness_lease_duration(duration);

--- a/rclcpp/test/rclcpp/test_service.cpp
+++ b/rclcpp/test/rclcpp/test_service.cpp
@@ -335,7 +335,7 @@ TEST_F(TestService, rcl_service_request_subscription_get_actual_qos_error) {
 TEST_F(TestService, server_qos) {
   rclcpp::ServicesQoS qos_profile;
   qos_profile.liveliness(rclcpp::LivelinessPolicy::Automatic);
-  rclcpp::Duration duration(std::chrono::nanoseconds(1));
+  rclcpp::Duration duration(std::chrono::milliseconds(1));
   qos_profile.deadline(duration);
   qos_profile.lifespan(duration);
   qos_profile.liveliness_lease_duration(duration);

--- a/rclcpp/test/rclcpp/test_service_introspection.cpp
+++ b/rclcpp/test/rclcpp/test_service_introspection.cpp
@@ -92,9 +92,9 @@ TEST_F(TestServiceIntrospection, service_introspection_nominal)
   request->set__int64_value(42);
 
   client->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
+    node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
   service->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
+    node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
 
   auto future = client->async_send_request(request);
   ASSERT_EQ(
@@ -163,9 +163,9 @@ TEST_F(TestServiceIntrospection, service_introspection_nominal)
 TEST_F(TestServiceIntrospection, service_introspection_enable_disable_events)
 {
   client->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_OFF);
+    node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_OFF);
   service->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_OFF);
+    node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_OFF);
 
   auto request = std::make_shared<BasicTypes::Request>();
   request->set__bool_value(true);
@@ -183,9 +183,9 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_events)
   events.clear();
 
   client->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
+    node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
   service->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_OFF);
+    node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_OFF);
 
   future = client->async_send_request(request);
   ASSERT_EQ(
@@ -200,9 +200,9 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_events)
   events.clear();
 
   client->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_OFF);
+    node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_OFF);
   service->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
+    node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
 
   future = client->async_send_request(request);
   ASSERT_EQ(
@@ -217,9 +217,9 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_events)
   events.clear();
 
   client->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
+    node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
   service->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
+    node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
 
   future = client->async_send_request(request);
   ASSERT_EQ(
@@ -235,9 +235,9 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_events)
 TEST_F(TestServiceIntrospection, service_introspection_enable_disable_event_content)
 {
   client->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
+    node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
   service->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
+    node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
 
   auto request = std::make_shared<BasicTypes::Request>();
   request->set__bool_value(true);
@@ -259,9 +259,9 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_event_cont
   events.clear();
 
   client->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
+    node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
   service->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
+    node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
 
   future = client->async_send_request(request);
   ASSERT_EQ(
@@ -292,9 +292,9 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_event_cont
   events.clear();
 
   client->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
+    node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
   service->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
+    node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
 
   future = client->async_send_request(request);
   ASSERT_EQ(
@@ -325,9 +325,9 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_event_cont
   events.clear();
 
   client->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
+    node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
   service->configure_introspection(
-    node->get_clock(), rclcpp::SystemDefaultsQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
+    node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
 
   future = client->async_send_request(request);
   ASSERT_EQ(

--- a/rclcpp/test/rclcpp/test_service_introspection.cpp
+++ b/rclcpp/test/rclcpp/test_service_introspection.cpp
@@ -96,6 +96,13 @@ TEST_F(TestServiceIntrospection, service_introspection_nominal)
   service->configure_introspection(
     node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
 
+  // Wait for the introspection to attach to our subscription
+  size_t tries = 1000;
+  while (this->sub->get_publisher_count() < 2 && tries-- > 0) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  ASSERT_EQ(sub->get_publisher_count(), 2u);
+
   auto future = client->async_send_request(request);
   ASSERT_EQ(
     rclcpp::FutureReturnCode::SUCCESS,
@@ -192,7 +199,7 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_events)
   // Wait for the introspection to attach to our subscription
   size_t tries = 1000;
   while (this->sub->get_publisher_count() < 1 && tries-- > 0) {
-     std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   ASSERT_EQ(sub->get_publisher_count(), 1u);
 
@@ -216,7 +223,7 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_events)
   // Wait for the introspection to attach to our subscription
   tries = 1000;
   while (this->sub->get_publisher_count() < 1 && tries-- > 0) {
-     std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   ASSERT_EQ(sub->get_publisher_count(), 1u);
 
@@ -240,7 +247,7 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_events)
   // Wait for the introspection to attach to our subscription
   tries = 1000;
   while (this->sub->get_publisher_count() < 2 && tries-- > 0) {
-     std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   ASSERT_EQ(sub->get_publisher_count(), 2u);
 
@@ -261,6 +268,13 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_event_cont
     node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
   service->configure_introspection(
     node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
+
+  // Wait for the introspection to attach to our subscription
+  size_t tries = 1000;
+  while (this->sub->get_publisher_count() < 2 && tries-- > 0) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  ASSERT_EQ(sub->get_publisher_count(), 2u);
 
   auto request = std::make_shared<BasicTypes::Request>();
   request->set__bool_value(true);
@@ -286,6 +300,13 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_event_cont
   service->configure_introspection(
     node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
 
+  // Wait for the introspection to attach to our subscription
+  tries = 1000;
+  while (this->sub->get_publisher_count() < 2 && tries-- > 0) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  ASSERT_EQ(sub->get_publisher_count(), 2u);
+
   future = client->async_send_request(request);
   ASSERT_EQ(
     rclcpp::FutureReturnCode::SUCCESS,
@@ -319,6 +340,13 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_event_cont
   service->configure_introspection(
     node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
 
+  // Wait for the introspection to attach to our subscription
+  tries = 1000;
+  while (this->sub->get_publisher_count() < 2 && tries-- > 0) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  ASSERT_EQ(sub->get_publisher_count(), 2u);
+
   future = client->async_send_request(request);
   ASSERT_EQ(
     rclcpp::FutureReturnCode::SUCCESS,
@@ -351,6 +379,13 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_event_cont
     node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
   service->configure_introspection(
     node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_CONTENTS);
+
+  // Wait for the introspection to attach to our subscription
+  tries = 1000;
+  while (this->sub->get_publisher_count() < 2 && tries-- > 0) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  ASSERT_EQ(sub->get_publisher_count(), 2u);
 
   future = client->async_send_request(request);
   ASSERT_EQ(

--- a/rclcpp/test/rclcpp/test_service_introspection.cpp
+++ b/rclcpp/test/rclcpp/test_service_introspection.cpp
@@ -167,6 +167,8 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_events)
   service->configure_introspection(
     node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_OFF);
 
+  ASSERT_EQ(sub->get_publisher_count(), 0);
+
   auto request = std::make_shared<BasicTypes::Request>();
   request->set__bool_value(true);
   request->set__int64_value(42);
@@ -187,6 +189,13 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_events)
   service->configure_introspection(
     node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_OFF);
 
+  // Wait for the introspection to attach to our subscription
+  size_t tries = 1000;
+  while (this->sub->get_publisher_count() < 1 && tries-- > 0) {
+     std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  ASSERT_EQ(sub->get_publisher_count(), 1u);
+
   future = client->async_send_request(request);
   ASSERT_EQ(
     rclcpp::FutureReturnCode::SUCCESS,
@@ -204,6 +213,13 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_events)
   service->configure_introspection(
     node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
 
+  // Wait for the introspection to attach to our subscription
+  tries = 1000;
+  while (this->sub->get_publisher_count() < 1 && tries-- > 0) {
+     std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  ASSERT_EQ(sub->get_publisher_count(), 1u);
+
   future = client->async_send_request(request);
   ASSERT_EQ(
     rclcpp::FutureReturnCode::SUCCESS,
@@ -220,6 +236,13 @@ TEST_F(TestServiceIntrospection, service_introspection_enable_disable_events)
     node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
   service->configure_introspection(
     node->get_clock(), rclcpp::ServicesQoS(), RCL_SERVICE_INTROSPECTION_METADATA);
+
+  // Wait for the introspection to attach to our subscription
+  tries = 1000;
+  while (this->sub->get_publisher_count() < 2 && tries-- > 0) {
+     std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  ASSERT_EQ(sub->get_publisher_count(), 2u);
 
   future = client->async_send_request(request);
   ASSERT_EQ(


### PR DESCRIPTION
When running the tests with RTI Connext as the default RMW, some of the tests are failing.  There are three different failures fixed here:

1.  Setting the liveliness duration to a value smaller than a microsecond causes Connext to throw an error.  Set it to a millisecond.

2.  Using the SystemDefaultsQoS sets the QoS to KEEP_LAST 1. Connext is somewhat slow in this regard, so it can be the case that we are overwriting a previous service introspection event with the next one.  Switch to the ServicesDefaultQoS in the test, which ensures we will not lose events.

3.  Connext is slow to match publishers and subscriptions.  Thus, when creating a subscription "on-the-fly", we should wait for the publisher to match it before expecting the subscription to actually receive data from it.

With these fixes in place, the test_client_common, test_generic_service, test_service_introspection, and test_executors tests all pass for me with rmw_connextdds.

This should fix #2613, #2611, and #2646.  @Crola1702 FYI