### PR TITLE
Cleanup the dependencies in rclcpp_components.

### DIFF
--- a/rclcpp_components/CMakeLists.txt
+++ b/rclcpp_components/CMakeLists.txt
@@ -19,7 +19,9 @@ find_package(ament_index_cpp REQUIRED)
 find_package(class_loader REQUIRED)
 find_package(composition_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rcl_interfaces REQUIRED)
 find_package(rcpputils REQUIRED)
+find_package(rmw REQUIRED)
 
 # Add an interface library that can be depended upon by libraries who register components
 add_library(component INTERFACE)
@@ -39,13 +41,15 @@ target_include_directories(component_manager PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 target_link_libraries(component_manager PUBLIC
+  class_loader::class_loader
   ${composition_interfaces_TARGETS}
   rclcpp::rclcpp
+  rmw::rmw
 )
 target_link_libraries(component_manager PRIVATE
   ament_index_cpp::ament_index_cpp
-  class_loader::class_loader
   rcpputils::rcpputils
+  ${rcl_interfaces_TARGETS}
 )
 target_compile_definitions(component_manager
   PRIVATE "RCLCPP_COMPONENTS_BUILDING_LIBRARY")
@@ -54,13 +58,13 @@ add_executable(
   component_container
   src/component_container.cpp
 )
-target_link_libraries(component_container component_manager rclcpp::rclcpp)
+target_link_libraries(component_container PRIVATE component_manager rclcpp::rclcpp)
 
 add_executable(
   component_container_event
   src/component_container_event.cpp
 )
-target_link_libraries(component_container_event component_manager rclcpp::rclcpp)
+target_link_libraries(component_container_event PRIVATE component_manager rclcpp::rclcpp)
 
 set(node_main_template_install_dir "share/${PROJECT_NAME}")
 install(FILES
@@ -71,19 +75,13 @@ add_executable(
   component_container_mt
   src/component_container_mt.cpp
 )
-target_link_libraries(component_container_mt component_manager rclcpp::rclcpp)
+target_link_libraries(component_container_mt PRIVATE component_manager rclcpp::rclcpp)
 
 add_executable(
   component_container_isolated
   src/component_container_isolated.cpp
 )
-target_link_libraries(component_container_isolated component_manager rclcpp::rclcpp)
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  target_link_libraries(component_container "stdc++fs")
-  target_link_libraries(component_container_mt "stdc++fs")
-  target_link_libraries(component_container_isolated "stdc++fs")
-endif()
+target_link_libraries(component_container_isolated PRIVATE component_manager rclcpp::rclcpp)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -174,9 +172,5 @@ ament_export_libraries(component_manager)
 # Export modern CMake targets
 ament_export_targets(export_${PROJECT_NAME})
 
-# specific order: dependents before dependencies
-ament_export_dependencies(ament_index_cpp)
-ament_export_dependencies(class_loader)
-ament_export_dependencies(composition_interfaces)
-ament_export_dependencies(rclcpp)
+ament_export_dependencies(class_loader composition_interfaces rclcpp rcpputils rmw)
 ament_package(CONFIG_EXTRAS rclcpp_components-extras.cmake.in)

--- a/rclcpp_components/include/rclcpp_components/component_manager.hpp
+++ b/rclcpp_components/include/rclcpp_components/component_manager.hpp
@@ -43,9 +43,12 @@
 
 #include <map>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
+
+#include "class_loader/class_loader.hpp"
 
 #include "composition_interfaces/srv/load_node.hpp"
 #include "composition_interfaces/srv/unload_node.hpp"
@@ -56,12 +59,10 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include "rclcpp_components/node_factory.hpp"
+#include "rclcpp_components/node_instance_wrapper.hpp"
 #include "rclcpp_components/visibility_control.hpp"
 
-namespace class_loader
-{
-class ClassLoader;
-}  // namespace class_loader
+#include "rmw/types.h"
 
 namespace rclcpp_components
 {

--- a/rclcpp_components/include/rclcpp_components/component_manager_isolated.hpp
+++ b/rclcpp_components/include/rclcpp_components/component_manager_isolated.hpp
@@ -16,14 +16,20 @@
 #ifndef RCLCPP_COMPONENTS__COMPONENT_MANAGER_ISOLATED_HPP__
 #define RCLCPP_COMPONENTS__COMPONENT_MANAGER_ISOLATED_HPP__
 
+#include <atomic>
+#include <chrono>
 #include <map>
 #include <memory>
 #include <string>
+#include <thread>
+#include <unordered_map>
 #include <utility>
 #include <vector>
-#include <unordered_map>
 #include <system_error>
 
+#include "rclcpp/executor.hpp"
+#include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rclcpp/utilities.hpp"
 #include "rclcpp_components/component_manager.hpp"
 #include "rcpputils/thread_name.hpp"
 

--- a/rclcpp_components/include/rclcpp_components/node_factory_template.hpp
+++ b/rclcpp_components/include/rclcpp_components/node_factory_template.hpp
@@ -18,7 +18,10 @@
 #include <functional>
 #include <memory>
 
+#include "rclcpp/node_options.hpp"
+
 #include "rclcpp_components/node_factory.hpp"
+#include "rclcpp_components/node_instance_wrapper.hpp"
 
 namespace rclcpp_components
 {

--- a/rclcpp_components/include/rclcpp_components/register_node_macro.hpp
+++ b/rclcpp_components/include/rclcpp_components/register_node_macro.hpp
@@ -16,6 +16,7 @@
 #define RCLCPP_COMPONENTS__REGISTER_NODE_MACRO_HPP__
 
 #include "class_loader/class_loader.hpp"
+#include "rclcpp_components/node_factory.hpp"
 #include "rclcpp_components/node_factory_template.hpp"
 
 /// Register a component that can be dynamically loaded at runtime.

--- a/rclcpp_components/package.xml
+++ b/rclcpp_components/package.xml
@@ -16,23 +16,32 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <build_export_depend>class_loader</build_export_depend>
+  <build_export_depend>composition_interfaces</build_export_depend>
+  <build_export_depend>rclcpp</build_export_depend>
+  <build_export_depend>rcpputils</build_export_depend>
+  <build_export_depend>rmw</build_export_depend>
+
   <build_depend>ament_index_cpp</build_depend>
   <build_depend>class_loader</build_depend>
   <build_depend>composition_interfaces</build_depend>
   <build_depend>rclcpp</build_depend>
+  <build_depend>rcl_interfaces</build_depend>
   <build_depend>rcpputils</build_depend>
+  <build_depend>rmw</build_depend>
 
   <exec_depend>ament_index_cpp</exec_depend>
   <exec_depend>class_loader</exec_depend>
   <exec_depend>composition_interfaces</exec_depend>
   <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rcl_interfaces</exec_depend>
+  <exec_depend>rcpputils</exec_depend>
+  <exec_depend>rmw</exec_depend>
 
   <test_depend>ament_cmake_google_benchmark</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>launch_testing</test_depend>
-  <test_depend>std_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -14,7 +14,8 @@
 
 #include <memory>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rclcpp/utilities.hpp"
 
 #include "rclcpp_components/component_manager.hpp"
 
@@ -26,4 +27,6 @@ int main(int argc, char * argv[])
   auto node = std::make_shared<rclcpp_components::ComponentManager>(exec);
   exec->add_node(node);
   exec->spin();
+
+  return 0;
 }

--- a/rclcpp_components/src/component_container_event.cpp
+++ b/rclcpp_components/src/component_container_event.cpp
@@ -14,7 +14,7 @@
 
 #include <memory>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/utilities.hpp"
 #include "rclcpp/experimental/executors/events_executor/events_executor.hpp"
 
 #include "rclcpp_components/component_manager.hpp"
@@ -27,4 +27,6 @@ int main(int argc, char * argv[])
   auto node = std::make_shared<rclcpp_components::ComponentManager>(exec);
   exec->add_node(node);
   exec->spin();
+
+  return 0;
 }

--- a/rclcpp_components/src/component_container_isolated.cpp
+++ b/rclcpp_components/src/component_container_isolated.cpp
@@ -16,8 +16,10 @@
 #include <vector>
 #include <string>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rclcpp/executors/multi_threaded_executor.hpp"
 #include "rclcpp/utilities.hpp"
+
 #include "rclcpp_components/component_manager_isolated.hpp"
 
 int main(int argc, char * argv[])
@@ -46,4 +48,6 @@ int main(int argc, char * argv[])
   }
   exec->add_node(node);
   exec->spin();
+
+  return 0;
 }

