### PR TITLE
fix: Expose timers used by rclcpp::Waitables

### DIFF
--- a/rclcpp/include/rclcpp/event_handler.hpp
+++ b/rclcpp/include/rclcpp/event_handler.hpp
@@ -20,6 +20,7 @@
 #include <mutex>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include "rcl/error_handling.h"
 #include "rcl/event_callback.h"
@@ -219,6 +220,13 @@ public:
       set_on_new_event_callback(nullptr, nullptr);
       on_new_event_callback_ = nullptr;
     }
+  }
+
+  RCLCPP_PUBLIC
+  std::vector<std::shared_ptr<rclcpp::TimerBase>>
+  get_timers() const override
+  {
+    return {};
   }
 
 protected:

--- a/rclcpp/include/rclcpp/executors/executor_notify_waitable.hpp
+++ b/rclcpp/include/rclcpp/executors/executor_notify_waitable.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <mutex>
 #include <set>
+#include <vector>
 
 #include "rclcpp/guard_condition.hpp"
 #include "rclcpp/waitable.hpp"
@@ -145,6 +146,14 @@ public:
   RCLCPP_PUBLIC
   size_t
   get_number_of_ready_guard_conditions() override;
+
+  /// Returns the number of used Timers
+  /**
+   * Will always return an empty vector.
+   */
+  RCLCPP_PUBLIC
+  std::vector<std::shared_ptr<rclcpp::TimerBase>>
+  get_timers() const override;
 
 private:
   /// Callback to run when waitable executes

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <vector>
 
 #include "rcl/wait.h"
 #include "rmw/impl/cpp/demangle.hpp"
@@ -178,6 +179,13 @@ public:
   {
     std::lock_guard<std::recursive_mutex> lock(callback_mutex_);
     on_new_message_callback_ = nullptr;
+  }
+
+  RCLCPP_PUBLIC
+  std::vector<std::shared_ptr<rclcpp::TimerBase>>
+  get_timers() const override
+  {
+    return {};
   }
 
 protected:

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -20,8 +20,8 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "rcl/event_callback.h"
 #include "rcl/subscription.h"

--- a/rclcpp/include/rclcpp/waitable.hpp
+++ b/rclcpp/include/rclcpp/waitable.hpp
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <vector>
 
 #include "rclcpp/macros.hpp"
 #include "rclcpp/visibility_control.hpp"
@@ -26,6 +27,8 @@
 
 namespace rclcpp
 {
+
+class TimerBase;
 
 class Waitable
 {
@@ -257,6 +260,17 @@ public:
   virtual
   void
   clear_on_ready_callback() = 0;
+
+  /// Returns all timers used by this waitable
+  /**
+   * Must return all timers used within the waitable.
+   * Note, it is not supported, that timers are added
+   * or removed over the lifetime of the waitable.
+   */
+  RCLCPP_PUBLIC
+  virtual
+  std::vector<std::shared_ptr<rclcpp::TimerBase>>
+  get_timers() const = 0;
 
 private:
   std::atomic<bool> in_use_by_wait_set_{false};

--- a/rclcpp/src/rclcpp/executors/executor_notify_waitable.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_notify_waitable.cpp
@@ -189,5 +189,12 @@ ExecutorNotifyWaitable::get_number_of_ready_guard_conditions()
   return notify_guard_conditions_.size();
 }
 
+std::vector<std::shared_ptr<rclcpp::TimerBase>>
+ExecutorNotifyWaitable::get_timers() const
+{
+  return {};
+}
+
+
 }  // namespace executors
 }  // namespace rclcpp

--- a/rclcpp/src/rclcpp/experimental/executors/events_executor/events_executor.cpp
+++ b/rclcpp/src/rclcpp/experimental/executors/events_executor/events_executor.cpp
@@ -408,8 +408,16 @@ EventsExecutor::refresh_current_collection(
     [this](auto waitable) {
       waitable->set_on_ready_callback(
         this->create_waitable_callback(waitable.get()));
+      for (const auto & t : waitable->get_timers()) {
+        timers_manager_->add_timer(t);
+      }
     },
-    [](auto waitable) {waitable->clear_on_ready_callback();});
+    [this](auto waitable) {
+      waitable->clear_on_ready_callback();
+      for (const auto & t : waitable->get_timers()) {
+        timers_manager_->remove_timer(t);
+      }
+    });
 }
 
 std::function<void(size_t)>

