### PR TITLE
fix: make the loop condition align with the description

### DIFF
--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -749,8 +749,7 @@ TYPED_TEST(TestExecutors, notifyTwiceWhileSpinning)
   this->publisher->publish(test_msgs::msg::Empty());
   start = std::chrono::steady_clock::now();
   while (
-    sub1_msg_count == 1 &&
-    sub2_msg_count == 0 &&
+    (sub1_msg_count == 1 || sub2_msg_count == 0) &&
     (std::chrono::steady_clock::now() - start) < 10s)
   {
     std::this_thread::sleep_for(1ms);


### PR DESCRIPTION
This failure happens sporadically when developing [rmw_zenoh](github.com/ros2/rmw_zenoh). This PR aims to correct the test behavior.  