### PR TITLE
remove I/O from signal handler.

### DIFF
--- a/rclcpp/src/rclcpp/signal_handler.cpp
+++ b/rclcpp/src/rclcpp/signal_handler.cpp
@@ -68,7 +68,6 @@ void
 SignalHandler::signal_handler(
   int signum, siginfo_t * siginfo, void * context)
 {
-  RCLCPP_INFO(SignalHandler::get_logger(), "signal_handler(signum=%d)", signum);
   auto & instance = SignalHandler::get_global_signal_handler();
 
   auto old_signal_handler = instance.get_old_signal_handler(signum);
@@ -91,7 +90,6 @@ SignalHandler::signal_handler(
 void
 SignalHandler::signal_handler(int signum)
 {
-  RCLCPP_INFO(SignalHandler::get_logger(), "signal_handler(signum=%d)", signum);
   auto & instance = SignalHandler::get_global_signal_handler();
   auto old_signal_handler = instance.get_old_signal_handler(signum);
   if (
@@ -249,9 +247,6 @@ SignalHandler::signal_handler_common()
 {
   auto & instance = SignalHandler::get_global_signal_handler();
   instance.signal_received_.store(true);
-  RCLCPP_DEBUG(
-    get_logger(),
-    "signal_handler(): notifying deferred signal handler");
   instance.notify_signal_handler();
 }
 

--- a/rclcpp/src/rclcpp/signal_handler.cpp
+++ b/rclcpp/src/rclcpp/signal_handler.cpp
@@ -255,6 +255,7 @@ SignalHandler::deferred_signal_handler()
 {
   while (true) {
     if (signal_received_.exchange(false)) {
+      RCLCPP_INFO(SignalHandler::get_logger(), "signal_handler(SIGINT/SIGTERM)");
       RCLCPP_DEBUG(get_logger(), "deferred_signal_handler(): shutting down");
       for (auto context_ptr : rclcpp::get_contexts()) {
         if (context_ptr->get_init_options().shutdown_on_signal) {


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Backport of https://github.com/ros2/rclcpp/pull/2986

I tried to think of the ABI compatible way to backport the https://github.com/ros2/rclcpp/pull/2986, because it is critical issue.
But ended up removing the I/O (including possible rcl_publish) from the signal handler.

- reuse `signal_received_` as `std::atomic_int` to store the signal number. this also changes the memory layout/alighment from 1 byte to 4 bytes. checked with amd64 and arm64 platform, this is also gonna be the breaking ABI change, and not guaranteed by standard.
- external data structure such as code space static variable or per-instance state using instance IDs or pointers, avoiding class member changes. However, this adds complexity and potential thread-safety concerns.

> [!Note]
> this requires https://github.com/ros2/system_tests/pull/580

### Is this user-facing behavior change?

Yes, the user application cannot expect the logging message (or publish) via signal handler.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No,

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
