### PR TITLE
Add parsing for rest of obvious boolean extra arguments and throw for unsupported ones

### DIFF
--- a/rclcpp_components/src/component_manager.cpp
+++ b/rclcpp_components/src/component_manager.cpp
@@ -223,6 +223,9 @@ ComponentManager::create_node_options(const std::shared_ptr<LoadNode::Request> r
             "Extra component argument 'enable_logger_service' must be a boolean");
       }
       options.enable_logger_service(extra_argument.get_value<bool>());
+    } else {
+      throw ComponentManagerException("Extra component argument '" + extra_argument.get_name() +
+          "' is not supported");
     }
   }
 

--- a/rclcpp_components/src/component_manager.cpp
+++ b/rclcpp_components/src/component_manager.cpp
@@ -169,24 +169,60 @@ ComponentManager::create_node_options(const std::shared_ptr<LoadNode::Request> r
 
   for (const auto & a : request->extra_arguments) {
     const rclcpp::Parameter extra_argument = rclcpp::Parameter::from_parameter_msg(a);
-    if (extra_argument.get_name() == "use_intra_process_comms") {
+    if (extra_argument.get_name() == "forward_global_arguments") {
       if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
         throw ComponentManagerException(
-                "Extra component argument 'use_intra_process_comms' must be a boolean");
-      }
-      options.use_intra_process_comms(extra_argument.get_value<bool>());
-    } else if (extra_argument.get_name() == "forward_global_arguments") {
-      if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
-        throw ComponentManagerException(
-                "Extra component argument 'forward_global_arguments' must be a boolean");
+            "Extra component argument 'forward_global_arguments' must be a boolean");
       }
       options.use_global_arguments(extra_argument.get_value<bool>());
       if (extra_argument.get_value<bool>()) {
         RCLCPP_WARN(
-          get_logger(), "forward_global_arguments is true by default in nodes, but is not "
-          "recommended in a component manager. If true, this will cause this node's behavior "
-          "to be influenced by global arguments, not only those targeted at this node.");
+            get_logger(), "forward_global_arguments is true by default in nodes, but is not "
+            "recommended in a component manager. If true, this will cause this node's behavior "
+            "to be influenced by global arguments, not only those targeted at this node.");
       }
+    } else if (extra_argument.get_name() == "enable_rosout") {
+      if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
+        throw ComponentManagerException(
+            "Extra component argument 'enable_rosout' must be a boolean");
+      }
+      options.enable_rosout(extra_argument.get_value<bool>());
+    } else if (extra_argument.get_name() == "use_intra_process_comms") {
+      if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
+        throw ComponentManagerException(
+            "Extra component argument 'use_intra_process_comms' must be a boolean");
+      }
+      options.use_intra_process_comms(extra_argument.get_value<bool>());
+    } else if (extra_argument.get_name() == "enable_topic_statistics") {
+      if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
+        throw ComponentManagerException(
+            "Extra component argument 'enable_topic_statistics' must be a boolean");
+      }
+      options.enable_topic_statistics(extra_argument.get_value<bool>());
+    } else if (extra_argument.get_name() == "start_parameter_services") {
+      if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
+        throw ComponentManagerException(
+            "Extra component argument 'start_parameter_services' must be a boolean");
+      }
+      options.start_parameter_services(extra_argument.get_value<bool>());
+    } else if (extra_argument.get_name() == "start_parameter_event_publisher") {
+      if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
+        throw ComponentManagerException(
+            "Extra component argument 'start_parameter_event_publisher' must be a boolean");
+      }
+      options.start_parameter_event_publisher(extra_argument.get_value<bool>());
+    } else if (extra_argument.get_name() == "use_clock_thread") {
+      if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
+        throw ComponentManagerException(
+            "Extra component argument 'use_clock_thread' must be a boolean");
+      }
+      options.use_clock_thread(extra_argument.get_value<bool>());
+    } else if (extra_argument.get_name() == "enable_logger_service") {
+      if (extra_argument.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
+        throw ComponentManagerException(
+            "Extra component argument 'enable_logger_service' must be a boolean");
+      }
+      options.enable_logger_service(extra_argument.get_value<bool>());
     }
   }
 

--- a/rclcpp_components/test/test_component_manager_api.cpp
+++ b/rclcpp_components/test/test_component_manager_api.cpp
@@ -180,91 +180,56 @@ void test_components_api(bool use_dedicated_executor)
     EXPECT_EQ(result->unique_id, 5u);
   }
 
