### PR TITLE
Add missing 's' to 'NodeParametersInterface' in doc/comment

### DIFF
--- a/rclcpp/include/rclcpp/node.hpp
+++ b/rclcpp/include/rclcpp/node.hpp
@@ -1560,7 +1560,7 @@ public:
    * has an additional sub-namespace (short for subordinate namespace)
    * associated with it.
    * A subordinate node and an instance of this class share all the node interfaces
-   * such as `rclcpp::node_interfaces::NodeParameterInterface`.
+   * such as `rclcpp::node_interfaces::NodeParametersInterface`.
    * Subordinate nodes are primarily used to organize namespaces and provide a
    * hierarchical structure, but they are not meant to be completely independent nodes.
    * The sub-namespace will extend the node's namespace for the purpose of

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -313,7 +313,7 @@ TEST_F(TestNode, subnode_parameter_operation) {
 
   auto value = subnode->declare_parameter("param", 5);
   EXPECT_EQ(value, 5);
-  // node and sub-node shares NodeParameterInterface, so expecting the exception.
+  // node and sub-node shares NodeParametersInterface, so expecting the exception.
   EXPECT_THROW(
     node->declare_parameter("param", 0),
     rclcpp::exceptions::ParameterAlreadyDeclaredException);


### PR DESCRIPTION
Follow-up to #2822.