### PR TITLE
Catch the exception from rate.sleep() if the context is invalid.

### DIFF
--- a/rclcpp/src/rclcpp/rate.cpp
+++ b/rclcpp/src/rclcpp/rate.cpp
@@ -67,7 +67,13 @@ Rate::sleep()
   // Calculate the time to sleep
   auto time_to_sleep = next_interval - now;
   // Sleep (will get interrupted by ctrl-c, may not sleep full time)
-  clock_->sleep_for(time_to_sleep);
+  try {
+    // If the context is invalid, an exception will be thrown.
+    clock_->sleep_for(time_to_sleep);
+  } catch (const std::runtime_error & e) {
+    // If it didn't sleep the full time, return false
+    return false;
+  }
   return true;
 }
 

--- a/rclcpp/test/rclcpp/test_rate.cpp
+++ b/rclcpp/test/rclcpp/test_rate.cpp
@@ -173,3 +173,12 @@ TEST_F(TestRate, incorrect_constuctor) {
     rclcpp::Rate rate(rclcpp::Duration(-1, 0)),
     std::invalid_argument("period must be greater than 0"));
 }
+
+TEST(TestRateBasic, invalid_context) {
+  rclcpp::init(0, nullptr);
+  rclcpp::Rate rate(1.0);
+  ASSERT_TRUE(rate.sleep());
+  rclcpp::shutdown();
+  EXPECT_NO_THROW(rate.sleep());
+  ASSERT_FALSE(rate.sleep());
+}


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #2862 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

Yes.

before, it throws the exception via rate.sleep() call if the context is already shutdown by other threads.
after, it does not throw the exception via rate.sleep() call, instead it just returns the false to indicate that it could not sleep for the full time.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
