### PR TITLE
Fix MSVC build: wrap max/min calls to prevent macro expansion

### DIFF
--- a/rclcpp/include/rclcpp/create_timer.hpp
+++ b/rclcpp/include/rclcpp/create_timer.hpp
@@ -53,7 +53,7 @@ safe_cast_to_period_in_ns(std::chrono::duration<DurationRepT, DurationT> period)
   // Casting to a double representation might lose precision and allow the check below to succeed
   // but the actual cast to nanoseconds fail. Using 1 DurationT worth of nanoseconds less than max.
   constexpr auto maximum_safe_cast_ns =
-    std::chrono::nanoseconds::max() - std::chrono::duration<DurationRepT, DurationT>(1);
+    (std::chrono::nanoseconds::max)() - std::chrono::duration<DurationRepT, DurationT>(1);
 
   // If period is greater than nanoseconds::max(), the duration_cast to nanoseconds will overflow
   // a signed integer, which is undefined behavior. Checking whether any std::chrono::duration is

--- a/rclcpp/include/rclcpp/experimental/executors/events_executor/events_queue.hpp
+++ b/rclcpp/include/rclcpp/experimental/executors/events_executor/events_queue.hpp
@@ -72,7 +72,7 @@ public:
   bool
   dequeue(
     rclcpp::experimental::executors::ExecutorEvent & event,
-    std::chrono::nanoseconds timeout = std::chrono::nanoseconds::max()) = 0;
+    std::chrono::nanoseconds timeout = (std::chrono::nanoseconds::max)()) = 0;
 
   /**
    * @brief Test whether queue is empty

--- a/rclcpp/include/rclcpp/experimental/executors/events_executor/simple_events_queue.hpp
+++ b/rclcpp/include/rclcpp/experimental/executors/events_executor/simple_events_queue.hpp
@@ -70,13 +70,13 @@ public:
   bool
   dequeue(
     rclcpp::experimental::executors::ExecutorEvent & event,
-    std::chrono::nanoseconds timeout = std::chrono::nanoseconds::max()) override
+    std::chrono::nanoseconds timeout = (std::chrono::nanoseconds::max)()) override
   {
     std::unique_lock<std::mutex> lock(mutex_);
 
     // Initialize to true because it's only needed if we have a valid timeout
     bool has_data = true;
-    if (timeout != std::chrono::nanoseconds::max()) {
+    if (timeout != (std::chrono::nanoseconds::max)()) {
       has_data =
         events_queue_cv_.wait_for(lock, timeout, [this]() {return !event_queue_.empty();});
     } else {

--- a/rclcpp/include/rclcpp/utilities.hpp
+++ b/rclcpp/include/rclcpp/utilities.hpp
@@ -247,7 +247,7 @@ template<typename T>
 bool
 add_will_overflow(const T x, const T y)
 {
-  return (y > 0) && (x > (std::numeric_limits<T>::max() - y));
+  return (y > 0) && (x > ((std::numeric_limits<T>::max)() - y));
 }
 
 /// Safely check if addition will underflow.
@@ -264,7 +264,7 @@ template<typename T>
 bool
 add_will_underflow(const T x, const T y)
 {
-  return (y < 0) && (x < (std::numeric_limits<T>::min() - y));
+  return (y < 0) && (x < ((std::numeric_limits<T>::min)() - y));
 }
 
 /// Safely check if subtraction will overflow.
@@ -281,7 +281,7 @@ template<typename T>
 bool
 sub_will_overflow(const T x, const T y)
 {
-  return (y < 0) && (x > (std::numeric_limits<T>::max() + y));
+  return (y < 0) && (x > ((std::numeric_limits<T>::max)() + y));
 }
 
 /// Safely check if subtraction will underflow.
@@ -298,7 +298,7 @@ template<typename T>
 bool
 sub_will_underflow(const T x, const T y)
 {
-  return (y > 0) && (x < (std::numeric_limits<T>::min() + y));
+  return (y > 0) && (x < ((std::numeric_limits<T>::min)() + y));
 }
 
 /// Return the given string.


### PR DESCRIPTION
Fixes #2947

## Description
Wrap `max()` and `min()` calls with parentheses to prevent windows.h macro interference.

Modified files:
- simple_events_queue.hpp
- events_queue.hpp  
- utilities.hpp
- create_timer.hpp

### Is this user-facing behavior change?
No

### Did you use Generative AI?
Yes, Claude was used to identify affected files and generate the fix pattern.

### Additional Information
This approach is more robust than defining NOMINMAX, as it works regardless of header include order.