### PR TITLE
Fix transient local IPC publish 

### DIFF
--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -317,8 +317,11 @@ public:
       return;
     }
 
+    // When durability is set to TransientLocal (i.e. there is a buffer),
+    // inter process publish should always take place to ensure
+    // late joiners receive past data.
     bool inter_process_publish_needed =
-      get_subscription_count() > get_intra_process_subscription_count();
+      get_subscription_count() > get_intra_process_subscription_count() || buffer_;
 
     if (inter_process_publish_needed) {
       auto ros_msg_ptr = std::make_shared<ROSMessageType>();

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -235,8 +235,12 @@ public:
     // interprocess publish, resulting in lower publish-to-subscribe latency.
     // It's not possible to do that with an unique_ptr,
     // as do_intra_process_publish takes the ownership of the message.
+
+    // When durability is set to TransientLocal (i.e. there is a buffer),
+    // inter process publish should always take place to ensure
+    // late joiners receive past data.
     bool inter_process_publish_needed =
-      get_subscription_count() > get_intra_process_subscription_count();
+      get_subscription_count() > get_intra_process_subscription_count() || buffer_;
 
     if (inter_process_publish_needed) {
       auto shared_msg =

--- a/rclcpp/test/rclcpp/test_publisher.cpp
+++ b/rclcpp/test/rclcpp/test_publisher.cpp
@@ -822,5 +822,5 @@ TEST_F(TestPublisher, intra_process_inter_process_mix_transient_local) {
   EXPECT_EQ(executor.spin_until_future_complete(inter_callback_future,
     std::chrono::milliseconds(100)), rclcpp::FutureReturnCode::SUCCESS);
   EXPECT_EQ(executor.spin_until_future_complete(intra_callback_future,
-    std::chrono::milliseconds(0)), rclcpp::FutureReturnCode::TIMEOUT);
+    std::chrono::milliseconds(100)), rclcpp::FutureReturnCode::TIMEOUT);
 }

--- a/rclcpp/test/rclcpp/test_publisher.cpp
+++ b/rclcpp/test/rclcpp/test_publisher.cpp
@@ -725,10 +725,7 @@ TEST_F(TestPublisher, intra_process_transient_local) {
   auto do_nothing = [](std::shared_ptr<const test_msgs::msg::Empty>) {};
   struct IntraProcessCallback
   {
-    void callback_fun(size_t)
-    {
-      called = true;
-    }
+    void callback_fun(size_t) {called = true;}
     bool called = false;
   };
   rclcpp::SubscriptionOptions sub_options_ipm_disabled;
@@ -805,10 +802,7 @@ TEST_F(TestPublisher, intra_process_inter_process_mix_transient_local) {
   auto do_nothing = [](std::shared_ptr<const test_msgs::msg::Empty>) {};
   struct SubscriptionCallback
   {
-    void callback_fun(size_t)
-    {
-      called = true;
-    }
+    void callback_fun(size_t) {called = true;}
     bool called = false;
   };
   rclcpp::SubscriptionOptions sub_options_ipm_disabled;

--- a/rclcpp/test/rclcpp/test_publisher.cpp
+++ b/rclcpp/test/rclcpp/test_publisher.cpp
@@ -786,8 +786,6 @@ TEST_F(TestPublisher, intra_process_transient_local) {
 TEST_F(TestPublisher, intra_process_inter_process_mix_transient_local) {
   constexpr auto history_depth = 10u;
   initialize(rclcpp::NodeOptions().use_intra_process_comms(true));
-  rclcpp::PublisherOptionsWithAllocator<std::allocator<void>> pub_options_ipm_disabled;
-  pub_options_ipm_disabled.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
 
   rclcpp::PublisherOptionsWithAllocator<std::allocator<void>> pub_options_ipm_enabled;
   pub_options_ipm_enabled.use_intra_process_comm = rclcpp::IntraProcessSetting::Enable;
@@ -807,8 +805,6 @@ TEST_F(TestPublisher, intra_process_inter_process_mix_transient_local) {
   };
   rclcpp::SubscriptionOptions sub_options_ipm_disabled;
   sub_options_ipm_disabled.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
-  rclcpp::SubscriptionOptions sub_options_ipm_enabled;
-  sub_options_ipm_enabled.use_intra_process_comm = rclcpp::IntraProcessSetting::Enable;
   SubscriptionCallback intra_callback, inter_callback;
   auto sub_ipm_disabled_transient_local_enabled = node->create_subscription<test_msgs::msg::Empty>(
     "topic1",


### PR DESCRIPTION
Signed-off-by: Jeffery Hsu [jefferyyjhsu@gmail.com](mailto:jefferyyjhsu@gmail.com)

Fix transient local publish when inter and intra process communications are both present described in #2704.
Add a new test case for transient local publish mixing communication types.

