### PR TITLE
Fix race condition in test clock

### DIFF
--- a/rclcpp/test/rclcpp/test_clock.cpp
+++ b/rclcpp/test/rclcpp/test_clock.cpp
@@ -184,7 +184,10 @@ TEST_F(TestClockWakeup, no_wakeup_on_sim_time) {
 TEST_F(TestClockWakeup, multiple_threads_wait_on_one_clock) {
   auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
 
-  std::vector<bool> thread_finished(10, false);
+  std::vector<std::atomic_bool> thread_finished(10);
+  for (std::atomic_bool & finished : thread_finished) {
+    finished = false;
+  }
 
   std::vector<std::thread> threads;
 
@@ -202,7 +205,7 @@ TEST_F(TestClockWakeup, multiple_threads_wait_on_one_clock) {
   // wait a bit so all threads can execute the sleep_until
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
-  for (const bool & finished : thread_finished) {
+  for (const std::atomic_bool & finished : thread_finished) {
     EXPECT_FALSE(finished);
   }
 
@@ -213,7 +216,7 @@ TEST_F(TestClockWakeup, multiple_threads_wait_on_one_clock) {
   bool threads_finished = false;
   while (!threads_finished && start_time + std::chrono::seconds(1) > cur_time) {
     threads_finished = true;
-    for (const bool finished : thread_finished) {
+    for (const std::atomic_bool & finished : thread_finished) {
       if (!finished) {
         threads_finished = false;
       }
@@ -223,7 +226,7 @@ TEST_F(TestClockWakeup, multiple_threads_wait_on_one_clock) {
     cur_time = std::chrono::steady_clock::now();
   }
 
-  for (const bool finished : thread_finished) {
+  for (const std::atomic_bool & finished : thread_finished) {
     EXPECT_TRUE(finished);
   }
 


### PR DESCRIPTION
This Pull Request intends to fix the issue #2804 

In order to do so, I first ran helgrind on the code, and found that there existed a race condition in a vector of booleans. Afterwards, I changed this vector to [`std::atomic_bool` ](https://en.cppreference.com/w/cpp/atomic/atomic). With that, I ran the helgrind again, and found there was no more race condition.

[This](https://pastebin.com/MXmxh4ar) is the full log of helgrind for the original code.
[This](https://pastebin.com/vrpBzwPt) is the full log of helgrind for the modified code.

Note that, since they are the full log of the helgrind, in both of these snippets, there are some unrelated warnings. However, by searching for `data race` inside this logs, it is possible to see that they were corrected.

This is my first Pull Request, so if there are any changes I still have to do, please let me know.
(Edit: I just realized my signature in the commit was wrong. I believe I have corrected it, hopefully everything is OK now)