-  {
-    // use_intra_process_comms
+
+  std::array<std::string, 8u> valid_extra_arguments = {
+    "forward_global_arguments",
+    "use_intra_process_comms",
+    "enable_rosout",
+    "enable_topic_statistics",
+    "start_parameter_services",
+    "start_parameter_event_publisher",
+    "use_clock_thread",
+    "enable_logger_service"
+  };
+
+  for (size_t i = 0; i < valid_extra_arguments.size(); ++i) {
+    const auto & arg = valid_extra_arguments[i];
     auto request = std::make_shared<composition_interfaces::srv::LoadNode::Request>();
     request->package_name = "rclcpp_components";
     request->plugin_name = "test_rclcpp_components::TestComponentFoo";
-    request->node_name = "test_component_intra_process";
-    rclcpp::Parameter use_intraprocess_comms("use_intra_process_comms",
-      rclcpp::ParameterValue(true));
-    request->extra_arguments.push_back(use_intraprocess_comms.to_parameter_msg());
+    {
+      // success
+      request->node_name = "test_component_" + arg;
+      rclcpp::Parameter extra_argument(arg, rclcpp::ParameterValue(true));
+      request->extra_arguments.push_back(extra_argument.to_parameter_msg());
 
-    auto future = composition_client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
-    auto result = future.get();
-    EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
-    EXPECT_EQ(result->success, true);
-    EXPECT_EQ(result->error_message, "");
-    std::cout << result->full_node_name << std::endl;
-    EXPECT_EQ(result->full_node_name, "/test_component_intra_process");
-    EXPECT_EQ(result->unique_id, 6u);
-  }
+      auto future = composition_client->async_send_request(request);
+      auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
+      auto result = future.get();
+      EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
+      EXPECT_EQ(result->success, true);
+      EXPECT_EQ(result->error_message, "");
+      EXPECT_EQ(result->full_node_name, "/test_component_" + arg);
+      EXPECT_EQ(result->unique_id, 6u + i);
+    }
 
-  {
-    // use_intra_process_comms is not a bool type parameter
-    auto request = std::make_shared<composition_interfaces::srv::LoadNode::Request>();
-    request->package_name = "rclcpp_components";
-    request->plugin_name = "test_rclcpp_components::TestComponentFoo";
-    request->node_name = "test_component_intra_process_str";
+    {
+      // not a bool type parameter
+      request->node_name = "test_component_" + arg + "_str";
+      rclcpp::Parameter extra_argument(arg, rclcpp::ParameterValue("hello"));
+      request->extra_arguments.clear();
+      request->extra_arguments.push_back(extra_argument.to_parameter_msg());
 
-    rclcpp::Parameter use_intraprocess_comms("use_intra_process_comms",
-      rclcpp::ParameterValue("hello"));
-    request->extra_arguments.push_back(use_intraprocess_comms.to_parameter_msg());
-
-    auto future = composition_client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
-    auto result = future.get();
-    EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
-    EXPECT_EQ(result->success, false);
-    EXPECT_EQ(
-      result->error_message,
-      "Extra component argument 'use_intra_process_comms' must be a boolean");
-    EXPECT_EQ(result->full_node_name, "");
-    EXPECT_EQ(result->unique_id, 0u);
-  }
-
-  {
-    // forward_global_arguments
-    auto request = std::make_shared<composition_interfaces::srv::LoadNode::Request>();
-    request->package_name = "rclcpp_components";
-    request->plugin_name = "test_rclcpp_components::TestComponentFoo";
-    request->node_name = "test_component_global_arguments";
-    rclcpp::Parameter forward_global_arguments("forward_global_arguments",
-      rclcpp::ParameterValue(true));
-    request->extra_arguments.push_back(forward_global_arguments.to_parameter_msg());
-
-    auto future = composition_client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
-    auto result = future.get();
-    EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
-    EXPECT_EQ(result->success, true);
-    EXPECT_EQ(result->error_message, "");
-    EXPECT_EQ(result->full_node_name, "/test_component_global_arguments");
-    EXPECT_EQ(result->unique_id, 7u);
-  }
-
-  {
-    // forward_global_arguments is not a bool type parameter
-    auto request = std::make_shared<composition_interfaces::srv::LoadNode::Request>();
-    request->package_name = "rclcpp_components";
-    request->plugin_name = "test_rclcpp_components::TestComponentFoo";
-    request->node_name = "test_component_global_arguments_str";
-
-    rclcpp::Parameter forward_global_arguments("forward_global_arguments",
-      rclcpp::ParameterValue("hello"));
-    request->extra_arguments.push_back(forward_global_arguments.to_parameter_msg());
-
-    auto future = composition_client->async_send_request(request);
-    auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
-    auto result = future.get();
-    EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
-    EXPECT_EQ(result->success, false);
-    EXPECT_EQ(
-      result->error_message,
-      "Extra component argument 'forward_global_arguments' must be a boolean");
-    EXPECT_EQ(result->full_node_name, "");
-    EXPECT_EQ(result->unique_id, 0u);
+      auto future = composition_client->async_send_request(request);
+      auto ret = exec->spin_until_future_complete(future, 5s);  // Wait for the result.
+      auto result = future.get();
+      EXPECT_EQ(ret, rclcpp::FutureReturnCode::SUCCESS);
+      EXPECT_EQ(result->success, false);
+      EXPECT_EQ(result->error_message,
+        "Extra component argument '" + arg + "' must be a boolean");
+      EXPECT_EQ(result->full_node_name, "");
+      EXPECT_EQ(result->unique_id, 0u);
+    }
   }
 
   auto node_names = node->get_node_names();
@@ -295,22 +260,19 @@ void test_components_api(bool use_dedicated_executor)
       auto result_node_names = result->full_node_names;
       auto result_unique_ids = result->unique_ids;
 
-      EXPECT_EQ(result_node_names.size(), 7u);
+      EXPECT_EQ(result_node_names.size(), 5u + valid_extra_arguments.size());
       EXPECT_EQ(result_node_names[0], "/test_component_foo");
       EXPECT_EQ(result_node_names[1], "/test_component_bar");
       EXPECT_EQ(result_node_names[2], "/test_component_baz");
       EXPECT_EQ(result_node_names[3], "/ns/test_component_bing");
       EXPECT_EQ(result_node_names[4], "/test_component_remap");
-      EXPECT_EQ(result_node_names[5], "/test_component_intra_process");
-      EXPECT_EQ(result_node_names[6], "/test_component_global_arguments");
-      EXPECT_EQ(result_unique_ids.size(), 7u);
-      EXPECT_EQ(result_unique_ids[0], 1u);
-      EXPECT_EQ(result_unique_ids[1], 2u);
-      EXPECT_EQ(result_unique_ids[2], 3u);
-      EXPECT_EQ(result_unique_ids[3], 4u);
-      EXPECT_EQ(result_unique_ids[4], 5u);
-      EXPECT_EQ(result_unique_ids[5], 6u);
-      EXPECT_EQ(result_unique_ids[6], 7u);
+      for (size_t i = 0u; i < valid_extra_arguments.size(); ++i) {
+        EXPECT_EQ(result_node_names[5u + i], "/test_component_" + valid_extra_arguments[i]);
+      }
+      EXPECT_EQ(result_unique_ids.size(), 5u + valid_extra_arguments.size());
+      for (size_t i = 0u; i < result_unique_ids.size(); ++i) {
+        EXPECT_EQ(result_unique_ids[i], 1u + i);
+      }
     }
   }
 
