### PR TITLE
Add qos parameter for wait_for_message function

### DIFF
--- a/rclcpp/include/rclcpp/wait_for_message.hpp
+++ b/rclcpp/include/rclcpp/wait_for_message.hpp
@@ -17,7 +17,7 @@
 
 #include <memory>
 #include <string>
-
+#include <future>
 #include "rcpputils/scope_exit.hpp"
 
 #include "rclcpp/node.hpp"
@@ -79,7 +79,6 @@ bool wait_for_message(
 /// Wait for the next incoming message.
 /**
  * Wait for the next incoming message to arrive on a specified topic before the specified timeout.
- * Specify the QoS settings for the subscription to control how messages are received.
  *
  * \param[out] out is the message to be filled when a new message is arriving
  * \param[in] node the node pointer to initialize the subscription on.

--- a/rclcpp/include/rclcpp/wait_for_message.hpp
+++ b/rclcpp/include/rclcpp/wait_for_message.hpp
@@ -95,7 +95,7 @@ bool wait_for_message(
   rclcpp::Node::SharedPtr node,
   const std::string & topic,
   std::chrono::duration<Rep, Period> time_to_wait = std::chrono::duration<Rep, Period>(-1),
-  const rclcpp::QoS& qos = rclcpp::QoS(1))
+  const rclcpp::QoS& qos = rclcpp::SystemDefaultsQoS(1))
 {
   auto sub = node->create_subscription<MsgT>(topic, qos, [](const std::shared_ptr<const MsgT>) {});
   return wait_for_message<MsgT, Rep, Period>(

--- a/rclcpp/include/rclcpp/wait_for_message.hpp
+++ b/rclcpp/include/rclcpp/wait_for_message.hpp
@@ -78,11 +78,13 @@ bool wait_for_message(
 /// Wait for the next incoming message.
 /**
  * Wait for the next incoming message to arrive on a specified topic before the specified timeout.
- *
- * \param[out] out is the message to be filled when a new message is arriving.
+ * Specify the QoS settings for the subscription to control how messages are received.
+ * 
+ * \param[out] out is the message to be filled when a new message is arriving
  * \param[in] node the node pointer to initialize the subscription on.
  * \param[in] topic the topic to wait for messages.
  * \param[in] time_to_wait parameter specifying the timeout before returning.
+ * \param[in] qos parameter specifying QoS settings for the subscription.
  * \return true if a message was successfully received, false if message could not
  * be obtained or shutdown was triggered asynchronously on the context.
  */
@@ -91,9 +93,10 @@ bool wait_for_message(
   MsgT & out,
   rclcpp::Node::SharedPtr node,
   const std::string & topic,
-  std::chrono::duration<Rep, Period> time_to_wait = std::chrono::duration<Rep, Period>(-1))
+  std::chrono::duration<Rep, Period> time_to_wait = std::chrono::duration<Rep, Period>(-1),
+  const rclcpp::Qos &qos = rclcpp::Qos(1))
 {
-  auto sub = node->create_subscription<MsgT>(topic, 1, [](const std::shared_ptr<const MsgT>) {});
+  auto sub = node->create_subscription<MsgT>(topic, qos, [](const std::shared_ptr<const MsgT>) {});
   return wait_for_message<MsgT, Rep, Period>(
     out, sub, node->get_node_options().context(), time_to_wait);
 }

--- a/rclcpp/include/rclcpp/wait_for_message.hpp
+++ b/rclcpp/include/rclcpp/wait_for_message.hpp
@@ -23,6 +23,7 @@
 #include "rclcpp/node.hpp"
 #include "rclcpp/visibility_control.hpp"
 #include "rclcpp/wait_set.hpp"
