### PR TITLE
Update exception documentation for goal cancellation in ServerGoalHandle

### DIFF
--- a/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
+++ b/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
@@ -210,7 +210,7 @@ public:
    * This is a terminal state, no more methods should be called on a goal handle after this is
    * called.
    *
-   * \throws rclcpp::exceptions::RCLError If the goal is in any state besides executing.
+   * \throws rclcpp::exceptions::RCLError If the goal has not been cancelled.
    *
    * \param[in] result_msg the final result to send to clients.
    */

--- a/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
+++ b/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
@@ -210,7 +210,7 @@ public:
    * This is a terminal state, no more methods should be called on a goal handle after this is
    * called.
    *
-   * \throws rclcpp::exceptions::RCLError If the goal has not been cancelled.
+   * \throws rclcpp::exceptions::RCLError If a cancel request for this goal has not been received.
    *
    * \param[in] result_msg the final result to send to clients.
    */


### PR DESCRIPTION
The documentation for the canceled function is misleading. Previously, the description said: 
1. "Only call this if the goal is canceling." and 
2. "\throws rclcpp::exceptions::RCLError If the goal is in any state besides executing." 

This is a contradiction according to the state diagram in the Goal States section of this document: https://design.ros2.org/articles/actions.html
Experimentally verified that if the goal is executing and this method is called, an error is thrown. This makes the second statement wrong => correct the statement in the documentation.

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
No

### Additional Information
Should I open PRs for the other distributions (humble, jazzy, kilted, etc) where this documentation change has to be made? :relaxed: 