### PR TITLE
Set envars to run tests with rmw_zenoh_cpp with multicast discovery

### DIFF
--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -675,11 +675,10 @@ function(test_on_all_rmws)
   set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
 
   # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+  # Note: This is a temporary change that will be reverted before we branch into Kilted.
   if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
     list(APPEND rmw_implementation_env_var
-      ZENOH_ROUTER_CHECK_ATTEMPTS=-1
       ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-      RUST_LOG=z=error
     )
   endif()
 

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -674,6 +674,15 @@ endif()
 function(test_on_all_rmws)
   set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
 
+  # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+  if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
+    list(APPEND rmw_implementation_env_var
+      ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+      ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+      RUST_LOG=z=error
+    )
+  endif()
+
   ament_add_gmock_test(test_qos_event
     TEST_NAME test_qos_event${target_suffix}
     ENV ${rmw_implementation_env_var}


### PR DESCRIPTION
See https://github.com/ros2/rmw_zenoh/issues/567

To test this PR, we can run the usual CI jobs to show there are no regressions and additionally run a CI job with a copy of the ros2.repos file from https://github.com/ros2/ros2/pull/1649 with CI Scripts branch set to yadu/cargo