### PR TITLE
Allow for implicitly convertable loggers as well

### DIFF
--- a/rclcpp/include/rclcpp/logging.hpp
+++ b/rclcpp/include/rclcpp/logging.hpp
@@ -32,9 +32,7 @@
 #define RCLCPP_STATIC_ASSERT_LOGGER(logger) \
   do { \
     static_assert( \
-      ::std::is_convertible<typename std::remove_cv_t< \
-        typename std::remove_reference_t<decltype(logger)>>, \
-      typename ::rclcpp::Logger>::value, \
+      ::std::is_convertible_v<decltype(logger), rclcpp::Logger>, \
       "First argument to logging macros must be an rclcpp::Logger"); \
   } while (0)
 

--- a/rclcpp/include/rclcpp/logging.hpp
+++ b/rclcpp/include/rclcpp/logging.hpp
@@ -32,7 +32,7 @@
 #define RCLCPP_STATIC_ASSERT_LOGGER(logger) \
   do { \
     static_assert( \
-      ::std::is_same<typename std::remove_cv_t< \
+      ::std::is_convertible<typename std::remove_cv_t< \
         typename std::remove_reference_t<decltype(logger)>>, \
       typename ::rclcpp::Logger>::value, \
       "First argument to logging macros must be an rclcpp::Logger"); \

--- a/rclcpp/include/rclcpp/logging.hpp
+++ b/rclcpp/include/rclcpp/logging.hpp
@@ -32,7 +32,7 @@
 #define RCLCPP_STATIC_ASSERT_LOGGER(logger) \
   do { \
     static_assert( \
-      ::std::is_convertible_v<decltype(logger), rclcpp::Logger>, \
+      ::std::is_convertible_v<decltype(logger), ::rclcpp::Logger>, \
       "First argument to logging macros must be an rclcpp::Logger"); \
   } while (0)
 

--- a/rclcpp/test/rclcpp/test_logging.cpp
+++ b/rclcpp/test/rclcpp/test_logging.cpp
@@ -253,9 +253,19 @@ bool log_function_const_ref(const rclcpp::Logger & logger)
   return true;
 }
 
+class DerivedLogger : public rclcpp::Logger
+{
+public:
+  explicit DerivedLogger(const rclcpp::Logger & logger)
+  : rclcpp::Logger(logger) {}
+};
+
 TEST_F(TestLoggingMacros, test_log_from_node) {
   auto logger = rclcpp::get_logger("test_logging_logger");
   EXPECT_TRUE(log_function(logger));
   EXPECT_TRUE(log_function_const(logger));
   EXPECT_TRUE(log_function_const_ref(logger));
+
+  DerivedLogger derived_logger(logger);
+  RCLCPP_INFO(derived_logger, "successful log from derived logger");
 }


### PR DESCRIPTION
## Description

This way I can inherit from `rclpp::Logger` and still pass it to the logger macros.

### Is this user-facing behavior change?

Backwards compatible

### Did you use Generative AI?

No

### Additional Information

If accepted I would like to have this backported to active distros as well.