### PR TITLE
fix TestTimeSource.ROS_time_valid_attach_detach.

### DIFF
--- a/rclcpp/test/rclcpp/test_time_source.cpp
+++ b/rclcpp/test/rclcpp/test_time_source.cpp
@@ -212,6 +212,9 @@ TEST_F(TestTimeSource, ROS_time_valid_attach_detach) {
   ts.attachNode(node);
   EXPECT_FALSE(ros_clock->ros_time_is_active());
 
+  ts.attachClock(ros_clock);
+  EXPECT_FALSE(ros_clock->ros_time_is_active());
+
   ts.detachClock(ros_clock);
   EXPECT_FALSE(ros_clock->ros_time_is_active());
 }


### PR DESCRIPTION
This PR fixes the `TestTimeSource.ROS_time_valid_attach_detach` error message below.
This test is expected to call `detachClock` with valid operation to remove the clock successfully.

- before

```bash
colcon test --event-handlers console_direct+ --packages-select rclcpp --ctest-args -R test_time_source
...
89: [ RUN      ] TestTimeSource.ROS_time_valid_attach_detach
89: [ERROR] [1733531284.881187504] [rclcpp]: failed to remove clock
89: [       OK ] TestTimeSource.ROS_time_valid_attach_detach (4 ms)
...
```

- after

```bash
colcon test --event-handlers console_direct+ --packages-select rclcpp --ctest-args -R test_time_source
...
89: [ RUN      ] TestTimeSource.ROS_time_valid_attach_detach
89: [       OK ] TestTimeSource.ROS_time_valid_attach_detach (4 ms)
...
```
