### PR TITLE
Adding in topic name to logging on IPC issues

### DIFF
--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -157,13 +157,13 @@ public:
       // Register the publisher with the intra process manager.
       if (qos.history() != rclcpp::HistoryPolicy::KeepLast) {
         throw std::invalid_argument(
-                "intraprocess communication on topic " + topic +
-                " allowed only with keep last history qos policy");
+                "intraprocess communication on topic '" + topic +
+                "' allowed only with keep last history qos policy");
       }
       if (qos.depth() == 0) {
         throw std::invalid_argument(
-                "intraprocess communication on topic " + topic +
-                " is not allowed with a zero qos history depth value");
+                "intraprocess communication on topic '" + topic +
+                "' is not allowed with a zero qos history depth value");
       }
       if (qos.durability() == rclcpp::DurabilityPolicy::TransientLocal) {
         buffer_ = rclcpp::experimental::create_intra_process_buffer<

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -147,7 +147,6 @@ public:
     const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options)
   {
     // Topic is unused for now.
-    (void)topic;
     (void)options;
 
     // If needed, setup intra process communication.
@@ -158,11 +157,13 @@ public:
       // Register the publisher with the intra process manager.
       if (qos.history() != rclcpp::HistoryPolicy::KeepLast) {
         throw std::invalid_argument(
-                "intraprocess communication allowed only with keep last history qos policy");
+                "intraprocess communication on topic " + topic +
+                " allowed only with keep last history qos policy");
       }
       if (qos.depth() == 0) {
         throw std::invalid_argument(
-                "intraprocess communication is not allowed with a zero qos history depth value");
+                "intraprocess communication on topic " + topic +
+                " is not allowed with a zero qos history depth value");
       }
       if (qos.durability() == rclcpp::DurabilityPolicy::TransientLocal) {
         buffer_ = rclcpp::experimental::create_intra_process_buffer<

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -147,11 +147,13 @@ public:
       auto qos_profile = get_actual_qos();
       if (qos_profile.history() != rclcpp::HistoryPolicy::KeepLast) {
         throw std::invalid_argument(
-                "intraprocess communication allowed only with keep last history qos policy");
+                "intraprocess communication on topic " + topic_name +
+                " allowed only with keep last history qos policy");
       }
       if (qos_profile.depth() == 0) {
         throw std::invalid_argument(
-                "intraprocess communication is not allowed with 0 depth qos policy");
+                "intraprocess communication on topic " + topic_name +
+                " is not allowed with 0 depth qos policy");
       }
 
       using SubscriptionIntraProcessT = rclcpp::experimental::SubscriptionIntraProcess<

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -147,13 +147,13 @@ public:
       auto qos_profile = get_actual_qos();
       if (qos_profile.history() != rclcpp::HistoryPolicy::KeepLast) {
         throw std::invalid_argument(
-                "intraprocess communication on topic " + topic_name +
-                " allowed only with keep last history qos policy");
+                "intraprocess communication on topic '" + topic_name +
+                "' allowed only with keep last history qos policy");
       }
       if (qos_profile.depth() == 0) {
         throw std::invalid_argument(
-                "intraprocess communication on topic " + topic_name +
-                " is not allowed with 0 depth qos policy");
+                "intraprocess communication on topic '" + topic_name +
+                "' is not allowed with 0 depth qos policy");
       }
 
       using SubscriptionIntraProcessT = rclcpp::experimental::SubscriptionIntraProcess<

--- a/rclcpp/test/rclcpp/test_publisher.cpp
+++ b/rclcpp/test/rclcpp/test_publisher.cpp
@@ -436,7 +436,8 @@ TEST_F(TestPublisher, intra_process_publish_failures) {
     node->create_publisher<test_msgs::msg::Empty>(
       "topic", rclcpp::QoS(0), options),
     std::invalid_argument(
-      "intraprocess communication on topic topic is not allowed with a zero qos history depth value"));
+      "intraprocess communication on topic 'topic' "
+      "is not allowed with a zero qos history depth value"));
 }
 
 TEST_F(TestPublisher, inter_process_publish_failures) {

--- a/rclcpp/test/rclcpp/test_publisher.cpp
+++ b/rclcpp/test/rclcpp/test_publisher.cpp
@@ -436,7 +436,7 @@ TEST_F(TestPublisher, intra_process_publish_failures) {
     node->create_publisher<test_msgs::msg::Empty>(
       "topic", rclcpp::QoS(0), options),
     std::invalid_argument(
-      "intraprocess communication is not allowed with a zero qos history depth value"));
+      "intraprocess communication on topic topic is not allowed with a zero qos history depth value"));
 }
 
 TEST_F(TestPublisher, inter_process_publish_failures) {


### PR DESCRIPTION
This enables more introspection on "why" something failed so a user can fix it. Without this, migrating a node to IPC can be excruciatingly painful to find what of dozens of interfaces are having problems. 

Addresses https://github.com/ros2/rclcpp/issues/2703