### PR TITLE
use maybe_unused attribute for the portability.

### DIFF
--- a/rclcpp/include/rclcpp/allocator/allocator_deleter.hpp
+++ b/rclcpp/include/rclcpp/allocator/allocator_deleter.hpp
@@ -69,18 +69,17 @@ private:
 };
 
 template<typename Alloc, typename T, typename D>
-void set_allocator_for_deleter(D * deleter, Alloc * alloc)
+void set_allocator_for_deleter([[maybe_unused]] D * deleter, [[maybe_unused]] Alloc * alloc)
 {
-  (void) alloc;
-  (void) deleter;
   throw std::runtime_error("Reached unexpected template specialization");
 }
 
 template<typename T, typename U>
-void set_allocator_for_deleter(std::default_delete<T> * deleter, std::allocator<U> * alloc)
+void set_allocator_for_deleter(
+  [[maybe_unused]] std::default_delete<T> * deleter,
+  [[maybe_unused]] std::allocator<U> * alloc)
 {
-  (void) deleter;
-  (void) alloc;
+  // This function is intentionally left empty.
 }
 
 template<typename Alloc, typename T>

--- a/rclcpp/include/rclcpp/event_handler.hpp
+++ b/rclcpp/include/rclcpp/event_handler.hpp
@@ -293,9 +293,8 @@ public:
   }
 
   std::shared_ptr<void>
-  take_data_by_entity_id(size_t id) override
+  take_data_by_entity_id([[maybe_unused]] size_t id) override
   {
-    (void)id;
     return take_data();
   }
 

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -79,9 +79,8 @@ public:
   take_data() override = 0;
 
   std::shared_ptr<void>
-  take_data_by_entity_id(size_t id) override
+  take_data_by_entity_id([[maybe_unused]] size_t id) override
   {
-    (void)id;
     return take_data();
   }
 

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_buffer.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_buffer.hpp
@@ -110,9 +110,8 @@ public:
   }
 
   bool
-  is_ready(const rcl_wait_set_t & wait_set) override
+  is_ready([[maybe_unused]] const rcl_wait_set_t & wait_set) override
   {
-    (void) wait_set;
     return buffer_->has_data();
   }
 

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -143,12 +143,9 @@ public:
   post_init_setup(
     rclcpp::node_interfaces::NodeBaseInterface * node_base,
     const std::string & topic,
-    const rclcpp::QoS & qos,
-    const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options)
+    [[maybe_unused]] const rclcpp::QoS & qos,
+    [[maybe_unused]] const rclcpp::PublisherOptionsWithAllocator<AllocatorT> & options)
   {
-    (void)qos;
-    (void)options;
-
     // If needed, setup intra process communication.
     if (rclcpp::detail::resolve_use_intra_process(options_, *node_base)) {
       auto context = node_base->get_context();

--- a/rclcpp/include/rclcpp/strategies/message_pool_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/message_pool_memory_strategy.hpp
@@ -114,9 +114,9 @@ public:
    * all references.
    * \param[in] msg Shared pointer to the message to return.
    */
-  void return_message(std::shared_ptr<MessageT> & msg)
+  void return_message([[maybe_unused]] std::shared_ptr<MessageT> & msg)
   {
-    (void)msg;
+    // This function is intentionally left empty.
   }
 
 protected:

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -209,13 +209,11 @@ public:
   /// Called after construction to continue setup that requires shared_from_this().
   void
   post_init_setup(
-    rclcpp::node_interfaces::NodeBaseInterface * node_base,
-    const rclcpp::QoS & qos,
-    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options)
+    [[maybe_unused]] rclcpp::node_interfaces::NodeBaseInterface * node_base,
+    [[maybe_unused]] const rclcpp::QoS & qos,
+    [[maybe_unused]] const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options)
   {
-    (void)node_base;
-    (void)qos;
-    (void)options;
+    // This function is intentionally left empty.
   }
 
   /// Take the next message from the inter-process subscription.
@@ -422,20 +420,17 @@ public:
 
   void
   return_dynamic_message(
-    rclcpp::dynamic_typesupport::DynamicMessage::SharedPtr & message) override
+    [[maybe_unused]] rclcpp::dynamic_typesupport::DynamicMessage::SharedPtr & message) override
   {
-    (void) message;
     throw rclcpp::exceptions::UnimplementedError(
             "return_dynamic_message is not implemented for Subscription");
   }
 
   void
   handle_dynamic_message(
-    const rclcpp::dynamic_typesupport::DynamicMessage::SharedPtr & message,
-    const rclcpp::MessageInfo & message_info) override
+    [[maybe_unused]] const rclcpp::dynamic_typesupport::DynamicMessage::SharedPtr & message,
+    [[maybe_unused]] const rclcpp::MessageInfo & message_info) override
   {
-    (void) message;
-    (void) message_info;
     throw rclcpp::exceptions::UnimplementedError(
             "handle_dynamic_message is not implemented for Subscription");
   }

--- a/rclcpp/src/rclcpp/detail/rmw_implementation_specific_publisher_payload.cpp
+++ b/rclcpp/src/rclcpp/detail/rmw_implementation_specific_publisher_payload.cpp
@@ -23,10 +23,9 @@ namespace detail
 
 void
 RMWImplementationSpecificPublisherPayload::modify_rmw_publisher_options(
-  rmw_publisher_options_t & rmw_publisher_options) const
+  [[maybe_unused]] rmw_publisher_options_t & rmw_publisher_options) const
 {
   // By default, do not mutate the rmw publisher options.
-  (void)rmw_publisher_options;
 }
 
 }  // namespace detail

