### PR TITLE
Add range constraints for applicable array parameters

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -222,6 +222,32 @@ __check_parameter_value_in_range(
     return result;
   }
 
+  if (!descriptor.integer_range.empty() && value.get_type() == rclcpp::PARAMETER_INTEGER_ARRAY) {
+    std::vector<int64_t> v = value.get<std::vector<int64_t>>();
+    auto integer_range = descriptor.integer_range.at(0);
+    for (const int64_t & val : v) {
+      if (val == integer_range.from_value || val == integer_range.to_value) {
+        continue;
+      }
+      RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "val: %ld, from_value: %ld, to_value: %ld", val, integer_range.from_value, integer_range.to_value);
+      if ((val < integer_range.from_value) || (val > integer_range.to_value)) {
+        result.successful = false;
+        result.reason = format_range_reason(descriptor.name, "integer");
+        return result;
+      }
+      if (integer_range.step == 0) {
+        continue;
+      }
+      if (((val - integer_range.from_value) % integer_range.step) == 0) {
+        continue;
+      }
+      result.successful = false;
+      result.reason = format_range_reason(descriptor.name, "integer");
+      return result;
+    }
+    return result;
+  }
+  
   if (!descriptor.floating_point_range.empty() && value.get_type() == rclcpp::PARAMETER_DOUBLE) {
     double v = value.get<double>();
     auto fp_range = descriptor.floating_point_range.at(0);
@@ -244,6 +270,33 @@ __check_parameter_value_in_range(
     result.reason = format_range_reason(descriptor.name, "floating point");
     return result;
   }
+
+  if (!descriptor.floating_point_range.empty() && value.get_type() == rclcpp::PARAMETER_DOUBLE_ARRAY) {
+    std::vector<double> v = value.get<std::vector<double>>();
+    auto fp_range = descriptor.floating_point_range.at(0);
+    for (const double & val : v) {
+      if (__are_doubles_equal(val, fp_range.from_value) || __are_doubles_equal(val, fp_range.to_value)) {
+          continue;
+      }
+      if ((val < fp_range.from_value) || (val > fp_range.to_value)) {
+          result.successful = false;
+          result.reason = format_range_reason(descriptor.name, "floating point");
+          return result;
+      }
+      if (fp_range.step == 0.0) {
+          continue;
+      }
+      double rounded_div = std::round((val - fp_range.from_value) / fp_range.step);
+      if (__are_doubles_equal(val, fp_range.from_value + rounded_div * fp_range.step)) {
+          continue;
+      }
+      result.successful = false;
+      result.reason = format_range_reason(descriptor.name, "floating point");
+      return result;
+    }
+    return result;
+  }
+
   return result;
 }
 

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -194,6 +194,65 @@ format_range_reason(const std::string & name, const char * range_type)
 
 RCLCPP_LOCAL
 rcl_interfaces::msg::SetParametersResult
+__check_integer_range(
+  const rcl_interfaces::msg::ParameterDescriptor & descriptor,
+  const int64_t value)
+{
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+  auto integer_range = descriptor.integer_range.at(0);
+  if (value == integer_range.from_value || value == integer_range.to_value) {
+    return result;
+  }
+  if ((value < integer_range.from_value) || (value > integer_range.to_value)) {
+    result.successful = false;
+    result.reason = format_range_reason(descriptor.name, "integer");
+    return result;
+  }
+  if (integer_range.step == 0) {
+    return result;
+  }
+  if (((value - integer_range.from_value) % integer_range.step) == 0) {
+    return result;
+  }
+  result.successful = false;
+  result.reason = format_range_reason(descriptor.name, "integer");
+  return result;
+}
+
+RCLCPP_LOCAL
+rcl_interfaces::msg::SetParametersResult
+__check_double_range(
+  const rcl_interfaces::msg::ParameterDescriptor & descriptor,
+  const double value)
+{
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+  auto fp_range = descriptor.floating_point_range.at(0);
+  if (__are_doubles_equal(value, fp_range.from_value) || __are_doubles_equal(value,
+    fp_range.to_value))
+  {
+    return result;
+  }
+  if ((value < fp_range.from_value) || (value > fp_range.to_value)) {
+    result.successful = false;
+    result.reason = format_range_reason(descriptor.name, "floating point");
+    return result;
+  }
+  if (fp_range.step == 0.0) {
+    return result;
+  }
+  double rounded_div = std::round((value - fp_range.from_value) / fp_range.step);
+  if (__are_doubles_equal(value, fp_range.from_value + rounded_div * fp_range.step)) {
+    return result;
+  }
+  result.successful = false;
+  result.reason = format_range_reason(descriptor.name, "floating point");
+  return result;
+}
+
+RCLCPP_LOCAL
+rcl_interfaces::msg::SetParametersResult
 __check_parameter_value_in_range(
   const rcl_interfaces::msg::ParameterDescriptor & descriptor,
   const rclcpp::ParameterValue & value)