--- a/rclcpp/test/rclcpp/executors/test_events_executor.cpp
+++ b/rclcpp/test/rclcpp/executors/test_events_executor.cpp
@@ -497,3 +497,122 @@ TEST_F(TestEventsExecutor, test_default_incompatible_qos_callbacks)
 
   rcutils_logging_set_output_handler(original_output_handler);
 }
+
+class TestWaitableWithTimer : public rclcpp::Waitable
+{
+  static constexpr int TimerCallbackType = 0;
+
+public:
+  explicit TestWaitableWithTimer(const rclcpp::Context::SharedPtr & context)
+  {
+    auto timer_callback = [this] () {
+        timer_ready = true;
+        if (ready_callback) {
+        // inform executor that the waitable is ready to process a timer event
+          ready_callback(1, TimerCallbackType);
+        }
+      };
+    timer =
+      std::make_shared<rclcpp::WallTimer<decltype (timer_callback)>>(std::chrono::milliseconds(10),
+      std::move(timer_callback), context);
+  }
+
+  void
+  add_to_wait_set(rcl_wait_set_t & /*wait_set*/) override {}
+
+  bool
+  is_ready(const rcl_wait_set_t & /*wait_set*/) override
+  {
+    return false;
+  }
+
+  std::shared_ptr<void>
+  take_data() override
+  {
+    return std::shared_ptr<void>(nullptr);
+  }
+
+  std::shared_ptr<void>
+  take_data_by_entity_id(size_t id) override
+  {
+    if (id != TimerCallbackType) {
+      throw std::runtime_error("Internal error, got wrong ID for take data");
+    }
+    return nullptr;
+  }
+
+  void
+  execute(const std::shared_ptr<void> &) override
+  {
+    if (timer_ready) {
+      timer_triggered_waitable_and_waitable_was_executed = true;
+    }
+  }
+
+  void
+  set_on_ready_callback(std::function<void(size_t, int)> callback) override
+  {
+    ready_callback = callback;
+  }
+
+  void
+  clear_on_ready_callback() override
+  {
+    ready_callback = std::function<void(size_t, int)>();
+  }
+
+  size_t
+  get_number_of_ready_guard_conditions() override
+  {
+    return 0;
+  }
+
+  std::vector<std::shared_ptr<rclcpp::TimerBase>> get_timers() const override
+  {
+    return {timer};
+  }
+
+  bool timerTriggeredWaitable() const
+  {
+    return timer_triggered_waitable_and_waitable_was_executed;
+  }
+
+private:
+  std::atomic_bool timer_triggered_waitable_and_waitable_was_executed = false;
+  std::atomic_bool timer_ready = false;
+  rclcpp::TimerBase::SharedPtr timer;
+  std::function<void(size_t, int)> ready_callback;
+};
+
+TEST_F(TestEventsExecutor, waitable_with_timer)
+{
+  auto node = std::make_shared<rclcpp::Node>("node");
+
+  auto waitable =
+    std::make_shared<TestWaitableWithTimer>(rclcpp::contexts::get_global_default_context());
+
+  EventsExecutor executor;
+  executor.add_node(node);
+
+  node->get_node_waitables_interface()->add_waitable(waitable,
+    node->get_node_base_interface()->get_default_callback_group());
+
+  std::thread spinner([&executor]() {executor.spin();});
+
+  size_t cnt = 0;
+  while (!waitable->timerTriggeredWaitable()) {
+    std::this_thread::sleep_for(10ms);
+    cnt++;
+
+    // This should terminate after ~20 ms, so a timeout of 500ms should be plenty
+    EXPECT_LT(cnt, 51);
+    if (cnt > 50) {
+      // timeout case
+      break;
+    }
+  }
+  executor.cancel();
+  spinner.join();
+
+  EXPECT_TRUE(waitable->timerTriggeredWaitable());
+}

