### PR TITLE
remove get_notify_guard_condition from NodeBaseInterface.

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base.hpp
@@ -121,11 +121,6 @@ public:
   std::atomic_bool &
   get_associated_with_executor_atomic() override;
 
-  [[deprecated("Use get_shared_notify_guard_condition or trigger_notify_guard_condition instead")]]
-  RCLCPP_PUBLIC
-  rclcpp::GuardCondition &
-  get_notify_guard_condition() override;
-
   RCLCPP_PUBLIC
   rclcpp::GuardCondition::SharedPtr
   get_shared_notify_guard_condition() override;

--- a/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_base_interface.hpp
@@ -148,17 +148,6 @@ public:
   /**
    * For example, this should be notified when a publisher is added or removed.
    *
-   * \return the GuardCondition if it is valid, else throw runtime error
-   */
-  RCLCPP_PUBLIC
-  virtual
-  rclcpp::GuardCondition &
-  get_notify_guard_condition() = 0;
-
-  /// Return a guard condition that should be notified when the internal node state changes.
-  /**
-   * For example, this should be notified when a publisher is added or removed.
-   *
    * \return the GuardCondition if it is valid, else nullptr
    */
   RCLCPP_PUBLIC

--- a/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_base.cpp
@@ -275,16 +275,6 @@ NodeBase::get_associated_with_executor_atomic()
   return associated_with_executor_;
 }
 
-rclcpp::GuardCondition &
-NodeBase::get_notify_guard_condition()
-{
-  std::lock_guard<std::recursive_mutex> notify_condition_lock(notify_guard_condition_mutex_);
-  if (!notify_guard_condition_is_valid_) {
-    throw std::runtime_error("failed to get notify guard condition because it is invalid");
-  }
-  return *notify_guard_condition_;
-}
-
 rclcpp::GuardCondition::SharedPtr
 NodeBase::get_shared_notify_guard_condition()
 {


### PR DESCRIPTION
just removes deprecated method for next turtle-L release.