### PR TITLE
Expose `typesupport_helpers` API needed for the Rosbag2

### DIFF
--- a/rclcpp/include/rclcpp/typesupport_helpers.hpp
+++ b/rclcpp/include/rclcpp/typesupport_helpers.hpp
@@ -54,27 +54,23 @@ RCLCPP_PUBLIC
 std::string get_typesupport_library_path(
   const std::string & package_name, const std::string & typesupport_identifier);
 
-/// Load the type support library for the given type.
-/**
- * \param[in] type The topic type, e.g. "std_msgs/msg/String"
- * \param[in] typesupport_identifier Type support identifier, typically "rosidl_typesupport_cpp"
- * \return A shared library
- * \throws std::runtime_error if the library is not found or cannot be loaded.
- */
+/// \brief Load the type support library for the given type.
+/// \param[in] type The topic type, e.g. "std_msgs/msg/String"
+/// \param[in] typesupport_identifier Type support identifier, typically "rosidl_typesupport_cpp"
+/// \throws std::runtime_error if the library is not found or cannot be loaded.
+/// \return A shared library
 RCLCPP_PUBLIC
 std::shared_ptr<rcpputils::SharedLibrary>
 get_typesupport_library(const std::string & type, const std::string & typesupport_identifier);
 
-/// Extract the message type support handle from the library.
-/**
- * The library needs to match the topic type. The shared library must stay loaded for the lifetime of the result.
- *
- * \param[in] type The topic type, e.g. "std_msgs/msg/String"
- * \param[in] typesupport_identifier Type support identifier, typically "rosidl_typesupport_cpp"
- * \param[in] library The shared type support library
- * \throws std::runtime_error if the symbol of type not found in the library.
- * \return A message type support handle
- */
+/// \brief Extracts the message type support handle from the library.
+/// \note The library needs to match the topic type. The shared library must stay loaded for the
+/// lifetime of the result.
+/// \param[in] type The topic type, e.g. "std_msgs/msg/String"
+/// \param[in] typesupport_identifier Type support identifier, typically "rosidl_typesupport_cpp"
+/// \param[in] library The shared type support library
+/// \throws std::runtime_error if the symbol of type not found in the library.
+/// \return A message type support handle
 RCLCPP_PUBLIC
 const rosidl_message_type_support_t *
 get_message_typesupport_handle(
@@ -82,16 +78,14 @@ get_message_typesupport_handle(
   const std::string & typesupport_identifier,
   rcpputils::SharedLibrary & library);
 
-/// Extract the service type support handle from the library.
-/**
- * The library needs to match the service type. The shared library must stay loaded for the lifetime of the result.
- *
- * \param[in] type The service type, e.g. "std_srvs/srv/Empty"
- * \param[in] typesupport_identifier Type support identifier, typically "rosidl_typesupport_cpp"
- * \param[in] library The shared type support library
- * \throws std::runtime_error if the symbol of type not found in the library.
- * \return A service type support handle
- */
+/// \brief Extracts the service type support handle from the library.
+/// \note The library needs to match the service type. The shared library must stay loaded for the
+/// lifetime of the result.
+/// \param[in] type The service type, e.g. "std_srvs/srv/Empty"
+/// \param[in] typesupport_identifier Type support identifier, typically "rosidl_typesupport_cpp"
+/// \param[in] library The shared type support library
+/// \throws std::runtime_error if the symbol of type not found in the library.
+/// \return A service type support handle
 RCLCPP_PUBLIC
 const rosidl_service_type_support_t *
 get_service_typesupport_handle(
@@ -99,17 +93,14 @@ get_service_typesupport_handle(
   const std::string & typesupport_identifier,
   rcpputils::SharedLibrary & library);
 
-/// Extract the action type support handle from the library.
-/**
- * The library needs to match the action type. The shared library must stay loaded for the lifetime
- * of the result.
- *
- * \param[in] type The action type, e.g. "example_interfaces/action/Fibonacci"
- * \param[in] typesupport_identifier Type support identifier, typically "rosidl_typesupport_cpp"
- * \param[in] library The shared type support library
- * \throws std::runtime_error if the symbol of type not found in the library.
- * \return A action type support handle
- */
+/// \brief Extracts the action type support handle from the library.
+/// \note The library needs to match the action type. The shared library must stay loaded for the
+/// lifetime of the result.
+/// \param[in] type The action type, e.g. "example_interfaces/action/Fibonacci"
+/// \param[in] typesupport_identifier Type support identifier, typically "rosidl_typesupport_cpp"
+/// \param[in] library The shared type support library
+/// \throws std::runtime_error if the symbol of type not found in the library.
+/// \return A action type support handle
 RCLCPP_PUBLIC
 const rosidl_action_type_support_t *
 get_action_typesupport_handle(

--- a/rclcpp/include/rclcpp/typesupport_helpers.hpp
+++ b/rclcpp/include/rclcpp/typesupport_helpers.hpp
@@ -29,11 +29,37 @@
 
 namespace rclcpp
 {
+
+/// \brief Extract the package name, middle module, and type name from a full type string.
+/// \details This function takes a full type string (e.g., "std_msgs/msg/String") and extracts
+/// the package name, middle module (if any), and type name. The middle module is the part
+/// between the package name and the type name, which is typically used for message types.
+/// For example, for "std_msgs/msg/String", it returns ("std_msgs", "msg", "String").
+/// \param[in] full_type
+/// \throws std::runtime_error if the input full type string is malformed or does not follow the
+/// expected format.
+/// \return A tuple containing the package name, middle module (if any), and type name.
+RCLCPP_PUBLIC
+std::tuple<std::string, std::string, std::string>
+extract_type_identifier(const std::string & full_type);
+
+/// \brief Look for the library in the ament prefix paths and return the path to the type support
+/// library.
+/// \param[in] package_name The name of the package containing the type support library,
+/// e.g. "std_msgs".
+/// \param[in] typesupport_identifier Type support identifier, typically "rosidl_typesupport_cpp"
+/// \throws std::runtime_error if the library is not found.
+/// \return The path to the type support library.
+RCLCPP_PUBLIC
+std::string get_typesupport_library_path(
+  const std::string & package_name, const std::string & typesupport_identifier);
+
 /// Load the type support library for the given type.
 /**
  * \param[in] type The topic type, e.g. "std_msgs/msg/String"
  * \param[in] typesupport_identifier Type support identifier, typically "rosidl_typesupport_cpp"
  * \return A shared library
+ * \throws std::runtime_error if the library is not found or cannot be loaded.
  */
 RCLCPP_PUBLIC
 std::shared_ptr<rcpputils::SharedLibrary>


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
- This PR exposes `extract_type_identifier(const std::string & full_type)` and `get_typesupport_library_path(
  const std::string & package_name, const std::string & typesupport_identifier)` API to be publicly available for usage from other packages.

Rationale:
- In Rosbag2 we need to use `extract_type_identifier(const std::string & full_type)` and `get_typesupport_library_path(
  const std::string & package_name, const std::string & typesupport_identifier)` API from the RCLCPP package in order to get rid of the code duplication and possible implementation divergences in the future for the same utility functions.
Please refer to the relevant Rosbag2 PR https://github.com/ros2/rosbag2/pull/2017

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue) N/A

### Is this user-facing behavior change? 
No.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI? 
Yes. Github Copilot, GPT-4.1, to help write Doxygen comments for the API.

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
