### PR TITLE
Switch to isolated testing via rmw_test_fixture

### DIFF
--- a/rclcpp/package.xml
+++ b/rclcpp/package.xml
@@ -48,6 +48,7 @@
   <depend>tracetools</depend>
 
   <test_depend>ament_cmake_google_benchmark</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rclcpp/package.xml
+++ b/rclcpp/package.xml
@@ -47,9 +47,8 @@
   <depend>statistics_msgs</depend>
   <depend>tracetools</depend>
 
-  <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_google_benchmark</test_depend>
-  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>mimick_vendor</test_depend>

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -662,24 +662,24 @@ endif()
 function(test_on_all_rmws)
   set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
 
-  ament_add_ros_isolated_gmock(test_qos_event
+  ament_add_ros_isolated_gmock_test(test_qos_event
     TEST_NAME test_qos_event${target_suffix}
     ENV ${rmw_implementation_env_var}
   )
   ament_add_test_label(test_qos_event${target_suffix} mimick)
 
-  ament_add_ros_isolated_gmock(test_generic_pubsub
+  ament_add_ros_isolated_gmock_test(test_generic_pubsub
     TEST_NAME test_generic_pubsub${target_suffix}
     ENV ${rmw_implementation_env_var}
   )
 
-  ament_add_ros_isolated_gmock(test_add_callback_groups_to_executor
+  ament_add_ros_isolated_gmock_test(test_add_callback_groups_to_executor
     TEST_NAME test_add_callback_groups_to_executor${target_suffix}
     ENV ${rmw_implementation_env_var}
     TIMEOUT 120
   )
 
-  ament_add_ros_isolated_gmock(test_subscription_content_filter
+  ament_add_ros_isolated_gmock_test(test_subscription_content_filter
     TEST_NAME test_subscription_content_filter${target_suffix}
     ENV ${rmw_implementation_env_var}
     TIMEOUT 120

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -662,32 +662,24 @@ endif()
 function(test_on_all_rmws)
   set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
 
-  # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
-  # Note: This is a temporary change that will be reverted before we branch into Kilted.
-  if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
-    list(APPEND rmw_implementation_env_var
-      ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-    )
-  endif()
-
-  ament_add_gmock_test(test_qos_event
+  ament_add_ros_isolated_gmock(test_qos_event
     TEST_NAME test_qos_event${target_suffix}
     ENV ${rmw_implementation_env_var}
   )
   ament_add_test_label(test_qos_event${target_suffix} mimick)
 
-  ament_add_gmock_test(test_generic_pubsub
+  ament_add_ros_isolated_gmock(test_generic_pubsub
     TEST_NAME test_generic_pubsub${target_suffix}
     ENV ${rmw_implementation_env_var}
   )
 
-  ament_add_gmock_test(test_add_callback_groups_to_executor
+  ament_add_ros_isolated_gmock(test_add_callback_groups_to_executor
     TEST_NAME test_add_callback_groups_to_executor${target_suffix}
     ENV ${rmw_implementation_env_var}
     TIMEOUT 120
   )
 
-  ament_add_gmock_test(test_subscription_content_filter
+  ament_add_ros_isolated_gmock(test_subscription_content_filter
     TEST_NAME test_subscription_content_filter${target_suffix}
     ENV ${rmw_implementation_env_var}
     TIMEOUT 120


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
This PR effectively reverts https://github.com/ros2/rclcpp/pull/2776 and relies on `rmw_test_fixture` to start a zenoh router when testing with `rmw_zenoh`.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

Partially addresses https://github.com/ros2/ros2/issues/1664

### Is this user-facing behavior change?
No
<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
No
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

`rclcpp/CMakeLists.txt` already calls `find_package(ament_cmake_ros REQUIRED)`.
<!--
If applicable, provide any additional context or details about the changes.
-->
