### PR TITLE
Remove comment about now-removed StaticSingleThreadedExecutor

### DIFF
--- a/rclcpp/test/rclcpp/executors/executor_types.hpp
+++ b/rclcpp/test/rclcpp/executors/executor_types.hpp
@@ -52,8 +52,6 @@ public:
   }
 };
 
-// StaticSingleThreadedExecutor is not included in these tests for now, due to:
-// https://github.com/ros2/rclcpp/issues/1219
 using StandardExecutors =
   ::testing::Types<
   rclcpp::executors::SingleThreadedExecutor,


### PR DESCRIPTION
## Description

The `StaticSingleThreadedExecutor` was removed in #2835, so this comment isn't needed anymore.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