--- a/rclcpp_components/src/component_container_mt.cpp
+++ b/rclcpp_components/src/component_container_mt.cpp
@@ -14,7 +14,8 @@
 
 #include <memory>
 
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/executors/multi_threaded_executor.hpp"
+#include "rclcpp/utilities.hpp"
 
 #include "rclcpp_components/component_manager.hpp"
 
@@ -35,4 +36,6 @@ int main(int argc, char * argv[])
   }
   exec->add_node(node);
   exec->spin();
+
+  return 0;
 }

--- a/rclcpp_components/src/component_manager.cpp
+++ b/rclcpp_components/src/component_manager.cpp
@@ -17,14 +17,28 @@
 #include <filesystem>
 #include <functional>
 #include <memory>
+#include <stdexcept>
+#include <sstream>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
 #include "ament_index_cpp/get_resource.hpp"
+
 #include "class_loader/class_loader.hpp"
-#include "rcpputils/filesystem_helper.hpp"
+
+#include "rclcpp/node_options.hpp"
+#include "rclcpp/qos.hpp"
+
+#include "rclcpp_components/node_factory.hpp"
+
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
+#include "rcl_interfaces/msg/integer_range.hpp"
+
 #include "rcpputils/split.hpp"
+
+#include "rmw/types.h"
 
 using namespace std::placeholders;
 


### PR DESCRIPTION
## Description

The most important change in here is the changes to the package.xml and the CMakeLists.txt, which now properly export the dependencies to downstream packages as required.  On those two fronts:

1.  Make sure to add a dependency on rmw, which this package does depend on for rmw_request_id_t
2. Make sure to add a dependency on rcl_interfaces, which this package also depends on.
3. Export depend class_loader, composition_interfaces, rclcpp, rcpputils, and rmw, all of which are exported in the header files.
4. Remove the unnecessary test dependencies on launch_testing and std_msgs, neither of which is used.

The rest of the change here is to cleanup the header files to include what you use everywhere.

### Is this user-facing behavior change?

Not really.  There is *some* possibility that a downstream package was inadvertently relying on this package to export `ament_index_cpp` to it, but it is a minor point.

### Did you use Generative AI?

No.

### Additional Information

N/A