### PR TITLE
Expanded docstring of `get_rmw_qos_profile()`

### DIFF
--- a/rclcpp/include/rclcpp/qos.hpp
+++ b/rclcpp/include/rclcpp/qos.hpp
@@ -145,11 +145,39 @@ public:
   // cppcheck-suppress noExplicitConstructor
   QoS(size_t history_depth);  // NOLINT(runtime/explicit): conversion constructor
 
-  /// Return the rmw qos profile.
+  /**
+   * Return the rmw qos profile where a profile is comprised of these policies:
+   *   - history (an enum from `HistoryPolicy`)
+   *   - queue size/depth
+   *   - reliability (an enum from `ReliabilityPolicy`)
+   *   - durability (an enum from `DurabilityPolicy`)
+   *   - deadline
+   *   - lifespan
+   *   - liveliness (an enum from `LivelinessPolicy`)
+   *   - lease duration
+   *   - boolean for `avoid_ros_namespace_conventions`
+   * 
+   * To retrieve an individual policy comprising the profile,
+   * use the the getter function for that policy.
+   */
   rmw_qos_profile_t &
   get_rmw_qos_profile();
 
-  /// Return the rmw qos profile.
+  /**
+   * Return the rmw qos profile where a profile is comprised of these policies:
+   *   - history (an enum from `HistoryPolicy`)
+   *   - queue size/depth
+   *   - reliability (an enum from `ReliabilityPolicy`)
+   *   - durability (an enum from `DurabilityPolicy`)
+   *   - deadline
+   *   - lifespan
+   *   - liveliness (an enum from `LivelinessPolicy`)
+   *   - lease duration
+   *   - boolean for `avoid_ros_namespace_conventions`
+   * 
+   * To retrieve an individual policy comprising the profile,
+   * use the the getter function for that policy.
+   */
   const rmw_qos_profile_t &
   get_rmw_qos_profile() const;
 

--- a/rclcpp/include/rclcpp/qos.hpp
+++ b/rclcpp/include/rclcpp/qos.hpp
@@ -145,38 +145,18 @@ public:
   // cppcheck-suppress noExplicitConstructor
   QoS(size_t history_depth);  // NOLINT(runtime/explicit): conversion constructor
 
+  /// Return the rmw qos profile.
   /**
-   * Return the rmw qos profile where a profile is comprised of these policies:
-   *   - history (an enum from `HistoryPolicy`)
-   *   - queue size/depth
-   *   - reliability (an enum from `ReliabilityPolicy`)
-   *   - durability (an enum from `DurabilityPolicy`)
-   *   - deadline
-   *   - lifespan
-   *   - liveliness (an enum from `LivelinessPolicy`)
-   *   - lease duration
-   *   - boolean for `avoid_ros_namespace_conventions`
-   * 
-   * To retrieve an individual policy comprising the profile,
-   * use the the getter function for that policy.
+   * The profile consists of various QoS policies such as history, reliability, and durability.
+   * Use the corresponding getter functions to retrieve individual policies.
    */
   rmw_qos_profile_t &
   get_rmw_qos_profile();
 
+  /// Return the rmw qos profile.
   /**
-   * Return the rmw qos profile where a profile is comprised of these policies:
-   *   - history (an enum from `HistoryPolicy`)
-   *   - queue size/depth
-   *   - reliability (an enum from `ReliabilityPolicy`)
-   *   - durability (an enum from `DurabilityPolicy`)
-   *   - deadline
-   *   - lifespan
-   *   - liveliness (an enum from `LivelinessPolicy`)
-   *   - lease duration
-   *   - boolean for `avoid_ros_namespace_conventions`
-   * 
-   * To retrieve an individual policy comprising the profile,
-   * use the the getter function for that policy.
+   * The profile consists of various QoS policies such as history, reliability, and durability.
+   * Use the corresponding getter functions to retrieve individual policies.
    */
   const rmw_qos_profile_t &
   get_rmw_qos_profile() const;


### PR DESCRIPTION
Per #2777

This PR makes the docstring for `QoS::get_rmw_qos_profile()` more informative by describing what is meant by a _profile_, as described at [Quality of Service settings](https://docs.ros.org/en/rolling/Concepts/Intermediate/About-Quality-of-Service-Settings.html).

Unsure what information related to `rmw` would be pertinent here :thinking: 