### PR TITLE
doc: Added warning to not instantiate Clock directly with RCL_ROS_TIME

### DIFF
--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -61,7 +61,7 @@ public:
    * Initializes the clock instance with the given clock_type.
    *
    * WARNING Don't instantiate a clock using RCL_ROS_TIME directly,
-   * unless your really know what you are doing. By default no TimeSource
+   * unless you really know what you are doing. By default no TimeSource
    * is attached to a new clock. This will lead to the unexpected behavior,
    * that your RCL_ROS_TIME will run always on system time. If you want
    * a RCL_ROS_TIME use Node::get_clock(), or make sure to attach a

--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -60,6 +60,13 @@ public:
   /**
    * Initializes the clock instance with the given clock_type.
    *
+   * WARNING Don't instantiate a clock using RCL_ROS_TIME directly,
+   * unless your really know what you are doing. By default no TimeSource
+   * is attached to a new clock. This will lead to the unexpected behavior,
+   * that your RCL_ROS_TIME will run always on system time. If you want
+   * a RCL_ROS_TIME use Node::get_clock(), or make sure to attach a
+   * TimeSource yourself.
+   *
    * \param clock_type type of the clock.
    * \throws anything rclcpp::exceptions::throw_from_rcl_error can throw.
    */


### PR DESCRIPTION
If one instantiates a clock with RCL_ROS_TIME one needs to make sure, to attach a valid time source, or the clock will fall back to system time, which is highly unexpected for users of the clock.