### PR TITLE
Fix warnings on Windows.

### DIFF
--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -388,7 +388,7 @@ to_nanoseconds_helper(DurationT duration)
 //   - works nominally (it can execute entities)
 //   - it can execute multiple items at once
 //   - it does not wait for work to be available before returning
-TYPED_TEST(TestExecutors, spin_some)
+TYPED_TEST(TestExecutors, spinSome)
 {
   using ExecutorType = TypeParam;
 
@@ -484,7 +484,7 @@ TYPED_TEST(TestExecutors, spin_some)
 //   do not properly implement max_duration (it seems), so disable this test
 //   for them in the meantime.
 //   see: https://github.com/ros2/rclcpp/issues/2462
-TYPED_TEST(TestExecutorsStable, spin_some_max_duration)
+TYPED_TEST(TestExecutorsStable, spinSomeMaxDuration)
 {
   using ExecutorType = TypeParam;
 
@@ -834,7 +834,7 @@ TEST(TestExecutors, testSpinWithNonDefaultContext)
   rclcpp::shutdown(non_default_context);
 }
 
-TYPED_TEST(TestExecutors, release_ownership_entity_after_spinning_cancel)
+TYPED_TEST(TestExecutors, releaseOwnershipEntityAfterSpinningCancel)
 {
   using ExecutorType = TypeParam;
   ExecutorType executor;
@@ -870,19 +870,20 @@ TYPED_TEST(TestExecutors, testRaceDropCallbackGroupFromSecondThread)
   }
 
   // Create an executor
-  auto executor = std::make_shared<ExecutorType>();
-  executor->add_node(this->node);
+  ExecutorType executor;
+  executor.add_node(this->node);
 
   // Start spinning
   auto executor_thread = std::thread(
-    [executor]() {
-      executor->spin();
+    [&executor]() {
+      executor.spin();
     });
 
   // As the problem is a race, we do this multiple times,
   // to raise our chances of hitting the problem
-  for(size_t i = 0; i < 10; i++) {
-    auto cg = this->node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  for (size_t i = 0; i < 10; i++) {
+    auto cg = this->node->create_callback_group(
+      rclcpp::CallbackGroupType::MutuallyExclusive);
     auto timer = this->node->create_timer(1s, [] {}, cg);
     // sleep a bit, so that the spin thread can pick up the callback group
     // and add it to the executor
@@ -893,6 +894,6 @@ TYPED_TEST(TestExecutors, testRaceDropCallbackGroupFromSecondThread)
     // If the executor has a race, we will experience a segfault at this point.
   }
 
-  executor->cancel();
+  executor.cancel();
   executor_thread.join();
 }


### PR DESCRIPTION
For reasons I admit I do not understand, the deprecation warnings for StaticSingleThreadedExecutor on Windows happen when we construct a shared_ptr for it in the tests. If we construct a regular object, then it is fine.  Luckily this test does not require a shared_ptr, so just make it a regular object here, which fixes the warning.

While we are in here, make all of the tests camel case to be consistent.

This should fix the warnings introduced by #2683 .  @jmachowinski @fujitatomoya FYI