### PR TITLE
Fix `start_type_description_service` param handling

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
@@ -86,7 +86,7 @@ public:
             "Invalid type '%s' for parameter 'start_type_description_service', should be 'bool'",
         rclcpp::to_string(enable_param.get_type()).c_str());
       std::ostringstream ss;
-	    ss << "Wrong parameter type, parameter {" << enable_param_name << "} is of type {bool}, "
+      ss << "Wrong parameter type, parameter {" << enable_param_name << "} is of type {bool}, "
          << "setting it to {" << to_string(enable_param.get_type()) << "} is not allowed.";
       throw rclcpp::exceptions::InvalidParameterTypeException(enable_param_name, ss.str());
     }

--- a/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
@@ -65,11 +65,11 @@ public:
   : logger_(node_logging->get_logger()),
     node_base_(node_base)
   {
+    rclcpp::ParameterValue enable_param;
     const std::string enable_param_name = "start_type_description_service";
 
-    bool enabled = false;
-    try {
-      auto enable_param = node_parameters->declare_parameter(
+    if (!node_parameters->has_parameter(enable_param_name)) {
+      enable_param = node_parameters->declare_parameter(
         enable_param_name,
         rclcpp::ParameterValue(true),
         rcl_interfaces::msg::ParameterDescriptor()
@@ -77,13 +77,19 @@ public:
         .set__type(rclcpp::PARAMETER_BOOL)
         .set__description("Start the ~/get_type_description service for this node.")
         .set__read_only(true));
-      enabled = enable_param.get<bool>();
-    } catch (const rclcpp::exceptions::InvalidParameterTypeException & exc) {
-      RCLCPP_ERROR(logger_, "%s", exc.what());
-      throw;
+    } else {
+      enable_param = node_parameters->get_parameter(enable_param_name).get_parameter_value();
+    }
+    if (enable_param.get_type() != rclcpp::PARAMETER_BOOL) {
+      RCLCPP_ERROR(
+        logger_,
+            "Invalid type '%s' for parameter 'start_type_description_service', should be 'bool'",
+        rclcpp::to_string(enable_param.get_type()).c_str());
+      throw std::invalid_argument(
+            "Invalid type for parameter 'start_type_description_service', should be 'bool'");
     }
 
-    if (enabled) {
+    if (enable_param.get<bool>()) {
       auto * rcl_node = node_base->get_rcl_node_handle();
       std::shared_ptr<rcl_service_t> rcl_srv(
         new rcl_service_t,

--- a/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp
@@ -85,8 +85,10 @@ public:
         logger_,
             "Invalid type '%s' for parameter 'start_type_description_service', should be 'bool'",
         rclcpp::to_string(enable_param.get_type()).c_str());
-      throw std::invalid_argument(
-            "Invalid type for parameter 'start_type_description_service', should be 'bool'");
+      std::ostringstream ss;
+	    ss << "Wrong parameter type, parameter {" << enable_param_name << "} is of type {bool}, "
+         << "setting it to {" << to_string(enable_param.get_type()) << "} is not allowed.";
+      throw rclcpp::exceptions::InvalidParameterTypeException(enable_param_name, ss.str());
     }
 
     if (enable_param.get<bool>()) {

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_type_descriptions.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_type_descriptions.cpp
@@ -49,6 +49,17 @@ TEST_F(TestNodeTypeDescriptions, automatically_declare_parameters_from_overrides
   });
 }
 
+TEST_F(TestNodeTypeDescriptions, bad_parameter_type)
+{
+  rclcpp::NodeOptions node_options;
+  node_options.append_parameter_override("start_type_description_service", "unexpected_type");
+  ASSERT_THROW(
+  {
+    auto node = std::make_shared<rclcpp::Node>("node", "ns", node_options);
+    (void) node;
+  }, std::invalid_argument);
+}
+
 TEST_F(TestNodeTypeDescriptions, disabled_no_service)
 {
   rclcpp::NodeOptions node_options;

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_type_descriptions.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_type_descriptions.cpp
@@ -53,14 +53,14 @@ TEST_F(TestNodeTypeDescriptions, bad_parameter_type)
 {
   rclcpp::NodeOptions node_options;
   node_options.append_parameter_override("start_type_description_service", "unexpected_type");
-  
+
   ASSERT_THROW(
   {
     node_options.automatically_declare_parameters_from_overrides(false);
     auto node = std::make_shared<rclcpp::Node>("node", "ns", node_options);
     (void) node;
   }, rclcpp::exceptions::InvalidParameterTypeException);
-  
+
   ASSERT_THROW(
   {
     node_options.automatically_declare_parameters_from_overrides(true);

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_type_descriptions.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_type_descriptions.cpp
@@ -53,8 +53,16 @@ TEST_F(TestNodeTypeDescriptions, bad_parameter_type)
 {
   rclcpp::NodeOptions node_options;
   node_options.append_parameter_override("start_type_description_service", "unexpected_type");
+  
   ASSERT_THROW(
   {
+    auto node = std::make_shared<rclcpp::Node>("node", "ns", node_options);
+    (void) node;
+  }, rclcpp::exceptions::InvalidParameterTypeException);
+  
+  ASSERT_THROW(
+  {
+    node_options.automatically_declare_parameters_from_overrides(true);
     auto node = std::make_shared<rclcpp::Node>("node", "ns", node_options);
     (void) node;
   }, std::invalid_argument);

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_type_descriptions.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_type_descriptions.cpp
@@ -56,6 +56,7 @@ TEST_F(TestNodeTypeDescriptions, bad_parameter_type)
   
   ASSERT_THROW(
   {
+    node_options.automatically_declare_parameters_from_overrides(false);
     auto node = std::make_shared<rclcpp::Node>("node", "ns", node_options);
     (void) node;
   }, rclcpp::exceptions::InvalidParameterTypeException);
@@ -65,7 +66,7 @@ TEST_F(TestNodeTypeDescriptions, bad_parameter_type)
     node_options.automatically_declare_parameters_from_overrides(true);
     auto node = std::make_shared<rclcpp::Node>("node", "ns", node_options);
     (void) node;
-  }, std::invalid_argument);
+  }, rclcpp::exceptions::InvalidParameterTypeException);
 }
 
 TEST_F(TestNodeTypeDescriptions, disabled_no_service)

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_type_descriptions.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_type_descriptions.cpp
@@ -37,6 +37,18 @@ TEST_F(TestNodeTypeDescriptions, interface_created)
   ASSERT_NE(nullptr, node.get_node_type_descriptions_interface());
 }
 
+TEST_F(TestNodeTypeDescriptions, automatically_declare_parameters_from_overrides)
+{
+  rclcpp::NodeOptions node_options;
+  node_options.automatically_declare_parameters_from_overrides(true);
+  node_options.append_parameter_override("start_type_description_service", false);
+  ASSERT_NO_THROW(
+  {
+    auto node = std::make_shared<rclcpp::Node>("node", "ns", node_options);
+    (void) node;
+  });
+}
+
 TEST_F(TestNodeTypeDescriptions, disabled_no_service)
 {
   rclcpp::NodeOptions node_options;


### PR DESCRIPTION
Closes #2892 by using the same exact strategy for declaring `use_sim_time`.
https://github.com/ros2/rclcpp/blob/7ebc9e4cae34483c8d0510b650032a80ae84fd92/rclcpp/src/rclcpp/time_source.cpp#L254-L274

Tested (you can try to define `start_type_description_service` like so, and pass it to Nav2 bt_navigator or diagnostic_aggregator):
```yaml
/**:
  ros__parameters:
    use_sim_time: false
    start_type_description_service: false
```
whithout the patch, it crashes like https://github.com/ros/diagnostics/issues/519.

- [x] Add test

### Did you use Generative AI?
No