@@ -364,20 +326,18 @@ void test_components_api(bool use_dedicated_executor)
       auto result_node_names = result->full_node_names;
       auto result_unique_ids = result->unique_ids;
 
-      EXPECT_EQ(result_node_names.size(), 6u);
+      EXPECT_EQ(result_node_names.size(), 4u + valid_extra_arguments.size());
       EXPECT_EQ(result_node_names[0], "/test_component_bar");
       EXPECT_EQ(result_node_names[1], "/test_component_baz");
       EXPECT_EQ(result_node_names[2], "/ns/test_component_bing");
       EXPECT_EQ(result_node_names[3], "/test_component_remap");
-      EXPECT_EQ(result_node_names[4], "/test_component_intra_process");
-      EXPECT_EQ(result_node_names[5], "/test_component_global_arguments");
-      EXPECT_EQ(result_unique_ids.size(), 6u);
-      EXPECT_EQ(result_unique_ids[0], 2u);
-      EXPECT_EQ(result_unique_ids[1], 3u);
-      EXPECT_EQ(result_unique_ids[2], 4u);
-      EXPECT_EQ(result_unique_ids[3], 5u);
-      EXPECT_EQ(result_unique_ids[4], 6u);
-      EXPECT_EQ(result_unique_ids[5], 7u);
+      for (size_t i = 0u; i < valid_extra_arguments.size(); ++i) {
+        EXPECT_EQ(result_node_names[4u + i], "/test_component_" + valid_extra_arguments[i]);
+      }
+      EXPECT_EQ(result_unique_ids.size(), 4u + valid_extra_arguments.size());
+      for (size_t i = 0u; i < result_unique_ids.size(); ++i) {
+        EXPECT_EQ(result_unique_ids[i], 2u + i);
+      }
     }
   }
 }


### PR DESCRIPTION
Improves situation for #978.

Instead of arbitrarily only allowing forward_global_arguments and use_intra_process_comms as extra arguments for loading a component, this PR enables support for all obvious boolean node options.

#978 discusses more problematic options like `allow_undeclared_parameters`, which are still unsupported.

At least, this PR adds an error message if such or other unsupported extra arguments are passed.