### PR TITLE
Removed warning

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
@@ -419,7 +419,7 @@ NodeGraph::get_node_names_and_namespaces() const
         rcl_get_error_string().str;
       rcl_reset_error();
     }
-    RCUTILS_LOG_ERROR_NAMED("rclcpp", error_msg.c_str());
+    RCUTILS_LOG_ERROR_NAMED("rclcpp", "%s", error_msg.c_str());
     throw std::runtime_error(error_msg);
   }
 
@@ -442,7 +442,7 @@ NodeGraph::get_node_names_and_namespaces() const
   }
 
   if (ret_names != RCUTILS_RET_OK || ret_ns != RCUTILS_RET_OK) {
-    RCUTILS_LOG_ERROR_NAMED("rclcpp", error.c_str());
+    RCUTILS_LOG_ERROR_NAMED("rclcpp", "%s", error.c_str());
     throw std::runtime_error(error);
   }
 


### PR DESCRIPTION
Related with this warning:
```
/home/ahcorde/ros2_rolling/src/ros2/rclcpp/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp:422:39: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
  422 |     RCUTILS_LOG_ERROR_NAMED("rclcpp", error_msg.c_str());
      |                                       ^~~~~~~~~~~~~~~~~
/home/ahcorde/ros2_rolling/install/include/rcutils/rcutils/logging_macros.h:701:55: note: expanded from macro 'RCUTILS_LOG_ERROR_NAMED'
  701 |   RCUTILS_LOG_NAMED(RCUTILS_LOG_SEVERITY_ERROR, name, __VA_ARGS__)
      |                                                       ^~~~~~~~~~~
/home/ahcorde/ros2_rolling/install/include/rcutils/rcutils/logging_macros.h:56:73: note: expanded from macro 'RCUTILS_LOG_NAMED'
   56 |       rcutils_log_internal(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
      |                                                                         ^~~~~~~~~~~
/home/ahcorde/ros2_rolling/src/ros2/rclcpp/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp:422:39: note: treat the string as an argument to avoid this
  422 |     RCUTILS_LOG_ERROR_NAMED("rclcpp", error_msg.c_str());
      |                                       ^
      |                                       "%s", 
/home/ahcorde/ros2_rolling/install/include/rcutils/rcutils/logging_macros.h:701:55: note: expanded from macro 'RCUTILS_LOG_ERROR_NAMED'
  701 |   RCUTILS_LOG_NAMED(RCUTILS_LOG_SEVERITY_ERROR, name, __VA_ARGS__)
      |                                                       ^
/home/ahcorde/ros2_rolling/install/include/rcutils/rcutils/logging_macros.h:56:73: note: expanded from macro 'RCUTILS_LOG_NAMED'
   56 |       rcutils_log_internal(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
      |                                                                         ^
/home/ahcorde/ros2_rolling/src/ros2/rclcpp/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp:445:39: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
  445 |     RCUTILS_LOG_ERROR_NAMED("rclcpp", error.c_str());
      |                                       ^~~~~~~~~~~~~
/home/ahcorde/ros2_rolling/install/include/rcutils/rcutils/logging_macros.h:701:55: note: expanded from macro 'RCUTILS_LOG_ERROR_NAMED'
  701 |   RCUTILS_LOG_NAMED(RCUTILS_LOG_SEVERITY_ERROR, name, __VA_ARGS__)
      |                                                       ^~~~~~~~~~~
/home/ahcorde/ros2_rolling/install/include/rcutils/rcutils/logging_macros.h:56:73: note: expanded from macro 'RCUTILS_LOG_NAMED'
   56 |       rcutils_log_internal(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
      |                                                                         ^~~~~~~~~~~
/home/ahcorde/ros2_rolling/src/ros2/rclcpp/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp:445:39: note: treat the string as an argument to avoid this
  445 |     RCUTILS_LOG_ERROR_NAMED("rclcpp", error.c_str());
      |                                       ^
      |                                       "%s", 
/home/ahcorde/ros2_rolling/install/include/rcutils/rcutils/logging_macros.h:701:55: note: expanded from macro 'RCUTILS_LOG_ERROR_NAMED'
  701 |   RCUTILS_LOG_NAMED(RCUTILS_LOG_SEVERITY_ERROR, name, __VA_ARGS__)
      |                                                       ^
/home/ahcorde/ros2_rolling/install/include/rcutils/rcutils/logging_macros.h:56:73: note: expanded from macro 'RCUTILS_LOG_NAMED'
   56 |       rcutils_log_internal(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
```