--- a/rclcpp/src/rclcpp/detail/rmw_implementation_specific_subscription_payload.cpp
+++ b/rclcpp/src/rclcpp/detail/rmw_implementation_specific_subscription_payload.cpp
@@ -23,10 +23,9 @@ namespace detail
 
 void
 RMWImplementationSpecificSubscriptionPayload::modify_rmw_subscription_options(
-  rmw_subscription_options_t & rmw_subscription_options) const
+  [[maybe_unused]] rmw_subscription_options_t & rmw_subscription_options) const
 {
   // By default, do not mutate the rmw subscription options.
-  (void)rmw_subscription_options;
 }
 
 }  // namespace detail

--- a/rclcpp/src/rclcpp/detail/utilities.cpp
+++ b/rclcpp/src/rclcpp/detail/utilities.cpp
@@ -31,11 +31,10 @@ namespace detail
 
 std::vector<std::string>
 get_unparsed_ros_arguments(
-  int argc, char const * const * argv,
+  [[maybe_unused]] int argc, char const * const * argv,
   rcl_arguments_t * arguments,
   rcl_allocator_t allocator)
 {
-  (void)argc;
   std::vector<std::string> unparsed_ros_arguments;
   int unparsed_ros_args_count = rcl_arguments_get_count_unparsed_ros(arguments);
   if (unparsed_ros_args_count > 0) {

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -167,10 +167,9 @@ Executor::get_automatically_added_callback_groups_from_nodes()
 void
 Executor::add_callback_group(
   rclcpp::CallbackGroup::SharedPtr group_ptr,
-  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr,
+  [[maybe_unused]] rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr,
   bool notify)
 {
-  (void) node_ptr;
   this->collector_.add_callback_group(group_ptr);
 
   try {

--- a/rclcpp/src/rclcpp/executors/executor_notify_waitable.cpp
+++ b/rclcpp/src/rclcpp/executors/executor_notify_waitable.cpp
@@ -102,9 +102,8 @@ ExecutorNotifyWaitable::take_data()
 }
 
 std::shared_ptr<void>
-ExecutorNotifyWaitable::take_data_by_entity_id(size_t id)
+ExecutorNotifyWaitable::take_data_by_entity_id([[maybe_unused]] size_t id)
 {
-  (void) id;
   return nullptr;
 }
 

--- a/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp
@@ -79,9 +79,8 @@ MultiThreadedExecutor::get_number_of_threads()
 }
 
 void
-MultiThreadedExecutor::run(size_t this_thread_number)
+MultiThreadedExecutor::run([[maybe_unused]] size_t this_thread_number)
 {
-  (void)this_thread_number;
   while (rclcpp::ok(this->context_) && spinning.load()) {
     rclcpp::AnyExecutable any_exec;
     {

--- a/rclcpp/src/rclcpp/experimental/executors/events_executor/events_executor.cpp
+++ b/rclcpp/src/rclcpp/experimental/executors/events_executor/events_executor.cpp
@@ -318,10 +318,8 @@ EventsExecutor::execute_event(const ExecutorEvent & event)
 }
 
 void
-EventsExecutor::handle_updated_entities(bool notify)
+EventsExecutor::handle_updated_entities([[maybe_unused]] bool notify)
 {
-  (void)notify;
-
   // Do not rebuild if we don't need to.
   // A rebuild event could be generated, but then
   // this function could end up being called from somewhere else

--- a/rclcpp/src/rclcpp/generic_subscription.cpp
+++ b/rclcpp/src/rclcpp/generic_subscription.cpp
@@ -56,10 +56,9 @@ GenericSubscription::handle_serialized_message(
 
 void
 GenericSubscription::handle_loaned_message(
-  void * message, const rclcpp::MessageInfo & message_info)
+  [[maybe_unused]] void * message,
+  [[maybe_unused]] const rclcpp::MessageInfo & message_info)
 {
-  (void) message;
-  (void) message_info;
   throw rclcpp::exceptions::UnimplementedError(
           "handle_loaned_message is not implemented for GenericSubscription");
 }
@@ -111,20 +110,17 @@ GenericSubscription::create_dynamic_message()
 
 void
 GenericSubscription::return_dynamic_message(
-  rclcpp::dynamic_typesupport::DynamicMessage::SharedPtr & message)
+  [[maybe_unused]] rclcpp::dynamic_typesupport::DynamicMessage::SharedPtr & message)
 {
-  (void) message;
   throw rclcpp::exceptions::UnimplementedError(
           "return_dynamic_message is not implemented for GenericSubscription");
 }
 
 void
 GenericSubscription::handle_dynamic_message(
-  const rclcpp::dynamic_typesupport::DynamicMessage::SharedPtr & message,
-  const rclcpp::MessageInfo & message_info)
+  [[maybe_unused]] const rclcpp::dynamic_typesupport::DynamicMessage::SharedPtr & message,
+  [[maybe_unused]] const rclcpp::MessageInfo & message_info)
 {
-  (void) message;
-  (void) message_info;
   throw rclcpp::exceptions::UnimplementedError(
           "handle_dynamic_message is not implemented for GenericSubscription");
 }

--- a/rclcpp/src/rclcpp/publisher_base.cpp
+++ b/rclcpp/src/rclcpp/publisher_base.cpp
@@ -367,10 +367,8 @@ PublisherBase::default_incompatible_qos_callback(
 
 void
 PublisherBase::default_incompatible_type_callback(
-  rclcpp::IncompatibleTypeInfo & event) const
+  [[maybe_unused]] rclcpp::IncompatibleTypeInfo & event) const
 {
-  (void)event;
-
   RCLCPP_WARN(
     rclcpp::get_logger(rcl_node_get_logger_name(rcl_node_handle_.get())),
     "Incompatible type on topic '%s', no messages will be sent to it.", get_topic_name());

--- a/rclcpp/src/rclcpp/subscription_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_base.cpp
@@ -381,10 +381,8 @@ SubscriptionBase::default_incompatible_qos_callback(
 
 void
 SubscriptionBase::default_incompatible_type_callback(
-  rclcpp::IncompatibleTypeInfo & event) const
+  [[maybe_unused]] rclcpp::IncompatibleTypeInfo & event) const
 {
-  (void)event;
-
   RCLCPP_WARN(
     rclcpp::get_logger(rcl_node_get_logger_name(node_handle_.get())),
     "Incompatible type on topic '%s', no messages will be sent to it.", get_topic_name());

--- a/rclcpp/test/rclcpp/executors/executor_types.hpp
+++ b/rclcpp/test/rclcpp/executors/executor_types.hpp
@@ -61,9 +61,8 @@ class ExecutorTypeNames
 {
 public:
   template<typename T>
-  static std::string GetName(int idx)
+  static std::string GetName([[maybe_unused]] int idx)
   {
-    (void)idx;
     if (std::is_same<T, rclcpp::executors::SingleThreadedExecutor>()) {
       return "SingleThreadedExecutor";
     }

--- a/rclcpp/test/rclcpp/executors/test_events_executor.cpp
+++ b/rclcpp/test/rclcpp/executors/test_events_executor.cpp
@@ -48,9 +48,8 @@ TEST_F(TestEventsExecutor, run_pub_sub)
   bool msg_received = false;
   auto subscription = node->create_subscription<test_msgs::msg::Empty>(
     "topic", rclcpp::SensorDataQoS(),
-    [&msg_received](test_msgs::msg::Empty::ConstSharedPtr msg)
+    [&msg_received]([[maybe_unused]] test_msgs::msg::Empty::ConstSharedPtr msg)
     {
-      (void)msg;
       msg_received = true;
     });
 
@@ -115,8 +114,8 @@ TEST_F(TestEventsExecutor, run_clients_servers)
   auto request = std::make_shared<test_msgs::srv::Empty::Request>();
   client->async_send_request(
     request,
-    [&response_received](rclcpp::Client<test_msgs::srv::Empty>::SharedFuture result_future) {
-      (void)result_future;
+    [&response_received]([[maybe_unused]] rclcpp::Client<test_msgs::srv::Empty>::SharedFuture
+    result_future){
       response_received = true;
     });
 

--- a/rclcpp/test/rclcpp/executors/test_waitable.cpp
+++ b/rclcpp/test/rclcpp/executors/test_waitable.cpp
@@ -64,9 +64,8 @@ TestWaitable::take_data()
 }
 
 std::shared_ptr<void>
-TestWaitable::take_data_by_entity_id(size_t id)
+TestWaitable::take_data_by_entity_id([[maybe_unused]] size_t id)
 {
-  (void) id;
   return nullptr;
 }
 

--- a/rclcpp/test/rclcpp/test_client_common.cpp
+++ b/rclcpp/test/rclcpp/test_client_common.cpp
@@ -184,9 +184,8 @@ class ClientTypeNames
 {
 public:
   template<typename T>
-  static std::string GetName(int idx)
+  static std::string GetName([[maybe_unused]] int idx)
   {
-    (void)idx;
     if (std::is_same_v<T, rclcpp::Client<test_msgs::srv::Empty>>) {
       return "Client";
     }

--- a/rclcpp/test/rclcpp/test_function_traits.cpp
+++ b/rclcpp/test/rclcpp/test_function_traits.cpp
@@ -74,29 +74,23 @@ struct FunctionObjectOneIntOneChar
 
 struct ObjectMember
 {
-  int callback_one_bool(bool a)
+  int callback_one_bool([[maybe_unused]] bool a)
   {
-    (void)a;
     return 7;
   }
 
-  int callback_one_bool_const(bool a) const
+  int callback_one_bool_const([[maybe_unused]] bool a) const
   {
-    (void)a;
     return 7;
   }
 
-  int callback_two_bools(bool a, bool b)
+  int callback_two_bools([[maybe_unused]] bool a, [[maybe_unused]] bool b)
   {
-    (void)a;
-    (void)b;
     return 8;
   }
 
-  int callback_one_bool_one_float(bool a, float b)
+  int callback_one_bool_one_float([[maybe_unused]] bool a, [[maybe_unused]] float b)
   {
-    (void)a;
-    (void)b;
     return 9;
   }
 };
@@ -212,20 +206,15 @@ TEST(TestFunctionTraits, arity) {
       return 0;
     };
 
-  auto lambda_one_int = [](int one) {
-      (void)one;
+  auto lambda_one_int = []([[maybe_unused]] int one) {
       return 1;
     };
 
-  auto lambda_two_ints = [](int one, int two) {
-      (void)one;
-      (void)two;
+  auto lambda_two_ints = []([[maybe_unused]] int one, [[maybe_unused]] int two) {
       return 2;
     };
 
-  auto lambda_one_int_one_char = [](int one, char two) {
-      (void)one;
-      (void)two;
+  auto lambda_one_int_one_char = []([[maybe_unused]] int one, [[maybe_unused]] char two) {
       return 3;
     };
 
@@ -303,20 +292,15 @@ TEST(TestFunctionTraits, argument_types) {
     >::value, "Functor accepts a char as second argument");
 
   // Test lambdas
-  auto lambda_one_int = [](int one) {
-      (void)one;
+  auto lambda_one_int = []([[maybe_unused]] int one) {
       return 1;
     };
 
-  auto lambda_two_ints = [](int one, int two) {
-      (void)one;
-      (void)two;
+  auto lambda_two_ints = []([[maybe_unused]] int one, [[maybe_unused]] int two) {
       return 2;
     };
 
-  auto lambda_one_int_one_char = [](int one, char two) {
-      (void)one;
-      (void)two;
+  auto lambda_one_int_one_char = []([[maybe_unused]] int one, [[maybe_unused]]  char two) {
       return 3;
     };
 
@@ -533,22 +517,17 @@ TEST(TestFunctionTraits, check_arguments) {
     "Functor accepts an int and a char as arguments");
 
   // Test lambdas
-  auto lambda_one_int = [](int one) {
-      (void)one;
+  auto lambda_one_int = []([[maybe_unused]] int one) {
       return 1;
     };
   (void)lambda_one_int;  // to quiet clang
 
-  auto lambda_two_ints = [](int one, int two) {
-      (void)one;
-      (void)two;
+  auto lambda_two_ints = []([[maybe_unused]] int one, [[maybe_unused]] int two) {
       return 2;
     };
   (void)lambda_two_ints;  // to quiet clang
 
-  auto lambda_one_int_one_char = [](int one, char two) {
-      (void)one;
-      (void)two;
+  auto lambda_one_int_one_char = []([[maybe_unused]] int one, [[maybe_unused]]  char two) {
       return 3;
     };
   (void)lambda_one_int_one_char;  // to quiet clang
@@ -603,14 +582,11 @@ TEST(TestFunctionTraits, check_arguments) {
    Tests that same_arguments work.
 */
 TEST(TestFunctionTraits, same_arguments) {
-  auto lambda_one_int = [](int one) {
-      (void)one;
+  auto lambda_one_int = []([[maybe_unused]] int one) {
       return 1;
     };
 
-  auto lambda_two_ints = [](int one, int two) {
-      (void)one;
-      (void)two;
+  auto lambda_two_ints = []([[maybe_unused]] int one, [[maybe_unused]]  int two) {
       return 1;
     };
 
@@ -658,8 +634,7 @@ TEST(TestFunctionTraits, return_type) {
     "Functor return ints");
 
   // Test lambda
-  auto lambda_one_int_return_double = [](int one) -> double {
-      (void)one;
+  auto lambda_one_int_return_double = []([[maybe_unused]] int one) -> double {
       return 1.0;
     };
 
@@ -697,20 +672,15 @@ TEST(TestFunctionTraits, sfinae_match) {
       return 0;
     };
 
-  auto lambda_one_int = [](int one) {
-      (void)one;
+  auto lambda_one_int = []([[maybe_unused]] int one) {
       return 1;
     };
 
-  auto lambda_two_ints = [](int one, int two) {
-      (void)one;
-      (void)two;
+  auto lambda_two_ints = []([[maybe_unused]] int one, [[maybe_unused]]  int two) {
       return 2;
     };
 
-  auto lambda_one_int_one_char = [](int one, char two) {
-      (void)one;
-      (void)two;
+  auto lambda_one_int_one_char = []([[maybe_unused]] int one, [[maybe_unused]]  char two) {
       return 3;
     };
 

--- a/rclcpp/test/rclcpp/test_intra_process_manager.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager.cpp
@@ -193,16 +193,14 @@ public:
   }
 
   bool
-  operator==(const rmw_gid_t & gid) const
+  operator==([[maybe_unused]] const rmw_gid_t & gid) const
   {
-    (void)gid;
     return false;
   }
 
   bool
-  operator==(const rmw_gid_t * gid) const
+  operator==([[maybe_unused]] const rmw_gid_t * gid) const
   {
-    (void)gid;
     return false;
   }
 
@@ -260,12 +258,12 @@ public:
   RCLCPP_SMART_PTR_ALIASES_ONLY(SubscriptionIntraProcessBase)
 
   explicit SubscriptionIntraProcessBase(
-    rclcpp::Context::SharedPtr context,
+    [[maybe_unused]] rclcpp::Context::SharedPtr context,
     const std::string & topic,
     const rclcpp::QoS & qos)
   : topic_name(topic), qos_profile(qos)
   {
-    (void)context;
+    // This function is intentionally left empty.
   }
 
   virtual ~SubscriptionIntraProcessBase() {}

--- a/rclcpp/test/rclcpp/test_intra_process_manager_with_allocators.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager_with_allocators.cpp
@@ -61,9 +61,8 @@ public:
     return static_cast<T *>(std::malloc(size * sizeof(T)));
   }
 
-  void deallocate(T * ptr, size_t size)
+  void deallocate(T * ptr, [[maybe_unused]] size_t size)
   {
-    (void)size;
     if (!ptr) {
       return;
     }

--- a/rclcpp/test/rclcpp/test_parameter_client.cpp
+++ b/rclcpp/test/rclcpp/test_parameter_client.cpp
@@ -34,9 +34,9 @@ using namespace std::chrono_literals;
 class TestParameterClient : public ::testing::Test
 {
 public:
-  void OnMessage(rcl_interfaces::msg::ParameterEvent::ConstSharedPtr event)
+  void OnMessage([[maybe_unused]] rcl_interfaces::msg::ParameterEvent::ConstSharedPtr event)
   {
-    (void)event;
+    // This function is intentionally left empty.
   }
 
 protected:

--- a/rclcpp/test/rclcpp/test_publisher_subscription_count_api.cpp
+++ b/rclcpp/test/rclcpp/test_publisher_subscription_count_api.cpp
@@ -122,9 +122,9 @@ public:
   }
 
 protected:
-  static void OnMessage(test_msgs::msg::Empty::ConstSharedPtr msg)
+  static void OnMessage([[maybe_unused]] test_msgs::msg::Empty::ConstSharedPtr msg)
   {
-    (void)msg;
+    // This function is intentionally left empty.
   }
 
   std::chrono::milliseconds offset{2000};

--- a/rclcpp/test/rclcpp/test_publisher_with_type_adapter.cpp
+++ b/rclcpp/test/rclcpp/test_publisher_with_type_adapter.cpp
@@ -88,21 +88,18 @@ struct TypeAdapter<int, rclcpp::msg::String>
 
   static void
   convert_to_ros_message(
-    const custom_type & source,
-    ros_message_type & destination)
+    [[maybe_unused]] const custom_type & source,
+    [[maybe_unused]] ros_message_type & destination)
   {
-    (void) source;
-    (void) destination;
     throw std::runtime_error("This should not happen");
   }
 
   static void
   convert_to_custom(
-    const ros_message_type & source,
-    custom_type & destination)
+    [[maybe_unused]] const ros_message_type & source,
+    [[maybe_unused]] custom_type & destination)
   {
-    (void) source;
-    (void) destination;
+    // This function is intentionally left empty.
   }
 };
 
@@ -165,9 +162,9 @@ TEST_F(TestPublisher, conversion_exception_is_passed_up) {
     options.use_intra_process_comms(is_intra_process);
 
     auto callback =
-      [](const rclcpp::msg::String::ConstSharedPtr msg) -> void
+      []([[maybe_unused]] const rclcpp::msg::String::ConstSharedPtr msg) -> void
       {
-        (void)msg;
+        // This function is intentionally left empty.
       };
 
     auto node = std::make_shared<rclcpp::Node>("my_node", "/ns", options);

--- a/rclcpp/test/rclcpp/test_service_introspection.cpp
+++ b/rclcpp/test/rclcpp/test_service_introspection.cpp
@@ -63,7 +63,6 @@ protected:
 
     auto callback = [this](const std::shared_ptr<const BasicTypes::Event> & msg) {
         events.push_back(msg);
-        (void)msg;
       };
 
     client = node->create_client<BasicTypes>("service");

--- a/rclcpp/test/rclcpp/test_subscription.cpp
+++ b/rclcpp/test/rclcpp/test_subscription.cpp
@@ -36,9 +36,9 @@ using namespace std::chrono_literals;
 class TestSubscription : public ::testing::Test
 {
 public:
-  void on_message(test_msgs::msg::Empty::ConstSharedPtr msg)
+  void on_message([[maybe_unused]] test_msgs::msg::Empty::ConstSharedPtr msg)
   {
-    (void)msg;
+    // This function is intentionally left empty.
   }
 
 protected:
@@ -66,8 +66,8 @@ protected:
 TEST_F(TestSubscription, construction_and_destruction) {
   initialize();
   using test_msgs::msg::Empty;
-  auto callback = [](Empty::ConstSharedPtr msg) {
-      (void)msg;
+  auto callback = []([[maybe_unused]] Empty::ConstSharedPtr msg) {
+    // This function is intentionally left empty.
     };
   {
     constexpr size_t depth = 10u;
@@ -156,9 +156,9 @@ public:
   }
 
 private:
-  void on_message(test_msgs::msg::Empty::ConstSharedPtr msg)
+  void on_message([[maybe_unused]] test_msgs::msg::Empty::ConstSharedPtr msg)
   {
-    (void)msg;
+    // This function is intentionally left empty.
   }
 };
 
@@ -178,9 +178,9 @@ public:
   }
 
 private:
-  void on_message(test_msgs::msg::Empty::ConstSharedPtr msg)
+  void on_message([[maybe_unused]] test_msgs::msg::Empty::ConstSharedPtr msg)
   {
-    (void)msg;
+    // This function is intentionally left empty.
   }
 };
 
@@ -502,8 +502,8 @@ TEST_F(TestSubscription, on_new_intra_process_message_callback) {
 TEST_F(TestSubscription, get_network_flow_endpoints_errors) {
   initialize();
   const rclcpp::QoS subscription_qos(1);
-  auto subscription_callback = [](test_msgs::msg::Empty::ConstSharedPtr msg) {
-      (void)msg;
+  auto subscription_callback = []([[maybe_unused]] test_msgs::msg::Empty::ConstSharedPtr msg) {
+      // This function is intentionally left empty.
     };
   auto subscription = node_->create_subscription<test_msgs::msg::Empty>(
     "topic", subscription_qos, subscription_callback);
@@ -560,8 +560,8 @@ protected:
    Testing subscription construction and destruction for subnodes.
  */
 TEST_F(TestSubscriptionSub, construction_and_destruction) {
-  auto callback = [](test_msgs::msg::Empty::ConstSharedPtr msg) {
-      (void)msg;
+  auto callback = []([[maybe_unused]] test_msgs::msg::Empty::ConstSharedPtr msg) {
+    // This function is intentionally left empty.
     };
   {
     auto sub = subnode_->create_subscription<test_msgs::msg::Empty>("topic", 1, callback);

--- a/rclcpp/test/rclcpp/test_subscription_publisher_count_api.cpp
+++ b/rclcpp/test/rclcpp/test_subscription_publisher_count_api.cpp
@@ -108,9 +108,9 @@ public:
   }
 
 protected:
-  static void OnMessage(test_msgs::msg::Empty::ConstSharedPtr msg)
+  static void OnMessage([[maybe_unused]] test_msgs::msg::Empty::ConstSharedPtr msg)
   {
-    (void)msg;
+    // This function is intentionally left empty.
   }
 
   std::chrono::milliseconds offset{2000};

--- a/rclcpp/test/rclcpp/test_subscription_publisher_with_same_type_adapter.cpp
+++ b/rclcpp/test/rclcpp/test_subscription_publisher_with_same_type_adapter.cpp
@@ -57,21 +57,17 @@ struct TypeAdapter<std::string, rclcpp::msg::String>
 
   static void
   convert_to_ros_message(
-    const custom_type & source,
-    ros_message_type & destination)
+    [[maybe_unused]] const custom_type & source,
+    [[maybe_unused]] ros_message_type & destination)
   {
-    (void) source;
-    (void) destination;
     throw std::runtime_error("This should not happen");
   }
 
   static void
   convert_to_custom(
-    const ros_message_type & source,
-    custom_type & destination)
+    [[maybe_unused]] const ros_message_type & source,
+    [[maybe_unused]] custom_type & destination)
   {
-    (void) source;
-    (void) destination;
     throw std::runtime_error("This should not happen");
   }
 };

--- a/rclcpp/test/rclcpp/test_subscription_traits.cpp
+++ b/rclcpp/test/rclcpp/test_subscription_traits.cpp
@@ -26,41 +26,44 @@
 
 #include "test_msgs/msg/empty.hpp"
 
-void serialized_callback_copy(rcl_serialized_message_t unused)
+void serialized_callback_copy([[maybe_unused]] rcl_serialized_message_t unused)
 {
-  (void) unused;
+  // This function is intentionally left empty.
 }
 
-void serialized_callback_shared_ptr(std::shared_ptr<rcl_serialized_message_t> unused)
+void serialized_callback_shared_ptr(
+  [[maybe_unused]] std::shared_ptr<rcl_serialized_message_t> unused)
 {
-  (void) unused;
+  // This function is intentionally left empty.
 }
 
-void not_serialized_callback(char * unused)
+void not_serialized_callback([[maybe_unused]] char * unused)
 {
-  (void) unused;
+  // This function is intentionally left empty.
 }
 
-void not_serialized_shared_ptr_callback(std::shared_ptr<char> unused)
+void not_serialized_shared_ptr_callback([[maybe_unused]] std::shared_ptr<char> unused)
 {
-  (void) unused;
+  // This function is intentionally left empty.
 }
 
 void not_serialized_unique_ptr_callback(
+  [[maybe_unused]]
   test_msgs::msg::Empty::UniquePtrWithDeleter<rclcpp::allocator::Deleter<std::allocator<void>,
   test_msgs::msg::Empty>> unused)
 {
-  (void) unused;
+  // This function is intentionally left empty.
 }
 
-void rclcpp_serialized_callback_copy(rclcpp::SerializedMessage unused)
+void rclcpp_serialized_callback_copy([[maybe_unused]] rclcpp::SerializedMessage unused)
 {
-  (void) unused;
+  // This function is intentionally left empty.
 }
 
-void rclcpp_serialized_callback_shared_ptr(std::shared_ptr<rclcpp::SerializedMessage> unused)
+void rclcpp_serialized_callback_shared_ptr(
+  [[maybe_unused]] std::shared_ptr<rclcpp::SerializedMessage> unused)
 {
-  (void) unused;
+  // This function is intentionally left empty.
 }
 
 TEST(TestSubscriptionTraits, is_serialized_callback) {
@@ -85,9 +88,9 @@ TEST(TestSubscriptionTraits, is_serialized_callback) {
     rclcpp::subscription_traits::is_serialized_callback<decltype(cb4)>::value == false,
     "passing a std::shared_tr<char> is not a serialized callback");
 
-  auto cb5 = [](rcl_serialized_message_t unused) -> void
+  auto cb5 = []([[maybe_unused]] rcl_serialized_message_t unused) -> void
     {
-      (void) unused;
+      // This function is intentionally left empty.
     };
   static_assert(
     rclcpp::subscription_traits::is_serialized_callback<decltype(cb5)>::value == false,
@@ -96,9 +99,10 @@ TEST(TestSubscriptionTraits, is_serialized_callback) {
   using MessageT = test_msgs::msg::Empty;
   using MessageTAllocator = std::allocator<void>;
   using MessageTDeallocator = rclcpp::allocator::Deleter<MessageTAllocator, MessageT>;
-  auto cb6 = [](MessageT::UniquePtrWithDeleter<MessageTDeallocator> unique_msg_ptr) -> void
+  auto cb6 = [](
+    [[maybe_unused]] MessageT::UniquePtrWithDeleter<MessageTDeallocator> unique_msg_ptr) -> void
     {
-      (void) unique_msg_ptr;
+      // This function is intentionally left empty.
     };
   static_assert(
     rclcpp::subscription_traits::is_serialized_callback<decltype(cb6)>::value == false,
@@ -167,9 +171,9 @@ TEST(TestSubscriptionTraits, callback_messages) {
       rclcpp::subscription_traits::has_message_type<decltype(cb4)>::type>::value,
     "not serialized shared_ptr callback message type is std::shared_ptr<char>");
 
-  auto cb5 = [](rcl_serialized_message_t unused) -> void
+  auto cb5 = []([[maybe_unused]] rcl_serialized_message_t unused) -> void
     {
-      (void) unused;
+      // This function is intentionally left empty.
     };
   static_assert(
     std::is_same<
@@ -180,9 +184,10 @@ TEST(TestSubscriptionTraits, callback_messages) {
   using MessageT = test_msgs::msg::Empty;
   using MessageTAllocator = std::allocator<MessageT>;
   using MessageTDeallocator = rclcpp::allocator::Deleter<MessageTAllocator, MessageT>;
-  auto cb6 = [](std::unique_ptr<MessageT, MessageTDeallocator> unique_msg_ptr) -> void
+  auto cb6 = [](
+    [[maybe_unused]] std::unique_ptr<MessageT, MessageTDeallocator> unique_msg_ptr) -> void
     {
-      (void) unique_msg_ptr;
+      // This function is intentionally left empty.
     };
   static_assert(
     std::is_same<

--- a/rclcpp/test/rclcpp/topic_statistics/test_subscription_topic_statistics.cpp
+++ b/rclcpp/test/rclcpp/topic_statistics/test_subscription_topic_statistics.cpp
@@ -189,8 +189,8 @@ public:
     options.topic_stats_options.state = rclcpp::TopicStatisticsState::Enable;
     options.topic_stats_options.publish_period = publish_period;
 
-    auto callback = [](typename MessageT::UniquePtr msg) {
-        (void) msg;
+    auto callback = []([[maybe_unused]] typename MessageT::UniquePtr msg) {
+        // This function is intentionally left empty.
       };
     subscription_ = create_subscription<MessageT,
         std::function<void(typename MessageT::UniquePtr)>>(

--- a/rclcpp_action/include/rclcpp_action/server.hpp
+++ b/rclcpp_action/include/rclcpp_action/server.hpp
@@ -501,13 +501,12 @@ protected:
       };
 
     std::function<void(const GoalUUID &)> on_executing =
-      [weak_this](const GoalUUID & goal_uuid)
+      [weak_this]([[maybe_unused]] const GoalUUID & goal_uuid)
       {
         std::shared_ptr<Server<ActionT>> shared_this = weak_this.lock();
         if (!shared_this) {
           return;
         }
-        (void)goal_uuid;
         // Publish a status message any time a goal handle changes state
         shared_this->publish_status();
       };

--- a/rclcpp_action/test/test_client.cpp
+++ b/rclcpp_action/test/test_client.cpp
@@ -545,11 +545,9 @@ TEST_F(TestClientAgainstServer, async_send_goal_with_feedback_callback_wait_for_
   int feedback_count = 0;
   auto send_goal_ops = rclcpp_action::Client<ActionType>::SendGoalOptions();
   send_goal_ops.feedback_callback = [&feedback_count](
-    typename ActionGoalHandle::SharedPtr goal_handle,
-    const std::shared_ptr<const ActionFeedback> feedback)
+    [[maybe_unused]] typename ActionGoalHandle::SharedPtr goal_handle,
+    [[maybe_unused]] const std::shared_ptr<const ActionFeedback> feedback)
     {
-      (void)goal_handle;
-      (void)feedback;
       feedback_count++;
     };
   auto future_goal_handle = action_client->async_send_goal(goal, send_goal_ops);

--- a/rclcpp_components/src/component_manager.cpp
+++ b/rclcpp_components/src/component_manager.cpp
@@ -253,12 +253,10 @@ ComponentManager::remove_node_from_executor(uint64_t node_id)
 
 void
 ComponentManager::on_load_node(
-  const std::shared_ptr<rmw_request_id_t> request_header,
+  [[maybe_unused]] const std::shared_ptr<rmw_request_id_t> request_header,
   const std::shared_ptr<LoadNode::Request> request,
   std::shared_ptr<LoadNode::Response> response)
 {
-  (void) request_header;
-
   try {
     auto resources = get_component_resources(request->package_name);
 
@@ -322,12 +320,10 @@ ComponentManager::on_load_node(
 
 void
 ComponentManager::on_unload_node(
-  const std::shared_ptr<rmw_request_id_t> request_header,
+  [[maybe_unused]] const std::shared_ptr<rmw_request_id_t> request_header,
   const std::shared_ptr<UnloadNode::Request> request,
   std::shared_ptr<UnloadNode::Response> response)
 {
-  (void) request_header;
-
   auto wrapper = node_wrappers_.find(request->unique_id);
 
   if (wrapper == node_wrappers_.end()) {
@@ -345,13 +341,10 @@ ComponentManager::on_unload_node(
 
 void
 ComponentManager::on_list_nodes(
-  const std::shared_ptr<rmw_request_id_t> request_header,
-  const std::shared_ptr<ListNodes::Request> request,
+  [[maybe_unused]] const std::shared_ptr<rmw_request_id_t> request_header,
+  [[maybe_unused]] const std::shared_ptr<ListNodes::Request> request,
   std::shared_ptr<ListNodes::Response> response)
 {
-  (void) request_header;
-  (void) request;
-
   for (auto & wrapper : node_wrappers_) {
     response->unique_ids.push_back(wrapper.first);
     response->full_node_names.push_back(

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.cpp
@@ -208,11 +208,10 @@ LifecycleNode::LifecycleNodeInterfaceImpl::register_callback(
 
 void
 LifecycleNode::LifecycleNodeInterfaceImpl::on_change_state(
-  const std::shared_ptr<rmw_request_id_t> header,
+  [[maybe_unused]] const std::shared_ptr<rmw_request_id_t> header,
   const std::shared_ptr<ChangeStateSrv::Request> req,
   std::shared_ptr<ChangeStateSrv::Response> resp)
 {
-  (void)header;
   std::uint8_t transition_id;
   {
     std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
@@ -252,12 +251,10 @@ LifecycleNode::LifecycleNodeInterfaceImpl::on_change_state(
 
 void
 LifecycleNode::LifecycleNodeInterfaceImpl::on_get_state(
-  const std::shared_ptr<rmw_request_id_t> header,
-  const std::shared_ptr<GetStateSrv::Request> req,
+  [[maybe_unused]] const std::shared_ptr<rmw_request_id_t> header,
+  [[maybe_unused]] const std::shared_ptr<GetStateSrv::Request> req,
   std::shared_ptr<GetStateSrv::Response> resp) const
 {
-  (void)header;
-  (void)req;
   std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
   if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
     throw std::runtime_error(
@@ -269,12 +266,10 @@ LifecycleNode::LifecycleNodeInterfaceImpl::on_get_state(
 
 void
 LifecycleNode::LifecycleNodeInterfaceImpl::on_get_available_states(
-  const std::shared_ptr<rmw_request_id_t> header,
-  const std::shared_ptr<GetAvailableStatesSrv::Request> req,
+  [[maybe_unused]] const std::shared_ptr<rmw_request_id_t> header,
+  [[maybe_unused]] const std::shared_ptr<GetAvailableStatesSrv::Request> req,
   std::shared_ptr<GetAvailableStatesSrv::Response> resp) const
 {
-  (void)header;
-  (void)req;
   std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
   if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
     throw std::runtime_error(
@@ -292,12 +287,10 @@ LifecycleNode::LifecycleNodeInterfaceImpl::on_get_available_states(
 
 void
 LifecycleNode::LifecycleNodeInterfaceImpl::on_get_available_transitions(
-  const std::shared_ptr<rmw_request_id_t> header,
-  const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
+  [[maybe_unused]] const std::shared_ptr<rmw_request_id_t> header,
+  [[maybe_unused]] const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
   std::shared_ptr<GetAvailableTransitionsSrv::Response> resp) const
 {
-  (void)header;
-  (void)req;
   std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
   if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
     throw std::runtime_error(
@@ -320,12 +313,10 @@ LifecycleNode::LifecycleNodeInterfaceImpl::on_get_available_transitions(
 
 void
 LifecycleNode::LifecycleNodeInterfaceImpl::on_get_transition_graph(
-  const std::shared_ptr<rmw_request_id_t> header,
-  const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
+  [[maybe_unused]] const std::shared_ptr<rmw_request_id_t> header,
+  [[maybe_unused]] const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
   std::shared_ptr<GetAvailableTransitionsSrv::Response> resp) const
 {
-  (void)header;
-  (void)req;
   std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
   if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
     throw std::runtime_error(

--- a/rclcpp_lifecycle/test/test_lifecycle_node.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_node.cpp
@@ -822,9 +822,8 @@ TEST_F(TestDefaultStateMachine, test_callback_groups) {
   auto test_node = std::make_shared<EmptyLifecycleNode>("testnode");
   size_t num_groups = 0;
   test_node->for_each_callback_group(
-    [&num_groups](rclcpp::CallbackGroup::SharedPtr group_ptr)
+    [&num_groups]([[maybe_unused]] rclcpp::CallbackGroup::SharedPtr group_ptr)
     {
-      (void)group_ptr;
       num_groups++;
     });
   EXPECT_EQ(num_groups, 1u);
@@ -835,9 +834,8 @@ TEST_F(TestDefaultStateMachine, test_callback_groups) {
 
   num_groups = 0;
   test_node->for_each_callback_group(
-    [&num_groups](rclcpp::CallbackGroup::SharedPtr group_ptr)
+    [&num_groups]([[maybe_unused]] rclcpp::CallbackGroup::SharedPtr group_ptr)
     {
-      (void)group_ptr;
       num_groups++;
     });
   EXPECT_EQ(num_groups, 2u);


### PR DESCRIPTION
CMAKE_CXX_STANDARD is set to 17, `[[maybe_unused]]`  is a C++17 attribute with more portability.