--- a/rclcpp/test/rclcpp/executors/test_waitable.hpp
+++ b/rclcpp/test/rclcpp/executors/test_waitable.hpp
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <vector>
 
 #include "rclcpp/waitable.hpp"
 #include "rclcpp/guard_condition.hpp"
@@ -63,6 +64,11 @@ public:
 
   size_t
   get_is_ready_call_count() const;
+
+  std::vector<std::shared_ptr<rclcpp::TimerBase>> get_timers() const override
+  {
+    return {};
+  }
 
 private:
   std::atomic<size_t> trigger_count_ = 0;

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_waitables.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_waitables.cpp
@@ -38,6 +38,11 @@ public:
   void clear_on_ready_callback() override {}
 
   std::shared_ptr<void> take_data_by_entity_id(size_t) override {return nullptr;}
+
+  std::vector<std::shared_ptr<rclcpp::TimerBase>> get_timers() const override
+  {
+    return {};
+  }
 };
 
 class TestNodeWaitables : public ::testing::Test

--- a/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
@@ -58,6 +58,11 @@ public:
   void clear_on_ready_callback() override {}
 
   std::shared_ptr<void> take_data_by_entity_id(size_t) override {return nullptr;}
+
+  std::vector<std::shared_ptr<rclcpp::TimerBase>> get_timers() const override
+  {
+    return {};
+  }
 };
 
 struct RclWaitSetSizes

--- a/rclcpp/test/rclcpp/test_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/test_memory_strategy.cpp
@@ -45,6 +45,11 @@ public:
   void clear_on_ready_callback() override {}
 
   std::shared_ptr<void> take_data_by_entity_id(size_t) override {return nullptr;}
+
+  std::vector<std::shared_ptr<rclcpp::TimerBase>> get_timers() const override
+  {
+    return {};
+  }
 };
 
 class TestMemoryStrategy : public ::testing::Test

--- a/rclcpp/test/rclcpp/wait_set_policies/test_dynamic_storage.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_dynamic_storage.cpp
@@ -64,6 +64,11 @@ public:
 
   std::shared_ptr<void> take_data_by_entity_id(size_t) override {return nullptr;}
 
+  std::vector<std::shared_ptr<rclcpp::TimerBase>> get_timers() const override
+  {
+    return {};
+  }
+
 private:
   bool is_ready_;
 };

--- a/rclcpp/test/rclcpp/wait_set_policies/test_static_storage.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_static_storage.cpp
@@ -64,6 +64,11 @@ public:
 
   std::shared_ptr<void> take_data_by_entity_id(size_t) override {return nullptr;}
 
+  std::vector<std::shared_ptr<rclcpp::TimerBase>> get_timers() const override
+  {
+    return {};
+  }
+
 private:
   bool is_ready_;
 };

--- a/rclcpp/test/rclcpp/wait_set_policies/test_storage_policy_common.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_storage_policy_common.cpp
@@ -72,6 +72,11 @@ public:
 
   std::shared_ptr<void> take_data_by_entity_id(size_t) override {return nullptr;}
 
+  std::vector<std::shared_ptr<rclcpp::TimerBase>> get_timers() const override
+  {
+    return {};
+  }
+
 private:
   bool is_ready_;
   bool add_to_wait_set_;

--- a/rclcpp/test/rclcpp/wait_set_policies/test_thread_safe_synchronization.cpp
+++ b/rclcpp/test/rclcpp/wait_set_policies/test_thread_safe_synchronization.cpp
@@ -64,6 +64,11 @@ public:
 
   std::shared_ptr<void> take_data_by_entity_id(size_t) override {return nullptr;}
 
+  std::vector<std::shared_ptr<rclcpp::TimerBase>> get_timers() const override
+  {
+    return {};
+  }
+
 private:
   bool is_ready_;
 };

--- a/rclcpp_action/include/rclcpp_action/client.hpp
+++ b/rclcpp_action/include/rclcpp_action/client.hpp
@@ -25,6 +25,7 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "rcl/event_callback.h"
 
