### PR TITLE
throws std::invalid_argument if ParameterEvent is NULL.

### DIFF
--- a/rclcpp/include/rclcpp/parameter_events_filter.hpp
+++ b/rclcpp/include/rclcpp/parameter_events_filter.hpp
@@ -45,6 +45,7 @@ public:
    * \param[in] names A list of parameter names of interest.
    * \param[in] types A list of the types of parameter events of iterest.
    *    EventType NEW, DELETED, or CHANGED
+   * \throws std::invalid_argument if event is NULL.
    *
    * Example Usage:
    *

--- a/rclcpp/src/rclcpp/parameter_events_filter.cpp
+++ b/rclcpp/src/rclcpp/parameter_events_filter.cpp
@@ -28,6 +28,9 @@ ParameterEventsFilter::ParameterEventsFilter(
   const std::vector<EventType> & types)
 : event_(event)
 {
+  if (!event) {
+    throw std::invalid_argument("event cannot be null");
+  }
   if (std::find(types.begin(), types.end(), EventType::NEW) != types.end()) {
     for (auto & new_parameter : event->new_parameters) {
       if (std::find(names.begin(), names.end(), new_parameter.name) != names.end()) {

--- a/rclcpp/test/rclcpp/test_parameter_events_filter.cpp
+++ b/rclcpp/test/rclcpp/test_parameter_events_filter.cpp
@@ -72,6 +72,13 @@ protected:
 /*
    Testing filters.
  */
+TEST_F(TestParameterEventFilter, invalide_arguments) {
+  EXPECT_THROW(
+    rclcpp::ParameterEventsFilter(nullptr, {"new"}, {nt}),
+    std::invalid_argument
+  );
+}
+
 TEST_F(TestParameterEventFilter, full_by_type) {
   auto res = rclcpp::ParameterEventsFilter(
     full,


### PR DESCRIPTION
closes https://github.com/ros2/rclcpp/issues/2810