### PR TITLE
Removed warning test_qos

### DIFF
--- a/rclcpp/test/rclcpp/test_qos.cpp
+++ b/rclcpp/test/rclcpp/test_qos.cpp
@@ -277,7 +277,8 @@ TEST(TestQoS, from_rmw_validity)
 {
   rmw_qos_profile_t invalid_qos;
   memset(&invalid_qos, 0, sizeof(invalid_qos));
-  reinterpret_cast<uint32_t &>(invalid_qos.history) = 999;
+  unsigned int n = 999;
+  memcpy(&invalid_qos.history, &n, sizeof(unsigned int));
 
   EXPECT_THROW({
     rclcpp::QoSInitialization::from_rmw(invalid_qos);

--- a/rclcpp/test/rclcpp/test_qos.cpp
+++ b/rclcpp/test/rclcpp/test_qos.cpp
@@ -278,7 +278,7 @@ TEST(TestQoS, from_rmw_validity)
   rmw_qos_profile_t invalid_qos;
   memset(&invalid_qos, 0, sizeof(invalid_qos));
   unsigned int n = 999;
-  memcpy(&invalid_qos.history, &n, sizeof(unsigned int));
+  memcpy(&invalid_qos.history, &n, sizeof(n));
 
   EXPECT_THROW({
     rclcpp::QoSInitialization::from_rmw(invalid_qos);


### PR DESCRIPTION
Related with this warning https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/3118/clang-tidy/source.5a3b4ec9-8227-46f0-99a4-80bce302114d/#280