### PR TITLE
Add ability to disable and enable subscription's callbacks

### DIFF
--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -494,11 +494,10 @@ public:
     std::shared_ptr<ROSMessageType> message,
     const rclcpp::MessageInfo & message_info)
   {
-    TRACETOOLS_TRACEPOINT(callback_start, static_cast<const void *>(this), false);
     if (callback_disabled_.load()) {
-      TRACETOOLS_TRACEPOINT(callback_end, static_cast<const void *>(this));
       return;
     }
+    TRACETOOLS_TRACEPOINT(callback_start, static_cast<const void *>(this), false);
     // Check if the variant is "unset", throw if it is.
     if (callback_variant_.index() == 0) {
       if (std::get<0>(callback_variant_) == nullptr) {
@@ -598,11 +597,10 @@ public:
     std::shared_ptr<const rclcpp::SerializedMessage> serialized_message,
     const rclcpp::MessageInfo & message_info)
   {
-    TRACETOOLS_TRACEPOINT(callback_start, static_cast<const void *>(this), false);
     if (callback_disabled_.load()) {
-      TRACETOOLS_TRACEPOINT(callback_end, static_cast<const void *>(this));
       return;
     }
+    TRACETOOLS_TRACEPOINT(callback_start, static_cast<const void *>(this), false);
     // Check if the variant is "unset", throw if it is.
     if (callback_variant_.index() == 0) {
       if (std::get<0>(callback_variant_) == nullptr) {
@@ -681,11 +679,10 @@ public:
     std::shared_ptr<const SubscribedType> message,
     const rclcpp::MessageInfo & message_info)
   {
-    TRACETOOLS_TRACEPOINT(callback_start, static_cast<const void *>(this), true);
     if (callback_disabled_.load()) {
-      TRACETOOLS_TRACEPOINT(callback_end, static_cast<const void *>(this));
       return;
     }
+    TRACETOOLS_TRACEPOINT(callback_start, static_cast<const void *>(this), true);
     // Check if the variant is "unset", throw if it is.
     if (callback_variant_.index() == 0) {
       if (std::get<0>(callback_variant_) == nullptr) {
@@ -815,11 +812,10 @@ public:
     std::unique_ptr<SubscribedType, SubscribedTypeDeleter> message,
     const rclcpp::MessageInfo & message_info)
   {
-    TRACETOOLS_TRACEPOINT(callback_start, static_cast<const void *>(this), true);
     if (callback_disabled_.load()) {
-      TRACETOOLS_TRACEPOINT(callback_end, static_cast<const void *>(this));
       return;
     }
+    TRACETOOLS_TRACEPOINT(callback_start, static_cast<const void *>(this), true);
     // Check if the variant is "unset", throw if it is.
     if (callback_variant_.index() == 0) {
       if (std::get<0>(callback_variant_) == nullptr) {

--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -416,14 +416,14 @@ public:
   /// Disable the callback from being called during dispatch.
   void disable()
   {
-    std::unique_lock<std::mutex> callback_lock(callback_mutex_);
+    std::unique_lock<std::recursive_mutex> callback_lock(callback_mutex_);
     callback_disabled_.store(true);
   }
 
   /// Enable the callback to be called during dispatch.
   void enable()
   {
-    std::unique_lock<std::mutex> callback_lock(callback_mutex_);
+    std::unique_lock<std::recursive_mutex> callback_lock(callback_mutex_);
     callback_disabled_.store(false);
   }
 
@@ -497,7 +497,7 @@ public:
     std::shared_ptr<ROSMessageType> message,
     const rclcpp::MessageInfo & message_info)
   {
-    std::unique_lock<std::mutex> callback_lock(callback_mutex_);
+    std::unique_lock<std::recursive_mutex> callback_lock(callback_mutex_);
     if (callback_disabled_.load()) {
       return;
     }
@@ -601,7 +601,7 @@ public:
     std::shared_ptr<const rclcpp::SerializedMessage> serialized_message,
     const rclcpp::MessageInfo & message_info)
   {
-    std::unique_lock<std::mutex> callback_lock(callback_mutex_);
+    std::unique_lock<std::recursive_mutex> callback_lock(callback_mutex_);
     if (callback_disabled_.load()) {
       return;
     }
@@ -684,7 +684,7 @@ public:
     std::shared_ptr<const SubscribedType> message,
     const rclcpp::MessageInfo & message_info)
   {
-    std::unique_lock<std::mutex> callback_lock(callback_mutex_);
+    std::unique_lock<std::recursive_mutex> callback_lock(callback_mutex_);
     if (callback_disabled_.load()) {
       return;
     }
@@ -818,7 +818,7 @@ public:
     std::unique_ptr<SubscribedType, SubscribedTypeDeleter> message,
     const rclcpp::MessageInfo & message_info)
   {
-    std::unique_lock<std::mutex> callback_lock(callback_mutex_);
+    std::unique_lock<std::recursive_mutex> callback_lock(callback_mutex_);
     if (callback_disabled_.load()) {
       return;
     }
@@ -1016,7 +1016,7 @@ private:
   //   http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2162r0.html
   // For now, compose the variant into this class as a private attribute.
   typename HelperT::variant_type callback_variant_;
-  std::mutex callback_mutex_;
+  std::recursive_mutex callback_mutex_;
   std::atomic_bool callback_disabled_{false};
 
   SubscribedTypeAllocator subscribed_type_allocator_;

--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
@@ -415,12 +416,14 @@ public:
   /// Disable the callback from being called during dispatch.
   void disable()
   {
+    std::unique_lock<std::mutex> callback_lock(callback_mutex_);
     callback_disabled_.store(true);
   }
 
   /// Enable the callback to be called during dispatch.
   void enable()
   {
+    std::unique_lock<std::mutex> callback_lock(callback_mutex_);
     callback_disabled_.store(false);
   }
 
@@ -494,6 +497,7 @@ public:
     std::shared_ptr<ROSMessageType> message,
     const rclcpp::MessageInfo & message_info)
   {
+    std::unique_lock<std::mutex> callback_lock(callback_mutex_);
     if (callback_disabled_.load()) {
       return;
     }
@@ -597,6 +601,7 @@ public:
     std::shared_ptr<const rclcpp::SerializedMessage> serialized_message,
     const rclcpp::MessageInfo & message_info)
   {
+    std::unique_lock<std::mutex> callback_lock(callback_mutex_);
     if (callback_disabled_.load()) {
       return;
     }
@@ -679,6 +684,7 @@ public:
     std::shared_ptr<const SubscribedType> message,
     const rclcpp::MessageInfo & message_info)
   {
+    std::unique_lock<std::mutex> callback_lock(callback_mutex_);
     if (callback_disabled_.load()) {
       return;
     }
@@ -812,6 +818,7 @@ public:
     std::unique_ptr<SubscribedType, SubscribedTypeDeleter> message,
     const rclcpp::MessageInfo & message_info)
   {
+    std::unique_lock<std::mutex> callback_lock(callback_mutex_);
     if (callback_disabled_.load()) {
       return;
     }
@@ -1009,6 +1016,7 @@ private:
   //   http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2162r0.html
   // For now, compose the variant into this class as a private attribute.
   typename HelperT::variant_type callback_variant_;
+  std::mutex callback_mutex_;
   std::atomic_bool callback_disabled_{false};
 
   SubscribedTypeAllocator subscribed_type_allocator_;

--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -15,6 +15,7 @@
 #ifndef RCLCPP__ANY_SUBSCRIPTION_CALLBACK_HPP_
 #define RCLCPP__ANY_SUBSCRIPTION_CALLBACK_HPP_
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <stdexcept>
@@ -375,7 +376,19 @@ public:
     allocator::set_allocator_for_deleter(&ros_message_type_deleter_, &ros_message_type_allocator_);
   }
 
-  AnySubscriptionCallback(const AnySubscriptionCallback &) = default;
+  AnySubscriptionCallback(const AnySubscriptionCallback & other)
+  : callback_variant_(other.callback_variant_),
+    callback_disabled_(other.callback_disabled_.load()),
+    subscribed_type_allocator_(other.subscribed_type_allocator_),
+    subscribed_type_deleter_(other.subscribed_type_deleter_),
+    ros_message_type_allocator_(other.ros_message_type_allocator_),
+    ros_message_type_deleter_(other.ros_message_type_deleter_),
+    serialized_message_allocator_(other.serialized_message_allocator_),
+    serialized_message_deleter_(other.serialized_message_deleter_)
+  {
+    allocator::set_allocator_for_deleter(&subscribed_type_deleter_, &subscribed_type_allocator_);
+    allocator::set_allocator_for_deleter(&ros_message_type_deleter_, &ros_message_type_allocator_);
+  }
 
   /// Generic function for setting the callback.
   /**
@@ -397,6 +410,18 @@ public:
 
     // Return copy of self for easier testing, normally will be compiled out.
     return *this;
+  }
+
+  /// Disable the callback from being called during dispatch.
+  void disable()
+  {
+    callback_disabled_.store(true);
+  }
+
+  /// Enable the callback to be called during dispatch.
+  void enable()
+  {
+    callback_disabled_.store(false);
   }
 
   std::unique_ptr<ROSMessageType, ROSMessageTypeDeleter>
@@ -470,6 +495,10 @@ public:
     const rclcpp::MessageInfo & message_info)
   {
     TRACETOOLS_TRACEPOINT(callback_start, static_cast<const void *>(this), false);
+    if (callback_disabled_.load()) {
+      TRACETOOLS_TRACEPOINT(callback_end, static_cast<const void *>(this));
+      return;
+    }
     // Check if the variant is "unset", throw if it is.
     if (callback_variant_.index() == 0) {
       if (std::get<0>(callback_variant_) == nullptr) {
@@ -570,6 +599,10 @@ public:
     const rclcpp::MessageInfo & message_info)
   {
     TRACETOOLS_TRACEPOINT(callback_start, static_cast<const void *>(this), false);
+    if (callback_disabled_.load()) {
+      TRACETOOLS_TRACEPOINT(callback_end, static_cast<const void *>(this));
+      return;
+    }
     // Check if the variant is "unset", throw if it is.
     if (callback_variant_.index() == 0) {
       if (std::get<0>(callback_variant_) == nullptr) {
@@ -649,6 +682,10 @@ public:
     const rclcpp::MessageInfo & message_info)
   {
     TRACETOOLS_TRACEPOINT(callback_start, static_cast<const void *>(this), true);
+    if (callback_disabled_.load()) {
+      TRACETOOLS_TRACEPOINT(callback_end, static_cast<const void *>(this));
+      return;
+    }
     // Check if the variant is "unset", throw if it is.
     if (callback_variant_.index() == 0) {
       if (std::get<0>(callback_variant_) == nullptr) {
@@ -779,6 +816,10 @@ public:
     const rclcpp::MessageInfo & message_info)
   {
     TRACETOOLS_TRACEPOINT(callback_start, static_cast<const void *>(this), true);
+    if (callback_disabled_.load()) {
+      TRACETOOLS_TRACEPOINT(callback_end, static_cast<const void *>(this));
+      return;
+    }
     // Check if the variant is "unset", throw if it is.
     if (callback_variant_.index() == 0) {
       if (std::get<0>(callback_variant_) == nullptr) {
@@ -972,6 +1013,7 @@ private:
   //   http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2162r0.html
   // For now, compose the variant into this class as a private attribute.
   typename HelperT::variant_type callback_variant_;
+  std::atomic_bool callback_disabled_{false};
 
   SubscribedTypeAllocator subscribed_type_allocator_;
   SubscribedTypeDeleter subscribed_type_deleter_;

--- a/rclcpp/include/rclcpp/event_handler.hpp
+++ b/rclcpp/include/rclcpp/event_handler.hpp
@@ -15,6 +15,7 @@
 #ifndef RCLCPP__EVENT_HANDLER_HPP_
 #define RCLCPP__EVENT_HANDLER_HPP_
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -109,6 +110,14 @@ public:
 
   RCLCPP_PUBLIC
   virtual ~EventHandlerBase();
+
+  RCLCPP_PUBLIC
+  virtual
+  void enable() = 0;
+
+  RCLCPP_PUBLIC
+  virtual
+  void disable() = 0;
 
   /// Get the number of ready events
   RCLCPP_PUBLIC
@@ -302,6 +311,9 @@ public:
   void
   execute(const std::shared_ptr<void> & data) override
   {
+    if (disabled_.load()) {
+      return;
+    }
     if (!data) {
       throw std::runtime_error("'data' is empty");
     }
@@ -310,12 +322,25 @@ public:
     callback_ptr.reset();
   }
 
+  /// Disable the event callback from being called when execute(..) invoked
+  void disable() override
+  {
+    disabled_.store(true);
+  }
+
+  /// Enable the event callback to be called when execute(..) invoked
+  void enable() override
+  {
+    disabled_.store(false);
+  }
+
 private:
   using EventCallbackInfoT = typename std::remove_reference<typename
       rclcpp::function_traits::function_traits<EventCallbackT>::template argument_type<0>>::type;
 
   ParentHandleT parent_handle_;
   EventCallbackT event_callback_;
+  std::atomic_bool disabled_{false};
 };
 }  // namespace rclcpp
 

--- a/rclcpp/include/rclcpp/event_handler.hpp
+++ b/rclcpp/include/rclcpp/event_handler.hpp
@@ -201,7 +201,7 @@ public:
         }
       };
 
-    std::lock_guard<std::recursive_mutex> lock(callback_mutex_);
+    std::lock_guard<std::recursive_mutex> lock(on_new_event_callback_mutex_);
 
     // Set it temporarily to the new callback, while we replace the old one.
     // This two-step setting, prevents a gap where the old std::function has
@@ -224,7 +224,7 @@ public:
   void
   clear_on_ready_callback() override
   {
-    std::lock_guard<std::recursive_mutex> lock(callback_mutex_);
+    std::lock_guard<std::recursive_mutex> lock(on_new_event_callback_mutex_);
     if (on_new_event_callback_) {
       set_on_new_event_callback(nullptr, nullptr);
       on_new_event_callback_ = nullptr;
@@ -243,7 +243,7 @@ protected:
   void
   set_on_new_event_callback(rcl_event_callback_t callback, const void * user_data);
 
-  std::recursive_mutex callback_mutex_;
+  std::recursive_mutex on_new_event_callback_mutex_;
   std::function<void(size_t)> on_new_event_callback_{nullptr};
 
   rcl_event_t event_handle_;
@@ -311,7 +311,7 @@ public:
   void
   execute(const std::shared_ptr<void> & data) override
   {
-    std::unique_lock<std::mutex> callback_lock(callback_mutex_);
+    std::unique_lock<std::mutex> event_callback_lock(event_callback_mutex_);
     if (disabled_.load()) {
       return;
     }
@@ -326,14 +326,14 @@ public:
   /// Disable the event callback from being called when execute(..) invoked
   void disable() override
   {
-    std::unique_lock<std::mutex> callback_lock(callback_mutex_);
+    std::lock_guard<std::mutex> event_callback_lock(event_callback_mutex_);
     disabled_.store(true);
   }
 
   /// Enable the event callback to be called when execute(..) invoked
   void enable() override
   {
-    std::unique_lock<std::mutex> callback_lock(callback_mutex_);
+    std::lock_guard<std::mutex> event_callback_lock(event_callback_mutex_);
     disabled_.store(false);
   }
 
@@ -343,7 +343,7 @@ private:
 
   ParentHandleT parent_handle_;
   EventCallbackT event_callback_;
-  std::mutex callback_mutex_;
+  std::mutex event_callback_mutex_;
   std::atomic_bool disabled_{false};
 };
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/event_handler.hpp
+++ b/rclcpp/include/rclcpp/event_handler.hpp
@@ -311,6 +311,7 @@ public:
   void
   execute(const std::shared_ptr<void> & data) override
   {
+    std::unique_lock<std::mutex> callback_lock(callback_mutex_);
     if (disabled_.load()) {
       return;
     }
@@ -325,12 +326,14 @@ public:
   /// Disable the event callback from being called when execute(..) invoked
   void disable() override
   {
+    std::unique_lock<std::mutex> callback_lock(callback_mutex_);
     disabled_.store(true);
   }
 
   /// Enable the event callback to be called when execute(..) invoked
   void enable() override
   {
+    std::unique_lock<std::mutex> callback_lock(callback_mutex_);
     disabled_.store(false);
   }
 
@@ -340,6 +343,7 @@ private:
 
   ParentHandleT parent_handle_;
   EventCallbackT event_callback_;
+  std::mutex callback_mutex_;
   std::atomic_bool disabled_{false};
 };
 }  // namespace rclcpp

--- a/rclcpp/include/rclcpp/event_handler.hpp
+++ b/rclcpp/include/rclcpp/event_handler.hpp
@@ -324,15 +324,40 @@ public:
   }
 
   /// Disable the event callback from being called when execute(..) invoked
+  /**
+   * This will also temporarily remove the on_new_event_callback from the underlying rmw layer,
+   *  so that it is not called from the middleware while disabled.
+   */
   void disable() override
   {
+    {
+      // Temporary remove the on_new_event_callback_ to prevent it from being called
+      std::lock_guard<std::recursive_mutex> on_new_event_lock(on_new_event_callback_mutex_);
+      if (on_new_event_callback_) {
+        set_on_new_event_callback(nullptr, nullptr);
+      }
+    }
     std::lock_guard<std::mutex> event_callback_lock(event_callback_mutex_);
     disabled_.store(true);
   }
 
   /// Enable the event callback to be called when execute(..) invoked
+  /**
+   * This will also set back the on_new_event_callback to the underlying rmw layer, if it was
+   * previously removed with disable().
+   */
   void enable() override
   {
+    {
+      // Set callback again if it was previously removed in disable()
+      std::lock_guard<std::recursive_mutex> on_new_event_lock(on_new_event_callback_mutex_);
+      if (on_new_event_callback_) {
+        set_on_new_event_callback(
+          rclcpp::detail::cpp_callback_trampoline<
+            decltype(on_new_event_callback_), const void *, size_t>,
+          static_cast<const void *>(&on_new_event_callback_));
+      }
+    }
     std::lock_guard<std::mutex> event_callback_lock(event_callback_mutex_);
     disabled_.store(false);
   }

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
@@ -154,13 +154,26 @@ public:
     execute_impl<SubscribedType>(data);
   }
 
+  /// Disable callbacks from being called
+  /**
+    * This method will block, until any subscription's callbacks currently being executed are
+    * finished.
+    * This method is thread safe, and provides a safe way to atomically disable the callbacks.
+    */
   void disable_callbacks() override
   {
+    SubscriptionIntraProcessBase::disable_callbacks();
     any_callback_.disable();
   }
 
+  /// Enable the callbacks to be called
+  /**
+    * This method is thread safe, and provides a safe way to atomically enable the callbacks
+    * in a multithreaded environment.
+    */
   void enable_callbacks() override
   {
+    SubscriptionIntraProcessBase::enable_callbacks();
     any_callback_.enable();
   }
 

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
@@ -154,6 +154,16 @@ public:
     execute_impl<SubscribedType>(data);
   }
 
+  void disable_callbacks() override
+  {
+    any_callback_.disable();
+  }
+
+  void enable_callbacks() override
+  {
+    any_callback_.enable();
+  }
+
 protected:
   template<typename T>
   typename std::enable_if<std::is_same<T, rcl_serialized_message_t>::value, void>::type

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -88,14 +88,20 @@ public:
   execute(const std::shared_ptr<void> & data) override = 0;
 
   /// Disable callbacks from being called
+  /**
+   * This function temporary disable on_new_message_callback to prevent it from being called.
+   */
   RCLCPP_PUBLIC
   virtual
-  void disable_callbacks() = 0;
+  void disable_callbacks();
 
   /// Enable the callbacks to be called
+  /**
+    * This function enable the on_new_message_callback if it was previously set.
+    */
   RCLCPP_PUBLIC
   virtual
-  void enable_callbacks() = 0;
+  void enable_callbacks();
 
   virtual
   bool
@@ -168,7 +174,7 @@ public:
         }
       };
 
-    std::lock_guard<std::recursive_mutex> lock(callback_mutex_);
+    std::lock_guard<std::recursive_mutex> lock(on_new_message_callback_mutex_);
     on_new_message_callback_ = new_callback;
 
     if (unread_count_ > 0) {
@@ -186,7 +192,7 @@ public:
   void
   clear_on_ready_callback() override
   {
-    std::lock_guard<std::recursive_mutex> lock(callback_mutex_);
+    std::lock_guard<std::recursive_mutex> lock(on_new_message_callback_mutex_);
     on_new_message_callback_ = nullptr;
   }
 
@@ -198,8 +204,9 @@ public:
   }
 
 protected:
-  std::recursive_mutex callback_mutex_;
+  std::recursive_mutex on_new_message_callback_mutex_;
   std::function<void(size_t)> on_new_message_callback_ {nullptr};
+  bool on_new_message_callback_disabled_{false};
   size_t unread_count_{0};
   rclcpp::GuardCondition gc_;
 
@@ -209,11 +216,13 @@ protected:
   void
   invoke_on_new_message()
   {
-    std::lock_guard<std::recursive_mutex> lock(this->callback_mutex_);
-    if (this->on_new_message_callback_) {
-      this->on_new_message_callback_(1);
-    } else {
-      this->unread_count_++;
+    std::lock_guard<std::recursive_mutex> lock(this->on_new_message_callback_mutex_);
+    if (!on_new_message_callback_disabled_) {
+      if (this->on_new_message_callback_) {
+        this->on_new_message_callback_(1);
+      } else {
+        this->unread_count_++;
+      }
     }
   }
 

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -87,6 +87,16 @@ public:
   void
   execute(const std::shared_ptr<void> & data) override = 0;
 
+  /// Disable callbacks from being called
+  RCLCPP_PUBLIC
+  virtual
+  void disable_callbacks() = 0;
+
+  /// Enable the callbacks to be called
+  RCLCPP_PUBLIC
+  virtual
+  void enable_callbacks() = 0;
+
   virtual
   bool
   use_take_shared_method() const = 0;

--- a/rclcpp/include/rclcpp/generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/generic_subscription.hpp
@@ -111,9 +111,23 @@ public:
   RCLCPP_PUBLIC
   std::shared_ptr<rclcpp::SerializedMessage> create_serialized_message() override;
 
+  /// Disable callbacks from being called
+  /**
+    * This method will block, until any subscription's callbacks provided during construction
+    * currently being executed are finished.
+    * \note This method also temporary removes the on new message callback and all
+    * on new event callbacks from the rmw layer to prevent them from being called. However, this
+    * method will not block and wait until the currently executing on_new_[message]event callbacks
+    * are finished.
+    */
   RCLCPP_PUBLIC
   void disable_callbacks() override;
 
+  /// Enable the callbacks to be called
+  /**
+    * This method is thread safe, and provides a safe way to atomically enable the callbacks
+    * in a multithreaded environment.
+    */
   RCLCPP_PUBLIC
   void enable_callbacks() override;
 

--- a/rclcpp/include/rclcpp/generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/generic_subscription.hpp
@@ -111,6 +111,12 @@ public:
   RCLCPP_PUBLIC
   std::shared_ptr<rclcpp::SerializedMessage> create_serialized_message() override;
 
+  RCLCPP_PUBLIC
+  void disable_callbacks() override;
+
+  RCLCPP_PUBLIC
+  void enable_callbacks() override;
+
   /// Cast the message to a rclcpp::SerializedMessage and call the callback.
   RCLCPP_PUBLIC
   void handle_message(

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -279,10 +279,19 @@ public:
     return message_memory_strategy_->borrow_serialized_message();
   }
 
-
+  /// Disable callbacks from being called
+  /**
+    * This method will block, until any subscription's callbacks provided during construction
+    * currently being executed are finished.
+    * \note This method also temporary removes the on new message callback and all
+    * on new event callbacks from the rmw layer to prevent them from being called. However, this
+    * method will not block and wait until the currently executing on_new_[message]event callbacks
+    * are finished.
+    */
   void
   disable_callbacks() override
   {
+    SubscriptionBase::disable_callbacks();
     any_callback_.disable();
     if (subscription_intra_process_) {
       subscription_intra_process_->disable_callbacks();
@@ -294,9 +303,15 @@ public:
     }
   }
 
+  /// Enable the callbacks to be called
+  /**
+    * This method is thread safe, and provides a safe way to atomically enable the callbacks
+    * in a multithreaded environment.
+    */
   void
   enable_callbacks() override
   {
+    SubscriptionBase::enable_callbacks();
     any_callback_.enable();
     if (subscription_intra_process_) {
       subscription_intra_process_->enable_callbacks();

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -279,6 +279,35 @@ public:
     return message_memory_strategy_->borrow_serialized_message();
   }
 
+
+  void
+  disable_callbacks() override
+  {
+    any_callback_.disable();
+    if (subscription_intra_process_) {
+      subscription_intra_process_->disable_callbacks();
+    }
+    for (const auto & [_, event_ptr] : event_handlers_) {
+      if (event_ptr) {
+        event_ptr->disable();
+      }
+    }
+  }
+
+  void
+  enable_callbacks() override
+  {
+    any_callback_.enable();
+    if (subscription_intra_process_) {
+      subscription_intra_process_->enable_callbacks();
+    }
+    for (const auto & [_, event_ptr] : event_handlers_) {
+      if (event_ptr) {
+        event_ptr->enable();
+      }
+    }
+  }
+
   void
   handle_message(
     std::shared_ptr<void> & message,

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -213,14 +213,21 @@ public:
   create_serialized_message() = 0;
 
   /// Disable callbacks from being called
+  /**
+   * This function temporary removes the on_new_message_callback to prevent it from being called.
+   */
   RCLCPP_PUBLIC
   virtual
-  void disable_callbacks() = 0;
+  void disable_callbacks();
 
   /// Enable the callbacks to be called
+  /**
+    * This function sets back the on_new_message_callback if it was previously removed in
+    * disable_callbacks().
+    */
   RCLCPP_PUBLIC
   virtual
-  void enable_callbacks() = 0;
+  void enable_callbacks();
 
   /// Check if we need to handle the message, and execute the callback if we do.
   /**
@@ -393,7 +400,7 @@ public:
         }
       };
 
-    std::lock_guard<std::recursive_mutex> lock(callback_mutex_);
+    std::lock_guard<std::recursive_mutex> lock(on_new_message_callback_mutex_);
 
     // Set it temporarily to the new callback, while we replace the old one.
     // This two-step setting, prevents a gap where the old std::function has
@@ -416,7 +423,7 @@ public:
   void
   clear_on_new_message_callback()
   {
-    std::lock_guard<std::recursive_mutex> lock(callback_mutex_);
+    std::lock_guard<std::recursive_mutex> lock(on_new_message_callback_mutex_);
 
     if (on_new_message_callback_) {
       set_on_new_message_callback(nullptr, nullptr);
@@ -656,7 +663,7 @@ protected:
 
   std::shared_ptr<rcl_node_t> node_handle_;
 
-  std::recursive_mutex callback_mutex_;
+  std::recursive_mutex on_new_message_callback_mutex_;
   // It is important to declare on_new_message_callback_ before
   // subscription_handle_, so on destruction the subscription is
   // destroyed first. Otherwise, the rmw subscription callback

--- a/rclcpp/include/rclcpp/subscription_base.hpp
+++ b/rclcpp/include/rclcpp/subscription_base.hpp
@@ -212,6 +212,16 @@ public:
   std::shared_ptr<rclcpp::SerializedMessage>
   create_serialized_message() = 0;
 
+  /// Disable callbacks from being called
+  RCLCPP_PUBLIC
+  virtual
+  void disable_callbacks() = 0;
+
+  /// Enable the callbacks to be called
+  RCLCPP_PUBLIC
+  virtual
+  void enable_callbacks() = 0;
+
   /// Check if we need to handle the message, and execute the callback if we do.
   /**
    * \param[in] message Shared pointer to the message to handle.

--- a/rclcpp/src/rclcpp/generic_subscription.cpp
+++ b/rclcpp/src/rclcpp/generic_subscription.cpp
@@ -38,6 +38,28 @@ GenericSubscription::create_serialized_message()
 }
 
 void
+GenericSubscription::disable_callbacks()
+{
+  any_callback_.disable();
+  for (const auto & [_, event_ptr] : event_handlers_) {
+    if (event_ptr) {
+      event_ptr->disable();
+    }
+  }
+}
+
+void
+GenericSubscription::enable_callbacks()
+{
+  any_callback_.enable();
+  for (const auto & [_, event_ptr] : event_handlers_) {
+    if (event_ptr) {
+      event_ptr->enable();
+    }
+  }
+}
+
+void
 GenericSubscription::handle_message(
   std::shared_ptr<void> &,
   const rclcpp::MessageInfo &)

--- a/rclcpp/src/rclcpp/generic_subscription.cpp
+++ b/rclcpp/src/rclcpp/generic_subscription.cpp
@@ -40,6 +40,7 @@ GenericSubscription::create_serialized_message()
 void
 GenericSubscription::disable_callbacks()
 {
+  SubscriptionBase::disable_callbacks();
   any_callback_.disable();
   for (const auto & [_, event_ptr] : event_handlers_) {
     if (event_ptr) {
@@ -51,6 +52,7 @@ GenericSubscription::disable_callbacks()
 void
 GenericSubscription::enable_callbacks()
 {
+  SubscriptionBase::enable_callbacks();
   any_callback_.enable();
   for (const auto & [_, event_ptr] : event_handlers_) {
     if (event_ptr) {

--- a/rclcpp/src/rclcpp/subscription_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_base.cpp
@@ -577,3 +577,26 @@ SubscriptionBase::take_dynamic_message(
   throw std::runtime_error("Unimplemented");
   return false;
 }
+
+void
+SubscriptionBase::disable_callbacks()
+{
+  // Temporary remove the on_new_message_callback_ to prevent it from being called
+  std::lock_guard<std::recursive_mutex> lock(on_new_message_callback_mutex_);
+  if (on_new_message_callback_) {
+    set_on_new_message_callback(nullptr, nullptr);
+  }
+}
+
+void
+SubscriptionBase::enable_callbacks()
+{
+  // Set callback again if it was previously removed in disable_callbacks()
+  std::lock_guard<std::recursive_mutex> lock(on_new_message_callback_mutex_);
+  if (on_new_message_callback_) {
+    set_on_new_message_callback(
+      rclcpp::detail::cpp_callback_trampoline<
+        decltype(on_new_message_callback_), const void *, size_t>,
+      static_cast<const void *>(&on_new_message_callback_));
+  }
+}

--- a/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
+++ b/rclcpp/src/rclcpp/subscription_intra_process_base.cpp
@@ -40,3 +40,17 @@ SubscriptionIntraProcessBase::is_durability_transient_local() const
 {
   return qos_profile_.durability() == rclcpp::DurabilityPolicy::TransientLocal;
 }
+
+void
+SubscriptionIntraProcessBase::disable_callbacks()
+{
+  std::lock_guard<std::recursive_mutex> lock(on_new_message_callback_mutex_);
+  on_new_message_callback_disabled_ = true;
+}
+
+void
+SubscriptionIntraProcessBase::enable_callbacks()
+{
+  std::lock_guard<std::recursive_mutex> lock(on_new_message_callback_mutex_);
+  on_new_message_callback_disabled_ = false;
+}

--- a/rclcpp/test/rclcpp/node_interfaces/test_node_topics.cpp
+++ b/rclcpp/test/rclcpp/node_interfaces/test_node_topics.cpp
@@ -94,6 +94,8 @@ public:
   void handle_dynamic_message(
     const DynamicMessage::SharedPtr &,
     const rclcpp::MessageInfo &) override {}
+  void disable_callbacks() override {}
+  void enable_callbacks() override {}
 };
 
 class TestNodeTopics : public ::testing::Test

--- a/rclcpp/test/rclcpp/test_any_subscription_callback.cpp
+++ b/rclcpp/test/rclcpp/test_any_subscription_callback.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <string>

--- a/rclcpp/test/rclcpp/test_any_subscription_callback.cpp
+++ b/rclcpp/test/rclcpp/test_any_subscription_callback.cpp
@@ -208,6 +208,126 @@ TEST_F(TestAnySubscriptionCallback, unset_dispatch_throw) {
 }
 
 //
+// Testing disable and enable callbacks
+//
+TEST_F(TestAnySubscriptionCallback, disable_enable_callbacks) {
+  std::atomic<int> callback_count{0};
+
+  rclcpp::AnySubscriptionCallback<test_msgs::msg::Empty> asc;
+  asc.set([&callback_count](const test_msgs::msg::Empty &) {
+      ++callback_count;
+  });
+
+  // Callback should work initially
+  asc.dispatch(msg_shared_ptr_, message_info_);
+  EXPECT_EQ(1, callback_count.load());
+
+  // Disable and verify callback is not called
+  asc.disable();
+  asc.dispatch(msg_shared_ptr_, message_info_);
+  EXPECT_EQ(1, callback_count.load());  // Count should not increase
+
+  // Enable and verify callback works again
+  asc.enable();
+  asc.dispatch(msg_shared_ptr_, message_info_);
+  EXPECT_EQ(2, callback_count.load());
+}
+
+TEST_F(TestAnySubscriptionCallback, disable_enable_callbacks_intra_process) {
+  std::atomic<int> callback_count{0};
+
+  rclcpp::AnySubscriptionCallback<test_msgs::msg::Empty> asc;
+  asc.set([&callback_count](std::shared_ptr<const test_msgs::msg::Empty>) {
+      ++callback_count;
+  });
+
+  // Callback should work initially
+  asc.dispatch_intra_process(msg_shared_ptr_, message_info_);
+  EXPECT_EQ(1, callback_count.load());
+
+  // Disable and verify callback is not called
+  asc.disable();
+  asc.dispatch_intra_process(msg_shared_ptr_, message_info_);
+  EXPECT_EQ(1, callback_count.load());
+
+  // Enable and verify callback works again
+  asc.enable();
+  asc.dispatch_intra_process(msg_shared_ptr_, message_info_);
+  EXPECT_EQ(2, callback_count.load());
+}
+
+TEST_F(TestAnySubscriptionCallback, disable_enable_callbacks_unique_ptr) {
+  std::atomic<int> callback_count{0};
+
+  rclcpp::AnySubscriptionCallback<test_msgs::msg::Empty> asc;
+  asc.set([&callback_count](std::unique_ptr<test_msgs::msg::Empty>) {
+      ++callback_count;
+  });
+
+  // Callback should work initially
+  asc.dispatch_intra_process(get_unique_ptr_msg(), message_info_);
+  EXPECT_EQ(1, callback_count.load());
+
+  // Disable and verify callback is not called
+  asc.disable();
+  asc.dispatch_intra_process(get_unique_ptr_msg(), message_info_);
+  EXPECT_EQ(1, callback_count.load());
+
+  // Enable and verify callback works again
+  asc.enable();
+  asc.dispatch_intra_process(get_unique_ptr_msg(), message_info_);
+  EXPECT_EQ(2, callback_count.load());
+}
+
+TEST_F(TestAnySubscriptionCallback, disable_enable_serialized_message) {
+  std::atomic<int> callback_count{0};
+
+  rclcpp::AnySubscriptionCallback<test_msgs::msg::Empty> asc;
+  asc.set([&callback_count](const rclcpp::SerializedMessage &) {
+      ++callback_count;
+  });
+
+  auto serialized_msg = std::make_shared<rclcpp::SerializedMessage>();
+
+  // Callback should work initially
+  asc.dispatch(serialized_msg, message_info_);
+  EXPECT_EQ(1, callback_count.load());
+
+  // Disable and verify callback is not called
+  asc.disable();
+  asc.dispatch(serialized_msg, message_info_);
+  EXPECT_EQ(1, callback_count.load());
+
+  // Enable and verify callback works again
+  asc.enable();
+  asc.dispatch(serialized_msg, message_info_);
+  EXPECT_EQ(2, callback_count.load());
+}
+
+TEST_F(TestAnySubscriptionCallbackTA, disable_enable_callbacks_type_adapter) {
+  std::atomic<int> callback_count{0};
+
+  rclcpp::AnySubscriptionCallback<MyTA> asc;
+  asc.set([&callback_count](const MyEmpty &) {
+      ++callback_count;
+  });
+
+  // Callback should work initially
+  asc.dispatch_intra_process(msg_shared_ptr_, message_info_);
+  EXPECT_EQ(1, callback_count.load());
+
+  // Disable and verify callback is not called
+  asc.disable();
+  asc.dispatch_intra_process(msg_shared_ptr_, message_info_);
+  EXPECT_EQ(1, callback_count.load());
+
+  // Enable and verify callback works again
+  asc.enable();
+  asc.dispatch_intra_process(msg_shared_ptr_, message_info_);
+  EXPECT_EQ(2, callback_count.load());
+}
+
+//
 // Parameterized test to test across all callback types and dispatch types.
 //
 

--- a/rclcpp/test/rclcpp/test_generic_pubsub.cpp
+++ b/rclcpp/test/rclcpp/test_generic_pubsub.cpp
@@ -28,6 +28,7 @@
 
 #include "rcl/graph.h"
 
+#include "rclcpp/executors/single_threaded_executor.hpp"
 #include "rclcpp/generic_publisher.hpp"
 #include "rclcpp/generic_subscription.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -338,12 +339,15 @@ TEST_F(RclcppGenericNodeFixture, disable_enable_subscription_callbacks)
     };
   ASSERT_TRUE(wait_for(connected, 10s));
 
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_);
+
   // Publish and verify callback is called
   publisher->publish(serialize_message<std::string, test_msgs::msg::Strings>("test1"));
 
   auto start = std::chrono::steady_clock::now();
   while (callback_count.load() == 0 && std::chrono::steady_clock::now() - start < 30s) {
-    rclcpp::spin_some(node_);
+    executor.spin_some();
     std::this_thread::sleep_for(10ms);
   }
   EXPECT_EQ(1, callback_count.load());
@@ -357,7 +361,7 @@ TEST_F(RclcppGenericNodeFixture, disable_enable_subscription_callbacks)
   start = std::chrono::steady_clock::now();
   auto initial_count = callback_count.load();
   while (std::chrono::steady_clock::now() - start < 500ms) {
-    rclcpp::spin_some(node_);
+    executor.spin_some();
     std::this_thread::sleep_for(10ms);
   }
   EXPECT_EQ(initial_count, callback_count.load());  // Should not increase
@@ -370,7 +374,7 @@ TEST_F(RclcppGenericNodeFixture, disable_enable_subscription_callbacks)
 
   start = std::chrono::steady_clock::now();
   while (callback_count.load() == initial_count && std::chrono::steady_clock::now() - start < 30s) {
-    rclcpp::spin_some(node_);
+    executor.spin_some();
     std::this_thread::sleep_for(10ms);
   }
   EXPECT_EQ(callback_count.load(), initial_count + 1);

--- a/rclcpp/test/rclcpp/test_generic_pubsub.cpp
+++ b/rclcpp/test/rclcpp/test_generic_pubsub.cpp
@@ -34,6 +34,7 @@
 
 using namespace ::testing;  // NOLINT
 using namespace rclcpp;  // NOLINT
+using namespace std::chrono_literals;  // NOLINT
 
 class RclcppGenericNodeFixture : public Test
 {
@@ -313,4 +314,131 @@ TEST_F(RclcppGenericNodeFixture, generic_subscription_different_callbacks)
     // It normally takes < 20ms, 5s chosen as "a very long time"
     ASSERT_TRUE(wait_for(connected, 5s));
   }
+}
+
+TEST_F(RclcppGenericNodeFixture, disable_enable_subscription_callbacks)
+{
+  const std::string topic_name = "test_disable_topic";
+  const std::string type = "test_msgs/msg/Strings";
+  const auto qos = rclcpp::QoS(10U);
+
+  std::atomic<int> callback_count{0};
+  auto callback = [&callback_count](std::shared_ptr<const rclcpp::SerializedMessage>) {
+      ++callback_count;
+    };
+
+  auto subscription = node_->create_generic_subscription(topic_name, type, qos, callback);
+  auto publisher = node_->create_generic_publisher(topic_name, type, qos);
+
+  // Wait for discovery
+  auto connected = [publisher, subscription]() -> bool {
+      return publisher->get_subscription_count() && subscription->get_publisher_count();
+    };
+  ASSERT_TRUE(wait_for(connected, 10s));
+
+  // Publish and verify callback is called
+  publisher->publish(serialize_message<std::string, test_msgs::msg::Strings>("test1"));
+
+  auto start = std::chrono::steady_clock::now();
+  while (callback_count.load() == 0 && std::chrono::steady_clock::now() - start < 30s) {
+    rclcpp::spin_some(node_);
+    std::this_thread::sleep_for(10ms);
+  }
+  EXPECT_EQ(1, callback_count.load());
+
+  // Disable callbacks
+  EXPECT_NO_THROW(subscription->disable_callbacks());
+
+  // Publish again and verify callback is NOT called
+  publisher->publish(serialize_message<std::string, test_msgs::msg::Strings>("test2"));
+
+  start = std::chrono::steady_clock::now();
+  auto initial_count = callback_count.load();
+  while (std::chrono::steady_clock::now() - start < 500ms) {
+    rclcpp::spin_some(node_);
+    std::this_thread::sleep_for(10ms);
+  }
+  EXPECT_EQ(initial_count, callback_count.load());  // Should not increase
+
+  // Enable callbacks
+  EXPECT_NO_THROW(subscription->enable_callbacks());
+
+  // Publish again and verify callback IS called
+  publisher->publish(serialize_message<std::string, test_msgs::msg::Strings>("test3"));
+
+  start = std::chrono::steady_clock::now();
+  while (callback_count.load() == initial_count && std::chrono::steady_clock::now() - start < 30s) {
+    rclcpp::spin_some(node_);
+    std::this_thread::sleep_for(10ms);
+  }
+  EXPECT_EQ(callback_count.load(), initial_count + 1);
+}
+
+TEST_F(RclcppGenericNodeFixture, disable_enable_subscription_event_callbacks)
+{
+  if (std::string(rmw_get_implementation_identifier()).find("rmw_zenoh_cpp") == 0) {
+    GTEST_SKIP() << "rmw_zenoh doesn't support deadline and liveliness events";
+  }
+  const std::string topic_name = "test_event_callbacks_topic";
+  const std::string type = "test_msgs/msg/Strings";
+  const auto qos = rclcpp::QoS(10U).deadline(100ms);
+
+  std::atomic<int> deadline_callback_count{0};
+  std::atomic<int> liveliness_callback_count{0};
+
+  rclcpp::SubscriptionOptions sub_options;
+  sub_options.event_callbacks.deadline_callback =
+    [&deadline_callback_count](rclcpp::QOSDeadlineRequestedInfo &) {
+      ++deadline_callback_count;
+    };
+
+  sub_options.event_callbacks.liveliness_callback =
+    [&liveliness_callback_count](rclcpp::QOSLivelinessChangedInfo &) {
+      ++liveliness_callback_count;
+    };
+
+  auto do_nothing = [](std::shared_ptr<const rclcpp::SerializedMessage>) {};
+
+  auto subscription =
+    node_->create_generic_subscription(topic_name, type, qos, do_nothing, sub_options);
+
+  const auto & event_handlers = subscription->get_event_handlers();
+
+  // Initially, both callbacks counters should be zero
+  EXPECT_EQ(deadline_callback_count, 0);
+  EXPECT_EQ(liveliness_callback_count, 0);
+
+  // Execute events and disable all event handlers
+  for (const auto & [event_type, handler] : event_handlers) {
+    if (handler) {
+      const std::shared_ptr<void> data = handler->take_data();
+      handler->execute(data);
+      EXPECT_NO_THROW(handler->disable());
+    }
+  }
+  // Expect both callbacks to have been called once since they should be enabled by default
+  EXPECT_EQ(deadline_callback_count, 1);
+  EXPECT_EQ(liveliness_callback_count, 1);
+
+  // Execute events one more time and enable all event handlers
+  for (const auto & [event_type, handler] : event_handlers) {
+    if (handler) {
+      const std::shared_ptr<void> data = handler->take_data();
+      handler->execute(data);
+      EXPECT_NO_THROW(handler->enable());
+    }
+  }
+  // Expect no change since they were disabled
+  EXPECT_EQ(deadline_callback_count, 1);
+  EXPECT_EQ(liveliness_callback_count, 1);
+
+  // Execute events one more time
+  for (const auto & [event_type, handler] : event_handlers) {
+    if (handler) {
+      const std::shared_ptr<void> data = handler->take_data();
+      handler->execute(data);
+    }
+  }
+  EXPECT_EQ(deadline_callback_count, 2);
+  EXPECT_EQ(liveliness_callback_count, 2);
 }

--- a/rclcpp/test/rclcpp/test_generic_pubsub.cpp
+++ b/rclcpp/test/rclcpp/test_generic_pubsub.cpp
@@ -15,11 +15,13 @@
 
 #include <gmock/gmock.h>
 
+#include <atomic>
 #include <chrono>
 #include <future>
 #include <memory>
 #include <string>
 #include <vector>
+#include <thread>
 
 #include "test_msgs/message_fixtures.hpp"
 #include "test_msgs/msg/basic_types.hpp"

--- a/rclcpp/test/rclcpp/test_subscription.cpp
+++ b/rclcpp/test/rclcpp/test_subscription.cpp
@@ -668,3 +668,206 @@ TEST_P(TestSubscriptionInvalidIntraprocessQos, test_subscription_throws_intrapro
         options);},
     std::runtime_error("Unrecognized IntraProcessSetting value"));
 }
+
+/*
+   Testing disable and enable callbacks on subscriptions
+ */
+TEST_F(TestSubscription, disable_enable_callbacks)
+{
+  const std::string topic_name = "~/test_disable";
+  initialize();
+  std::atomic<int> callback_count{0};
+
+  auto callback = [&callback_count](test_msgs::msg::Empty::ConstSharedPtr) {
+      ++callback_count;
+    };
+
+  rclcpp::SubscriptionOptions sub_options;
+  sub_options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
+  auto sub = node_->create_subscription<test_msgs::msg::Empty>(
+    topic_name, 10U, callback, sub_options);
+
+  rclcpp::PublisherOptions pub_options;
+  pub_options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
+  auto pub = node_->create_publisher<test_msgs::msg::Empty>(topic_name, 10U, pub_options);
+
+  // Wait for discovery
+  auto start = std::chrono::steady_clock::now();
+  while ((pub->get_subscription_count() == 0U || sub->get_publisher_count() == 0U) &&
+    std::chrono::steady_clock::now() - start < 10s)
+  {
+    rclcpp::spin_some(node_);
+    std::this_thread::sleep_for(10ms);
+  }
+
+  // Publish and verify callback is called
+  {
+    test_msgs::msg::Empty msg;
+    pub->publish(msg);
+  }
+
+  start = std::chrono::steady_clock::now();
+  while (callback_count.load() == 0 && std::chrono::steady_clock::now() - start < 30s) {
+    rclcpp::spin_some(node_);
+    std::this_thread::sleep_for(10ms);
+  }
+  EXPECT_EQ(1, callback_count.load());
+
+  // Disable callbacks
+  sub->disable_callbacks();
+
+  // Publish again and verify callback is NOT called
+  {
+    test_msgs::msg::Empty msg;
+    pub->publish(msg);
+  }
+
+  start = std::chrono::steady_clock::now();
+  auto initial_count = callback_count.load();
+  while (std::chrono::steady_clock::now() - start < 500ms) {
+    rclcpp::spin_some(node_);
+    std::this_thread::sleep_for(10ms);
+  }
+  EXPECT_EQ(initial_count, callback_count.load());  // Should not increase
+
+  // Enable callbacks
+  sub->enable_callbacks();
+
+  // Publish again and verify callback IS called
+  {
+    test_msgs::msg::Empty msg;
+    pub->publish(msg);
+  }
+
+  start = std::chrono::steady_clock::now();
+  while (callback_count.load() == initial_count && std::chrono::steady_clock::now() - start < 30s) {
+    rclcpp::spin_some(node_);
+    std::this_thread::sleep_for(10ms);
+  }
+  EXPECT_EQ(callback_count.load(), initial_count + 1);
+}
+
+TEST_F(TestSubscription, disable_enable_callbacks_intra_process)
+{
+  const std::string topic_name = "~/test_disable_ipc";
+  initialize(rclcpp::NodeOptions().use_intra_process_comms(true));
+  std::atomic<int> callback_count{0};
+
+  auto callback = [&callback_count](test_msgs::msg::Empty::ConstSharedPtr) {
+      ++callback_count;
+    };
+
+  auto sub = node_->create_subscription<test_msgs::msg::Empty>(topic_name, 10U, callback);
+  auto pub = node_->create_publisher<test_msgs::msg::Empty>(topic_name, 10U);
+
+  // Publish and verify callback is called
+  {
+    test_msgs::msg::Empty msg;
+    pub->publish(msg);
+  }
+
+  auto start = std::chrono::steady_clock::now();
+  while (callback_count.load() == 0 && std::chrono::steady_clock::now() - start < 30s) {
+    rclcpp::spin_some(node_);
+    std::this_thread::sleep_for(10ms);
+  }
+  EXPECT_EQ(1, callback_count.load());
+
+  // Disable callbacks
+  sub->disable_callbacks();
+
+  // Publish again and verify callback is NOT called
+  {
+    test_msgs::msg::Empty msg;
+    pub->publish(msg);
+  }
+
+  start = std::chrono::steady_clock::now();
+  auto initial_count = callback_count.load();
+  while (std::chrono::steady_clock::now() - start < 500ms) {
+    rclcpp::spin_some(node_);
+    std::this_thread::sleep_for(10ms);
+  }
+  EXPECT_EQ(initial_count, callback_count.load());
+
+  // Enable callbacks
+  sub->enable_callbacks();
+
+  // Publish again and verify callback IS called
+  {
+    test_msgs::msg::Empty msg;
+    pub->publish(msg);
+  }
+
+  start = std::chrono::steady_clock::now();
+  while (callback_count.load() == initial_count && std::chrono::steady_clock::now() - start < 30s) {
+    rclcpp::spin_some(node_);
+    std::this_thread::sleep_for(10ms);
+  }
+  EXPECT_EQ(callback_count.load(), initial_count + 1);
+}
+
+TEST_F(TestSubscription, disable_enable_event_callbacks)
+{
+  initialize();
+  std::atomic<int> deadline_callback_count{0};
+  std::atomic<int> liveliness_callback_count{0};
+
+  rclcpp::SubscriptionOptions subscription_options;
+  subscription_options.event_callbacks.deadline_callback =
+    [&deadline_callback_count](rclcpp::QOSDeadlineRequestedInfo &) {
+      ++deadline_callback_count;
+    };
+
+  subscription_options.event_callbacks.liveliness_callback =
+    [&liveliness_callback_count](rclcpp::QOSLivelinessChangedInfo &) {
+      ++liveliness_callback_count;
+    };
+
+  auto do_nothing = [](std::shared_ptr<const test_msgs::msg::Empty>) {};
+
+  const auto qos = rclcpp::QoS(10U).deadline(100ms);
+
+  auto subscription = node_->create_subscription<test_msgs::msg::Empty>(
+    "test_event_callbacks_topic", qos, do_nothing, subscription_options);
+
+  const auto & event_handlers = subscription->get_event_handlers();
+
+  // Initially, both callbacks counters should be zero
+  EXPECT_EQ(deadline_callback_count, 0);
+  EXPECT_EQ(liveliness_callback_count, 0);
+
+  // Execute events and disable all event handlers
+  for (const auto & [event_type, handler] : event_handlers) {
+    if (handler) {
+      const std::shared_ptr<void> data = handler->take_data();
+      handler->execute(data);
+      EXPECT_NO_THROW(handler->disable());
+    }
+  }
+  // Expect both callbacks to have been called once since they should be enabled by default
+  EXPECT_EQ(deadline_callback_count, 1);
+  EXPECT_EQ(liveliness_callback_count, 1);
+
+  // Execute events one more time and enable all event handlers
+  for (const auto & [event_type, handler] : event_handlers) {
+    if (handler) {
+      const std::shared_ptr<void> data = handler->take_data();
+      handler->execute(data);
+      EXPECT_NO_THROW(handler->enable());
+    }
+  }
+  // Expect no change since they were disabled
+  EXPECT_EQ(deadline_callback_count, 1);
+  EXPECT_EQ(liveliness_callback_count, 1);
+
+  // Execute events one more time
+  for (const auto & [event_type, handler] : event_handlers) {
+    if (handler) {
+      const std::shared_ptr<void> data = handler->take_data();
+      handler->execute(data);
+    }
+  }
+  EXPECT_EQ(deadline_callback_count, 2);
+  EXPECT_EQ(liveliness_callback_count, 2);
+}

--- a/rclcpp/test/rclcpp/test_subscription.cpp
+++ b/rclcpp/test/rclcpp/test_subscription.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <functional>
 #include <memory>

--- a/rclcpp/test/rclcpp/test_subscription.cpp
+++ b/rclcpp/test/rclcpp/test_subscription.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "rclcpp/exceptions.hpp"
+#include "rclcpp/executors/single_threaded_executor.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include "../mocking_utils/patch.hpp"
@@ -692,12 +693,15 @@ TEST_F(TestSubscription, disable_enable_callbacks)
   pub_options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
   auto pub = node_->create_publisher<test_msgs::msg::Empty>(topic_name, 10U, pub_options);
 
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_);
+
   // Wait for discovery
   auto start = std::chrono::steady_clock::now();
   while ((pub->get_subscription_count() == 0U || sub->get_publisher_count() == 0U) &&
     std::chrono::steady_clock::now() - start < 10s)
   {
-    rclcpp::spin_some(node_);
+    executor.spin_some();
     std::this_thread::sleep_for(10ms);
   }
 
@@ -709,7 +713,7 @@ TEST_F(TestSubscription, disable_enable_callbacks)
 
   start = std::chrono::steady_clock::now();
   while (callback_count.load() == 0 && std::chrono::steady_clock::now() - start < 30s) {
-    rclcpp::spin_some(node_);
+    executor.spin_some();
     std::this_thread::sleep_for(10ms);
   }
   EXPECT_EQ(1, callback_count.load());
@@ -726,7 +730,7 @@ TEST_F(TestSubscription, disable_enable_callbacks)
   start = std::chrono::steady_clock::now();
   auto initial_count = callback_count.load();
   while (std::chrono::steady_clock::now() - start < 500ms) {
-    rclcpp::spin_some(node_);
+    executor.spin_some();
     std::this_thread::sleep_for(10ms);
   }
   EXPECT_EQ(initial_count, callback_count.load());  // Should not increase
@@ -742,7 +746,7 @@ TEST_F(TestSubscription, disable_enable_callbacks)
 
   start = std::chrono::steady_clock::now();
   while (callback_count.load() == initial_count && std::chrono::steady_clock::now() - start < 30s) {
-    rclcpp::spin_some(node_);
+    executor.spin_some();
     std::this_thread::sleep_for(10ms);
   }
   EXPECT_EQ(callback_count.load(), initial_count + 1);
@@ -761,6 +765,9 @@ TEST_F(TestSubscription, disable_enable_callbacks_intra_process)
   auto sub = node_->create_subscription<test_msgs::msg::Empty>(topic_name, 10U, callback);
   auto pub = node_->create_publisher<test_msgs::msg::Empty>(topic_name, 10U);
 
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node_);
+
   // Publish and verify callback is called
   {
     test_msgs::msg::Empty msg;
@@ -769,7 +776,7 @@ TEST_F(TestSubscription, disable_enable_callbacks_intra_process)
 
   auto start = std::chrono::steady_clock::now();
   while (callback_count.load() == 0 && std::chrono::steady_clock::now() - start < 30s) {
-    rclcpp::spin_some(node_);
+    executor.spin_some();
     std::this_thread::sleep_for(10ms);
   }
   EXPECT_EQ(1, callback_count.load());
@@ -786,7 +793,7 @@ TEST_F(TestSubscription, disable_enable_callbacks_intra_process)
   start = std::chrono::steady_clock::now();
   auto initial_count = callback_count.load();
   while (std::chrono::steady_clock::now() - start < 500ms) {
-    rclcpp::spin_some(node_);
+    executor.spin_some();
     std::this_thread::sleep_for(10ms);
   }
   EXPECT_EQ(initial_count, callback_count.load());
@@ -802,7 +809,7 @@ TEST_F(TestSubscription, disable_enable_callbacks_intra_process)
 
   start = std::chrono::steady_clock::now();
   while (callback_count.load() == initial_count && std::chrono::steady_clock::now() - start < 30s) {
-    rclcpp::spin_some(node_);
+    executor.spin_some();
     std::this_thread::sleep_for(10ms);
   }
   EXPECT_EQ(callback_count.load(), initial_count + 1);


### PR DESCRIPTION
## Description

This PR adds a new API to be able to disable and enable subscription's callbacks.
<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

- Fixes #https://github.com/ros2/rclcpp/issues/2984

### Is this user-facing behavior change?
Yes. The new API `disable_callbacks()` and  `enable_callbacks()` are available for the `SubscriptionBase` class.

### Did you use Generative AI?
Yes, I am using GitHub Copilot, GPT-5.0 in my workflow to help with Doxygen comments and unit tests.

### Additional Information
This PR can't be backported due to the ABI breaking changes. It was added two new virtual functions.