+#include "rclcpp/qos.hpp"
 
 namespace rclcpp
 {
@@ -94,7 +95,7 @@ bool wait_for_message(
   rclcpp::Node::SharedPtr node,
   const std::string & topic,
   std::chrono::duration<Rep, Period> time_to_wait = std::chrono::duration<Rep, Period>(-1),
-  const rclcpp::Qos &qos = rclcpp::Qos(1))
+  const rclcpp::QoS& qos = rclcpp::QoS(1))
 {
   auto sub = node->create_subscription<MsgT>(topic, qos, [](const std::shared_ptr<const MsgT>) {});
   return wait_for_message<MsgT, Rep, Period>(

--- a/rclcpp/include/rclcpp/wait_for_message.hpp
+++ b/rclcpp/include/rclcpp/wait_for_message.hpp
@@ -95,7 +95,7 @@ bool wait_for_message(
   rclcpp::Node::SharedPtr node,
   const std::string & topic,
   std::chrono::duration<Rep, Period> time_to_wait = std::chrono::duration<Rep, Period>(-1),
-  const rclcpp::QoS& qos = rclcpp::SystemDefaultsQoS(1))
+  const rclcpp::QoS& qos = rclcpp::SystemDefaultsQoS())
 {
   auto sub = node->create_subscription<MsgT>(topic, qos, [](const std::shared_ptr<const MsgT>) {});
   return wait_for_message<MsgT, Rep, Period>(

--- a/rclcpp/include/rclcpp/wait_for_message.hpp
+++ b/rclcpp/include/rclcpp/wait_for_message.hpp
@@ -80,7 +80,7 @@ bool wait_for_message(
 /**
  * Wait for the next incoming message to arrive on a specified topic before the specified timeout.
  * Specify the QoS settings for the subscription to control how messages are received.
- * 
+ *
  * \param[out] out is the message to be filled when a new message is arriving
  * \param[in] node the node pointer to initialize the subscription on.
  * \param[in] topic the topic to wait for messages.

--- a/rclcpp/include/rclcpp/wait_for_message.hpp
+++ b/rclcpp/include/rclcpp/wait_for_message.hpp
@@ -95,7 +95,7 @@ bool wait_for_message(
   rclcpp::Node::SharedPtr node,
   const std::string & topic,
   std::chrono::duration<Rep, Period> time_to_wait = std::chrono::duration<Rep, Period>(-1),
-  const rclcpp::QoS& qos = rclcpp::SystemDefaultsQoS())
+  const rclcpp::QoS & qos = rclcpp::SystemDefaultsQoS())
 {
   auto sub = node->create_subscription<MsgT>(topic, qos, [](const std::shared_ptr<const MsgT>) {});
   return wait_for_message<MsgT, Rep, Period>(

--- a/rclcpp/include/rclcpp/wait_for_message.hpp
+++ b/rclcpp/include/rclcpp/wait_for_message.hpp
@@ -15,9 +15,10 @@
 #ifndef RCLCPP__WAIT_FOR_MESSAGE_HPP_
 #define RCLCPP__WAIT_FOR_MESSAGE_HPP_
 
+#include <future>
 #include <memory>
 #include <string>
-#include <future>
+
 #include "rcpputils/scope_exit.hpp"
 
 #include "rclcpp/node.hpp"

--- a/rclcpp/test/rclcpp/test_wait_for_message.cpp
+++ b/rclcpp/test/rclcpp/test_wait_for_message.cpp
@@ -109,7 +109,7 @@ TEST(TestUtilities, wait_for_message_twice_one_sub) {
   rclcpp::shutdown();
 }
 
-TEST(TestUtilities, wait_for_last_message){
+TEST(TestUtilities, wait_for_last_message) {
   rclcpp::init(0, nullptr);
 
   auto node = std::make_shared<rclcpp::Node>("wait_for_last_message_node");

--- a/rclcpp/test/rclcpp/test_wait_for_message.cpp
+++ b/rclcpp/test/rclcpp/test_wait_for_message.cpp
@@ -108,3 +108,30 @@ TEST(TestUtilities, wait_for_message_twice_one_sub) {
 
   rclcpp::shutdown();
 }
+
+TEST(TestUtilities, wait_for_last_message){
+
+  rclcpp::init(0, nullptr);
+
+  auto node = std::make_shared<rclcpp::Node>("wait_for_last_message_node");
+  auto qos = rclcpp::QoS(1).reliable().transient_local();
+
+  using MsgT = test_msgs::msg::Strings;
+  auto pub = node->create_publisher<MsgT>("wait_for_last_message_topic", qos);
+  pub->publish(*get_messages_strings()[0]);
+
+  MsgT out;
+  auto received = false;
+  auto wait = std::async(
+    [&]() {
+      auto ret = rclcpp::wait_for_message(out, node, "wait_for_last_message_topic", 5s, qos);
+      EXPECT_TRUE(ret);
+      received = true;
+    });
+
+  ASSERT_NO_THROW(wait.get());
+  ASSERT_TRUE(received);
+  EXPECT_EQ(out, *get_messages_strings()[0]);
+
+  rclcpp::shutdown();
+}

--- a/rclcpp/test/rclcpp/test_wait_for_message.cpp
+++ b/rclcpp/test/rclcpp/test_wait_for_message.cpp
@@ -110,7 +110,6 @@ TEST(TestUtilities, wait_for_message_twice_one_sub) {
 }
 
 TEST(TestUtilities, wait_for_last_message){
-
   rclcpp::init(0, nullptr);
 
   auto node = std::make_shared<rclcpp::Node>("wait_for_last_message_node");


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
A small change to include the QoS settings as one of the parameters for `rclcpp::wait_for_message`.  This is useful in cases where we want just to get the last published message on the topic, rather than always waiting for a new message. 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