@@ -201,101 +260,35 @@ __check_parameter_value_in_range(
   rcl_interfaces::msg::SetParametersResult result;
   result.successful = true;
   if (!descriptor.integer_range.empty() && value.get_type() == rclcpp::PARAMETER_INTEGER) {
-    int64_t v = value.get<int64_t>();
-    auto integer_range = descriptor.integer_range.at(0);
-    if (v == integer_range.from_value || v == integer_range.to_value) {
-      return result;
-    }
-    if ((v < integer_range.from_value) || (v > integer_range.to_value)) {
-      result.successful = false;
-      result.reason = format_range_reason(descriptor.name, "integer");
-      return result;
-    }
-    if (integer_range.step == 0) {
-      return result;
-    }
-    if (((v - integer_range.from_value) % integer_range.step) == 0) {
-      return result;
-    }
-    result.successful = false;
-    result.reason = format_range_reason(descriptor.name, "integer");
+    result = __check_integer_range(descriptor, value.get<int64_t>());
     return result;
   }
 
   if (!descriptor.integer_range.empty() && value.get_type() == rclcpp::PARAMETER_INTEGER_ARRAY) {
-    std::vector<int64_t> v = value.get<std::vector<int64_t>>();
-    auto integer_range = descriptor.integer_range.at(0);
-    for (const int64_t & val : v) {
-      if (val == integer_range.from_value || val == integer_range.to_value) {
-        continue;
-      }
-      if ((val < integer_range.from_value) || (val > integer_range.to_value)) {
-        result.successful = false;
-        result.reason = format_range_reason(descriptor.name, "integer");
+    std::vector<int64_t> val_array = value.get<std::vector<int64_t>>();
+    for (const int64_t & val : val_array) {
+      result = __check_integer_range(descriptor, val);
+      if (!result.successful) {
         return result;
       }
-      if (integer_range.step == 0) {
-        continue;
-      }
-      if (((val - integer_range.from_value) % integer_range.step) == 0) {
-        continue;
-      }
-      result.successful = false;
-      result.reason = format_range_reason(descriptor.name, "integer");
-      return result;
     }
     return result;
   }
 
   if (!descriptor.floating_point_range.empty() && value.get_type() == rclcpp::PARAMETER_DOUBLE) {
-    double v = value.get<double>();
-    auto fp_range = descriptor.floating_point_range.at(0);
-    if (__are_doubles_equal(v, fp_range.from_value) || __are_doubles_equal(v, fp_range.to_value)) {
-      return result;
-    }
-    if ((v < fp_range.from_value) || (v > fp_range.to_value)) {
-      result.successful = false;
-      result.reason = format_range_reason(descriptor.name, "floating point");
-      return result;
-    }
-    if (fp_range.step == 0.0) {
-      return result;
-    }
-    double rounded_div = std::round((v - fp_range.from_value) / fp_range.step);
-    if (__are_doubles_equal(v, fp_range.from_value + rounded_div * fp_range.step)) {
-      return result;
-    }
-    result.successful = false;
-    result.reason = format_range_reason(descriptor.name, "floating point");
+    result = __check_double_range(descriptor, value.get<double>());
     return result;
   }
 
   if (!descriptor.floating_point_range.empty() &&
     value.get_type() == rclcpp::PARAMETER_DOUBLE_ARRAY)
   {
-    std::vector<double> v = value.get<std::vector<double>>();
-    auto fp_range = descriptor.floating_point_range.at(0);
-    for (const double & val : v) {
-      if (__are_doubles_equal(val, fp_range.from_value) || __are_doubles_equal(val,
-        fp_range.to_value))
-      {
-        continue;
-      }
-      if ((val < fp_range.from_value) || (val > fp_range.to_value)) {
-        result.successful = false;
-        result.reason = format_range_reason(descriptor.name, "floating point");
+    std::vector<double> val_array = value.get<std::vector<double>>();
+    for (const double & val : val_array) {
+      result = __check_double_range(descriptor, val);
+      if (!result.successful) {
         return result;
       }
-      if (fp_range.step == 0.0) {
-        continue;
-      }
-      double rounded_div = std::round((val - fp_range.from_value) / fp_range.step);
-      if (__are_doubles_equal(val, fp_range.from_value + rounded_div * fp_range.step)) {
-        continue;
-      }
-      result.successful = false;
-      result.reason = format_range_reason(descriptor.name, "floating point");
-      return result;
     }
     return result;
   }

--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -229,7 +229,6 @@ __check_parameter_value_in_range(
       if (val == integer_range.from_value || val == integer_range.to_value) {
         continue;
       }
-      RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "val: %ld, from_value: %ld, to_value: %ld", val, integer_range.from_value, integer_range.to_value);
       if ((val < integer_range.from_value) || (val > integer_range.to_value)) {
         result.successful = false;
         result.reason = format_range_reason(descriptor.name, "integer");
@@ -247,7 +246,7 @@ __check_parameter_value_in_range(
     }
     return result;
   }
-  
+
   if (!descriptor.floating_point_range.empty() && value.get_type() == rclcpp::PARAMETER_DOUBLE) {
     double v = value.get<double>();
     auto fp_range = descriptor.floating_point_range.at(0);
@@ -271,24 +270,28 @@ __check_parameter_value_in_range(
     return result;
   }
 
-  if (!descriptor.floating_point_range.empty() && value.get_type() == rclcpp::PARAMETER_DOUBLE_ARRAY) {
+  if (!descriptor.floating_point_range.empty() &&
+    value.get_type() == rclcpp::PARAMETER_DOUBLE_ARRAY)
+  {
     std::vector<double> v = value.get<std::vector<double>>();
     auto fp_range = descriptor.floating_point_range.at(0);
     for (const double & val : v) {
-      if (__are_doubles_equal(val, fp_range.from_value) || __are_doubles_equal(val, fp_range.to_value)) {
-          continue;
+      if (__are_doubles_equal(val, fp_range.from_value) || __are_doubles_equal(val,
+        fp_range.to_value))
+      {
+        continue;
       }
       if ((val < fp_range.from_value) || (val > fp_range.to_value)) {
-          result.successful = false;
-          result.reason = format_range_reason(descriptor.name, "floating point");
-          return result;
+        result.successful = false;
+        result.reason = format_range_reason(descriptor.name, "floating point");
+        return result;
       }
       if (fp_range.step == 0.0) {
-          continue;
+        continue;
       }
       double rounded_div = std::round((val - fp_range.from_value) / fp_range.step);
       if (__are_doubles_equal(val, fp_range.from_value + rounded_div * fp_range.step)) {
-          continue;
+        continue;
       }
       result.successful = false;
       result.reason = format_range_reason(descriptor.name, "floating point");

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -1333,6 +1333,159 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
       rclcpp::exceptions::InvalidParameterValueException);
   }
   {
+    // setting an array parameter with integer range descriptor
+    auto name = "parameter"_unq;
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.integer_range.resize(1);
+    auto & integer_range = descriptor.integer_range.at(0);
+    integer_range.from_value = 10;
+    integer_range.to_value = 18;
+    integer_range.step = 2;
+    node->declare_parameter(name, std::vector<int64_t>{10, 12, 14, 16, 18}, descriptor);
+    EXPECT_TRUE(node->has_parameter(name));
+    auto value = node->get_parameter(name);
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER_ARRAY);
+    EXPECT_EQ(value.get_value<std::vector<int64_t>>(), std::vector<int64_t>({10, 12, 14, 16, 18}));
+
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({12, 14, 10}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({12, 14, 10}));
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({10, 10, 10}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({10, 10, 10}));
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({14}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({14}));
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({18}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({15}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({20}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({8}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({12, 8, 18}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18}));
+  }
+  {
+    // setting an array parameter with integer range descriptor, from_value > to_value
+    auto name = "parameter"_unq;
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.integer_range.resize(1);
+    auto & integer_range = descriptor.integer_range.at(0);
+    integer_range.from_value = 20;
+    integer_range.to_value = 18;
+    integer_range.step = 1;
+    node->declare_parameter(name, std::vector<int64_t>({18, 20}), descriptor);
+    EXPECT_TRUE(node->has_parameter(name));
+    auto value = node->get_parameter(name);
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER_ARRAY);
+    EXPECT_EQ(value.get_value<std::vector<int64_t>>(), std::vector<int64_t>({18, 20}));
+
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({20, 18}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({20, 18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({18, 19, 20}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({20, 18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({10}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({20, 18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({25}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({20, 18}));
+  }
+  {
+    // setting an array parameter with integer range descriptor, from_value = to_value
+    auto name = "parameter"_unq;
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.integer_range.resize(1);
+    auto & integer_range = descriptor.integer_range.at(0);
+    integer_range.from_value = 18;
+    integer_range.to_value = 18;
+    integer_range.step = 1;
+    node->declare_parameter(name, std::vector<int64_t>({18}), descriptor);
+    EXPECT_TRUE(node->has_parameter(name));
+    auto value = node->get_parameter(name);
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER_ARRAY);
+    EXPECT_EQ(value.get_value<std::vector<int64_t>>(), std::vector<int64_t>({18}));
+
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({17}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({19}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18}));
+  }
+  {
+    // setting an array parameter with integer range descriptor, step > distance(from_value, to_value)
+    auto name = "parameter"_unq;
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.integer_range.resize(1);
+    auto & integer_range = descriptor.integer_range.at(0);
+    integer_range.from_value = 18;
+    integer_range.to_value = 25;
+    integer_range.step = 10;
+    node->declare_parameter(name, std::vector<int64_t>({18, 25}), descriptor);
+    EXPECT_TRUE(node->has_parameter(name));
+    auto value = node->get_parameter(name);
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER_ARRAY);
+    EXPECT_EQ(value.get_value<std::vector<int64_t>>(), std::vector<int64_t>({18, 25}));
+
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({17}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18, 25}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({19}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18, 25}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({26}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18, 25}));
+  }
+  {
+    // setting an array parameter with integer range descriptor, distance not multiple of the step.
+    auto name = "parameter"_unq;
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.integer_range.resize(1);
+    auto & integer_range = descriptor.integer_range.at(0);
+    integer_range.from_value = 18;
+    integer_range.to_value = 28;
+    integer_range.step = 7;
+    node->declare_parameter(name, std::vector<int64_t>({18, 25, 28}), descriptor);
+    EXPECT_TRUE(node->has_parameter(name));
+    auto value = node->get_parameter(name);
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER_ARRAY);
+    EXPECT_EQ(value.get_value<std::vector<int64_t>>(), std::vector<int64_t>({18, 25, 28}));
+
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({17}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18, 25, 28}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({19}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18, 25, 28}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({32}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18, 25, 28}));
+  }
+  {
+    // setting an array parameter with integer range descriptor, step=0
+    auto name = "parameter"_unq;
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.integer_range.resize(1);
+    auto & integer_range = descriptor.integer_range.at(0);
+    integer_range.from_value = 10;
+    integer_range.to_value = 18;
+    integer_range.step = 0;
+    node->declare_parameter(name, std::vector<int64_t>({10, 11, 12, 13, 14, 15, 16, 17, 18}), descriptor);
+    EXPECT_TRUE(node->has_parameter(name));
+    auto value = node->get_parameter(name);
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER_ARRAY);
+    EXPECT_EQ(value.get_value<std::vector<int64_t>>(), std::vector<int64_t>({10, 11, 12, 13, 14, 15, 16, 17, 18}));
+
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({9}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({10, 11, 12, 13, 14, 15, 16, 17, 18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({19}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({10, 11, 12, 13, 14, 15, 16, 17, 18}));
+  }
+  {
+    // setting an array parameter with integer range descriptor and wrong default value will throw
+    auto name = "parameter"_unq;
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.integer_range.resize(1);
+    auto & integer_range = descriptor.integer_range.at(0);
+    integer_range.from_value = 10;
+    integer_range.to_value = 18;
+    integer_range.step = 2;
+    ASSERT_THROW(
+      node->declare_parameter(name, std::vector<int64_t>({10, 11, 12, 13, 14, 15, 16, 17, 18}), descriptor),
+      rclcpp::exceptions::InvalidParameterValueException);
+  } // check here
+  {
     // setting a parameter with floating point range descriptor
     auto name = "parameter"_unq;
     rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -1501,6 +1654,158 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     EXPECT_EQ(node->get_parameter(name).get_value<double>(), 11.0);
     EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, 9.999)).successful);
     EXPECT_EQ(node->get_parameter(name).get_value<double>(), 11.0);
+  }
+  {
+    // setting an array parameter with floating point range descriptor
+    auto name = "parameter"_unq;
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.floating_point_range.resize(1);
+    auto & floating_point_range = descriptor.floating_point_range.at(0);
+    floating_point_range.from_value = 10.0;
+    floating_point_range.to_value = 11.0;
+    floating_point_range.step = 0.2;
+    node->declare_parameter(name, std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}), descriptor);
+    EXPECT_TRUE(node->has_parameter(name));
+    auto value = node->get_parameter(name);
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_DOUBLE_ARRAY);
+    EXPECT_EQ(value.get_value<std::vector<double>>(), std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}));
+
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({10.8, 10.0, 10.6}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.8, 10.0, 10.6}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({11.3}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.8, 10.0, 10.6}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({12.0}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.8, 10.0, 10.6}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({9.4}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.8, 10.0, 10.6}));
+  }
+  {
+    // setting an array parameter with floating point range descriptor, negative step
+    auto name = "parameter"_unq;
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.floating_point_range.resize(1);
+    auto & floating_point_range = descriptor.floating_point_range.at(0);
+    floating_point_range.from_value = 10.0;
+    floating_point_range.to_value = 11.0;
+    floating_point_range.step = -0.2;
+    node->declare_parameter(name, std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}), descriptor);
+    EXPECT_TRUE(node->has_parameter(name));
+    auto value = node->get_parameter(name);
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_DOUBLE_ARRAY);
+    EXPECT_EQ(value.get_value<std::vector<double>>(), std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}));
+
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({10.3}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({12.0}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({9.4}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}));
+  }
+  {
+    // setting an array parameter with floating point range descriptor, from_value > to_value
+    auto name = "parameter"_unq;
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.floating_point_range.resize(1);
+    auto & floating_point_range = descriptor.floating_point_range.at(0);
+    floating_point_range.from_value = 11.0;
+    floating_point_range.to_value = 10.0;
+    floating_point_range.step = 0.2;
+    node->declare_parameter(name, std::vector<double>({10.0, 11.0}), descriptor);
+    EXPECT_TRUE(node->has_parameter(name));
+    auto value = node->get_parameter(name);
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_DOUBLE_ARRAY);
+    EXPECT_EQ(value.get_value<std::vector<double>>(), std::vector<double>({10.0, 11.0}));
+
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({10.2}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({12.0}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({9.4}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 11.0}));
+  }
+  {
+    // setting an array parameter with floating point range descriptor, from_value = to_value
+    auto name = "parameter"_unq;
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.floating_point_range.resize(1);
+    auto & floating_point_range = descriptor.floating_point_range.at(0);
+    floating_point_range.from_value = 10.0;
+    floating_point_range.to_value = 10.0;
+    floating_point_range.step = 0.2;
+    node->declare_parameter(name, std::vector<double>({10.0}), descriptor);
+    EXPECT_TRUE(node->has_parameter(name));
+    auto value = node->get_parameter(name);
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_DOUBLE_ARRAY);
+    EXPECT_EQ(value.get_value<std::vector<double>>(), std::vector<double>({10.0}));
+
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({11.2}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({12.0}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({9.4}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0}));
+  }
+  {
+    // setting an array parameter with floating point range descriptor, step > distance
+    auto name = "parameter"_unq;
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.floating_point_range.resize(1);
+    auto & floating_point_range = descriptor.floating_point_range.at(0);
+    floating_point_range.from_value = 10.0;
+    floating_point_range.to_value = 11.0;
+    floating_point_range.step = 2.2;
+    node->declare_parameter(name, std::vector<double>({10.0, 11.0}), descriptor);
+    EXPECT_TRUE(node->has_parameter(name));
+    auto value = node->get_parameter(name);
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_DOUBLE_ARRAY);
+    EXPECT_EQ(value.get_value<std::vector<double>>(), std::vector<double>({10.0, 11.0}));
+
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({12.2}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({7.8}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 11.0}));
+  }
+  {
+    // setting an array parameter with floating point range descriptor, distance not multiple of the step.
+    auto name = "parameter"_unq;
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.floating_point_range.resize(1);
+    auto & floating_point_range = descriptor.floating_point_range.at(0);
+    floating_point_range.from_value = 10.0;
+    floating_point_range.to_value = 11.0;
+    floating_point_range.step = 0.7;
+    node->declare_parameter(name, std::vector<double>({10.0, 10.7, 11.0}), descriptor);
+    EXPECT_TRUE(node->has_parameter(name));
+    auto value = node->get_parameter(name);
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_DOUBLE_ARRAY);
+    EXPECT_EQ(value.get_value<std::vector<double>>(), std::vector<double>({10.0, 10.7, 11.0}));
+
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({12.2}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 10.7, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({11.4}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 10.7, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({9.3}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 10.7, 11.0}));
+  }
+  {
+    // setting an array parameter with floating point range descriptor, step=0
+    auto name = "parameter"_unq;
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.floating_point_range.resize(1);
+    auto & floating_point_range = descriptor.floating_point_range.at(0);
+    floating_point_range.from_value = 10.0;
+    floating_point_range.to_value = 11.0;
+    floating_point_range.step = 0.0;
+    node->declare_parameter(name, std::vector<double>({10.0, 10.0001, 10.5479051, 11.0}), descriptor);
+    EXPECT_TRUE(node->has_parameter(name));
+    auto value = node->get_parameter(name);
+    EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_DOUBLE_ARRAY);
+    EXPECT_EQ(value.get_value<std::vector<double>>(), std::vector<double>({10.0, 10.0001, 10.5479051, 11.0}));
+
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({11.001}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 10.0001, 10.5479051, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({9.999}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 10.0001, 10.5479051, 11.0}));
   }
   {
     // setting a parameter with a different type is still possible

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -1437,7 +1437,8 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
       std::vector<int64_t>({18}));
   }
   {
-    // setting an array parameter with integer range descriptor, step > distance(from_value, to_value)
+    // setting an array parameter with integer range descriptor,
+    // step > distance(from_value, to_value)
     auto name = "parameter"_unq;
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.integer_range.resize(1);
@@ -1847,7 +1848,8 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
       std::vector<double>({10.0, 11.0}));
   }
   {
-    // setting an array parameter with floating point range descriptor, distance not multiple of the step.
+    // setting an array parameter with floating point range descriptor,
+    // distance not multiple of the step.
     auto name = "parameter"_unq;
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.floating_point_range.resize(1);

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -1356,10 +1356,6 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
       std::vector<int64_t>({10, 10, 10}));
     EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name,
