### PR TITLE
QoSInitialization::from_rmw does not validate invalid history policy …

### DIFF
--- a/rclcpp/src/rclcpp/qos.cpp
+++ b/rclcpp/src/rclcpp/qos.cpp
@@ -69,8 +69,10 @@ QoSInitialization::from_rmw(const rmw_qos_profile_t & rmw_qos)
       return KeepLast(rmw_qos.depth, false);
     case RMW_QOS_POLICY_HISTORY_KEEP_LAST:
     case RMW_QOS_POLICY_HISTORY_UNKNOWN:
-    default:
       return KeepLast(rmw_qos.depth);
+    default:
+      throw std::invalid_argument(
+        "Invalid history policy enum value passed to QoSInitialization::from_rmw");
   }
 }
 

--- a/rclcpp/test/rclcpp/test_qos.cpp
+++ b/rclcpp/test/rclcpp/test_qos.cpp
@@ -272,3 +272,14 @@ TEST(TestQoS, qos_check_compatible)
     }
   }
 }
+
+TEST(TestQoS, from_rmw_validity)
+{
+  rmw_qos_profile_t invalid_qos;
+  memset(&invalid_qos, 0, sizeof(invalid_qos));
+  reinterpret_cast<uint32_t &>(invalid_qos.history) = 999;
+
+  EXPECT_THROW({
+    rclcpp::QoSInitialization::from_rmw(invalid_qos);
+  }, std::invalid_argument);
+}


### PR DESCRIPTION
Related with https://github.com/ros2/rclcpp/issues/2812