### PR TITLE
Fix expiration of action goals when EventsExecutors are used

### DIFF
--- a/rclcpp_action/include/rclcpp_action/server.hpp
+++ b/rclcpp_action/include/rclcpp_action/server.hpp
@@ -205,6 +205,10 @@ public:
     const rclcpp::QoS & qos_service_event_pub,
     rcl_service_introspection_state_t introspection_state);
 
+  RCLCPP_ACTION_PUBLIC
+  size_t
+  get_number_of_goal_handles();
+
 protected:
   RCLCPP_ACTION_PUBLIC
   ServerBase(

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -158,7 +158,15 @@ ServerBase::ServerBase(
   rcl_node_t * rcl_node = node_base->get_rcl_node_handle();
 
   std::function<void()> timer_callback = [this] () {
+        try {
       execute_check_expired_goals();
+        } 
+        catch (const rclcpp::exceptions::RCLError & ex) {
+          RCLCPP_ERROR(
+            rclcpp::get_logger("rclcpp_action"),
+            "Failed to check for expired goals: %s", ex.what()
+          );
+      };
     };
   pimpl_->expire_timer_ = std::make_shared<rclcpp::GenericTimer<decltype (timer_callback)>>(
       node_clock->get_clock(), std::chrono::nanoseconds(options.result_timeout.nanoseconds),

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -158,15 +158,15 @@ ServerBase::ServerBase(
   rcl_node_t * rcl_node = node_base->get_rcl_node_handle();
 
   std::function<void()> timer_callback = [this] () {
-        try {
-          execute_check_expired_goals();
-        } 
-        catch (const rclcpp::exceptions::RCLError & ex) {
-          RCLCPP_ERROR(
+      try {
+        execute_check_expired_goals();
+      } catch (const rclcpp::exceptions::RCLError & ex) {
+        RCLCPP_ERROR(
             rclcpp::get_logger("rclcpp_action"),
             "Failed to check for expired goals: %s", ex.what()
-          );
-      };
+        );
+      }
+      ;
     };
   pimpl_->expire_timer_ = std::make_shared<rclcpp::GenericTimer<decltype (timer_callback)>>(
       node_clock->get_clock(), std::chrono::nanoseconds(options.result_timeout.nanoseconds),

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -158,8 +158,8 @@ ServerBase::ServerBase(
   rcl_node_t * rcl_node = node_base->get_rcl_node_handle();
 
   std::function<void()> timer_callback = [this] () {
-    execute_check_expired_goals();
-  };
+      execute_check_expired_goals();
+    };
   pimpl_->expire_timer_ = std::make_shared<rclcpp::GenericTimer<decltype (timer_callback)>>(
       node_clock->get_clock(), std::chrono::nanoseconds(options.result_timeout.nanoseconds),
       std::move(timer_callback), node_base->get_context(), false);
@@ -637,6 +637,13 @@ ServerBase::execute_result_request_received(
       rclcpp::exceptions::throw_from_rcl_error(rcl_ret);
     }
   }
+}
+
+size_t
+ServerBase::get_number_of_goal_handles()
+{
+  std::lock_guard<std::recursive_mutex> lock(pimpl_->unordered_map_mutex_);
+  return pimpl_->goal_handles_.size();
 }
 
 void

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -159,7 +159,7 @@ ServerBase::ServerBase(
 
   std::function<void()> timer_callback = [this] () {
         try {
-      execute_check_expired_goals();
+          execute_check_expired_goals();
         } 
         catch (const rclcpp::exceptions::RCLError & ex) {
           RCLCPP_ERROR(
@@ -195,6 +195,7 @@ ServerBase::ServerBase(
 
 ServerBase::~ServerBase()
 {
+  pimpl_->expire_timer_->cancel();
 }
 
 size_t

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -160,7 +160,7 @@ ServerBase::ServerBase(
   // This timer callback will be exchanged at the RCL layer
   // with a _timer_ callback that will call the _event_ callback
   // passed in by set_on_ready_callback.
-  std::function<void()> timer_callback = [&] () {};
+  std::function<void()> timer_callback = [] () {};
   pimpl_->expire_timer_ = std::make_shared<rclcpp::GenericTimer<decltype (timer_callback)>>(
       node_clock->get_clock(), std::chrono::nanoseconds(options.result_timeout.nanoseconds),
       std::move(timer_callback), node_base->get_context(), false);

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -157,9 +157,9 @@ ServerBase::ServerBase(
 
   rcl_node_t * rcl_node = node_base->get_rcl_node_handle();
 
-  // This timer callback will never be called, we are only interested in
-  // weather the timer itself becomes ready or not.
-  std::function<void()> timer_callback = [] () {};
+  std::function<void()> timer_callback = [this] () {
+    execute_check_expired_goals();
+  };
   pimpl_->expire_timer_ = std::make_shared<rclcpp::GenericTimer<decltype (timer_callback)>>(
       node_clock->get_clock(), std::chrono::nanoseconds(options.result_timeout.nanoseconds),
       std::move(timer_callback), node_base->get_context(), false);

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -157,17 +157,10 @@ ServerBase::ServerBase(
 
   rcl_node_t * rcl_node = node_base->get_rcl_node_handle();
 
-  std::function<void()> timer_callback = [this] () {
-      try {
-        execute_check_expired_goals();
-      } catch (const rclcpp::exceptions::RCLError & ex) {
-        RCLCPP_ERROR(
-            rclcpp::get_logger("rclcpp_action"),
-            "Failed to check for expired goals: %s", ex.what()
-        );
-      }
-      ;
-    };
+  // This timer callback will be exchanged at the RCL layer
+  // with a _timer_ callback that will call the _event_ callback
+  // passed in by set_on_ready_callback.
+  std::function<void()> timer_callback = [&] () {};
   pimpl_->expire_timer_ = std::make_shared<rclcpp::GenericTimer<decltype (timer_callback)>>(
       node_clock->get_clock(), std::chrono::nanoseconds(options.result_timeout.nanoseconds),
       std::move(timer_callback), node_base->get_context(), false);
@@ -827,6 +820,7 @@ ServerBase::set_on_ready_callback(std::function<void(size_t, int)> callback)
   set_callback_to_entity(EntityType::GoalService, callback);
   set_callback_to_entity(EntityType::ResultService, callback);
   set_callback_to_entity(EntityType::CancelService, callback);
+  set_callback_to_entity(EntityType::Expired, callback);
 }
 
 void
@@ -926,7 +920,11 @@ ServerBase::set_on_ready_callback(
 
     case EntityType::Expired:
       {
-        throw std::runtime_error("Expired entity type does not support callbacks");
+        ret = rcl_action_server_set_expired_event_callback(
+          pimpl_->action_server_.get(),
+          callback,
+          user_data);
+        break;
       }
   }
 
@@ -945,6 +943,7 @@ ServerBase::clear_on_ready_callback()
     set_on_ready_callback(EntityType::GoalService, nullptr, nullptr);
     set_on_ready_callback(EntityType::ResultService, nullptr, nullptr);
     set_on_ready_callback(EntityType::CancelService, nullptr, nullptr);
+    set_on_ready_callback(EntityType::Expired, nullptr, nullptr);
     on_ready_callback_set_ = false;
   }
 

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -49,6 +49,7 @@ protected:
   std::shared_ptr<Fibonacci::Impl::SendGoalService::Request>
   send_goal_request(
     rclcpp::Node::SharedPtr node, GoalUUID uuid,
+    rclcpp::Executor & executor,
     std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
   {
     auto client = node->create_client<Fibonacci::Impl::SendGoalService>(
@@ -59,7 +60,8 @@ protected:
     auto request = std::make_shared<Fibonacci::Impl::SendGoalService::Request>();
     request->goal_id.uuid = uuid;
     auto future = client->async_send_request(request);
-    auto return_code = rclcpp::spin_until_future_complete(node, future, timeout);
+    auto return_code = rclcpp::executors::spin_node_until_future_complete(executor,
+      node->get_node_base_interface(), future, timeout);
     if (rclcpp::FutureReturnCode::SUCCESS == return_code) {
       return request;
     } else if (rclcpp::FutureReturnCode::TIMEOUT == return_code) {
@@ -69,9 +71,19 @@ protected:
     }
   }
 
+  std::shared_ptr<Fibonacci::Impl::SendGoalService::Request>
+  send_goal_request(
+    rclcpp::Node::SharedPtr node, GoalUUID uuid,
+    std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
+  {
+    rclcpp::executors::SingleThreadedExecutor ex;
+    return send_goal_request(node, uuid, ex, timeout);
+  }
+
   CancelResponse::SharedPtr
   send_cancel_request(
     rclcpp::Node::SharedPtr node, GoalUUID uuid,
+    rclcpp::Executor & executor,
     std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
   {
     auto cancel_client = node->create_client<Fibonacci::Impl::CancelGoalService>(
@@ -82,7 +94,8 @@ protected:
     auto request = std::make_shared<Fibonacci::Impl::CancelGoalService::Request>();
     request->goal_info.goal_id.uuid = uuid;
     auto future = cancel_client->async_send_request(request);
-    auto return_code = rclcpp::spin_until_future_complete(node, future, timeout);
+    auto return_code = rclcpp::executors::spin_node_until_future_complete(executor,
+      node->get_node_base_interface(), future, timeout);
     if (rclcpp::FutureReturnCode::SUCCESS == return_code) {
       return future.get();
     } else if (rclcpp::FutureReturnCode::TIMEOUT == return_code) {
@@ -90,6 +103,15 @@ protected:
     } else {
       throw std::runtime_error("cancel request future didn't complete succesfully");
     }
+  }
+
+  CancelResponse::SharedPtr
+  send_cancel_request(
+    rclcpp::Node::SharedPtr node, GoalUUID uuid,
+    std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
+  {
+    rclcpp::executors::SingleThreadedExecutor ex;
+    return send_cancel_request(node, uuid, ex, timeout);
   }
 };
 
@@ -1021,6 +1043,104 @@ TEST_F(TestServer, deferred_execution)
   received_handle->execute();
   EXPECT_TRUE(received_handle->is_executing());
 }
+
+TEST_F(TestServer, goals_expired_with_events_executor)
+{
+
+  rclcpp::ExecutorOptions opts;
+
+  // Because timer expiration was typically tied to the waitsets for
+  // the SingleThreadedExecutor and MultiThreadedExecutor,
+  // We specifically want to test with the EventsExecutor here
+  // so we can verify the timer based goal expiration works
+  // and expired goals are properly cleared.
+
+  rclcpp::experimental::executors::EventsExecutor executor(opts);
+  auto node = std::make_shared<rclcpp::Node>("expire_goals", "/rclcpp_action/expire_goals");
+  const std::vector<GoalUUID> uuids{
+    {{1, 2, 3, 40, 5, 6, 70, 8, 9, 1, 11, 120, 13, 140, 15, 160}},
+    {{10, 2, 3, 40, 50, 6, 70, 8, 9, 1, 11, 12, 13, 140, 15, 160}},
+    {{12, 23, 34, 45, 50, 6, 70, 8, 9, 100, 11, 120, 13, 140, 15, 170}},
+    {{12, 23, 34, 45, 50, 6, 70, 8, 9, 100, 11, 120, 13, 140, 115, 16}}
+  };
+
+  auto handle_goal = [](
+    const GoalUUID &, std::shared_ptr<const Fibonacci::Goal>)
+    {
+      return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+    };
+
+  using GoalHandle = rclcpp_action::ServerGoalHandle<Fibonacci>;
+
+  auto handle_cancel = [](std::shared_ptr<GoalHandle>)
+    {
+      return rclcpp_action::CancelResponse::ACCEPT;
+    };
+
+  std::shared_ptr<GoalHandle> received_handle;
+  auto handle_accepted = [&received_handle](std::shared_ptr<GoalHandle> handle)
+    {
+      received_handle = handle;
+    };
+
+  const std::chrono::milliseconds result_timeout{25};
+
+  rcl_action_server_options_t options = rcl_action_server_get_default_options();
+  options.result_timeout.nanoseconds = RCL_MS_TO_NS(result_timeout.count());
+  auto as = rclcpp_action::create_server<Fibonacci>(
+    node, "fibonacci",
+    handle_goal,
+    handle_cancel,
+    handle_accepted,
+    options);
+
+
+  for (const auto & uuid : uuids) {
+    send_goal_request(node, uuid, executor);
+
+    EXPECT_TRUE(received_handle->is_active());
+    EXPECT_TRUE(received_handle->is_executing());
+
+    // Send result request
+    auto result_client = node->create_client<Fibonacci::Impl::GetResultService>(
+      "fibonacci/_action/get_result");
+    if (!result_client->wait_for_service(std::chrono::seconds(20))) {
+      throw std::runtime_error("get result service didn't become available");
+    }
+    auto request = std::make_shared<Fibonacci::Impl::GetResultService::Request>();
+    request->goal_id.uuid = uuid;
+    auto future = result_client->async_send_request(request);
+
+    // Send a result
+    auto result = std::make_shared<Fibonacci::Result>();
+    result->sequence = {5, 8, 13, 21};
+    received_handle->succeed(result);
+
+    // Wait for the result request to be received
+
+    executor.add_node(node);
+
+    ASSERT_EQ(
+      rclcpp::FutureReturnCode::SUCCESS,
+      executor.spin_until_future_complete(future));
+
+    auto response = future.get();
+    EXPECT_EQ(action_msgs::msg::GoalStatus::STATUS_SUCCEEDED, response->status);
+    EXPECT_EQ(result->sequence, response->result.sequence);
+
+    ASSERT_TRUE(as->get_number_of_goal_handles() != 0);
+
+    // Wait for goal expiration
+    rclcpp::sleep_for(2 * result_timeout);
+
+    // Allow for expiration to take place
+    executor.spin_some();
+    executor.remove_node(node);
+  }
+
+  ASSERT_TRUE(as->get_number_of_goal_handles() == 0);
+}
+
 
 class TestBasicServer : public TestServer
 {

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -1138,13 +1138,13 @@ TEST_F(TestServer, goals_expired_with_events_executor)
     EXPECT_EQ(action_msgs::msg::GoalStatus::STATUS_SUCCEEDED, response->status);
     EXPECT_EQ(result->sequence, response->result.sequence);
 
-    ASSERT_NE(as->get_number_of_goal_handles(), 0);
-
-    // Wait for goal expiration
-    rclcpp::sleep_for(2 * result_timeout);
-
-    // Allow for expiration to take place
-    executor.spin_some();
+    auto start = std::chrono::steady_clock::now();
+    while (as->get_number_of_goal_handles() != 0 &&
+      std::chrono::steady_clock::now() - start < std::chrono::seconds(5))
+    {
+      executor.spin_some();
+      rclcpp::sleep_for(std::chrono::milliseconds(10));
+    }
   }
   executor.remove_node(node);
 

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -50,7 +50,8 @@ protected:
   send_goal_request(
     rclcpp::Node::SharedPtr node, GoalUUID uuid,
     rclcpp::Executor & executor,
-    std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
+    std::chrono::milliseconds timeout = std::chrono::milliseconds(-1),
+    bool executor_owns_node = false)
   {
     auto client = node->create_client<Fibonacci::Impl::SendGoalService>(
       "fibonacci/_action/send_goal");
@@ -60,7 +61,9 @@ protected:
     auto request = std::make_shared<Fibonacci::Impl::SendGoalService::Request>();
     request->goal_id.uuid = uuid;
     auto future = client->async_send_request(request);
-    auto return_code = rclcpp::executors::spin_node_until_future_complete(executor,
+    auto return_code = (executor_owns_node) ?
+      executor.spin_until_future_complete(future, timeout) :
+      rclcpp::executors::spin_node_until_future_complete(executor,
       node->get_node_base_interface(), future, timeout);
     if (rclcpp::FutureReturnCode::SUCCESS == return_code) {
       return request;
@@ -76,15 +79,19 @@ protected:
     rclcpp::Node::SharedPtr node, GoalUUID uuid,
     std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
   {
-    rclcpp::executors::SingleThreadedExecutor ex;
-    return send_goal_request(node, uuid, ex, timeout);
+    rclcpp::ExecutorOptions options;
+    options.context = node->get_node_base_interface()->get_context();
+    rclcpp::executors::SingleThreadedExecutor executor(options);
+    auto ret = send_goal_request(node, uuid, executor, timeout);
+    return ret;
   }
 
   CancelResponse::SharedPtr
   send_cancel_request(
     rclcpp::Node::SharedPtr node, GoalUUID uuid,
     rclcpp::Executor & executor,
-    std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
+    std::chrono::milliseconds timeout = std::chrono::milliseconds(-1),
+    bool executor_owns_node = false)
   {
     auto cancel_client = node->create_client<Fibonacci::Impl::CancelGoalService>(
       "fibonacci/_action/cancel_goal");
@@ -94,7 +101,9 @@ protected:
     auto request = std::make_shared<Fibonacci::Impl::CancelGoalService::Request>();
     request->goal_info.goal_id.uuid = uuid;
     auto future = cancel_client->async_send_request(request);
-    auto return_code = rclcpp::executors::spin_node_until_future_complete(executor,
+    auto return_code = (executor_owns_node) ?
+      executor.spin_until_future_complete(future, timeout) :
+      rclcpp::executors::spin_node_until_future_complete(executor,
       node->get_node_base_interface(), future, timeout);
     if (rclcpp::FutureReturnCode::SUCCESS == return_code) {
       return future.get();
@@ -110,8 +119,11 @@ protected:
     rclcpp::Node::SharedPtr node, GoalUUID uuid,
     std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
   {
-    rclcpp::executors::SingleThreadedExecutor ex;
-    return send_cancel_request(node, uuid, ex, timeout);
+    rclcpp::ExecutorOptions options;
+    options.context = node->get_node_base_interface()->get_context();
+    rclcpp::executors::SingleThreadedExecutor executor(options);
+    auto ret = send_cancel_request(node, uuid, executor, timeout);
+    return ret;
   }
 };
 
@@ -1046,17 +1058,17 @@ TEST_F(TestServer, deferred_execution)
 
 TEST_F(TestServer, goals_expired_with_events_executor)
 {
-
-  rclcpp::ExecutorOptions opts;
-
   // Because timer expiration was typically tied to the waitsets for
   // the SingleThreadedExecutor and MultiThreadedExecutor,
   // We specifically want to test with the EventsExecutor here
   // so we can verify the timer based goal expiration works
   // and expired goals are properly cleared.
+  auto node = std::make_shared<rclcpp::Node>("expire_goals", "/rclcpp_action/expire_goals");
+  rclcpp::ExecutorOptions opts;
+  opts.context = node->get_node_base_interface()->get_context();
 
   rclcpp::experimental::executors::EventsExecutor executor(opts);
-  auto node = std::make_shared<rclcpp::Node>("expire_goals", "/rclcpp_action/expire_goals");
+  executor.add_node(node);
   const std::vector<GoalUUID> uuids{
     {{1, 2, 3, 40, 5, 6, 70, 8, 9, 1, 11, 120, 13, 140, 15, 160}},
     {{10, 2, 3, 40, 50, 6, 70, 8, 9, 1, 11, 12, 13, 140, 15, 160}},
@@ -1096,7 +1108,8 @@ TEST_F(TestServer, goals_expired_with_events_executor)
 
 
   for (const auto & uuid : uuids) {
-    send_goal_request(node, uuid, executor);
+    constexpr bool owns_node {true};
+    send_goal_request(node, uuid, executor, std::chrono::milliseconds(-1), owns_node);
 
     EXPECT_TRUE(received_handle->is_active());
     EXPECT_TRUE(received_handle->is_executing());
@@ -1117,9 +1130,6 @@ TEST_F(TestServer, goals_expired_with_events_executor)
     received_handle->succeed(result);
 
     // Wait for the result request to be received
-
-    executor.add_node(node);
-
     ASSERT_EQ(
       rclcpp::FutureReturnCode::SUCCESS,
       executor.spin_until_future_complete(future));
@@ -1128,17 +1138,17 @@ TEST_F(TestServer, goals_expired_with_events_executor)
     EXPECT_EQ(action_msgs::msg::GoalStatus::STATUS_SUCCEEDED, response->status);
     EXPECT_EQ(result->sequence, response->result.sequence);
 
-    ASSERT_TRUE(as->get_number_of_goal_handles() != 0);
+    ASSERT_NE(as->get_number_of_goal_handles(), 0);
 
     // Wait for goal expiration
     rclcpp::sleep_for(2 * result_timeout);
 
     // Allow for expiration to take place
     executor.spin_some();
-    executor.remove_node(node);
   }
+  executor.remove_node(node);
 
-  ASSERT_TRUE(as->get_number_of_goal_handles() == 0);
+  ASSERT_EQ(as->get_number_of_goal_handles(), 0);
 }
 
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
In the [long actions ram usage section](https://discourse.openrobotics.org/t/ros2-state-of-the-events-executors-benchmark-comparison-between-rclcpp-eventsexecutor-and-cm-executors-eventscbgexecutor/50337#p-105487-ram-usage-actions-long-test-10m-18) of the benchmarks iRobot shared back in September 2025, there was a memory leak identified in rolling for both the EventsExecutor implementations. I did some deeper profiling and found that it was the result of expired goal results never being cleared out.

This PR introduces changes to register an on_ready callback with the action server at the rcl layer. Events based executors will now be able to call `set_on_ready_callback` for `EntityType::Expired` events, and the callback will be called in the rcl timer layer to enqueue an expired event. This allows for goal expiration to happen through the expected code path of `take_data_by_entity_id` -> `execute`. 



<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Followup to https://github.com/ros2/rclcpp/pull/2699. 
Alternative to https://github.com/ros2/rclcpp/pull/3012
Requires https://github.com/ros2/rcl/pull/1295
### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
Properly fixes a memory leak in actions where goal handles are stored indefinitely and never expired if using the EventsExecutor.
### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No
### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

EventsExecutor heaptrack allocation profile of irobot benchmark using 1MB payload, before:
<img width="1269" height="613" alt="image" src="https://github.com/user-attachments/assets/cc5177ff-9ece-4a83-aeca-b6cbc5592599" />

after:
<img width="1272" height="612" alt="image" src="https://github.com/user-attachments/assets/e8959f22-1749-4382-b2ed-514fd58ed3c0" />