-      std::vector<int64_t>({14}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
-      std::vector<int64_t>({14}));
-    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name,
       std::vector<int64_t>({18}))).successful);
     EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
       std::vector<int64_t>({18}));
@@ -1461,7 +1457,7 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
       std::vector<int64_t>({18, 25}));
     EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
-      std::vector<int64_t>({26}))).successful);
+      std::vector<int64_t>({28}))).successful);
     EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
       std::vector<int64_t>({18, 25}));
   }
@@ -1712,30 +1708,26 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     floating_point_range.from_value = 10.0;
     floating_point_range.to_value = 11.0;
     floating_point_range.step = 0.2;
-    node->declare_parameter(name, std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}),
+    node->declare_parameter(name, std::vector<double>({10.0, 10.4, 11.0, 10.8, 10.2, 10.6}),
       descriptor);
     EXPECT_TRUE(node->has_parameter(name));
     auto value = node->get_parameter(name);
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_DOUBLE_ARRAY);
     EXPECT_EQ(value.get_value<std::vector<double>>(),
-      std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}));
+      std::vector<double>({10.0, 10.4, 11.0, 10.8, 10.2, 10.6}));
 
-    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name,
-      std::vector<double>({10.8, 10.0, 10.6}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
-      std::vector<double>({10.8, 10.0, 10.6}));
     EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
