### PR TITLE
Added static assert asserting custom types have no overloaded operator new

### DIFF
--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -576,10 +576,9 @@ protected:
   {
     /// Assert that the published type has no overloaded operator new since this leads to
     /// new/delete mismatch (see https://github.com/ros2/rclcpp/issues/2951)
-    static_assert(!detail::has_overloaded_operator_new_v<PublishedType>,
-        "When publishing by value (i.e. when calling publish(const T& msg)), the published message"
-        "type must not have an overloaded operator new. In this case, please use the"
-        "publish(std::unique_ptr<T> msg) method instead.");
+    if constexpr (detail::has_overloaded_operator_new_v<PublishedType>) {
+      detail::warn_for_overloaded_operator_new();
+    }
     auto ptr = PublishedTypeAllocatorTraits::allocate(published_type_allocator_, 1);
     PublishedTypeAllocatorTraits::construct(published_type_allocator_, ptr, msg);
     return std::unique_ptr<PublishedType, PublishedTypeDeleter>(ptr, published_type_deleter_);

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -52,7 +52,6 @@
 namespace rclcpp
 {
 
-
 template<typename MessageT, typename AllocatorT>
 class LoanedMessage;
 
@@ -87,7 +86,6 @@ public:
 
   /// MessageT::custom_type if MessageT is a TypeAdapter, otherwise just MessageT.
   using PublishedType = typename rclcpp::TypeAdapter<MessageT>::custom_type;
-
   using ROSMessageType = typename rclcpp::TypeAdapter<MessageT>::ros_message_type;
 
   using PublishedTypeAllocatorTraits = allocator::AllocRebind<PublishedType, AllocatorT>;

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -52,6 +52,7 @@
 namespace rclcpp
 {
 
+
 template<typename MessageT, typename AllocatorT>
 class LoanedMessage;
 
@@ -576,7 +577,8 @@ protected:
   {
     /// Assert that the published type has no overloaded operator new since this leads to
     /// new/delete mismatch (see https://github.com/ros2/rclcpp/issues/2951)
-    detail::DeprecationEmitterOverloadedOperatorNew<detail::has_overloaded_operator_new_v<PublishedType>>::warn();
+    DeprecationEmitterOverloadedOperatorNew<has_overloaded_operator_new_v<
+        PublishedType>>::warn();
 
     auto ptr = PublishedTypeAllocatorTraits::allocate(published_type_allocator_, 1);
     PublishedTypeAllocatorTraits::construct(published_type_allocator_, ptr, msg);

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -576,7 +576,7 @@ protected:
   {
     /// Assert that the published type has no overloaded operator new since this leads to
     /// new/delete mismatch (see https://github.com/ros2/rclcpp/issues/2951)
-    detail::DeprecationEmitterOverloadedOperatorNew<detail::has_overloaded_operator_new_v<PublishedType>>::warn();    
+    detail::DeprecationEmitterOverloadedOperatorNew<detail::has_overloaded_operator_new_v<PublishedType>>::warn();
 
     auto ptr = PublishedTypeAllocatorTraits::allocate(published_type_allocator_, 1);
     PublishedTypeAllocatorTraits::construct(published_type_allocator_, ptr, msg);

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -576,7 +576,7 @@ protected:
   {
     /// Assert that the published type has no overloaded operator new since this leads to
     /// new/delete mismatch (see https://github.com/ros2/rclcpp/issues/2951)
-    detail::DeprecationEmitterOverloadedOperatorNew<detail::has_overloaded_operator_new_v<PublishedType>>{};
+    detail::DeprecationEmitterOverloadedOperatorNew<detail::has_overloaded_operator_new_v<PublishedType>>::warn();    
 
     auto ptr = PublishedTypeAllocatorTraits::allocate(published_type_allocator_, 1);
     PublishedTypeAllocatorTraits::construct(published_type_allocator_, ptr, msg);

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -578,8 +578,10 @@ protected:
   {
     /// Assert that the published type has no overloaded operator new since this leads to
     /// new/delete mismatch (see https://github.com/ros2/rclcpp/issues/2951)
-    detail::DeprecationEmitterOverloadedOperatorNew<detail::has_overloaded_operator_new_v<
-        PublishedType>>::warn();
+    static_assert(!detail::has_overloaded_operator_new_v<PublishedType>,
+        "When publishing by value (i.e. when calling publish(const T& msg)), the published "
+    "message type must not have an overloaded operator new. In this case, please use the "
+    "publish(std::unique_ptr<T> msg) method instead.");
 
     auto ptr = PublishedTypeAllocatorTraits::allocate(published_type_allocator_, 1);
     PublishedTypeAllocatorTraits::construct(published_type_allocator_, ptr, msg);

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -574,6 +574,9 @@ protected:
   std::unique_ptr<PublishedType, PublishedTypeDeleter>
   duplicate_type_adapt_message_as_unique_ptr(const PublishedType & msg)
   {
+    /// Assert that the published type has no overloaded operator new since this leads to new/delete mismatch (see https://github.com/ros2/rclcpp/issues/2951)
+    static_assert(!detail::has_overloaded_operator_new_v<PublishedType>, 
+        "When publishing by value (i.e. when calling publish(const T& msg)), the published message type must not have an overloaded operator new. In this case, please use the publish(std::unique_ptr<T> msg) method instead.");
     auto ptr = PublishedTypeAllocatorTraits::allocate(published_type_allocator_, 1);
     PublishedTypeAllocatorTraits::construct(published_type_allocator_, ptr, msg);
     return std::unique_ptr<PublishedType, PublishedTypeDeleter>(ptr, published_type_deleter_);

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -574,9 +574,12 @@ protected:
   std::unique_ptr<PublishedType, PublishedTypeDeleter>
   duplicate_type_adapt_message_as_unique_ptr(const PublishedType & msg)
   {
-    /// Assert that the published type has no overloaded operator new since this leads to new/delete mismatch (see https://github.com/ros2/rclcpp/issues/2951)
-    static_assert(!detail::has_overloaded_operator_new_v<PublishedType>, 
-        "When publishing by value (i.e. when calling publish(const T& msg)), the published message type must not have an overloaded operator new. In this case, please use the publish(std::unique_ptr<T> msg) method instead.");
+    /// Assert that the published type has no overloaded operator new since this leads to
+    /// new/delete mismatch (see https://github.com/ros2/rclcpp/issues/2951)
+    static_assert(!detail::has_overloaded_operator_new_v<PublishedType>,
+        "When publishing by value (i.e. when calling publish(const T& msg)), the published message"
+        "type must not have an overloaded operator new. In this case, please use the"
+        "publish(std::unique_ptr<T> msg) method instead.");
     auto ptr = PublishedTypeAllocatorTraits::allocate(published_type_allocator_, 1);
     PublishedTypeAllocatorTraits::construct(published_type_allocator_, ptr, msg);
     return std::unique_ptr<PublishedType, PublishedTypeDeleter>(ptr, published_type_deleter_);

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -87,6 +87,7 @@ public:
 
   /// MessageT::custom_type if MessageT is a TypeAdapter, otherwise just MessageT.
   using PublishedType = typename rclcpp::TypeAdapter<MessageT>::custom_type;
+
   using ROSMessageType = typename rclcpp::TypeAdapter<MessageT>::ros_message_type;
 
   using PublishedTypeAllocatorTraits = allocator::AllocRebind<PublishedType, AllocatorT>;
@@ -577,7 +578,7 @@ protected:
   {
     /// Assert that the published type has no overloaded operator new since this leads to
     /// new/delete mismatch (see https://github.com/ros2/rclcpp/issues/2951)
-    DeprecationEmitterOverloadedOperatorNew<has_overloaded_operator_new_v<
+    detail::DeprecationEmitterOverloadedOperatorNew<detail::has_overloaded_operator_new_v<
         PublishedType>>::warn();
 
     auto ptr = PublishedTypeAllocatorTraits::allocate(published_type_allocator_, 1);

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -576,9 +576,8 @@ protected:
   {
     /// Assert that the published type has no overloaded operator new since this leads to
     /// new/delete mismatch (see https://github.com/ros2/rclcpp/issues/2951)
-    if constexpr (detail::has_overloaded_operator_new_v<PublishedType>) {
-      detail::warn_for_overloaded_operator_new();
-    }
+    detail::DeprecationEmitterOverloadedOperatorNew<detail::has_overloaded_operator_new_v<PublishedType>>{};
+
     auto ptr = PublishedTypeAllocatorTraits::allocate(published_type_allocator_, 1);
     PublishedTypeAllocatorTraits::construct(published_type_allocator_, ptr, msg);
     return std::unique_ptr<PublishedType, PublishedTypeDeleter>(ptr, published_type_deleter_);

--- a/rclcpp/include/rclcpp/type_adapter.hpp
+++ b/rclcpp/include/rclcpp/type_adapter.hpp
@@ -146,14 +146,20 @@ template<typename T>
 inline constexpr bool has_overloaded_operator_new_v = has_overloaded_operator_new<T>::value;
 
 template<bool cond>
-struct DeprecationEmitterOverloadedOperatorNew {};
+struct DeprecationEmitterOverloadedOperatorNew
+{
+};
 
-template<> struct DeprecationEmitterOverloadedOperatorNew<false> {
+template<>
+struct DeprecationEmitterOverloadedOperatorNew<false>
+{
   static void warn() {}
 };
 
-template<> struct 
-DeprecationEmitterOverloadedOperatorNew<true> {
+template<>
+struct
+DeprecationEmitterOverloadedOperatorNew<true>
+{
   [[deprecated("When publishing by value (i.e. when calling publish(const T& msg)), the published message"
         "type must not have an overloaded operator new. In this case, please use the"
         "publish(std::unique_ptr<T> msg) method instead.")]]

--- a/rclcpp/include/rclcpp/type_adapter.hpp
+++ b/rclcpp/include/rclcpp/type_adapter.hpp
@@ -136,16 +136,18 @@ struct has_overloaded_operator_new<T, std::void_t<
     decltype(T::operator new(std::size_t()))
   >>: std::true_type {};
 
-/// Aligned operator new (C++17)
+template<typename, typename = void>
+struct has_overloaded_aligned_operator_new : std::false_type {};
 template<typename T>
-struct has_overloaded_operator_new<T,
+struct has_overloaded_aligned_operator_new<T,
   std::void_t<decltype( T::operator new(std::size_t(), std::align_val_t()) )>>
   : std::true_type {};
 
 template<typename T>
-inline constexpr bool has_overloaded_operator_new_v = has_overloaded_operator_new<T>::value;
+inline constexpr bool has_overloaded_operator_new_v = has_overloaded_operator_new<T>::value ||
+  has_overloaded_aligned_operator_new<T>::value;
 
-template<bool cond>
+template<bool>
 struct DeprecationEmitterOverloadedOperatorNew
 {
 };
@@ -160,9 +162,9 @@ template<>
 struct
 DeprecationEmitterOverloadedOperatorNew<true>
 {
-  [[deprecated("When publishing by value (i.e. when calling publish(const T& msg)), the published message"
-        "type must not have an overloaded operator new. In this case, please use the"
-        "publish(std::unique_ptr<T> msg) method instead.")]]
+  [[deprecated("When publishing by value (i.e. when calling publish(const T& msg)), the published "
+    "message type must not have an overloaded operator new. In this case, please use the "
+    "publish(std::unique_ptr<T> msg) method instead.")]]
   static void warn() {}
 };
 

--- a/rclcpp/include/rclcpp/type_adapter.hpp
+++ b/rclcpp/include/rclcpp/type_adapter.hpp
@@ -16,6 +16,7 @@
 #define RCLCPP__TYPE_ADAPTER_HPP_
 
 #include <type_traits>
+#include <new> // For std::align_val_t
 
 namespace rclcpp
 {
@@ -127,6 +128,22 @@ struct assert_type_pair_is_specialized_type_adapter
     type_adapter::is_specialized::value,
     "No type adapter for this custom type/ros message type pair");
 };
+
+template <typename, typename = void>
+struct has_overloaded_operator_new : std::false_type {};
+template <typename T>
+struct has_overloaded_operator_new<T, std::void_t<
+    decltype(T::operator new(std::size_t()))  
+>> : std::true_type {};
+
+/// Aligned operator new (C++17)
+template<class T>
+struct has_overloaded_operator_new<T,
+    std::void_t<decltype( T::operator new(std::size_t(), std::align_val_t()) )>>
+  : std::true_type {};
+
+template <typename T>
+inline constexpr bool has_overloaded_operator_new_v = has_overloaded_operator_new<T>::value;
 
 }  // namespace detail
 

--- a/rclcpp/include/rclcpp/type_adapter.hpp
+++ b/rclcpp/include/rclcpp/type_adapter.hpp
@@ -147,27 +147,6 @@ template<typename T>
 inline constexpr bool has_overloaded_operator_new_v = has_overloaded_operator_new<T>::value ||
   has_overloaded_aligned_operator_new<T>::value;
 
-template<bool>
-struct DeprecationEmitterOverloadedOperatorNew
-{
-};
-
-template<>
-struct DeprecationEmitterOverloadedOperatorNew<false>
-{
-  static void warn() {}
-};
-
-template<>
-struct
-DeprecationEmitterOverloadedOperatorNew<true>
-{
-  [[deprecated("When publishing by value (i.e. when calling publish(const T& msg)), the published "
-    "message type must not have an overloaded operator new. In this case, please use the "
-    "publish(std::unique_ptr<T> msg) method instead.")]]
-  static void warn() {}
-};
-
 }  // namespace detail
 
 /// Template metafunction that can make the type being adapted explicit.

--- a/rclcpp/include/rclcpp/type_adapter.hpp
+++ b/rclcpp/include/rclcpp/type_adapter.hpp
@@ -147,12 +147,18 @@ inline constexpr bool has_overloaded_operator_new_v = has_overloaded_operator_ne
 
 template<bool cond>
 struct DeprecationEmitterOverloadedOperatorNew {};
-template<> struct DeprecationEmitterOverloadedOperatorNew<false> {};
+
+template<> struct DeprecationEmitterOverloadedOperatorNew<false> {
+  static void warn() {}
+};
+
 template<> struct 
-[[deprecated("When publishing by value (i.e. when calling publish(const T& msg)), the published message"
+DeprecationEmitterOverloadedOperatorNew<true> {
+  [[deprecated("When publishing by value (i.e. when calling publish(const T& msg)), the published message"
         "type must not have an overloaded operator new. In this case, please use the"
         "publish(std::unique_ptr<T> msg) method instead.")]]
-DeprecationEmitterOverloadedOperatorNew<true> {};
+  static void warn() {}
+};
 
 }  // namespace detail
 

--- a/rclcpp/include/rclcpp/type_adapter.hpp
+++ b/rclcpp/include/rclcpp/type_adapter.hpp
@@ -145,6 +145,11 @@ struct has_overloaded_operator_new<T,
 template<typename T>
 inline constexpr bool has_overloaded_operator_new_v = has_overloaded_operator_new<T>::value;
 
+[[deprecated("When publishing by value (i.e. when calling publish(const T& msg)), the published message"
+        "type must not have an overloaded operator new. In this case, please use the"
+        "publish(std::unique_ptr<T> msg) method instead.")]]
+static void warn_for_overloaded_operator_new() {}
+
 }  // namespace detail
 
 /// Template metafunction that can make the type being adapted explicit.

--- a/rclcpp/include/rclcpp/type_adapter.hpp
+++ b/rclcpp/include/rclcpp/type_adapter.hpp
@@ -137,7 +137,7 @@ struct has_overloaded_operator_new<T, std::void_t<
   >>: std::true_type {};
 
 /// Aligned operator new (C++17)
-template<class T>
+template<typename T>
 struct has_overloaded_operator_new<T,
   std::void_t<decltype( T::operator new(std::size_t(), std::align_val_t()) )>>
   : std::true_type {};
@@ -145,10 +145,14 @@ struct has_overloaded_operator_new<T,
 template<typename T>
 inline constexpr bool has_overloaded_operator_new_v = has_overloaded_operator_new<T>::value;
 
+template<bool cond>
+struct DeprecationEmitterOverloadedOperatorNew {};
+template<> struct DeprecationEmitterOverloadedOperatorNew<false> {};
+template<> struct 
 [[deprecated("When publishing by value (i.e. when calling publish(const T& msg)), the published message"
         "type must not have an overloaded operator new. In this case, please use the"
         "publish(std::unique_ptr<T> msg) method instead.")]]
-static void warn_for_overloaded_operator_new() {}
+DeprecationEmitterOverloadedOperatorNew<true> {};
 
 }  // namespace detail
 

--- a/rclcpp/include/rclcpp/type_adapter.hpp
+++ b/rclcpp/include/rclcpp/type_adapter.hpp
@@ -16,7 +16,7 @@
 #define RCLCPP__TYPE_ADAPTER_HPP_
 
 #include <type_traits>
-#include <new> // For std::align_val_t
+#include <new>
 
 namespace rclcpp
 {
@@ -129,20 +129,20 @@ struct assert_type_pair_is_specialized_type_adapter
     "No type adapter for this custom type/ros message type pair");
 };
 
-template <typename, typename = void>
+template<typename, typename = void>
 struct has_overloaded_operator_new : std::false_type {};
-template <typename T>
+template<typename T>
 struct has_overloaded_operator_new<T, std::void_t<
-    decltype(T::operator new(std::size_t()))  
->> : std::true_type {};
+    decltype(T::operator new(std::size_t()))
+  >>: std::true_type {};
 
 /// Aligned operator new (C++17)
 template<class T>
 struct has_overloaded_operator_new<T,
-    std::void_t<decltype( T::operator new(std::size_t(), std::align_val_t()) )>>
+  std::void_t<decltype( T::operator new(std::size_t(), std::align_val_t()) )>>
   : std::true_type {};
 
-template <typename T>
+template<typename T>
 inline constexpr bool has_overloaded_operator_new_v = has_overloaded_operator_new<T>::value;
 
 }  // namespace detail

--- a/rclcpp/include/rclcpp/type_adapter.hpp
+++ b/rclcpp/include/rclcpp/type_adapter.hpp
@@ -143,17 +143,6 @@ struct has_overloaded_operator_new<T,
   : std::true_type {};
 
 template <typename T>
-struct has_overloaded_operator_new<T, std::void_t<
-    decltype(T::operator new[](std::size_t()))  
->> : std::true_type {};
-
-/// Aligned array operator new (C++17)
-template<class T>
-struct has_overloaded_operator_new<T,
-    std::void_t<decltype( T::operator new[](std::size_t(), std::align_val_t()) )>>
-  : std::true_type {};
-
-template <typename T>
 inline constexpr bool has_overloaded_operator_new_v = has_overloaded_operator_new<T>::value;
 
 }  // namespace detail

--- a/rclcpp/include/rclcpp/type_adapter.hpp
+++ b/rclcpp/include/rclcpp/type_adapter.hpp
@@ -143,6 +143,17 @@ struct has_overloaded_operator_new<T,
   : std::true_type {};
 
 template <typename T>
+struct has_overloaded_operator_new<T, std::void_t<
+    decltype(T::operator new[](std::size_t()))  
+>> : std::true_type {};
+
+/// Aligned array operator new (C++17)
+template<class T>
+struct has_overloaded_operator_new<T,
+    std::void_t<decltype( T::operator new[](std::size_t(), std::align_val_t()) )>>
+  : std::true_type {};
+
+template <typename T>
 inline constexpr bool has_overloaded_operator_new_v = has_overloaded_operator_new<T>::value;
 
 }  // namespace detail


### PR DESCRIPTION
## Description

Fixes https://github.com/ros2/rclcpp/issues/2951

### Is this user-facing behavior change?

When users publish custom message types using type adapters, they must now publish by unique_ptr if the custom message type overloads operator new. This is to prevent new/delete mismatch.

### Did you use Generative AI?

No

### Additional Information

Tested, and correctly fails to compile if I try to publish a pcl::PointCloud by value AND I'm pulling the dependency on PCL via pcl_ros. 

According to [cppreference](https://en.cppreference.com/w/cpp/memory/new/operator_new.html), there are 22 overloads of operator new. I only implement detecting the class-specific ones 15 and 17. I do not implement the array-operators (16 and 18) since the detection becomes ambiguous and causes compile error.
I do not think it is reasonable to guard against overloaded global operator new/delete, i.e. overloads 1-10.

Also, overloads 11-14 and 19-22 accept arbitrary arguments and are therefore likely to be undetectable. 

