### PR TITLE
Improve the robustness of the TopicEndpointInfo constructor

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
@@ -57,13 +57,17 @@ public:
   /// Construct a TopicEndpointInfo from a rcl_topic_endpoint_info_t.
   RCLCPP_PUBLIC
   explicit TopicEndpointInfo(const rcl_topic_endpoint_info_t & info)
-  : node_name_(info.node_name ? info.node_name : ""),
-    node_namespace_(info.node_namespace ? info.node_namespace : ""),
-    topic_type_(info.topic_type ? info.topic_type : ""),
-    endpoint_type_(static_cast<rclcpp::EndpointType>(info.endpoint_type)),
+  : endpoint_type_(static_cast<rclcpp::EndpointType>(info.endpoint_type)),
     qos_profile_({info.qos_profile.history, info.qos_profile.depth}, info.qos_profile),
     topic_type_hash_(info.topic_type_hash)
   {
+    if (!info.node_name || !info.node_namespace || !info.topic_type) {
+      throw std::invalid_argument("Constructor TopicEndpointInfo with invalid topic endpoint info");
+    }
+    node_name_ = info.node_name;
+    node_namespace_ = info.node_namespace;
+    topic_type_ = info.topic_type;
+
     std::copy(info.endpoint_gid, info.endpoint_gid + RMW_GID_STORAGE_SIZE, endpoint_gid_.begin());
   }
 

--- a/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
@@ -57,9 +57,9 @@ public:
   /// Construct a TopicEndpointInfo from a rcl_topic_endpoint_info_t.
   RCLCPP_PUBLIC
   explicit TopicEndpointInfo(const rcl_topic_endpoint_info_t & info)
-  : node_name_(info.node_name),
-    node_namespace_(info.node_namespace),
-    topic_type_(info.topic_type),
+  : node_name_(info.node_name ? info.node_name : ""),
+    node_namespace_(info.node_namespace ? info.node_namespace : ""),
+    topic_type_(info.topic_type ? info.topic_type : ""),
     endpoint_type_(static_cast<rclcpp::EndpointType>(info.endpoint_type)),
     qos_profile_({info.qos_profile.history, info.qos_profile.depth}, info.qos_profile),
     topic_type_hash_(info.topic_type_hash)


### PR DESCRIPTION
## Description

`node_name`, `node_namespace` and `topic_type` may be nullptr. This will result in initializing a std::string with nullptr, which will cause an exception during construction.  This issue is mentioned here ros2/rosbag2#2293.
https://github.com/ros2/rclcpp/blob/c85ff926d2ea6c3fb8b8075e28b93632a791fd5c/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp#L59-L62

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

N/A