-      std::vector<double>({11.3}))).successful);
+      std::vector<double>({10.3}))).successful);
     EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
-      std::vector<double>({10.8, 10.0, 10.6}));
+      std::vector<double>({10.0, 10.4, 11.0, 10.8, 10.2, 10.6}));
     EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
       std::vector<double>({12.0}))).successful);
     EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
-      std::vector<double>({10.8, 10.0, 10.6}));
+      std::vector<double>({10.0, 10.4, 11.0, 10.8, 10.2, 10.6}));
     EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
       std::vector<double>({9.4}))).successful);
     EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
-      std::vector<double>({10.8, 10.0, 10.6}));
+      std::vector<double>({10.0, 10.4, 11.0, 10.8, 10.2, 10.6}));
   }
   {
     // setting an array parameter with floating point range descriptor, negative step

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -1347,22 +1347,38 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER_ARRAY);
     EXPECT_EQ(value.get_value<std::vector<int64_t>>(), std::vector<int64_t>({10, 12, 14, 16, 18}));
 
-    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({12, 14, 10}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({12, 14, 10}));
-    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({10, 10, 10}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({10, 10, 10}));
-    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({14}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({14}));
-    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({18}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({15}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({20}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({8}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({12, 8, 18}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18}));
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({12, 14, 10}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({12, 14, 10}));
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({10, 10, 10}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({10, 10, 10}));
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({14}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({14}));
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({18}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({15}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({20}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({8}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({12, 8, 18}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({18}));
   }
   {
     // setting an array parameter with integer range descriptor, from_value > to_value
@@ -1379,14 +1395,22 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER_ARRAY);
     EXPECT_EQ(value.get_value<std::vector<int64_t>>(), std::vector<int64_t>({18, 20}));
 
-    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({20, 18}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({20, 18}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({18, 19, 20}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({20, 18}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({10}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({20, 18}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({25}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({20, 18}));
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({20, 18}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({20, 18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({18, 19, 20}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({20, 18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({10}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({20, 18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({25}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({20, 18}));
   }
   {
     // setting an array parameter with integer range descriptor, from_value = to_value
@@ -1403,10 +1427,14 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER_ARRAY);
     EXPECT_EQ(value.get_value<std::vector<int64_t>>(), std::vector<int64_t>({18}));
 
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({17}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({19}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({17}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({19}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({18}));
   }
   {
     // setting an array parameter with integer range descriptor, step > distance(from_value, to_value)
@@ -1423,12 +1451,18 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER_ARRAY);
     EXPECT_EQ(value.get_value<std::vector<int64_t>>(), std::vector<int64_t>({18, 25}));
 
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({17}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18, 25}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({19}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18, 25}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({26}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18, 25}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({17}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({18, 25}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({19}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({18, 25}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({26}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({18, 25}));
   }
   {
     // setting an array parameter with integer range descriptor, distance not multiple of the step.
@@ -1445,12 +1479,18 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER_ARRAY);
     EXPECT_EQ(value.get_value<std::vector<int64_t>>(), std::vector<int64_t>({18, 25, 28}));
 
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({17}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18, 25, 28}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({19}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18, 25, 28}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({32}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({18, 25, 28}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({17}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({18, 25, 28}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({19}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({18, 25, 28}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({32}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({18, 25, 28}));
   }
   {
     // setting an array parameter with integer range descriptor, step=0
@@ -1461,16 +1501,22 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     integer_range.from_value = 10;
     integer_range.to_value = 18;
     integer_range.step = 0;
-    node->declare_parameter(name, std::vector<int64_t>({10, 11, 12, 13, 14, 15, 16, 17, 18}), descriptor);
+    node->declare_parameter(name, std::vector<int64_t>({10, 11, 12, 13, 14, 15, 16, 17, 18}),
+      descriptor);
     EXPECT_TRUE(node->has_parameter(name));
     auto value = node->get_parameter(name);
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_INTEGER_ARRAY);
-    EXPECT_EQ(value.get_value<std::vector<int64_t>>(), std::vector<int64_t>({10, 11, 12, 13, 14, 15, 16, 17, 18}));
+    EXPECT_EQ(value.get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({10, 11, 12, 13, 14, 15, 16, 17, 18}));
 
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({9}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({10, 11, 12, 13, 14, 15, 16, 17, 18}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<int64_t>({19}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(), std::vector<int64_t>({10, 11, 12, 13, 14, 15, 16, 17, 18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({9}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({10, 11, 12, 13, 14, 15, 16, 17, 18}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<int64_t>({19}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<int64_t>>(),
+      std::vector<int64_t>({10, 11, 12, 13, 14, 15, 16, 17, 18}));
   }
   {
     // setting an array parameter with integer range descriptor and wrong default value will throw
@@ -1482,9 +1528,10 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     integer_range.to_value = 18;
     integer_range.step = 2;
     ASSERT_THROW(
-      node->declare_parameter(name, std::vector<int64_t>({10, 11, 12, 13, 14, 15, 16, 17, 18}), descriptor),
+      node->declare_parameter(name, std::vector<int64_t>({10, 11, 12, 13, 14, 15, 16, 17, 18}),
+      descriptor),
       rclcpp::exceptions::InvalidParameterValueException);
-  } // check here
+  }
   {
     // setting a parameter with floating point range descriptor
     auto name = "parameter"_unq;
@@ -1664,20 +1711,30 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     floating_point_range.from_value = 10.0;
     floating_point_range.to_value = 11.0;
     floating_point_range.step = 0.2;
-    node->declare_parameter(name, std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}), descriptor);
+    node->declare_parameter(name, std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}),
+      descriptor);
     EXPECT_TRUE(node->has_parameter(name));
     auto value = node->get_parameter(name);
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_DOUBLE_ARRAY);
-    EXPECT_EQ(value.get_value<std::vector<double>>(), std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}));
+    EXPECT_EQ(value.get_value<std::vector<double>>(),
+      std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}));
 
-    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({10.8, 10.0, 10.6}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.8, 10.0, 10.6}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({11.3}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.8, 10.0, 10.6}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({12.0}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.8, 10.0, 10.6}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({9.4}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.8, 10.0, 10.6}));
+    EXPECT_TRUE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({10.8, 10.0, 10.6}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.8, 10.0, 10.6}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({11.3}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.8, 10.0, 10.6}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({12.0}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.8, 10.0, 10.6}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({9.4}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.8, 10.0, 10.6}));
   }
   {
     // setting an array parameter with floating point range descriptor, negative step
@@ -1688,18 +1745,26 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     floating_point_range.from_value = 10.0;
     floating_point_range.to_value = 11.0;
     floating_point_range.step = -0.2;
-    node->declare_parameter(name, std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}), descriptor);
+    node->declare_parameter(name, std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}),
+      descriptor);
     EXPECT_TRUE(node->has_parameter(name));
     auto value = node->get_parameter(name);
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_DOUBLE_ARRAY);
-    EXPECT_EQ(value.get_value<std::vector<double>>(), std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}));
+    EXPECT_EQ(value.get_value<std::vector<double>>(),
+      std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}));
 
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({10.3}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({12.0}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({9.4}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({10.3}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({12.0}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({9.4}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.0, 10.2, 10.4, 10.6, 10.8, 11.0}));
   }
   {
     // setting an array parameter with floating point range descriptor, from_value > to_value
@@ -1716,12 +1781,18 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_DOUBLE_ARRAY);
     EXPECT_EQ(value.get_value<std::vector<double>>(), std::vector<double>({10.0, 11.0}));
 
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({10.2}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 11.0}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({12.0}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 11.0}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({9.4}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({10.2}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.0, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({12.0}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.0, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({9.4}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.0, 11.0}));
   }
   {
     // setting an array parameter with floating point range descriptor, from_value = to_value
@@ -1738,12 +1809,18 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_DOUBLE_ARRAY);
     EXPECT_EQ(value.get_value<std::vector<double>>(), std::vector<double>({10.0}));
 
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({11.2}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({12.0}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({9.4}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({11.2}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({12.0}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({9.4}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.0}));
   }
   {
     // setting an array parameter with floating point range descriptor, step > distance
@@ -1760,10 +1837,14 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_DOUBLE_ARRAY);
     EXPECT_EQ(value.get_value<std::vector<double>>(), std::vector<double>({10.0, 11.0}));
 
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({12.2}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 11.0}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({7.8}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({12.2}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.0, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({7.8}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.0, 11.0}));
   }
   {
     // setting an array parameter with floating point range descriptor, distance not multiple of the step.
@@ -1780,12 +1861,18 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_DOUBLE_ARRAY);
     EXPECT_EQ(value.get_value<std::vector<double>>(), std::vector<double>({10.0, 10.7, 11.0}));
 
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({12.2}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 10.7, 11.0}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({11.4}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 10.7, 11.0}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({9.3}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 10.7, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({12.2}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.0, 10.7, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({11.4}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.0, 10.7, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({9.3}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.0, 10.7, 11.0}));
   }
   {
     // setting an array parameter with floating point range descriptor, step=0
@@ -1796,16 +1883,22 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     floating_point_range.from_value = 10.0;
     floating_point_range.to_value = 11.0;
     floating_point_range.step = 0.0;
-    node->declare_parameter(name, std::vector<double>({10.0, 10.0001, 10.5479051, 11.0}), descriptor);
+    node->declare_parameter(name, std::vector<double>({10.0, 10.0001, 10.5479051, 11.0}),
+      descriptor);
     EXPECT_TRUE(node->has_parameter(name));
     auto value = node->get_parameter(name);
     EXPECT_EQ(value.get_type(), rclcpp::PARAMETER_DOUBLE_ARRAY);
-    EXPECT_EQ(value.get_value<std::vector<double>>(), std::vector<double>({10.0, 10.0001, 10.5479051, 11.0}));
+    EXPECT_EQ(value.get_value<std::vector<double>>(),
+      std::vector<double>({10.0, 10.0001, 10.5479051, 11.0}));
 
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({11.001}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 10.0001, 10.5479051, 11.0}));
-    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, std::vector<double>({9.999}))).successful);
-    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(), std::vector<double>({10.0, 10.0001, 10.5479051, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({11.001}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.0, 10.0001, 10.5479051, 11.0}));
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name,
+      std::vector<double>({9.999}))).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<std::vector<double>>(),
+      std::vector<double>({10.0, 10.0001, 10.5479051, 11.0}));
   }
   {
     // setting a parameter with a different type is still possible


### PR DESCRIPTION
I noticed that array numeric parameters (integer and double) didn't have any range checking. To me it seemed that if you had an array and bounds you would simply just want each element of the array to be within those bounds. So instead of requiring a new constraint class for array types I thought it made sense to apply the constraint to each element.

Additional thoughts: Would this be limiting for potential future constraints for arrays? The only additional thing I could think of for an array would be min/max length, although I don't have an immediate use-case for that. 

If there are array specific constraints to be implemented in the future, they can exist as a separate class and validated in a similar manner. I don't think this limits the ability to add array specific constraints and allows re-use of the already implemented constraint checks of the base type.