### PR TITLE
Fix: improve exception context for parameter_value_from

### DIFF
--- a/rclcpp/src/rclcpp/parameter_map.cpp
+++ b/rclcpp/src/rclcpp/parameter_map.cpp
@@ -89,7 +89,7 @@ rclcpp::parameter_map_from(const rcl_params_t * const c_params, const char * nod
           std::string("parameter_value_from failed for parameter '") +
           c_param_name + "': " + e.what());
       }
-      parameters.emplace_back(c_param_name, value);
+      params_node.emplace_back(c_param_name, value);
     }
   }
 

--- a/rclcpp/src/rclcpp/parameter_map.cpp
+++ b/rclcpp/src/rclcpp/parameter_map.cpp
@@ -84,8 +84,8 @@ rclcpp::parameter_map_from(const rcl_params_t * const c_params, const char * nod
       ParameterValue value;
       try {
         value = parameter_value_from(param);
-      } catch (const rclcpp::exceptions::InvalidParameterValueException & e) {
-        throw rclcpp::exceptions::InvalidParameterValueException(
+      } catch (const InvalidParameterValueException & e) {
+        throw InvalidParameterValueException(
           std::string("parameter_value_from failed for parameter '") +
           c_param_name + "': " + e.what());
       }

--- a/rclcpp/src/rclcpp/parameter_map.cpp
+++ b/rclcpp/src/rclcpp/parameter_map.cpp
@@ -83,7 +83,7 @@ rclcpp::parameter_map_from(const rcl_params_t * const c_params, const char * nod
       const rcl_variant_t * const c_param_value = &(c_params_node->parameter_values[p]);
       ParameterValue value;
       try {
-        value = parameter_value_from(param);
+        value = parameter_value_from(c_param_value);
       } catch (const InvalidParameterValueException & e) {
         throw InvalidParameterValueException(
           std::string("parameter_value_from failed for parameter '") +

--- a/rclcpp/src/rclcpp/parameter_map.cpp
+++ b/rclcpp/src/rclcpp/parameter_map.cpp
@@ -81,7 +81,7 @@ rclcpp::parameter_map_from(const rcl_params_t * const c_params, const char * nod
         throw InvalidParametersException(message);
       }
       const rcl_variant_t * const c_param_value = &(c_params_node->parameter_values[p]);
-      rclcpp::ParameterValue value;
+      ParameterValue value;
       try {
         value = parameter_value_from(param);
       } catch (const rclcpp::exceptions::InvalidParameterValueException & e) {

--- a/rclcpp/src/rclcpp/parameter_map.cpp
+++ b/rclcpp/src/rclcpp/parameter_map.cpp
@@ -81,7 +81,15 @@ rclcpp::parameter_map_from(const rcl_params_t * const c_params, const char * nod
         throw InvalidParametersException(message);
       }
       const rcl_variant_t * const c_param_value = &(c_params_node->parameter_values[p]);
-      params_node.emplace_back(c_param_name, parameter_value_from(c_param_value));
+      rclcpp::ParameterValue value;
+      try {
+        value = parameter_value_from(param);
+      } catch (const rclcpp::exceptions::InvalidParameterValueException & e) {
+        throw rclcpp::exceptions::InvalidParameterValueException(
+          std::string("parameter_value_from failed for parameter '") +
+          c_param_name + "': " + e.what());
+      }
+      parameters.emplace_back(c_param_name, value);
     }
   }
 


### PR DESCRIPTION
## Description
Adds c_param_name to error messages without changing API interface of parameter_value_from.

Fixes #2916 

### Is this user-facing behavior change?

### Did you use Generative AI?
ChatGPT 4o

### Additional Information

I was missing instructions for testing/building. I'm used to having Github automatically building my repos. But it has been a long while since my last bit of CPP. So please edit/improve before merging if that is required.