### PR TITLE
Add overload of `NodeOptions::append_parameter_override()`

### DIFF
--- a/rclcpp/include/rclcpp/node_options.hpp
+++ b/rclcpp/include/rclcpp/node_options.hpp
@@ -146,6 +146,15 @@ public:
     return *this;
   }
 
+  /// Append a single parameter override, parameter idiom style.
+  template<typename ParameterT>
+  NodeOptions &
+  append_parameter_override(const rclcpp::Parameter & param)
+  {
+    this->parameter_overrides().push_back(param);
+    return *this;
+  }
+
   /// Return the use_global_arguments flag.
   RCLCPP_PUBLIC
   bool


### PR DESCRIPTION
This would allow to add the override in a more concise manner.

If you already have an `rclcpp::Parameter` declared for some reason, you can push it to the overrides list, and it becomes even more convenient if you have to do it for multiple `NodeOptions` objects.