### PR TITLE
Deprecate the shared_ptr<MessageT> subscription callback signatures

### DIFF
--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -406,7 +406,9 @@ public:
     // automatically with lambda functions in cases where the arguments can be
     // converted to one another, e.g. shared_ptr and unique_ptr.
     using scbth = detail::SubscriptionCallbackTypeHelper<MessageT, CallbackT>;
-    constexpr auto is_invalid_signature =
+
+    // Determine if the given CallbackT is a deprecated signature or not.
+    constexpr auto is_deprecated =
       rclcpp::function_traits::same_arguments<
       typename scbth::callback_type,
       std::function<void(std::shared_ptr<SubscribedType>)>
@@ -434,7 +436,7 @@ public:
 
     // Use the discovered type to force the type of callback when assigning
     // into the variant.
-    if constexpr (is_invalid_signature) {
+    if constexpr (is_deprecated) {
       // If deprecated, call sub-routine that is deprecated.
       set_deprecated(static_cast<typename scbth::callback_type>(callback));
     } else {
@@ -446,9 +448,12 @@ public:
     return *this;
   }
 
-  template<typename SetT>
   /// Function for shared_ptr to non-const MessageT, which is deprecated.
+  template<typename SetT>
+  #if !defined(RCLCPP_AVOID_DEPRECATIONS_FOR_UNIT_TESTS)
+  // suppress deprecation warnings in `test_any_subscription_callback.cpp`
   [[deprecated("use 'void(std::shared_ptr<const MessageT>)' instead")]]
+  #endif
   void
   set_deprecated(std::function<void(std::shared_ptr<SetT>)> callback)
   {
@@ -457,13 +462,18 @@ public:
 
   /// Function for shared_ptr to non-const MessageT with MessageInfo, which is deprecated.
   template<typename SetT>
+  #if !defined(RCLCPP_AVOID_DEPRECATIONS_FOR_UNIT_TESTS)
+  // suppress deprecation warnings in `test_any_subscription_callback.cpp`
   [[deprecated(
           "use 'void(std::shared_ptr<const MessageT>, const rclcpp::MessageInfo &)' instead"
   )]]
+  #endif
   void
   set_deprecated(std::function<void(std::shared_ptr<SetT>, const rclcpp::MessageInfo &)> callback)
   {
     callback_variant_ = callback;
+  }
+
   /// Disable the callback from being called during dispatch.
   void disable()
   {

--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -450,10 +450,12 @@ public:
 
   /// Function for shared_ptr to non-const MessageT, which is deprecated.
   template<typename SetT>
+  // *INDENT-OFF*
   #if !defined(RCLCPP_AVOID_DEPRECATIONS_FOR_UNIT_TESTS)
   // suppress deprecation warnings in `test_any_subscription_callback.cpp`
   [[deprecated("use 'void(std::shared_ptr<const MessageT>)' instead")]]
   #endif
+  // *INDENT-ON*
   void
   set_deprecated(std::function<void(std::shared_ptr<SetT>)> callback)
   {
@@ -462,12 +464,14 @@ public:
 
   /// Function for shared_ptr to non-const MessageT with MessageInfo, which is deprecated.
   template<typename SetT>
+  // *INDENT-OFF*
   #if !defined(RCLCPP_AVOID_DEPRECATIONS_FOR_UNIT_TESTS)
   // suppress deprecation warnings in `test_any_subscription_callback.cpp`
   [[deprecated(
           "use 'void(std::shared_ptr<const MessageT>, const rclcpp::MessageInfo &)' instead"
   )]]
   #endif
+  // *INDENT-ON*
   void
   set_deprecated(std::function<void(std::shared_ptr<SetT>, const rclcpp::MessageInfo &)> callback)
   {

--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -392,6 +392,34 @@ public:
     // automatically with lambda functions in cases where the arguments can be
     // converted to one another, e.g. shared_ptr and unique_ptr.
     using scbth = detail::SubscriptionCallbackTypeHelper<MessageT, CallbackT>;
+    constexpr auto is_invalid_signature =
+      rclcpp::function_traits::same_arguments<
+      typename scbth::callback_type,
+      std::function<void(std::shared_ptr<SubscribedType>)>
+      >::value ||
+      rclcpp::function_traits::same_arguments<
+      typename scbth::callback_type,
+      std::function<void(std::shared_ptr<SubscribedType>, const rclcpp::MessageInfo &)>
+      >::value ||
+      rclcpp::function_traits::same_arguments<
+      typename scbth::callback_type,
+      std::function<void(std::shared_ptr<ROSMessageType>)>
+      >::value ||
+      rclcpp::function_traits::same_arguments<
+      typename scbth::callback_type,
+      std::function<void(std::shared_ptr<ROSMessageType>, const rclcpp::MessageInfo &)>
+      >::value ||
+      rclcpp::function_traits::same_arguments<
+      typename scbth::callback_type,
+      std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)>
+      >::value ||
+      rclcpp::function_traits::same_arguments<
+      typename scbth::callback_type,
+      std::function<void(std::shared_ptr<rclcpp::SerializedMessage>, const rclcpp::MessageInfo &)>
+      >::value;
+    static_assert(!is_invalid_signature,
+      "std::shared_ptr<> callback signature is unsupported "
+      "Use std::shared_ptr<const> or std::unique_ptr<> instead.");
 
     callback_variant_ = static_cast<typename scbth::callback_type>(callback);
 

--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -417,14 +417,39 @@ public:
       typename scbth::callback_type,
       std::function<void(std::shared_ptr<rclcpp::SerializedMessage>, const rclcpp::MessageInfo &)>
       >::value;
-    static_assert(!is_invalid_signature,
-      "std::shared_ptr<> callback signature is unsupported "
-      "Use std::shared_ptr<const> or std::unique_ptr<> instead.");
 
-    callback_variant_ = static_cast<typename scbth::callback_type>(callback);
+    // Use the discovered type to force the type of callback when assigning
+    // into the variant.
+    if constexpr (is_invalid_signature) {
+      // If deprecated, call sub-routine that is deprecated.
+      set_deprecated(static_cast<typename scbth::callback_type>(callback));
+    } else {
+      // Otherwise just assign it.
+      callback_variant_ = static_cast<typename scbth::callback_type>(callback);
+    }
 
     // Return copy of self for easier testing, normally will be compiled out.
     return *this;
+  }
+
+  template<typename SetT>
+  /// Function for shared_ptr to non-const MessageT, which is deprecated.
+  [[deprecated("use 'void(std::shared_ptr<const MessageT>)' instead")]]
+  void
+  set_deprecated(std::function<void(std::shared_ptr<SetT>)> callback)
+  {
+    callback_variant_ = callback;
+  }
+
+  /// Function for shared_ptr to non-const MessageT with MessageInfo, which is deprecated.
+  template<typename SetT>
+  [[deprecated(
+          "use 'void(std::shared_ptr<const MessageT>, const rclcpp::MessageInfo &)' instead"
+  )]]
+  void
+  set_deprecated(std::function<void(std::shared_ptr<SetT>, const rclcpp::MessageInfo &)> callback)
+  {
+    callback_variant_ = callback;
   }
 
   std::unique_ptr<ROSMessageType, ROSMessageTypeDeleter>

--- a/rclcpp/test/rclcpp/test_any_subscription_callback.cpp
+++ b/rclcpp/test/rclcpp/test_any_subscription_callback.cpp
@@ -177,7 +177,7 @@ TEST_F(TestAnySubscriptionCallback, is_serialized_message_callback) {
   }
   {
     rclcpp::AnySubscriptionCallback<test_msgs::msg::Empty> asc;
-    asc.set([](std::shared_ptr<rclcpp::SerializedMessage>) {});
+    asc.set([](std::shared_ptr<const rclcpp::SerializedMessage>) {});
     EXPECT_TRUE(asc.is_serialized_message_callback());
     EXPECT_NO_THROW(
       asc.dispatch(
@@ -186,7 +186,7 @@ TEST_F(TestAnySubscriptionCallback, is_serialized_message_callback) {
   }
   {
     rclcpp::AnySubscriptionCallback<test_msgs::msg::Empty> asc;
-    asc.set([](std::shared_ptr<rclcpp::SerializedMessage>, const rclcpp::MessageInfo &) {});
+    asc.set([](std::shared_ptr<const rclcpp::SerializedMessage>, const rclcpp::MessageInfo &) {});
     EXPECT_TRUE(asc.is_serialized_message_callback());
     EXPECT_NO_THROW(
       asc.dispatch(
@@ -642,81 +642,6 @@ INSTANTIATE_TEST_SUITE_P(
     BindContext<MyTA, const std::shared_ptr<const test_msgs::msg::Empty> &>("bind_method"),
     BindContext<MyTA, const std::shared_ptr<const test_msgs::msg::Empty> &,
     const rclcpp::MessageInfo &>(
-      "bind_method_with_info")
-  ),
-  format_parameter_with_ta
-);
-
-//
-// Versions of `std::shared_ptr<MessageT>`
-//
-void shared_ptr_free_func(std::shared_ptr<test_msgs::msg::Empty>) {}
-void shared_ptr_w_info_free_func(
-  std::shared_ptr<test_msgs::msg::Empty>, const rclcpp::MessageInfo &)
-{}
-
-INSTANTIATE_TEST_SUITE_P(
-  SharedPtrCallbackTests,
-  DispatchTests,
-  ::testing::Values(
-    // lambda
-    InstanceContext{"lambda", rclcpp::AnySubscriptionCallback<test_msgs::msg::Empty>().set(
-        [](std::shared_ptr<test_msgs::msg::Empty>) {})},
-    InstanceContext{"lambda_with_info",
-      rclcpp::AnySubscriptionCallback<test_msgs::msg::Empty>().set(
-        [](std::shared_ptr<test_msgs::msg::Empty>, const rclcpp::MessageInfo &) {})},
-    // free function
-    InstanceContext{"free_function", rclcpp::AnySubscriptionCallback<test_msgs::msg::Empty>().set(
-        shared_ptr_free_func)},
-    InstanceContext{"free_function_with_info",
-      rclcpp::AnySubscriptionCallback<test_msgs::msg::Empty>().set(
-        shared_ptr_w_info_free_func)},
-    // bind function
-    BindContext<test_msgs::msg::Empty, std::shared_ptr<test_msgs::msg::Empty>>("bind_method"),
-    BindContext<test_msgs::msg::Empty, std::shared_ptr<test_msgs::msg::Empty>,
-    const rclcpp::MessageInfo &>(
-      "bind_method_with_info")
-  ),
-  format_parameter
-);
-
-void shared_ptr_ta_free_func(std::shared_ptr<MyEmpty>) {}
-void shared_ptr_ta_w_info_free_func(
-  std::shared_ptr<MyEmpty>, const rclcpp::MessageInfo &)
-{}
-
-INSTANTIATE_TEST_SUITE_P(
-  SharedPtrCallbackTests,
-  DispatchTestsWithTA,
-  ::testing::Values(
-    // lambda
-    InstanceContext<MyTA>{"lambda_ta", rclcpp::AnySubscriptionCallback<MyTA>().set(
-        [](std::shared_ptr<MyEmpty>) {})},
-    InstanceContext<MyTA>{"lambda_ta_with_info",
-      rclcpp::AnySubscriptionCallback<MyTA>().set(
-        [](std::shared_ptr<MyEmpty>, const rclcpp::MessageInfo &) {})},
-    InstanceContext<MyTA>{"lambda", rclcpp::AnySubscriptionCallback<MyTA>().set(
-        [](std::shared_ptr<test_msgs::msg::Empty>) {})},
-    InstanceContext<MyTA>{"lambda_with_info",
-      rclcpp::AnySubscriptionCallback<MyTA>().set(
-        [](std::shared_ptr<test_msgs::msg::Empty>, const rclcpp::MessageInfo &) {})},
-    // free function
-    InstanceContext<MyTA>{"free_function_ta", rclcpp::AnySubscriptionCallback<MyTA>().set(
-        shared_ptr_ta_free_func)},
-    InstanceContext<MyTA>{"free_function_ta_with_info",
-      rclcpp::AnySubscriptionCallback<MyTA>().set(
-        shared_ptr_ta_w_info_free_func)},
-    InstanceContext<MyTA>{"free_function", rclcpp::AnySubscriptionCallback<MyTA>().set(
-        shared_ptr_free_func)},
-    InstanceContext<MyTA>{"free_function_with_info",
-      rclcpp::AnySubscriptionCallback<MyTA>().set(
-        shared_ptr_w_info_free_func)},
-    // bind function
-    BindContext<MyTA, std::shared_ptr<MyEmpty>>("bind_method_ta"),
-    BindContext<MyTA, std::shared_ptr<MyEmpty>, const rclcpp::MessageInfo &>(
-      "bind_method_ta_with_info"),
-    BindContext<MyTA, std::shared_ptr<test_msgs::msg::Empty>>("bind_method"),
-    BindContext<MyTA, std::shared_ptr<test_msgs::msg::Empty>, const rclcpp::MessageInfo &>(
       "bind_method_with_info")
   ),
   format_parameter_with_ta

--- a/rclcpp/test/rclcpp/test_any_subscription_callback.cpp
+++ b/rclcpp/test/rclcpp/test_any_subscription_callback.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <utility>
 
+#define RCLCPP_AVOID_DEPRECATIONS_FOR_UNIT_TESTS 1
 #include "rclcpp/any_subscription_callback.hpp"
 #include "test_msgs/msg/empty.hpp"
 
@@ -763,6 +764,82 @@ INSTANTIATE_TEST_SUITE_P(
     BindContext<MyTA, const std::shared_ptr<const test_msgs::msg::Empty> &>("bind_method"),
     BindContext<MyTA, const std::shared_ptr<const test_msgs::msg::Empty> &,
     const rclcpp::MessageInfo &>(
+      "bind_method_with_info")
+  ),
+  format_parameter_with_ta
+);
+
+
+//
+// Versions of `std::shared_ptr<MessageT>`
+//
+void shared_ptr_free_func(std::shared_ptr<test_msgs::msg::Empty>) {}
+void shared_ptr_w_info_free_func(
+  std::shared_ptr<test_msgs::msg::Empty>, const rclcpp::MessageInfo &)
+{}
+
+INSTANTIATE_TEST_SUITE_P(
+  SharedPtrCallbackTests,
+  DispatchTests,
+  ::testing::Values(
+    // lambda
+    InstanceContext{"lambda", rclcpp::AnySubscriptionCallback<test_msgs::msg::Empty>().set(
+        [](std::shared_ptr<test_msgs::msg::Empty>) {})},
+    InstanceContext{"lambda_with_info",
+      rclcpp::AnySubscriptionCallback<test_msgs::msg::Empty>().set(
+        [](std::shared_ptr<test_msgs::msg::Empty>, const rclcpp::MessageInfo &) {})},
+    // free function
+    InstanceContext{"free_function", rclcpp::AnySubscriptionCallback<test_msgs::msg::Empty>().set(
+        shared_ptr_free_func)},
+    InstanceContext{"free_function_with_info",
+      rclcpp::AnySubscriptionCallback<test_msgs::msg::Empty>().set(
+        shared_ptr_w_info_free_func)},
+    // bind function
+    BindContext<test_msgs::msg::Empty, std::shared_ptr<test_msgs::msg::Empty>>("bind_method"),
+    BindContext<test_msgs::msg::Empty, std::shared_ptr<test_msgs::msg::Empty>,
+    const rclcpp::MessageInfo &>(
+      "bind_method_with_info")
+  ),
+  format_parameter
+);
+
+void shared_ptr_ta_free_func(std::shared_ptr<MyEmpty>) {}
+void shared_ptr_ta_w_info_free_func(
+  std::shared_ptr<MyEmpty>, const rclcpp::MessageInfo &)
+{}
+
+INSTANTIATE_TEST_SUITE_P(
+  SharedPtrCallbackTests,
+  DispatchTestsWithTA,
+  ::testing::Values(
+    // lambda
+    InstanceContext<MyTA>{"lambda_ta", rclcpp::AnySubscriptionCallback<MyTA>().set(
+        [](std::shared_ptr<MyEmpty>) {})},
+    InstanceContext<MyTA>{"lambda_ta_with_info",
+      rclcpp::AnySubscriptionCallback<MyTA>().set(
+        [](std::shared_ptr<MyEmpty>, const rclcpp::MessageInfo &) {})},
+    InstanceContext<MyTA>{"lambda", rclcpp::AnySubscriptionCallback<MyTA>().set(
+        [](std::shared_ptr<test_msgs::msg::Empty>) {})},
+    InstanceContext<MyTA>{"lambda_with_info",
+      rclcpp::AnySubscriptionCallback<MyTA>().set(
+        [](std::shared_ptr<test_msgs::msg::Empty>, const rclcpp::MessageInfo &) {})},
+    // free function
+    InstanceContext<MyTA>{"free_function_ta", rclcpp::AnySubscriptionCallback<MyTA>().set(
+        shared_ptr_ta_free_func)},
+    InstanceContext<MyTA>{"free_function_ta_with_info",
+      rclcpp::AnySubscriptionCallback<MyTA>().set(
+        shared_ptr_ta_w_info_free_func)},
+    InstanceContext<MyTA>{"free_function", rclcpp::AnySubscriptionCallback<MyTA>().set(
+        shared_ptr_free_func)},
+    InstanceContext<MyTA>{"free_function_with_info",
+      rclcpp::AnySubscriptionCallback<MyTA>().set(
+        shared_ptr_w_info_free_func)},
+    // bind function
+    BindContext<MyTA, std::shared_ptr<MyEmpty>>("bind_method_ta"),
+    BindContext<MyTA, std::shared_ptr<MyEmpty>, const rclcpp::MessageInfo &>(
+      "bind_method_ta_with_info"),
+    BindContext<MyTA, std::shared_ptr<test_msgs::msg::Empty>>("bind_method"),
+    BindContext<MyTA, std::shared_ptr<test_msgs::msg::Empty>, const rclcpp::MessageInfo &>(
       "bind_method_with_info")
   ),
   format_parameter_with_ta

--- a/rclcpp/test/rclcpp/test_any_subscription_callback.cpp
+++ b/rclcpp/test/rclcpp/test_any_subscription_callback.cpp
@@ -769,7 +769,6 @@ INSTANTIATE_TEST_SUITE_P(
   format_parameter_with_ta
 );
 
-
 //
 // Versions of `std::shared_ptr<MessageT>`
 //

--- a/rclcpp/test/rclcpp/test_subscription_publisher_with_same_type_adapter.cpp
+++ b/rclcpp/test/rclcpp/test_subscription_publisher_with_same_type_adapter.cpp
@@ -212,7 +212,7 @@ TEST_F(
     bool is_received = false;
     auto callback =
       [message_data, &is_received](
-      std::shared_ptr<std::string> msg) -> void {
+      std::shared_ptr<const std::string> msg) -> void {
         is_received = true;
         EXPECT_STREQ(message_data.c_str(), (*msg).c_str());
       };
@@ -230,7 +230,7 @@ TEST_F(
     bool is_received = false;
     auto callback =
       [message_data, &is_received](
-      std::shared_ptr<std::string> msg,
+      std::shared_ptr<const std::string> msg,
       const rclcpp::MessageInfo & message_info) -> void {
         is_received = true;
         EXPECT_STREQ(message_data.c_str(), (*msg).c_str());
@@ -422,7 +422,7 @@ TEST_F(
     bool is_received = false;
     auto callback =
       [message_data, &is_received](
-      std::shared_ptr<std::string> msg) -> void {
+      std::shared_ptr<const std::string> msg) -> void {
         is_received = true;
         EXPECT_STREQ(message_data.c_str(), (*msg).c_str());
       };
@@ -440,7 +440,7 @@ TEST_F(
     bool is_received = false;
     auto callback =
       [message_data, &is_received](
-      std::shared_ptr<std::string> msg,
+      std::shared_ptr<const std::string> msg,
       const rclcpp::MessageInfo & message_info) -> void {
         is_received = true;
         EXPECT_STREQ(message_data.c_str(), (*msg).c_str());
@@ -637,7 +637,7 @@ TEST_F(
     bool is_received = false;
     auto callback =
       [message_data, &is_received](
-      std::shared_ptr<double> msg) -> void {
+      std::shared_ptr<const double> msg) -> void {
         is_received = true;
         ASSERT_EQ(message_data, *msg);
       };
@@ -656,7 +656,7 @@ TEST_F(
     bool is_received = false;
     auto callback =
       [message_data, &is_received](
-      std::shared_ptr<double> msg,
+      std::shared_ptr<const double> msg,
       const rclcpp::MessageInfo & message_info) -> void {
         is_received = true;
         ASSERT_EQ(message_data, *msg);
@@ -862,7 +862,7 @@ TEST_F(
     bool is_received = false;
     auto callback =
       [message_data, &is_received](
-      std::shared_ptr<double> msg) -> void {
+      std::shared_ptr<const double> msg) -> void {
         is_received = true;
         ASSERT_EQ(message_data, *msg);
       };
@@ -882,7 +882,7 @@ TEST_F(
     bool is_received = false;
     auto callback =
       [message_data, &is_received](
-      std::shared_ptr<double> msg,
+      std::shared_ptr<const double> msg,
       const rclcpp::MessageInfo & message_info) -> void {
         is_received = true;
         ASSERT_EQ(message_data, *msg);


### PR DESCRIPTION
## Description

- Add static assert for removed subscription callback signatures

Fixes #2972

### Is this user-facing behavior change?

Yes

### Did you use Generative AI?

No

### Additional Information

When working on this PR, I noticed that #1713 only deprecates `MessageT`. However, looking at the comment here:
https://github.com/ros2/rclcpp/blob/eb49444c3229f03255083d7992564b83ec2d9e2c/rclcpp/include/rclcpp/any_subscription_callback.hpp#L140-L154
it looks like the type_adaptation/serialized message are not yet deprecated, how should we proceed?

In the meantime, I have also updated the tests for type_adaptation/serialized  to use `std::shared_ptr<const>`