### PR TITLE
Replace std::default_random_engine with std::mt19937 (humble)

### DIFF
--- a/rclcpp_action/src/client.cpp
+++ b/rclcpp_action/src/client.cpp
@@ -183,7 +183,7 @@ public:
   std::mutex cancel_requests_mutex;
 
   std::independent_bits_engine<
-    std::default_random_engine, 8, unsigned int> random_bytes_generator;
+    std::mt19937, 8, unsigned int> random_bytes_generator;
 };
 
 ClientBase::ClientBase(


### PR DESCRIPTION
This PR addresses issue https://github.com/ros2/rclcpp/issues/2842, where std::default_random_engine can lead to periodic goal ID duplication due to its underlying implementation in GCC (minstd_rand0). When actions are executed frequently, this periodicity increases the likelihood of duplicate goal IDs, potentially causing unintended behavior.

In extreme cases, duplicate goal IDs can:

Trigger an exception when attempting to accept a new goal (goal ID already exists).

Extend the expiration time of the first goal when a duplicate ID is encountered.

To mitigate this, this PR replaces std::default_random_engine with std::mt19937, which provides a higher-quality random number generator with better distribution properties, reducing the risk of goal ID collisions.

Changes in this PR
std::default_random_engine → std::mt19937 in client_base.cpp

Ensures goal ID randomness to prevent collisions in high-frequency action executions.

Testing
In a 13-hour test, we observed periodic goal ID duplication when using std::default_random_engine.

Same goal ID appeared twice within a 10-minute period.

When goal ID retention was reduced to 1 minute, the issue no longer occurred.

With std::mt19937, goal ID duplication is effectively mitigated.

Impact
No ABI breakage.

Improves reliability of goal ID generation.

Addresses unintended goal expiration extension issues.