### PR TITLE
Replace std::default_random_engine with std::mt19937 (rolling)

### DIFF
--- a/rclcpp_action/src/client_base.cpp
+++ b/rclcpp_action/src/client_base.cpp
@@ -181,7 +181,7 @@ public:
   std::recursive_mutex cancel_requests_mutex;
 
   std::independent_bits_engine<
-    std::default_random_engine, 8, unsigned int> random_bytes_generator;
+    std::mt19937, 8, unsigned int> random_bytes_generator;
 };
 
 ClientBase::ClientBase(

--- a/rclcpp_action/test/test_types.cpp
+++ b/rclcpp_action/test/test_types.cpp
@@ -67,7 +67,7 @@ TEST(TestActionTypes, goal_uuid_to_hashed_uuid_random) {
   // Use std::random_device to seed the generator of goal IDs.
   std::random_device rd;
   std::independent_bits_engine<
-    std::default_random_engine, 8, decltype(rd())> random_bytes_generator(rd());
+    std::mt19937, 8, decltype(rd())> random_bytes_generator(rd());
 
   std::vector<size_t> hashed_guuids;
   constexpr size_t iterations = 1000;


### PR DESCRIPTION
This PR addresses issue #2842, where std::default_random_engine can lead to periodic goal ID duplication due to its underlying implementation in GCC (minstd_rand0). When actions are executed frequently, this periodicity increases the likelihood of duplicate goal IDs, potentially causing unintended behavior.

In extreme cases, duplicate goal IDs can:

Trigger an exception when attempting to accept a new goal (goal ID already exists).

Extend the expiration time of the first goal when a duplicate ID is encountered.

To mitigate this, this PR replaces std::default_random_engine with std::mt19937, which provides a higher-quality random number generator with better distribution properties, reducing the risk of goal ID collisions.

Changes in this PR
std::default_random_engine → std::mt19937 in client_base.cpp

Ensures goal ID randomness to prevent collisions in high-frequency action executions.

Testing
In a 13-hour test, we observed periodic goal ID duplication when using std::default_random_engine.

Same goal ID appeared twice within a 10-minute period.

When goal ID retention was reduced to 1 minute, the issue no longer occurred.

With std::mt19937, goal ID duplication is effectively mitigated.

Impact
No ABI breakage.

Improves reliability of goal ID generation.

Addresses unintended goal expiration extension issues.