@@ -178,6 +179,10 @@ public:
   RCLCPP_ACTION_PUBLIC
   void
   clear_on_ready_callback() override;
+
+  RCLCPP_ACTION_PUBLIC
+  std::vector<std::shared_ptr<rclcpp::TimerBase>>
+  get_timers() const override;
 
   // End Waitables API
   // -----------------

--- a/rclcpp_action/include/rclcpp_action/server.hpp
+++ b/rclcpp_action/include/rclcpp_action/server.hpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "action_msgs/srv/cancel_goal.hpp"
 #include "rcl/event_callback.h"
@@ -177,6 +178,11 @@ public:
   RCLCPP_ACTION_PUBLIC
   void
   clear_on_ready_callback() override;
+
+  /// Returns all timers used by this waitable
+  RCLCPP_ACTION_PUBLIC
+  std::vector<std::shared_ptr<rclcpp::TimerBase>>
+  get_timers() const override;
 
   // End Waitables API
   // -----------------

--- a/rclcpp_action/src/client.cpp
+++ b/rclcpp_action/src/client.cpp
@@ -643,6 +643,12 @@ ClientBase::clear_on_ready_callback()
   entity_type_to_on_ready_callback_.clear();
 }
 
+std::vector<std::shared_ptr<rclcpp::TimerBase>>
+ClientBase::get_timers() const
+{
+  return {};
+}
+
 std::shared_ptr<void>
 ClientBase::take_data()
 {

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -86,6 +86,8 @@ public:
 
   rclcpp::Clock::SharedPtr clock_;
 
+  rclcpp::TimerBase::SharedPtr expire_timer_;
+
   // Do not declare this before clock_ as this depends on clock_(see #1526)
   std::shared_ptr<rcl_action_server_t> action_server_;
 
@@ -144,10 +146,17 @@ ServerBase::ServerBase(
   *(pimpl_->action_server_) = rcl_action_get_zero_initialized_server();
 
   rcl_node_t * rcl_node = node_base->get_rcl_node_handle();
-  rcl_clock_t * rcl_clock = pimpl_->clock_->get_clock_handle();
 
-  rcl_ret_t ret = rcl_action_server_init(
-    pimpl_->action_server_.get(), rcl_node, rcl_clock, type_support, name.c_str(), &options);
+  // This timer callback will never be called, we are only interested in
+  // weather the timer itself becomes ready or not.
+  std::function<void()> timer_callback = [] () {};
+  pimpl_->expire_timer_ = std::make_shared<rclcpp::GenericTimer<decltype (timer_callback)>>(
+      node_clock->get_clock(), std::chrono::nanoseconds(options.result_timeout.nanoseconds),
+      std::move(timer_callback), node_base->get_context(), false);
+
+  rcl_ret_t ret = rcl_action_server_init2(
+      pimpl_->action_server_.get(), rcl_node, pimpl_->expire_timer_->get_timer_handle().get(),
+      type_support, name.c_str(), &options);
 
   if (RCL_RET_OK != ret) {
     rclcpp::exceptions::throw_from_rcl_error(ret);
@@ -913,4 +922,10 @@ ServerBase::clear_on_ready_callback()
   }
 
   entity_type_to_on_ready_callback_.clear();
+}
+
+std::vector<std::shared_ptr<rclcpp::TimerBase>>
+ServerBase::get_timers() const
+{
+  return {pimpl_->expire_timer_};
 }

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -164,7 +164,7 @@ TEST_F(TestServer, construction_and_destruction_callback_group)
 TEST_F(TestServer, construction_and_destruction_server_init_error)
 {
   auto mock = mocking_utils::patch_and_return(
-    "lib:rclcpp_action", rcl_action_server_init, RCL_RET_ERROR);
+    "lib:rclcpp_action", rcl_action_server_init2, RCL_RET_ERROR);
   auto node = std::make_shared<rclcpp::Node>("construct_node", "/rclcpp_action/construct");
 
   EXPECT_THROW(


### PR DESCRIPTION
This change was needed, as an events based executors needs to be aware of the timers, in order generate the timer ready events.

@alsora @wjwwood This PR is the followup to the discussion two weeks back in the client workgroup.