### PR TITLE
fix: Compilefix for clang

### DIFF
--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -210,8 +210,8 @@ public:
    * This function can be used by one thread, to wakeup another thread that is
    * blocked using any of the sleep_ or wait_ methods of this class.
    */
-  RCLCPP_PUBLIC
   [[deprecated("Use ClockConditionalVariable")]]
+  RCLCPP_PUBLIC
   void
   cancel_sleep_or_wait();
 


### PR DESCRIPTION
clang does not like :
    __attribute__ ((visibility("default")))
    [[deprecated("Don't like'")]]
while
    [[deprecated("Don't like'")]]
    __attribute__ ((visibility("default")))
is fine...