### PR TITLE
Explicit Undeclarable parameter descriptor check

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -583,10 +583,22 @@ public:
    *   has not been declared.
    * \throws rclcpp::exceptions::ParameterImmutableException if the parameter
    *   was create as read_only (immutable).
+   * \throws rclcpp::exceptions::InvalidParameterTypeException if the parameter was set as not undeclareable
    */
   RCLCPP_PUBLIC
   void
   undeclare_parameter(const std::string & name);
+
+
+  /// Undeclare all previously declared parameters.
+  /**
+   * This method will not cause a callback registered with add_on_set_parameters_callback to be called. 
+   * 
+   * Unlike undeclare_parameter, this method will not throw exceptions if a parameter can not be undeclared, any parameters that can not be undeclared will not be effected.
+   */
+  RCLCPP_PUBLIC
+  void
+  undeclare_all_parameters();
 
   /// Return true if a given parameter is declared.
   /**

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters.hpp
@@ -137,6 +137,10 @@ public:
   undeclare_parameter(const std::string & name) override;
 
   RCLCPP_PUBLIC
+  void
+  undeclare_all_parameters() override;
+
+  RCLCPP_PUBLIC
   bool
   has_parameter(const std::string & name) const override;
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -113,6 +113,14 @@ public:
   void
   undeclare_parameter(const std::string & name) = 0;
 
+  ///Undeclare all parameters.
+  /** 
+  * \sa rclcpp::Node::undeclare_all_parameters
+  */
+  RCLCPP_PUBLIC
+  virtual
+  void undeclare_all_parameters() = 0;
+
   /// Return true if the parameter has been declared, otherwise false.
   /**
    * \sa rclcpp::Node::has_parameter

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -374,6 +374,13 @@ Node::undeclare_parameter(const std::string & name)
   this->node_parameters_->undeclare_parameter(name);
 }
 
+void
+Node::undeclare_all_parameters()
+{
+  this->node_parameters_->undeclare_all_parameters();
+}
+
+
 bool
 Node::has_parameter(const std::string & name) const
 {

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -649,9 +649,9 @@ NodeParameters::undeclare_parameter(const std::string & name)
     throw rclcpp::exceptions::ParameterImmutableException(
             "cannot undeclare parameter '" + name + "' because it is read-only");
   }
-  if (!parameter_info->second.descriptor.dynamic_typing) {
+  if (!parameter_info->second.descriptor.undeclarable) {
     throw rclcpp::exceptions::InvalidParameterTypeException{
-            name, "cannot undeclare a statically typed parameter"};
+            name, "cannot undeclare an parameter with undeclarable set to false"};
   }
 
   parameters_.erase(parameter_info);

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -657,6 +657,23 @@ NodeParameters::undeclare_parameter(const std::string & name)
   parameters_.erase(parameter_info);
 }
 
+void 
+NodeParameters::undeclare_all_parameters()
+{
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+
+  ParameterMutationRecursionGuard guard(parameter_modification_enabled_);
+
+  for(auto it = parameters_.begin(); it != parameters_.end(); ){
+    if(it->second.descriptor.undeclarable){
+      it = parameters_.erase(it);
+    }
+    else{
+      ++it;
+    }
+  }
+}
+
 bool
 NodeParameters::has_parameter(const std::string & name) const
 {

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -649,7 +649,7 @@ NodeParameters::undeclare_parameter(const std::string & name)
     throw rclcpp::exceptions::ParameterImmutableException(
             "cannot undeclare parameter '" + name + "' because it is read-only");
   }
-  if (!parameter_info->second.descriptor.undeclarable) {
+  if (!parameter_info->second.descriptor.undeclarable && !parameter_info->second.descriptor.dynamic_typing) {
     throw rclcpp::exceptions::InvalidParameterTypeException{
             name, "cannot undeclare an parameter with undeclarable set to false"};
   }


### PR DESCRIPTION
Currently for node parameters to be undeclared they must also be dynamically typed. however I think that there are cases where statically typed params should be undeclared and dynamically typed params should be able to be removed. This commit removes the dynamic parameter check in NodeParameters::undeclare_parameter method and adds a check for the undeclarable field in the parameter description, if this flag is set to false, then the parameter can not be undeclared. 

This should be pared with the PR on the rcl_interfaces repo linked here https://github.com/ros2/rcl_interfaces/pull/172, which adds the undeclarable field to the parameter descriptor message