### PR TITLE
try aborting before canceling 1st on dtor of ServerGoalHandle.

### DIFF
--- a/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
+++ b/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
@@ -24,6 +24,8 @@
 
 #include "action_msgs/msg/goal_status.hpp"
 
+#include "rclcpp/logging.hpp"
+
 #include "rclcpp_action/visibility_control.hpp"
 #include "rclcpp_action/types.hpp"
 
@@ -107,6 +109,12 @@ protected:
   RCLCPP_ACTION_PUBLIC
   bool
   try_canceling() noexcept;
+
+  /// Transition the goal to aborted state if it never reached a terminal state.
+  /// \internal
+  RCLCPP_ACTION_PUBLIC
+  bool
+  try_aborting() noexcept;
 
   // End API for communication between ServerGoalHandleBase and ServerGoalHandle<>
   // -----------------------------------------------------------------------------
@@ -243,11 +251,22 @@ public:
 
   virtual ~ServerGoalHandle()
   {
-    // Cancel goal if handle was allowed to destruct without reaching a terminal state
-    if (try_canceling()) {
-      auto null_result = std::make_shared<typename ActionT::Impl::GetResultService::Response>();
-      null_result->status = action_msgs::msg::GoalStatus::STATUS_CANCELED;
-      on_terminal_state_(uuid_, null_result);
+    try {
+      // Abort goal if handle was allowed to destruct without reaching a terminal state
+      if (try_aborting()) {
+        auto null_result = std::make_shared<typename ActionT::Impl::GetResultService::Response>();
+        null_result->status = action_msgs::msg::GoalStatus::STATUS_ABORTED;
+        on_terminal_state_(uuid_, null_result);
+      } else if (try_canceling()) {
+        // Cancel goal if handle was allowed to destruct without reaching a terminal state
+        auto null_result = std::make_shared<typename ActionT::Impl::GetResultService::Response>();
+        null_result->status = action_msgs::msg::GoalStatus::STATUS_CANCELED;
+        on_terminal_state_(uuid_, null_result);
+      }
+    } catch (const std::exception & ex) {
+      RCLCPP_DEBUG(
+        rclcpp::get_logger("rclcpp_action"),
+        "Failed to abort/cancel goal handler in destructor: %s", ex.what());
     }
   }
 

--- a/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
+++ b/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
@@ -105,12 +105,14 @@ protected:
   _execute();
 
   /// Transition the goal to canceled state if it never reached a terminal state.
+  /// Returns true if transitioned to canceled, else false.
   /// \internal
   RCLCPP_ACTION_PUBLIC
   bool
   try_canceling() noexcept;
 
   /// Transition the goal to aborted state if it never reached a terminal state.
+  /// Returns true if transitioned to aborted, else false.
   /// \internal
   RCLCPP_ACTION_PUBLIC
   bool

--- a/rclcpp_action/src/server_goal_handle.cpp
+++ b/rclcpp_action/src/server_goal_handle.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <memory>
+#include <mutex>
 
 #include "rcl_action/action_server.h"
 #include "rcl_action/goal_handle.h"

--- a/rclcpp_action/src/server_goal_handle.cpp
+++ b/rclcpp_action/src/server_goal_handle.cpp
@@ -135,7 +135,7 @@ ServerGoalHandleBase::try_canceling() noexcept
     return RCL_RET_OK == ret;
   }
 
-  return false;
+  return is_cancelable;
 }
 
 bool
@@ -153,6 +153,6 @@ ServerGoalHandleBase::try_aborting() noexcept
     }
   }
 
-  return true;
+  return is_abortable;
 }
 }  // namespace rclcpp_action

--- a/rclcpp_action/src/server_goal_handle.cpp
+++ b/rclcpp_action/src/server_goal_handle.cpp
@@ -137,4 +137,22 @@ ServerGoalHandleBase::try_canceling() noexcept
 
   return false;
 }
+
+bool
+ServerGoalHandleBase::try_aborting() noexcept
+{
+  std::lock_guard<std::mutex> lock(rcl_handle_mutex_);
+  rcl_ret_t ret;
+  // Check if the goal is abortable
+  const bool is_abortable = rcl_action_goal_handle_is_abortable(rcl_handle_.get());
+  if (is_abortable) {
+    // Transition to ABORTED
+    ret = rcl_action_update_goal_state(rcl_handle_.get(), GOAL_EVENT_ABORT);
+    if (RCL_RET_OK != ret) {
+      return false;
+    }
+  }
+
+  return true;
+}
 }  // namespace rclcpp_action

--- a/rclcpp_action/test/test_server_goal_handle.cpp
+++ b/rclcpp_action/test/test_server_goal_handle.cpp
@@ -44,6 +44,8 @@ public:
 
   bool try_cancel() {return try_canceling();}
 
+  bool try_abort() {return try_aborting();}
+
   void cancel_goal() {_cancel_goal();}
 };
 
@@ -123,6 +125,20 @@ TEST_F(TestServerGoalHandle, abort) {
   test_msgs::action::Fibonacci::Result::SharedPtr result =
     std::make_shared<test_msgs::action::Fibonacci::Result>();
   handle_->abort(result);
+  EXPECT_FALSE(handle_->is_canceling());
+  EXPECT_FALSE(handle_->is_active());
+  EXPECT_FALSE(handle_->is_executing());
+
+  auto mock = mocking_utils::patch_and_return(
+    "lib:rclcpp_action", rcl_action_update_goal_state, RCL_RET_ERROR);
+  EXPECT_THROW(handle_->abort(result), rclcpp::exceptions::RCLError);
+}
+
+TEST_F(TestServerGoalHandle, try_abort) {
+  handle_->execute();
+  test_msgs::action::Fibonacci::Result::SharedPtr result =
+    std::make_shared<test_msgs::action::Fibonacci::Result>();
+  EXPECT_TRUE(handle_->try_abort());
   EXPECT_FALSE(handle_->is_canceling());
   EXPECT_FALSE(handle_->is_active());
   EXPECT_FALSE(handle_->is_executing());


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Depends on https://github.com/ros2/rcl/pull/1257

Fixes https://github.com/ros2/rclcpp/issues/2948 and https://github.com/ros2/rclcpp/issues/2757

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

Yes.

before, on the destruction of `ServerGoalHandle`, it only tries to cancel the goal.
after, it tries to abort the goal 1st, and if not possible in the current state, it then falls back to cancel the goal.

the goal should be aborted if possible in the 1st place on destruction rather than canceled to match design spec as following.

- ABORTED: The goal was terminated by the action server without an external request.
- CANCELED: The goal was canceled after an external request from an action client.

https://design.ros2.org/articles/actions.html

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
