### PR TITLE
Redundant .c_str() usage in rclcpp_components triggers ament_clang_tidy warning

### DIFF
--- a/rclcpp_components/src/node_main.cpp.in
+++ b/rclcpp_components/src/node_main.cpp.in
@@ -40,7 +40,7 @@ int main(int argc, char * argv[])
   auto loader = new class_loader::ClassLoader(library_name);
   auto classes = loader->getAvailableClasses<rclcpp_components::NodeFactory>();
   for (const auto & clazz : classes) {
-    std::string name = clazz.c_str();
+    std::string name = clazz;
     if (name.compare(class_name) == 0) {
       RCLCPP_DEBUG(logger, "Instantiate class %s", clazz.c_str());
       std::shared_ptr<rclcpp_components::NodeFactory> node_factory = nullptr;

--- a/rclcpp_components/src/node_main.cpp.in
+++ b/rclcpp_components/src/node_main.cpp.in
@@ -40,8 +40,7 @@ int main(int argc, char * argv[])
   auto loader = new class_loader::ClassLoader(library_name);
   auto classes = loader->getAvailableClasses<rclcpp_components::NodeFactory>();
   for (const auto & clazz : classes) {
-    std::string name = clazz;
-    if (name.compare(class_name) == 0) {
+    if (clazz.compare(class_name) == 0) {
       RCLCPP_DEBUG(logger, "Instantiate class %s", clazz.c_str());
       std::shared_ptr<rclcpp_components::NodeFactory> node_factory = nullptr;
       try {


### PR DESCRIPTION
The code snippet:

```cpp
std::string name = clazz.c_str();
```
is redundant and unnecessary when initializing a `std::string` object. 

The method `std::string::operator=(const char*)`, which takes a C-style string (`const char*`), introduces an extra conversion step when the input is already a `std::string`. Specifically, the `c_str()` method is used to extract a `const char*` pointer from `clazz`, and then `std::string` reconstructs the string from the pointer.

Instead, the simpler and more efficient approach is:

```cpp
std::string name = clazz;
```

This directly utilizes the copy constructor or move constructor of `std::string`, avoiding the unnecessary intermediate conversion to `const char*`. It results in cleaner, more idiomatic C++ code with no performance penalty.

Addresses: https://github.com/ros2/rclcpp/issues/2717