### PR TITLE
Add library dependency to node executable in rclcpp_components_register_node

### DIFF
--- a/rclcpp_components/cmake/rclcpp_components_register_node.cmake
+++ b/rclcpp_components/cmake/rclcpp_components_register_node.cmake
@@ -30,9 +30,11 @@
 # :type RESOURCE_INDEX: string
 # :param NO_UNDEFINED_SYMBOLS: add linker flags to deny undefined symbols
 # :type NO_UNDEFINED_SYMBOLS: option
+# :param SKIP_LIBRARY_DEPENDENCY: skip adding dependency on the library target
+# :type SKIP_LIBRARY_DEPENDENCY: option
 #
 macro(rclcpp_components_register_node target)
-  cmake_parse_arguments(ARGS "NO_UNDEFINED_SYMBOLS" "PLUGIN;EXECUTABLE;EXECUTOR;RESOURCE_INDEX" "" ${ARGN})
+  cmake_parse_arguments(ARGS "NO_UNDEFINED_SYMBOLS;SKIP_LIBRARY_DEPENDENCY" "PLUGIN;EXECUTABLE;EXECUTOR;RESOURCE_INDEX" "" ${ARGN})
   if(ARGS_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "rclcpp_components_register_node() called with unused "
       "arguments: ${ARGS_UNPARSED_ARGUMENTS}")
@@ -97,6 +99,9 @@ macro(rclcpp_components_register_node target)
   file(GENERATE OUTPUT ${PROJECT_BINARY_DIR}/rclcpp_components/node_main_${node}.cpp
     INPUT ${PROJECT_BINARY_DIR}/rclcpp_components/node_main_configured_${node}.cpp.in)
   add_executable(${node} ${PROJECT_BINARY_DIR}/rclcpp_components/node_main_${node}.cpp)
+  if(NOT ARGS_SKIP_LIBRARY_DEPENDENCY)
+    add_dependencies(${node} ${target})
+  endif()
   target_link_libraries(${node}
     class_loader::class_loader
     rclcpp::rclcpp


### PR DESCRIPTION
Fixes #2868

## Description

The executable created by `rclcpp_components_register_node` now depends on the library target, ensuring the library is rebuilt when the executable is rebuilt.

As suggested by @sloretz in #2868, added `SKIP_LIBRARY_DEPENDENCY` option for cases where the plugin is provided by a different package.

## Changes

- Added `add_dependencies(${node} ${target})` after `add_executable()`
- Added `SKIP_LIBRARY_DEPENDENCY` option to opt-out of this behavior

## Is this user-facing behavior change?

No

## Did you use Generative AI?

Yes, Claude was used to identify the fix location and generate the implementation.