### PR TITLE
feat(rclcpp): add enhanced error messages and exceptions

### DIFF
--- a/rclcpp/include/rclcpp/exceptions/enhanced_exceptions.hpp
+++ b/rclcpp/include/rclcpp/exceptions/enhanced_exceptions.hpp
@@ -1,0 +1,598 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__EXCEPTIONS__ENHANCED_EXCEPTIONS_HPP_
+#define RCLCPP__EXCEPTIONS__ENHANCED_EXCEPTIONS_HPP_
+
+#include <exception>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/exceptions/error_codes.hpp"
+#include "rclcpp/visibility_control.hpp"
+
+// Use source_location if available (C++20), otherwise provide fallback
+#if __cplusplus >= 202002L && __has_include(<source_location>)
+#include <source_location>
+#define RCLCPP_HAS_SOURCE_LOCATION 1
+#else
+#define RCLCPP_HAS_SOURCE_LOCATION 0
+#endif
+
+namespace rclcpp
+{
+namespace exceptions
+{
+
+#if !RCLCPP_HAS_SOURCE_LOCATION
+/// Fallback source location for pre-C++20 compilers
+struct SourceLocation
+{
+  const char * file_name_ = "";
+  const char * function_name_ = "";
+  uint32_t line_ = 0;
+  uint32_t column_ = 0;
+
+  constexpr const char * file_name() const noexcept {return file_name_;}
+  constexpr const char * function_name() const noexcept {return function_name_;}
+  constexpr uint32_t line() const noexcept {return line_;}
+  constexpr uint32_t column() const noexcept {return column_;}
+
+  static constexpr SourceLocation current(
+    const char * file = __builtin_FILE(),
+    const char * func = __builtin_FUNCTION(),
+    uint32_t line = __builtin_LINE()) noexcept
+  {
+    return SourceLocation{file, func, line, 0};
+  }
+};
+#else
+using SourceLocation = std::source_location;
+#endif
+
+/// Forward declaration for context builder
+class ErrorContext;
+
+/// Structure to hold recovery suggestions
+struct RCLCPP_PUBLIC ErrorSuggestion
+{
+  std::string primary;                      ///< Main suggestion for fixing the error
+  std::vector<std::string> alternatives;    ///< Alternative solutions
+  std::string documentation_url;            ///< Link to relevant documentation
+
+  /// Create an empty suggestion
+  ErrorSuggestion() = default;
+
+  /// Create a suggestion with just a primary message
+  explicit ErrorSuggestion(const std::string & primary_suggestion)
+  : primary(primary_suggestion) {}
+
+  /// Create a suggestion with primary and alternatives
+  ErrorSuggestion(
+    const std::string & primary_suggestion,
+    const std::vector<std::string> & alt_suggestions)
+  : primary(primary_suggestion), alternatives(alt_suggestions) {}
+
+  /// Create a full suggestion with documentation link
+  ErrorSuggestion(
+    const std::string & primary_suggestion,
+    const std::vector<std::string> & alt_suggestions,
+    const std::string & doc_url)
+  : primary(primary_suggestion), alternatives(alt_suggestions), documentation_url(doc_url) {}
+
+  /// Check if the suggestion is empty
+  [[nodiscard]] bool empty() const noexcept
+  {
+    return primary.empty() && alternatives.empty();
+  }
+
+  /// Format the suggestion as a string
+  [[nodiscard]] std::string format() const;
+};
+
+/// Base exception class for all rclcpp exceptions with enhanced information
+/**
+ * This exception class provides:
+ * - Error codes for programmatic handling
+ * - Contextual information about the error
+ * - Recovery suggestions
+ * - Source location information
+ * - Optional stack trace support
+ *
+ * It maintains backward compatibility with std::exception by providing
+ * a meaningful what() message.
+ */
+class RCLCPP_PUBLIC RclcppException : public std::exception
+{
+public:
+  /// Construct an exception with an error code and message
+  /**
+   * \param[in] code The error code identifying the type of error
+   * \param[in] message A human-readable description of the error
+   * \param[in] location Source location where the exception was thrown
+   */
+  explicit RclcppException(
+    ErrorCode code,
+    const std::string & message,
+#if RCLCPP_HAS_SOURCE_LOCATION
+    const std::source_location & location = std::source_location::current()
+#else
+    const SourceLocation & location = SourceLocation::current()
+#endif
+  );
+
+  /// Construct an exception with error code, message, and suggestion
+  /**
+   * \param[in] code The error code identifying the type of error
+   * \param[in] message A human-readable description of the error
+   * \param[in] suggestion A suggestion for how to fix the error
+   * \param[in] location Source location where the exception was thrown
+   */
+  RclcppException(
+    ErrorCode code,
+    const std::string & message,
+    const std::string & suggestion,
+#if RCLCPP_HAS_SOURCE_LOCATION
+    const std::source_location & location = std::source_location::current()
+#else
+    const SourceLocation & location = SourceLocation::current()
+#endif
+  );
+
+  /// Construct an exception with full error suggestion
+  /**
+   * \param[in] code The error code identifying the type of error
+   * \param[in] message A human-readable description of the error
+   * \param[in] suggestion Full suggestion structure with alternatives
+   * \param[in] location Source location where the exception was thrown
+   */
+  RclcppException(
+    ErrorCode code,
+    const std::string & message,
+    const ErrorSuggestion & suggestion,
+#if RCLCPP_HAS_SOURCE_LOCATION
+    const std::source_location & location = std::source_location::current()
+#else
+    const SourceLocation & location = SourceLocation::current()
+#endif
+  );
+
+  /// Construct an exception with context
+  /**
+   * \param[in] code The error code identifying the type of error
+   * \param[in] message A human-readable description of the error
+   * \param[in] suggestion A suggestion for how to fix the error
+   * \param[in] context Additional contextual information
+   * \param[in] location Source location where the exception was thrown
+   */
+  RclcppException(
+    ErrorCode code,
+    const std::string & message,
+    const ErrorSuggestion & suggestion,
+    const ErrorContext & context,
+#if RCLCPP_HAS_SOURCE_LOCATION
+    const std::source_location & location = std::source_location::current()
+#else
+    const SourceLocation & location = SourceLocation::current()
+#endif
+  );
+
+  /// Copy constructor
+  RclcppException(const RclcppException & other);
+
+  /// Move constructor
+  RclcppException(RclcppException && other) noexcept;
+
+  /// Copy assignment operator
+  RclcppException & operator=(const RclcppException & other);
+
+  /// Move assignment operator
+  RclcppException & operator=(RclcppException && other) noexcept;
+
+  /// Destructor
+  ~RclcppException() override;
+
+  /// Get the error code
+  /**
+   * \return The error code associated with this exception
+   */
+  [[nodiscard]] ErrorCode error_code() const noexcept;
+
+  /// Get the error category
+  /**
+   * \return The category of this error
+   */
+  [[nodiscard]] ErrorCategory error_category() const noexcept;
+
+  /// Get the error severity
+  /**
+   * \return The severity level of this error
+   */
+  [[nodiscard]] ErrorSeverity error_severity() const noexcept;
+
+  /// Get the error message (without formatting)
+  /**
+   * \return The raw error message
+   */
+  [[nodiscard]] const std::string & message() const noexcept;
+
+  /// Get the primary suggestion for fixing the error
+  /**
+   * \return The suggestion string, or empty if none provided
+   */
+  [[nodiscard]] const std::string & suggestion() const noexcept;
+
+  /// Get the full suggestion structure
+  /**
+   * \return The complete suggestion with alternatives
+   */
+  [[nodiscard]] const ErrorSuggestion & full_suggestion() const noexcept;
+
+  /// Get the formatted context information
+  /**
+   * \return Context as a formatted string
+   */
+  [[nodiscard]] std::string context() const;
+
+  /// Get the context as a key-value map
+  /**
+   * \return Map of context key-value pairs
+   */
+  [[nodiscard]] const std::map<std::string, std::string> & context_map() const noexcept;
+
+  /// Get the source file name where the exception was thrown
+  /**
+   * \return File name or empty string if not available
+   */
+  [[nodiscard]] const char * file_name() const noexcept;
+
+  /// Get the function name where the exception was thrown
+  /**
+   * \return Function name or empty string if not available
+   */
+  [[nodiscard]] const char * function_name() const noexcept;
+
+  /// Get the line number where the exception was thrown
+  /**
+   * \return Line number or 0 if not available
+   */
+  [[nodiscard]] uint32_t line() const noexcept;
+
+  /// Get the formatted location string
+  /**
+   * \return Location as "file:line in function()"
+   */
+  [[nodiscard]] std::string location_string() const;
+
+  /// Get the full error message with all available information
+  /**
+   * This is the standard exception interface. Returns a formatted
+   * message including error code, message, context, and suggestion.
+   *
+   * \return Formatted error message
+   */
+  [[nodiscard]] const char * what() const noexcept override;
+
+  /// Get a detailed multi-line error report
+  /**
+   * \return Detailed error information formatted for logging
+   */
+  [[nodiscard]] std::string detailed_report() const;
+
+  /// Add context information to the exception
+  /**
+   * \param[in] key Context key
+   * \param[in] value Context value
+   * \return Reference to this exception for chaining
+   */
+  RclcppException & with_context(const std::string & key, const std::string & value);
+
+protected:
+  /// Format the what() message - called lazily
+  void format_what_message() const;
+
+private:
+  /// Private implementation to allow future changes without ABI breaks
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+/// Builder class for constructing error context
+/**
+ * Provides a fluent interface for building up error context information
+ * that can be attached to exceptions.
+ */
+class RCLCPP_PUBLIC ErrorContext
+{
+public:
+  /// Default constructor
+  ErrorContext() = default;
+
+  /// Copy constructor
+  ErrorContext(const ErrorContext & other);
+
+  /// Move constructor
+  ErrorContext(ErrorContext && other) noexcept;
+
+  /// Copy assignment
+  ErrorContext & operator=(const ErrorContext & other);
+
+  /// Move assignment
+  ErrorContext & operator=(ErrorContext && other) noexcept;
+
+  /// Destructor
+  ~ErrorContext();
+
+  /// Add node name to context
+  ErrorContext & with_node_name(const std::string & name);
+
+  /// Add topic name to context
+  ErrorContext & with_topic_name(const std::string & name);
+
+  /// Add service name to context
+  ErrorContext & with_service_name(const std::string & name);
+
+  /// Add parameter name to context
+  ErrorContext & with_parameter_name(const std::string & name);
+
+  /// Add expected type information
+  ErrorContext & with_expected_type(const std::string & type);
+
+  /// Add actual type information
+  ErrorContext & with_actual_type(const std::string & type);
+
+  /// Add expected value information
+  ErrorContext & with_expected_value(const std::string & value);
+
+  /// Add actual value information
+  ErrorContext & with_actual_value(const std::string & value);
+
+  /// Add QoS profile information
+  ErrorContext & with_qos_profile(const std::string & profile);
+
+  /// Add namespace information
+  ErrorContext & with_namespace(const std::string & ns);
+
+  /// Add custom key-value pair
+  ErrorContext & with(const std::string & key, const std::string & value);
+
+  /// Format the context as a string
+  [[nodiscard]] std::string format() const;
+
+  /// Get the context as a map
+  [[nodiscard]] const std::map<std::string, std::string> & as_map() const noexcept;
+
+  /// Check if context is empty
+  [[nodiscard]] bool empty() const noexcept;
+
+private:
+  std::map<std::string, std::string> context_;
+};
+
+// ============================================================================
+// Specialized Exception Classes
+// ============================================================================
+
+/// Base class for node-related exceptions
+class RCLCPP_PUBLIC NodeException : public RclcppException
+{
+public:
+  using RclcppException::RclcppException;
+};
+
+/// Exception thrown when a node name is invalid
+class RCLCPP_PUBLIC InvalidNodeNameError : public NodeException
+{
+public:
+  explicit InvalidNodeNameError(
+    const std::string & node_name,
+    const std::string & reason = "",
+#if RCLCPP_HAS_SOURCE_LOCATION
+    const std::source_location & location = std::source_location::current()
+#else
+    const SourceLocation & location = SourceLocation::current()
+#endif
+  );
+};
+
+/// Exception thrown when a namespace is invalid
+class RCLCPP_PUBLIC InvalidNamespaceError : public NodeException
+{
+public:
+  explicit InvalidNamespaceError(
+    const std::string & namespace_name,
+    const std::string & reason = "",
+#if RCLCPP_HAS_SOURCE_LOCATION
+    const std::source_location & location = std::source_location::current()
+#else
+    const SourceLocation & location = SourceLocation::current()
+#endif
+  );
+};
+
+/// Exception thrown when node initialization fails
+class RCLCPP_PUBLIC NodeInitializationError : public NodeException
+{
+public:
+  explicit NodeInitializationError(
+    const std::string & node_name,
+    const std::string & reason,
+#if RCLCPP_HAS_SOURCE_LOCATION
+    const std::source_location & location = std::source_location::current()
+#else
+    const SourceLocation & location = SourceLocation::current()
+#endif
+  );
+};
+
+/// Base class for topic-related exceptions
+class RCLCPP_PUBLIC TopicException : public RclcppException
+{
+public:
+  using RclcppException::RclcppException;
+};
+
+/// Exception thrown when a topic name is invalid
+class RCLCPP_PUBLIC InvalidTopicNameError : public TopicException
+{
+public:
+  explicit InvalidTopicNameError(
+    const std::string & topic_name,
+    const std::string & reason = "",
+#if RCLCPP_HAS_SOURCE_LOCATION
+    const std::source_location & location = std::source_location::current()
+#else
+    const SourceLocation & location = SourceLocation::current()
+#endif
+  );
+};
+
+/// Base class for service-related exceptions
+class RCLCPP_PUBLIC ServiceException : public RclcppException
+{
+public:
+  using RclcppException::RclcppException;
+};
+
+/// Exception thrown when a service name is invalid
+class RCLCPP_PUBLIC InvalidServiceNameError : public ServiceException
+{
+public:
+  explicit InvalidServiceNameError(
+    const std::string & service_name,
+    const std::string & reason = "",
+#if RCLCPP_HAS_SOURCE_LOCATION
+    const std::source_location & location = std::source_location::current()
+#else
+    const SourceLocation & location = SourceLocation::current()
+#endif
+  );
+};
+
+/// Exception thrown when a service is not available
+class RCLCPP_PUBLIC ServiceNotAvailableError : public ServiceException
+{
+public:
+  explicit ServiceNotAvailableError(
+    const std::string & service_name,
+#if RCLCPP_HAS_SOURCE_LOCATION
+    const std::source_location & location = std::source_location::current()
+#else
+    const SourceLocation & location = SourceLocation::current()
+#endif
+  );
+};
+
+/// Base class for parameter-related exceptions
+class RCLCPP_PUBLIC ParameterException : public RclcppException
+{
+public:
+  using RclcppException::RclcppException;
+};
+
+/// Exception thrown when accessing an undeclared parameter
+class RCLCPP_PUBLIC ParameterNotDeclaredException : public ParameterException
+{
+public:
+  explicit ParameterNotDeclaredException(
+    const std::string & parameter_name,
+#if RCLCPP_HAS_SOURCE_LOCATION
+    const std::source_location & location = std::source_location::current()
+#else
+    const SourceLocation & location = SourceLocation::current()
+#endif
+  );
+};
+
+/// Exception thrown when parameter type doesn't match
+class RCLCPP_PUBLIC ParameterTypeMismatchException : public ParameterException
+{
+public:
+  ParameterTypeMismatchException(
+    const std::string & parameter_name,
+    const std::string & expected_type,
+    const std::string & actual_type,
+#if RCLCPP_HAS_SOURCE_LOCATION
+    const std::source_location & location = std::source_location::current()
+#else
+    const SourceLocation & location = SourceLocation::current()
+#endif
+  );
+};
+
+/// Exception thrown when parameter value is invalid
+class RCLCPP_PUBLIC InvalidParameterValueException : public ParameterException
+{
+public:
+  InvalidParameterValueException(
+    const std::string & parameter_name,
+    const std::string & reason,
+#if RCLCPP_HAS_SOURCE_LOCATION
+    const std::source_location & location = std::source_location::current()
+#else
+    const SourceLocation & location = SourceLocation::current()
+#endif
+  );
+};
+
+/// Base class for QoS-related exceptions
+class RCLCPP_PUBLIC QoSException : public RclcppException
+{
+public:
+  using RclcppException::RclcppException;
+};
+
+/// Exception thrown when QoS settings are incompatible
+class RCLCPP_PUBLIC QoSIncompatibleError : public QoSException
+{
+public:
+  QoSIncompatibleError(
+    const std::string & topic_name,
+    const std::string & publisher_qos,
+    const std::string & subscriber_qos,
+#if RCLCPP_HAS_SOURCE_LOCATION
+    const std::source_location & location = std::source_location::current()
+#else
+    const SourceLocation & location = SourceLocation::current()
+#endif
+  );
+};
+
+/// Base class for executor-related exceptions
+class RCLCPP_PUBLIC ExecutorException : public RclcppException
+{
+public:
+  using RclcppException::RclcppException;
+};
+
+/// Exception thrown for callback group configuration errors
+class RCLCPP_PUBLIC CallbackGroupError : public ExecutorException
+{
+public:
+  explicit CallbackGroupError(
+    const std::string & reason,
+#if RCLCPP_HAS_SOURCE_LOCATION
+    const std::source_location & location = std::source_location::current()
+#else
+    const SourceLocation & location = SourceLocation::current()
+#endif
+  );
+};
+
+}  // namespace exceptions
+}  // namespace rclcpp
+
+#endif  // RCLCPP__EXCEPTIONS__ENHANCED_EXCEPTIONS_HPP_

--- a/rclcpp/include/rclcpp/exceptions/error_codes.hpp
+++ b/rclcpp/include/rclcpp/exceptions/error_codes.hpp
@@ -1,0 +1,222 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__EXCEPTIONS__ERROR_CODES_HPP_
+#define RCLCPP__EXCEPTIONS__ERROR_CODES_HPP_
+
+#include <cstdint>
+#include <string>
+
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+namespace exceptions
+{
+
+/// Error severity levels
+enum class ErrorSeverity : uint8_t
+{
+  UNKNOWN = 0,   ///< Unknown or unclassified error
+  INFO = 1,      ///< Informational, may not require action
+  WARNING = 2,   ///< Potential issue, operation may succeed
+  ERROR = 3,     ///< Operation failed, recoverable
+  FATAL = 4      ///< Operation failed, unrecoverable
+};
+
+/// Error category for grouping related errors
+enum class ErrorCategory : uint16_t
+{
+  UNKNOWN = 0,     ///< Unknown category
+  NODE = 1,        ///< Node-related errors (1000-1999)
+  TOPIC = 2,       ///< Topic and pub/sub errors (2000-2999)
+  SERVICE = 3,     ///< Service-related errors (3000-3999)
+  PARAMETER = 4,   ///< Parameter handling errors (4000-4999)
+  QOS = 5,         ///< Quality of Service errors (5000-5999)
+  EXECUTOR = 6,    ///< Executor and callback errors (6000-6999)
+  TIMER = 7,       ///< Timer-related errors (7000-7999)
+  ACTION = 8,      ///< Action-related errors (8000-8999)
+  INTERNAL = 9     ///< Internal/system errors (9000-9999)
+};
+
+/// Specific error codes for rclcpp exceptions
+enum class ErrorCode : uint32_t
+{
+  // Unknown/Generic (0)
+  UNKNOWN = 0,
+
+  // Node Errors (1000-1999)
+  NODE_NAME_INVALID = 1001,
+  NODE_NAMESPACE_INVALID = 1002,
+  NODE_INIT_FAILED = 1003,
+  NODE_ALREADY_EXISTS = 1004,
+  NODE_NOT_FOUND = 1005,
+  NODE_NAME_EMPTY = 1006,
+  NODE_NAME_RESERVED = 1007,
+
+  // Topic Errors (2000-2999)
+  TOPIC_NAME_INVALID = 2001,
+  TOPIC_NOT_AVAILABLE = 2002,
+  PUBLISHER_CREATION_FAILED = 2003,
+  SUBSCRIBER_CREATION_FAILED = 2004,
+  TOPIC_ALREADY_EXISTS = 2005,
+  TOPIC_TYPE_MISMATCH = 2006,
+  TOPIC_NAME_EMPTY = 2007,
+
+  // Service Errors (3000-3999)
+  SERVICE_NAME_INVALID = 3001,
+  SERVICE_NOT_AVAILABLE = 3002,
+  SERVICE_CREATION_FAILED = 3003,
+  CLIENT_CREATION_FAILED = 3004,
+  SERVICE_CALL_FAILED = 3005,
+  SERVICE_TIMEOUT = 3006,
+  SERVICE_TYPE_MISMATCH = 3007,
+
+  // Parameter Errors (4000-4999)
+  PARAMETER_NOT_DECLARED = 4001,
+  PARAMETER_TYPE_MISMATCH = 4002,
+  PARAMETER_READ_ONLY = 4003,
+  PARAMETER_INVALID_VALUE = 4004,
+  PARAMETER_ALREADY_DECLARED = 4005,
+  PARAMETER_NAME_INVALID = 4006,
+  PARAMETER_RANGE_VIOLATION = 4007,
+
+  // QoS Errors (5000-5999)
+  QOS_INCOMPATIBLE = 5001,
+  QOS_RELIABILITY_MISMATCH = 5002,
+  QOS_DURABILITY_MISMATCH = 5003,
+  QOS_DEADLINE_MISSED = 5004,
+  QOS_LIVELINESS_LOST = 5005,
+  QOS_INVALID_PROFILE = 5006,
+
+  // Executor Errors (6000-6999)
+  EXECUTOR_NODE_ALREADY_ADDED = 6001,
+  EXECUTOR_CALLBACK_ERROR = 6002,
+  EXECUTOR_SPIN_ERROR = 6003,
+  EXECUTOR_INVALID_STATE = 6004,
+  CALLBACK_GROUP_ERROR = 6005,
+
+  // Timer Errors (7000-7999)
+  TIMER_CREATION_FAILED = 7001,
+  TIMER_CANCELLED = 7002,
+  TIMER_INVALID_PERIOD = 7003,
+
+  // Action Errors (8000-8999)
+  ACTION_SERVER_ERROR = 8001,
+  ACTION_CLIENT_ERROR = 8002,
+  ACTION_GOAL_REJECTED = 8003,
+  ACTION_CANCELLED = 8004,
+
+  // Internal Errors (9000-9999)
+  RCL_ERROR = 9001,
+  RMW_ERROR = 9002,
+  ALLOCATION_FAILED = 9003,
+  INTERNAL_ERROR = 9004
+};
+
+/// Get the error category from an error code
+/**
+ * \param[in] code The error code to categorize
+ * \return The category of the error
+ */
+RCLCPP_PUBLIC
+constexpr ErrorCategory
+get_error_category(ErrorCode code) noexcept
+{
+  uint32_t code_value = static_cast<uint32_t>(code);
+  if (code_value == 0) {
+    return ErrorCategory::UNKNOWN;
+  }
+  uint32_t category_value = code_value / 1000;
+  if (category_value > 9) {
+    return ErrorCategory::UNKNOWN;
+  }
+  return static_cast<ErrorCategory>(category_value);
+}
+
+/// Get the severity level for an error code
+/**
+ * \param[in] code The error code
+ * \return The severity level (defaults to ERROR for most codes)
+ */
+RCLCPP_PUBLIC
+constexpr ErrorSeverity
+get_error_severity(ErrorCode code) noexcept
+{
+  // Most errors are recoverable ERROR level
+  // Fatal errors are explicitly marked
+  switch (code) {
+    case ErrorCode::ALLOCATION_FAILED:
+    case ErrorCode::INTERNAL_ERROR:
+      return ErrorSeverity::FATAL;
+    case ErrorCode::UNKNOWN:
+      return ErrorSeverity::UNKNOWN;
+    default:
+      return ErrorSeverity::ERROR;
+  }
+}
+
+/// Get a human-readable name for an error code
+/**
+ * \param[in] code The error code
+ * \return String name of the error code
+ */
+RCLCPP_PUBLIC
+std::string
+get_error_code_name(ErrorCode code);
+
+/// Get a human-readable description for an error code
+/**
+ * \param[in] code The error code
+ * \return Description of what the error means
+ */
+RCLCPP_PUBLIC
+std::string
+get_error_code_description(ErrorCode code);
+
+/// Get the category name as a string
+/**
+ * \param[in] category The error category
+ * \return String name of the category
+ */
+RCLCPP_PUBLIC
+std::string
+get_category_name(ErrorCategory category);
+
+/// Get the severity name as a string
+/**
+ * \param[in] severity The error severity
+ * \return String name of the severity level
+ */
+RCLCPP_PUBLIC
+std::string
+get_severity_name(ErrorSeverity severity);
+
+/// Check if an error code is in a specific category
+/**
+ * \param[in] code The error code to check
+ * \param[in] category The category to check against
+ * \return true if the code belongs to the category
+ */
+RCLCPP_PUBLIC
+constexpr bool
+is_error_in_category(ErrorCode code, ErrorCategory category) noexcept
+{
+  return get_error_category(code) == category;
+}
+
+}  // namespace exceptions
+}  // namespace rclcpp
+
+#endif  // RCLCPP__EXCEPTIONS__ERROR_CODES_HPP_

--- a/rclcpp/include/rclcpp/exceptions/error_macros.hpp
+++ b/rclcpp/include/rclcpp/exceptions/error_macros.hpp
@@ -1,0 +1,572 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__EXCEPTIONS__ERROR_MACROS_HPP_
+#define RCLCPP__EXCEPTIONS__ERROR_MACROS_HPP_
+
+#include <sstream>
+#include <string>
+#include <utility>
+
+#include "rclcpp/exceptions/enhanced_exceptions.hpp"
+#include "rclcpp/exceptions/error_codes.hpp"
+
+/**
+ * @file error_macros.hpp
+ * @brief Convenience macros for throwing enhanced rclcpp exceptions
+ *
+ * This file provides macros that simplify throwing exceptions with
+ * proper source location information. Using these macros ensures
+ * consistent error handling throughout the codebase.
+ */
+
+// ============================================================================
+// Basic Exception Throwing Macros
+// ============================================================================
+
+/**
+ * @brief Throw an RclcppException with an error code and message
+ *
+ * @param code The rclcpp::exceptions::ErrorCode
+ * @param msg The error message (can be a string literal or expression)
+ *
+ * Example:
+ * @code
+ * RCLCPP_THROW(ErrorCode::NODE_NAME_INVALID, "Node name cannot be empty");
+ * @endcode
+ */
+#define RCLCPP_THROW(code, msg) \
+  throw rclcpp::exceptions::RclcppException( \
+    code, \
+    msg)
+
+/**
+ * @brief Throw an RclcppException with error code, message, and suggestion
+ *
+ * @param code The rclcpp::exceptions::ErrorCode
+ * @param msg The error message
+ * @param suggestion A suggestion for how to fix the error
+ *
+ * Example:
+ * @code
+ * RCLCPP_THROW_WITH_SUGGESTION(
+ *   ErrorCode::PARAMETER_NOT_DECLARED,
+ *   "Parameter 'max_speed' not found",
+ *   "Declare the parameter first with declare_parameter()");
+ * @endcode
+ */
+#define RCLCPP_THROW_WITH_SUGGESTION(code, msg, suggestion) \
+  throw rclcpp::exceptions::RclcppException( \
+    code, \
+    msg, \
+    suggestion)
+
+/**
+ * @brief Throw an RclcppException with full error suggestion structure
+ *
+ * @param code The rclcpp::exceptions::ErrorCode
+ * @param msg The error message
+ * @param suggestion An ErrorSuggestion object with alternatives
+ *
+ * Example:
+ * @code
+ * RCLCPP_THROW_WITH_FULL_SUGGESTION(
+ *   ErrorCode::QOS_INCOMPATIBLE,
+ *   "QoS mismatch detected",
+ *   ErrorSuggestion("Check QoS profiles", {"Use RELIABLE", "Use BEST_EFFORT"}));
+ * @endcode
+ */
+#define RCLCPP_THROW_WITH_FULL_SUGGESTION(code, msg, suggestion) \
+  throw rclcpp::exceptions::RclcppException( \
+    code, \
+    msg, \
+    rclcpp::exceptions::ErrorSuggestion(suggestion))
+
+/**
+ * @brief Throw an RclcppException with context information
+ *
+ * @param code The rclcpp::exceptions::ErrorCode
+ * @param msg The error message
+ * @param suggestion A suggestion string
+ * @param context An ErrorContext object
+ *
+ * Example:
+ * @code
+ * auto ctx = ErrorContext().with_node_name("my_node").with_topic_name("/chatter");
+ * RCLCPP_THROW_WITH_CONTEXT(
+ *   ErrorCode::TOPIC_NAME_INVALID,
+ *   "Invalid topic name",
+ *   "Topic names must start with a letter",
+ *   ctx);
+ * @endcode
+ */
+#define RCLCPP_THROW_WITH_CONTEXT(code, msg, suggestion, context) \
+  throw rclcpp::exceptions::RclcppException( \
+    code, \
+    msg, \
+    rclcpp::exceptions::ErrorSuggestion(suggestion), \
+    context)
+
+// ============================================================================
+// Conditional Throwing Macros
+// ============================================================================
+
+/**
+ * @brief Throw if condition is true
+ *
+ * @param condition Boolean expression to evaluate
+ * @param code Error code to use if throwing
+ * @param msg Error message
+ *
+ * Example:
+ * @code
+ * RCLCPP_THROW_IF(node_name.empty(), ErrorCode::NODE_NAME_EMPTY, "Node name is empty");
+ * @endcode
+ */
+#define RCLCPP_THROW_IF(condition, code, msg) \
+  do { \
+    if (condition) { \
+      RCLCPP_THROW(code, msg); \
+    } \
+  } while (0)
+
+/**
+ * @brief Throw if condition is false
+ *
+ * @param condition Boolean expression to evaluate
+ * @param code Error code to use if throwing
+ * @param msg Error message
+ *
+ * Example:
+ * @code
+ * RCLCPP_THROW_UNLESS(is_valid_name(name), ErrorCode::NODE_NAME_INVALID, "Invalid name");
+ * @endcode
+ */
+#define RCLCPP_THROW_UNLESS(condition, code, msg) \
+  RCLCPP_THROW_IF(!(condition), code, msg)
+
+/**
+ * @brief Throw if pointer is null
+ *
+ * @param ptr Pointer to check
+ * @param code Error code to use if null
+ * @param msg Error message
+ *
+ * Example:
+ * @code
+ * RCLCPP_THROW_IF_NULL(node_ptr, ErrorCode::INTERNAL_ERROR, "Node pointer is null");
+ * @endcode
+ */
+#define RCLCPP_THROW_IF_NULL(ptr, code, msg) \
+  RCLCPP_THROW_IF((ptr) == nullptr, code, msg)
+
+// ============================================================================
+// Category-Specific Throwing Macros
+// ============================================================================
+
+/**
+ * @brief Throw a node-related exception
+ */
+#define RCLCPP_THROW_NODE_ERROR(code, msg, suggestion) \
+  static_assert( \
+    static_cast<uint32_t>(code) >= 1000 && static_cast<uint32_t>(code) < 2000, \
+    "Error code must be in NODE category (1000-1999)"); \
+  RCLCPP_THROW_WITH_SUGGESTION(code, msg, suggestion)
+
+/**
+ * @brief Throw a topic-related exception
+ */
+#define RCLCPP_THROW_TOPIC_ERROR(code, msg, suggestion) \
+  static_assert( \
+    static_cast<uint32_t>(code) >= 2000 && static_cast<uint32_t>(code) < 3000, \
+    "Error code must be in TOPIC category (2000-2999)"); \
+  RCLCPP_THROW_WITH_SUGGESTION(code, msg, suggestion)
+
+/**
+ * @brief Throw a service-related exception
+ */
+#define RCLCPP_THROW_SERVICE_ERROR(code, msg, suggestion) \
+  static_assert( \
+    static_cast<uint32_t>(code) >= 3000 && static_cast<uint32_t>(code) < 4000, \
+    "Error code must be in SERVICE category (3000-3999)"); \
+  RCLCPP_THROW_WITH_SUGGESTION(code, msg, suggestion)
+
+/**
+ * @brief Throw a parameter-related exception
+ */
+#define RCLCPP_THROW_PARAMETER_ERROR(code, msg, suggestion) \
+  static_assert( \
+    static_cast<uint32_t>(code) >= 4000 && static_cast<uint32_t>(code) < 5000, \
+    "Error code must be in PARAMETER category (4000-4999)"); \
+  RCLCPP_THROW_WITH_SUGGESTION(code, msg, suggestion)
+
+/**
+ * @brief Throw a QoS-related exception
+ */
+#define RCLCPP_THROW_QOS_ERROR(code, msg, suggestion) \
+  static_assert( \
+    static_cast<uint32_t>(code) >= 5000 && static_cast<uint32_t>(code) < 6000, \
+    "Error code must be in QOS category (5000-5999)"); \
+  RCLCPP_THROW_WITH_SUGGESTION(code, msg, suggestion)
+
+// ============================================================================
+// Specialized Exception Throwing Macros
+// ============================================================================
+
+/**
+ * @brief Throw InvalidNodeNameError
+ *
+ * @param name The invalid node name
+ * @param reason Optional reason string
+ */
+#define RCLCPP_THROW_INVALID_NODE_NAME(name, ...) \
+  throw rclcpp::exceptions::InvalidNodeNameError(name, ##__VA_ARGS__)
+
+/**
+ * @brief Throw InvalidNamespaceError
+ *
+ * @param ns The invalid namespace
+ * @param reason Optional reason string
+ */
+#define RCLCPP_THROW_INVALID_NAMESPACE(ns, ...) \
+  throw rclcpp::exceptions::InvalidNamespaceError(ns, ##__VA_ARGS__)
+
+/**
+ * @brief Throw InvalidTopicNameError
+ *
+ * @param name The invalid topic name
+ * @param reason Optional reason string
+ */
+#define RCLCPP_THROW_INVALID_TOPIC_NAME(name, ...) \
+  throw rclcpp::exceptions::InvalidTopicNameError(name, ##__VA_ARGS__)
+
+/**
+ * @brief Throw InvalidServiceNameError
+ *
+ * @param name The invalid service name
+ * @param reason Optional reason string
+ */
+#define RCLCPP_THROW_INVALID_SERVICE_NAME(name, ...) \
+  throw rclcpp::exceptions::InvalidServiceNameError(name, ##__VA_ARGS__)
+
+/**
+ * @brief Throw ServiceNotAvailableError
+ *
+ * @param name The service name that is not available
+ */
+#define RCLCPP_THROW_SERVICE_NOT_AVAILABLE(name) \
+  throw rclcpp::exceptions::ServiceNotAvailableError(name)
+
+/**
+ * @brief Throw ParameterNotDeclaredException
+ *
+ * @param name The parameter name that was not declared
+ */
+#define RCLCPP_THROW_PARAMETER_NOT_DECLARED(name) \
+  throw rclcpp::exceptions::ParameterNotDeclaredException(name)
+
+/**
+ * @brief Throw ParameterTypeMismatchException
+ *
+ * @param name The parameter name
+ * @param expected The expected type name
+ * @param actual The actual type name
+ */
+#define RCLCPP_THROW_PARAMETER_TYPE_MISMATCH(name, expected, actual) \
+  throw rclcpp::exceptions::ParameterTypeMismatchException(name, expected, actual)
+
+/**
+ * @brief Throw InvalidParameterValueException
+ *
+ * @param name The parameter name
+ * @param reason The reason the value is invalid
+ */
+#define RCLCPP_THROW_INVALID_PARAMETER_VALUE(name, reason) \
+  throw rclcpp::exceptions::InvalidParameterValueException(name, reason)
+
+/**
+ * @brief Throw QoSIncompatibleError
+ *
+ * @param topic The topic name
+ * @param pub_qos Publisher QoS description
+ * @param sub_qos Subscriber QoS description
+ */
+#define RCLCPP_THROW_QOS_INCOMPATIBLE(topic, pub_qos, sub_qos) \
+  throw rclcpp::exceptions::QoSIncompatibleError(topic, pub_qos, sub_qos)
+
+// ============================================================================
+// Message Formatting Helpers
+// ============================================================================
+
+/**
+ * @brief Helper macro for building formatted error messages
+ *
+ * @param ... Stream operations to build the message
+ *
+ * Example:
+ * @code
+ * std::string msg = RCLCPP_ERROR_MSG("Invalid value " << value << " for parameter " << name);
+ * @endcode
+ */
+#define RCLCPP_ERROR_MSG(...) \
+  (static_cast<std::ostringstream &&>(std::ostringstream() << __VA_ARGS__).str())
+
+/**
+ * @brief Throw with a formatted message
+ *
+ * @param code The error code
+ * @param ... Stream operations to build the message
+ *
+ * Example:
+ * @code
+ * RCLCPP_THROW_FMT(ErrorCode::NODE_NAME_INVALID, "Node '" << name << "' has invalid character '" << ch << "'");
+ * @endcode
+ */
+#define RCLCPP_THROW_FMT(code, ...) \
+  RCLCPP_THROW(code, RCLCPP_ERROR_MSG(__VA_ARGS__))
+
+/**
+ * @brief Throw with formatted message and suggestion
+ *
+ * @param code The error code
+ * @param suggestion The suggestion string
+ * @param ... Stream operations to build the message
+ */
+#define RCLCPP_THROW_FMT_WITH_SUGGESTION(code, suggestion, ...) \
+  RCLCPP_THROW_WITH_SUGGESTION(code, RCLCPP_ERROR_MSG(__VA_ARGS__), suggestion)
+
+// ============================================================================
+// Context Builder Helpers
+// ============================================================================
+
+namespace rclcpp
+{
+namespace exceptions
+{
+
+/**
+ * @brief Create an ErrorContext with fluent interface
+ *
+ * @return A new ErrorContext instance for chaining
+ *
+ * Example:
+ * @code
+ * auto context = make_context()
+ *   .with_node_name("my_node")
+ *   .with_topic_name("/chatter");
+ * @endcode
+ */
+inline ErrorContext
+make_context()
+{
+  return ErrorContext();
+}
+
+/**
+ * @brief Create an ErrorContext starting with node name
+ *
+ * @param name The node name to include
+ * @return ErrorContext for chaining
+ */
+inline ErrorContext
+context_for_node(const std::string & name)
+{
+  return ErrorContext().with_node_name(name);
+}
+
+/**
+ * @brief Create an ErrorContext starting with topic name
+ *
+ * @param name The topic name to include
+ * @return ErrorContext for chaining
+ */
+inline ErrorContext
+context_for_topic(const std::string & name)
+{
+  return ErrorContext().with_topic_name(name);
+}
+
+/**
+ * @brief Create an ErrorContext starting with service name
+ *
+ * @param name The service name to include
+ * @return ErrorContext for chaining
+ */
+inline ErrorContext
+context_for_service(const std::string & name)
+{
+  return ErrorContext().with_service_name(name);
+}
+
+/**
+ * @brief Create an ErrorContext starting with parameter name
+ *
+ * @param name The parameter name to include
+ * @return ErrorContext for chaining
+ */
+inline ErrorContext
+context_for_parameter(const std::string & name)
+{
+  return ErrorContext().with_parameter_name(name);
+}
+
+/**
+ * @brief Create an ErrorSuggestion with primary message
+ *
+ * @param primary The primary suggestion message
+ * @return ErrorSuggestion for use in exceptions
+ */
+inline ErrorSuggestion
+make_suggestion(const std::string & primary)
+{
+  return ErrorSuggestion(primary);
+}
+
+/**
+ * @brief Create an ErrorSuggestion with alternatives
+ *
+ * @param primary The primary suggestion message
+ * @param alternatives Vector of alternative suggestions
+ * @return ErrorSuggestion for use in exceptions
+ */
+inline ErrorSuggestion
+make_suggestion(const std::string & primary, const std::vector<std::string> & alternatives)
+{
+  return ErrorSuggestion(primary, alternatives);
+}
+
+/**
+ * @brief Create an ErrorSuggestion with documentation link
+ *
+ * @param primary The primary suggestion message
+ * @param alternatives Vector of alternative suggestions
+ * @param doc_url URL to relevant documentation
+ * @return ErrorSuggestion for use in exceptions
+ */
+inline ErrorSuggestion
+make_suggestion(
+  const std::string & primary,
+  const std::vector<std::string> & alternatives,
+  const std::string & doc_url)
+{
+  return ErrorSuggestion(primary, alternatives, doc_url);
+}
+
+// ============================================================================
+// Error Handler Utilities
+// ============================================================================
+
+/**
+ * @brief RAII guard for collecting exception context
+ *
+ * Use this class to automatically add context to any exceptions
+ * thrown within a scope.
+ *
+ * Example:
+ * @code
+ * void process_node(const std::string& name) {
+ *   ExceptionContextGuard guard;
+ *   guard.add("node_name", name);
+ *   // Any exceptions thrown here will have the node_name context
+ * }
+ * @endcode
+ */
+class RCLCPP_PUBLIC ExceptionContextGuard
+{
+public:
+  ExceptionContextGuard() = default;
+  ~ExceptionContextGuard() = default;
+
+  ExceptionContextGuard(const ExceptionContextGuard &) = delete;
+  ExceptionContextGuard & operator=(const ExceptionContextGuard &) = delete;
+
+  /**
+   * @brief Add a context key-value pair
+   */
+  ExceptionContextGuard & add(const std::string & key, const std::string & value)
+  {
+    context_.with(key, value);
+    return *this;
+  }
+
+  /**
+   * @brief Get the accumulated context
+   */
+  const ErrorContext & context() const noexcept
+  {
+    return context_;
+  }
+
+private:
+  ErrorContext context_;
+};
+
+/**
+ * @brief Convert an error code to its string representation
+ *
+ * @param code The error code
+ * @return String in format "[CODE] NAME"
+ */
+inline std::string
+error_code_to_string(ErrorCode code)
+{
+  return "[" + std::to_string(static_cast<uint32_t>(code)) + "] " + get_error_code_name(code);
+}
+
+/**
+ * @brief Check if an exception is of a specific error category
+ *
+ * @param ex The exception to check
+ * @param category The category to match
+ * @return true if the exception belongs to the category
+ */
+inline bool
+is_exception_category(const RclcppException & ex, ErrorCategory category) noexcept
+{
+  return ex.error_category() == category;
+}
+
+/**
+ * @brief Check if an exception has a specific error code
+ *
+ * @param ex The exception to check
+ * @param code The code to match
+ * @return true if the exception has the specified code
+ */
+inline bool
+is_exception_code(const RclcppException & ex, ErrorCode code) noexcept
+{
+  return ex.error_code() == code;
+}
+
+}  // namespace exceptions
+}  // namespace rclcpp
+
+// ============================================================================
+// Legacy Compatibility Macros
+// ============================================================================
+
+// These macros provide backward compatibility with older error handling patterns
+
+/**
+ * @brief Throw a runtime error with rclcpp exception info
+ *
+ * This is provided for gradual migration from std::runtime_error
+ */
+#define RCLCPP_RUNTIME_ERROR(msg) \
+  throw rclcpp::exceptions::RclcppException( \
+    rclcpp::exceptions::ErrorCode::INTERNAL_ERROR, \
+    msg)
+
+#endif  // RCLCPP__EXCEPTIONS__ERROR_MACROS_HPP_

--- a/rclcpp/include/rclcpp/exceptions/error_macros.hpp
+++ b/rclcpp/include/rclcpp/exceptions/error_macros.hpp
@@ -15,9 +15,11 @@
 #ifndef RCLCPP__EXCEPTIONS__ERROR_MACROS_HPP_
 #define RCLCPP__EXCEPTIONS__ERROR_MACROS_HPP_
 
+#include <cstdint>
 #include <sstream>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "rclcpp/exceptions/enhanced_exceptions.hpp"
 #include "rclcpp/exceptions/error_codes.hpp"

--- a/rclcpp/src/exceptions/enhanced_exceptions.cpp
+++ b/rclcpp/src/exceptions/enhanced_exceptions.cpp
@@ -1,0 +1,1277 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/exceptions/enhanced_exceptions.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <mutex>
+#include <sstream>
+#include <utility>
+
+namespace rclcpp
+{
+namespace exceptions
+{
+
+// ============================================================================
+// Error Code Utility Functions Implementation
+// ============================================================================
+
+std::string
+get_error_code_name(ErrorCode code)
+{
+  switch (code) {
+    case ErrorCode::UNKNOWN:
+      return "UNKNOWN";
+    case ErrorCode::NODE_NAME_INVALID:
+      return "NODE_NAME_INVALID";
+    case ErrorCode::NODE_NAMESPACE_INVALID:
+      return "NODE_NAMESPACE_INVALID";
+    case ErrorCode::NODE_INIT_FAILED:
+      return "NODE_INIT_FAILED";
+    case ErrorCode::NODE_ALREADY_EXISTS:
+      return "NODE_ALREADY_EXISTS";
+    case ErrorCode::NODE_NOT_FOUND:
+      return "NODE_NOT_FOUND";
+    case ErrorCode::NODE_NAME_EMPTY:
+      return "NODE_NAME_EMPTY";
+    case ErrorCode::NODE_NAME_RESERVED:
+      return "NODE_NAME_RESERVED";
+    case ErrorCode::TOPIC_NAME_INVALID:
+      return "TOPIC_NAME_INVALID";
+    case ErrorCode::TOPIC_NOT_AVAILABLE:
+      return "TOPIC_NOT_AVAILABLE";
+    case ErrorCode::PUBLISHER_CREATION_FAILED:
+      return "PUBLISHER_CREATION_FAILED";
+    case ErrorCode::SUBSCRIBER_CREATION_FAILED:
+      return "SUBSCRIBER_CREATION_FAILED";
+    case ErrorCode::TOPIC_ALREADY_EXISTS:
+      return "TOPIC_ALREADY_EXISTS";
+    case ErrorCode::TOPIC_TYPE_MISMATCH:
+      return "TOPIC_TYPE_MISMATCH";
+    case ErrorCode::TOPIC_NAME_EMPTY:
+      return "TOPIC_NAME_EMPTY";
+    case ErrorCode::SERVICE_NAME_INVALID:
+      return "SERVICE_NAME_INVALID";
+    case ErrorCode::SERVICE_NOT_AVAILABLE:
+      return "SERVICE_NOT_AVAILABLE";
+    case ErrorCode::SERVICE_CREATION_FAILED:
+      return "SERVICE_CREATION_FAILED";
+    case ErrorCode::CLIENT_CREATION_FAILED:
+      return "CLIENT_CREATION_FAILED";
+    case ErrorCode::SERVICE_CALL_FAILED:
+      return "SERVICE_CALL_FAILED";
+    case ErrorCode::SERVICE_TIMEOUT:
+      return "SERVICE_TIMEOUT";
+    case ErrorCode::SERVICE_TYPE_MISMATCH:
+      return "SERVICE_TYPE_MISMATCH";
+    case ErrorCode::PARAMETER_NOT_DECLARED:
+      return "PARAMETER_NOT_DECLARED";
+    case ErrorCode::PARAMETER_TYPE_MISMATCH:
+      return "PARAMETER_TYPE_MISMATCH";
+    case ErrorCode::PARAMETER_READ_ONLY:
+      return "PARAMETER_READ_ONLY";
+    case ErrorCode::PARAMETER_INVALID_VALUE:
+      return "PARAMETER_INVALID_VALUE";
+    case ErrorCode::PARAMETER_ALREADY_DECLARED:
+      return "PARAMETER_ALREADY_DECLARED";
+    case ErrorCode::PARAMETER_NAME_INVALID:
+      return "PARAMETER_NAME_INVALID";
+    case ErrorCode::PARAMETER_RANGE_VIOLATION:
+      return "PARAMETER_RANGE_VIOLATION";
+    case ErrorCode::QOS_INCOMPATIBLE:
+      return "QOS_INCOMPATIBLE";
+    case ErrorCode::QOS_RELIABILITY_MISMATCH:
+      return "QOS_RELIABILITY_MISMATCH";
+    case ErrorCode::QOS_DURABILITY_MISMATCH:
+      return "QOS_DURABILITY_MISMATCH";
+    case ErrorCode::QOS_DEADLINE_MISSED:
+      return "QOS_DEADLINE_MISSED";
+    case ErrorCode::QOS_LIVELINESS_LOST:
+      return "QOS_LIVELINESS_LOST";
+    case ErrorCode::QOS_INVALID_PROFILE:
+      return "QOS_INVALID_PROFILE";
+    case ErrorCode::EXECUTOR_NODE_ALREADY_ADDED:
+      return "EXECUTOR_NODE_ALREADY_ADDED";
+    case ErrorCode::EXECUTOR_CALLBACK_ERROR:
+      return "EXECUTOR_CALLBACK_ERROR";
+    case ErrorCode::EXECUTOR_SPIN_ERROR:
+      return "EXECUTOR_SPIN_ERROR";
+    case ErrorCode::EXECUTOR_INVALID_STATE:
+      return "EXECUTOR_INVALID_STATE";
+    case ErrorCode::CALLBACK_GROUP_ERROR:
+      return "CALLBACK_GROUP_ERROR";
+    case ErrorCode::TIMER_CREATION_FAILED:
+      return "TIMER_CREATION_FAILED";
+    case ErrorCode::TIMER_CANCELLED:
+      return "TIMER_CANCELLED";
+    case ErrorCode::TIMER_INVALID_PERIOD:
+      return "TIMER_INVALID_PERIOD";
+    case ErrorCode::ACTION_SERVER_ERROR:
+      return "ACTION_SERVER_ERROR";
+    case ErrorCode::ACTION_CLIENT_ERROR:
+      return "ACTION_CLIENT_ERROR";
+    case ErrorCode::ACTION_GOAL_REJECTED:
+      return "ACTION_GOAL_REJECTED";
+    case ErrorCode::ACTION_CANCELLED:
+      return "ACTION_CANCELLED";
+    case ErrorCode::RCL_ERROR:
+      return "RCL_ERROR";
+    case ErrorCode::RMW_ERROR:
+      return "RMW_ERROR";
+    case ErrorCode::ALLOCATION_FAILED:
+      return "ALLOCATION_FAILED";
+    case ErrorCode::INTERNAL_ERROR:
+      return "INTERNAL_ERROR";
+    default:
+      return "UNKNOWN_ERROR_CODE";
+  }
+}
+
+std::string
+get_error_code_description(ErrorCode code)
+{
+  switch (code) {
+    case ErrorCode::UNKNOWN:
+      return "Unknown or unclassified error";
+    case ErrorCode::NODE_NAME_INVALID:
+      return "Node name does not meet ROS 2 naming requirements";
+    case ErrorCode::NODE_NAMESPACE_INVALID:
+      return "Namespace is invalid";
+    case ErrorCode::NODE_INIT_FAILED:
+      return "Node initialization failed";
+    case ErrorCode::NODE_ALREADY_EXISTS:
+      return "A node with this name already exists";
+    case ErrorCode::NODE_NOT_FOUND:
+      return "Specified node was not found";
+    case ErrorCode::NODE_NAME_EMPTY:
+      return "Node name cannot be empty";
+    case ErrorCode::NODE_NAME_RESERVED:
+      return "Node name uses a reserved prefix";
+    case ErrorCode::TOPIC_NAME_INVALID:
+      return "Topic name is invalid";
+    case ErrorCode::TOPIC_NOT_AVAILABLE:
+      return "Topic is not available";
+    case ErrorCode::PUBLISHER_CREATION_FAILED:
+      return "Failed to create publisher";
+    case ErrorCode::SUBSCRIBER_CREATION_FAILED:
+      return "Failed to create subscriber";
+    case ErrorCode::TOPIC_ALREADY_EXISTS:
+      return "Topic is already registered";
+    case ErrorCode::TOPIC_TYPE_MISMATCH:
+      return "Message type does not match the topic";
+    case ErrorCode::TOPIC_NAME_EMPTY:
+      return "Topic name cannot be empty";
+    case ErrorCode::SERVICE_NAME_INVALID:
+      return "Service name is invalid";
+    case ErrorCode::SERVICE_NOT_AVAILABLE:
+      return "Service is not available";
+    case ErrorCode::SERVICE_CREATION_FAILED:
+      return "Failed to create service";
+    case ErrorCode::CLIENT_CREATION_FAILED:
+      return "Failed to create service client";
+    case ErrorCode::SERVICE_CALL_FAILED:
+      return "Service call failed";
+    case ErrorCode::SERVICE_TIMEOUT:
+      return "Service call timed out";
+    case ErrorCode::SERVICE_TYPE_MISMATCH:
+      return "Service type does not match";
+    case ErrorCode::PARAMETER_NOT_DECLARED:
+      return "Parameter was not declared before use";
+    case ErrorCode::PARAMETER_TYPE_MISMATCH:
+      return "Parameter type does not match expected type";
+    case ErrorCode::PARAMETER_READ_ONLY:
+      return "Parameter is read-only and cannot be modified";
+    case ErrorCode::PARAMETER_INVALID_VALUE:
+      return "Parameter value is invalid";
+    case ErrorCode::PARAMETER_ALREADY_DECLARED:
+      return "Parameter has already been declared";
+    case ErrorCode::PARAMETER_NAME_INVALID:
+      return "Parameter name is invalid";
+    case ErrorCode::PARAMETER_RANGE_VIOLATION:
+      return "Parameter value is outside the allowed range";
+    case ErrorCode::QOS_INCOMPATIBLE:
+      return "QoS settings are incompatible between publisher and subscriber";
+    case ErrorCode::QOS_RELIABILITY_MISMATCH:
+      return "Reliability QoS settings do not match";
+    case ErrorCode::QOS_DURABILITY_MISMATCH:
+      return "Durability QoS settings do not match";
+    case ErrorCode::QOS_DEADLINE_MISSED:
+      return "QoS deadline was missed";
+    case ErrorCode::QOS_LIVELINESS_LOST:
+      return "QoS liveliness assertion failed";
+    case ErrorCode::QOS_INVALID_PROFILE:
+      return "Invalid QoS profile specified";
+    case ErrorCode::EXECUTOR_NODE_ALREADY_ADDED:
+      return "Node has already been added to an executor";
+    case ErrorCode::EXECUTOR_CALLBACK_ERROR:
+      return "Error occurred during callback execution";
+    case ErrorCode::EXECUTOR_SPIN_ERROR:
+      return "Error occurred during spin operation";
+    case ErrorCode::EXECUTOR_INVALID_STATE:
+      return "Executor is in an invalid state";
+    case ErrorCode::CALLBACK_GROUP_ERROR:
+      return "Callback group configuration error";
+    case ErrorCode::TIMER_CREATION_FAILED:
+      return "Failed to create timer";
+    case ErrorCode::TIMER_CANCELLED:
+      return "Timer was cancelled";
+    case ErrorCode::TIMER_INVALID_PERIOD:
+      return "Invalid timer period specified";
+    case ErrorCode::ACTION_SERVER_ERROR:
+      return "Action server error";
+    case ErrorCode::ACTION_CLIENT_ERROR:
+      return "Action client error";
+    case ErrorCode::ACTION_GOAL_REJECTED:
+      return "Action goal was rejected";
+    case ErrorCode::ACTION_CANCELLED:
+      return "Action was cancelled";
+    case ErrorCode::RCL_ERROR:
+      return "Error from RCL layer";
+    case ErrorCode::RMW_ERROR:
+      return "Error from RMW layer";
+    case ErrorCode::ALLOCATION_FAILED:
+      return "Memory allocation failed";
+    case ErrorCode::INTERNAL_ERROR:
+      return "Internal error";
+    default:
+      return "Unknown error";
+  }
+}
+
+std::string
+get_category_name(ErrorCategory category)
+{
+  switch (category) {
+    case ErrorCategory::UNKNOWN:
+      return "Unknown";
+    case ErrorCategory::NODE:
+      return "Node";
+    case ErrorCategory::TOPIC:
+      return "Topic";
+    case ErrorCategory::SERVICE:
+      return "Service";
+    case ErrorCategory::PARAMETER:
+      return "Parameter";
+    case ErrorCategory::QOS:
+      return "QoS";
+    case ErrorCategory::EXECUTOR:
+      return "Executor";
+    case ErrorCategory::TIMER:
+      return "Timer";
+    case ErrorCategory::ACTION:
+      return "Action";
+    case ErrorCategory::INTERNAL:
+      return "Internal";
+    default:
+      return "Unknown";
+  }
+}
+
+std::string
+get_severity_name(ErrorSeverity severity)
+{
+  switch (severity) {
+    case ErrorSeverity::UNKNOWN:
+      return "UNKNOWN";
+    case ErrorSeverity::INFO:
+      return "INFO";
+    case ErrorSeverity::WARNING:
+      return "WARNING";
+    case ErrorSeverity::ERROR:
+      return "ERROR";
+    case ErrorSeverity::FATAL:
+      return "FATAL";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+// ============================================================================
+// ErrorSuggestion Implementation
+// ============================================================================
+
+std::string
+ErrorSuggestion::format() const
+{
+  if (empty()) {
+    return "";
+  }
+
+  std::ostringstream oss;
+  if (!primary.empty()) {
+    oss << primary;
+  }
+
+  if (!alternatives.empty()) {
+    oss << "\n  Alternatives:";
+    for (const auto & alt : alternatives) {
+      oss << "\n    - " << alt;
+    }
+  }
+
+  if (!documentation_url.empty()) {
+    oss << "\n  Documentation: " << documentation_url;
+  }
+
+  return oss.str();
+}
+
+// ============================================================================
+// ErrorContext Implementation
+// ============================================================================
+
+ErrorContext::ErrorContext(const ErrorContext & other)
+: context_(other.context_)
+{
+}
+
+ErrorContext::ErrorContext(ErrorContext && other) noexcept
+: context_(std::move(other.context_))
+{
+}
+
+ErrorContext &
+ErrorContext::operator=(const ErrorContext & other)
+{
+  if (this != &other) {
+    context_ = other.context_;
+  }
+  return *this;
+}
+
+ErrorContext &
+ErrorContext::operator=(ErrorContext && other) noexcept
+{
+  if (this != &other) {
+    context_ = std::move(other.context_);
+  }
+  return *this;
+}
+
+ErrorContext::~ErrorContext() = default;
+
+ErrorContext &
+ErrorContext::with_node_name(const std::string & name)
+{
+  context_["node_name"] = name;
+  return *this;
+}
+
+ErrorContext &
+ErrorContext::with_topic_name(const std::string & name)
+{
+  context_["topic_name"] = name;
+  return *this;
+}
+
+ErrorContext &
+ErrorContext::with_service_name(const std::string & name)
+{
+  context_["service_name"] = name;
+  return *this;
+}
+
+ErrorContext &
+ErrorContext::with_parameter_name(const std::string & name)
+{
+  context_["parameter_name"] = name;
+  return *this;
+}
+
+ErrorContext &
+ErrorContext::with_expected_type(const std::string & type)
+{
+  context_["expected_type"] = type;
+  return *this;
+}
+
+ErrorContext &
+ErrorContext::with_actual_type(const std::string & type)
+{
+  context_["actual_type"] = type;
+  return *this;
+}
+
+ErrorContext &
+ErrorContext::with_expected_value(const std::string & value)
+{
+  context_["expected_value"] = value;
+  return *this;
+}
+
+ErrorContext &
+ErrorContext::with_actual_value(const std::string & value)
+{
+  context_["actual_value"] = value;
+  return *this;
+}
+
+ErrorContext &
+ErrorContext::with_qos_profile(const std::string & profile)
+{
+  context_["qos_profile"] = profile;
+  return *this;
+}
+
+ErrorContext &
+ErrorContext::with_namespace(const std::string & ns)
+{
+  context_["namespace"] = ns;
+  return *this;
+}
+
+ErrorContext &
+ErrorContext::with(const std::string & key, const std::string & value)
+{
+  context_[key] = value;
+  return *this;
+}
+
+std::string
+ErrorContext::format() const
+{
+  if (context_.empty()) {
+    return "";
+  }
+
+  std::ostringstream oss;
+  bool first = true;
+  for (const auto & [key, value] : context_) {
+    if (!first) {
+      oss << ", ";
+    }
+    oss << key << "=" << value;
+    first = false;
+  }
+  return oss.str();
+}
+
+const std::map<std::string, std::string> &
+ErrorContext::as_map() const noexcept
+{
+  return context_;
+}
+
+bool
+ErrorContext::empty() const noexcept
+{
+  return context_.empty();
+}
+
+// ============================================================================
+// RclcppException Implementation
+// ============================================================================
+
+struct RclcppException::Impl
+{
+  ErrorCode code;
+  std::string message;
+  ErrorSuggestion suggestion;
+  std::map<std::string, std::string> context;
+  const char * file_name;
+  const char * function_name;
+  uint32_t line;
+
+  mutable std::string what_message;
+  mutable bool what_formatted = false;
+  mutable std::mutex format_mutex;
+};
+
+#if RCLCPP_HAS_SOURCE_LOCATION
+RclcppException::RclcppException(
+  ErrorCode code,
+  const std::string & message,
+  const std::source_location & location)
+: impl_(std::make_unique<Impl>())
+{
+  impl_->code = code;
+  impl_->message = message;
+  impl_->file_name = location.file_name();
+  impl_->function_name = location.function_name();
+  impl_->line = location.line();
+}
+
+RclcppException::RclcppException(
+  ErrorCode code,
+  const std::string & message,
+  const std::string & suggestion,
+  const std::source_location & location)
+: impl_(std::make_unique<Impl>())
+{
+  impl_->code = code;
+  impl_->message = message;
+  impl_->suggestion = ErrorSuggestion(suggestion);
+  impl_->file_name = location.file_name();
+  impl_->function_name = location.function_name();
+  impl_->line = location.line();
+}
+
+RclcppException::RclcppException(
+  ErrorCode code,
+  const std::string & message,
+  const ErrorSuggestion & suggestion,
+  const std::source_location & location)
+: impl_(std::make_unique<Impl>())
+{
+  impl_->code = code;
+  impl_->message = message;
+  impl_->suggestion = suggestion;
+  impl_->file_name = location.file_name();
+  impl_->function_name = location.function_name();
+  impl_->line = location.line();
+}
+
+RclcppException::RclcppException(
+  ErrorCode code,
+  const std::string & message,
+  const ErrorSuggestion & suggestion,
+  const ErrorContext & context,
+  const std::source_location & location)
+: impl_(std::make_unique<Impl>())
+{
+  impl_->code = code;
+  impl_->message = message;
+  impl_->suggestion = suggestion;
+  impl_->context = context.as_map();
+  impl_->file_name = location.file_name();
+  impl_->function_name = location.function_name();
+  impl_->line = location.line();
+}
+#else
+RclcppException::RclcppException(
+  ErrorCode code,
+  const std::string & message,
+  const SourceLocation & location)
+: impl_(std::make_unique<Impl>())
+{
+  impl_->code = code;
+  impl_->message = message;
+  impl_->file_name = location.file_name();
+  impl_->function_name = location.function_name();
+  impl_->line = location.line();
+}
+
+RclcppException::RclcppException(
+  ErrorCode code,
+  const std::string & message,
+  const std::string & suggestion,
+  const SourceLocation & location)
+: impl_(std::make_unique<Impl>())
+{
+  impl_->code = code;
+  impl_->message = message;
+  impl_->suggestion = ErrorSuggestion(suggestion);
+  impl_->file_name = location.file_name();
+  impl_->function_name = location.function_name();
+  impl_->line = location.line();
+}
+
+RclcppException::RclcppException(
+  ErrorCode code,
+  const std::string & message,
+  const ErrorSuggestion & suggestion,
+  const SourceLocation & location)
+: impl_(std::make_unique<Impl>())
+{
+  impl_->code = code;
+  impl_->message = message;
+  impl_->suggestion = suggestion;
+  impl_->file_name = location.file_name();
+  impl_->function_name = location.function_name();
+  impl_->line = location.line();
+}
+
+RclcppException::RclcppException(
+  ErrorCode code,
+  const std::string & message,
+  const ErrorSuggestion & suggestion,
+  const ErrorContext & context,
+  const SourceLocation & location)
+: impl_(std::make_unique<Impl>())
+{
+  impl_->code = code;
+  impl_->message = message;
+  impl_->suggestion = suggestion;
+  impl_->context = context.as_map();
+  impl_->file_name = location.file_name();
+  impl_->function_name = location.function_name();
+  impl_->line = location.line();
+}
+#endif
+
+RclcppException::RclcppException(const RclcppException & other)
+: std::exception(other),
+  impl_(std::make_unique<Impl>())
+{
+  impl_->code = other.impl_->code;
+  impl_->message = other.impl_->message;
+  impl_->suggestion = other.impl_->suggestion;
+  impl_->context = other.impl_->context;
+  impl_->file_name = other.impl_->file_name;
+  impl_->function_name = other.impl_->function_name;
+  impl_->line = other.impl_->line;
+  impl_->what_formatted = false;
+}
+
+RclcppException::RclcppException(RclcppException && other) noexcept
+: std::exception(std::move(other)),
+  impl_(std::move(other.impl_))
+{
+}
+
+RclcppException &
+RclcppException::operator=(const RclcppException & other)
+{
+  if (this != &other) {
+    std::exception::operator=(other);
+    impl_ = std::make_unique<Impl>();
+    impl_->code = other.impl_->code;
+    impl_->message = other.impl_->message;
+    impl_->suggestion = other.impl_->suggestion;
+    impl_->context = other.impl_->context;
+    impl_->file_name = other.impl_->file_name;
+    impl_->function_name = other.impl_->function_name;
+    impl_->line = other.impl_->line;
+    impl_->what_formatted = false;
+  }
+  return *this;
+}
+
+RclcppException &
+RclcppException::operator=(RclcppException && other) noexcept
+{
+  if (this != &other) {
+    std::exception::operator=(std::move(other));
+    impl_ = std::move(other.impl_);
+  }
+  return *this;
+}
+
+RclcppException::~RclcppException() = default;
+
+ErrorCode
+RclcppException::error_code() const noexcept
+{
+  return impl_->code;
+}
+
+ErrorCategory
+RclcppException::error_category() const noexcept
+{
+  return get_error_category(impl_->code);
+}
+
+ErrorSeverity
+RclcppException::error_severity() const noexcept
+{
+  return get_error_severity(impl_->code);
+}
+
+const std::string &
+RclcppException::message() const noexcept
+{
+  return impl_->message;
+}
+
+const std::string &
+RclcppException::suggestion() const noexcept
+{
+  return impl_->suggestion.primary;
+}
+
+const ErrorSuggestion &
+RclcppException::full_suggestion() const noexcept
+{
+  return impl_->suggestion;
+}
+
+std::string
+RclcppException::context() const
+{
+  if (impl_->context.empty()) {
+    return "";
+  }
+
+  std::ostringstream oss;
+  bool first = true;
+  for (const auto & [key, value] : impl_->context) {
+    if (!first) {
+      oss << ", ";
+    }
+    oss << key << "=" << value;
+    first = false;
+  }
+  return oss.str();
+}
+
+const std::map<std::string, std::string> &
+RclcppException::context_map() const noexcept
+{
+  return impl_->context;
+}
+
+const char *
+RclcppException::file_name() const noexcept
+{
+  return impl_->file_name ? impl_->file_name : "";
+}
+
+const char *
+RclcppException::function_name() const noexcept
+{
+  return impl_->function_name ? impl_->function_name : "";
+}
+
+uint32_t
+RclcppException::line() const noexcept
+{
+  return impl_->line;
+}
+
+std::string
+RclcppException::location_string() const
+{
+  std::ostringstream oss;
+  if (impl_->file_name && impl_->file_name[0] != '\0') {
+    oss << impl_->file_name;
+    if (impl_->line > 0) {
+      oss << ":" << impl_->line;
+    }
+    if (impl_->function_name && impl_->function_name[0] != '\0') {
+      oss << " in " << impl_->function_name << "()";
+    }
+  }
+  return oss.str();
+}
+
+void
+RclcppException::format_what_message() const
+{
+  std::lock_guard<std::mutex> lock(impl_->format_mutex);
+  if (impl_->what_formatted) {
+    return;
+  }
+
+  std::ostringstream oss;
+
+  // Error code and message
+  oss << "[" << static_cast<uint32_t>(impl_->code) << "] " << impl_->message;
+
+  // Context (compact inline)
+  if (!impl_->context.empty()) {
+    oss << " (";
+    bool first = true;
+    for (const auto & [key, value] : impl_->context) {
+      if (!first) {
+        oss << ", ";
+      }
+      oss << key << "=" << value;
+      first = false;
+    }
+    oss << ")";
+  }
+
+  // Suggestion
+  if (!impl_->suggestion.primary.empty()) {
+    oss << " | Suggestion: " << impl_->suggestion.primary;
+  }
+
+  // Location
+  if (impl_->file_name && impl_->file_name[0] != '\0' && impl_->line > 0) {
+    oss << " [" << impl_->file_name << ":" << impl_->line << "]";
+  }
+
+  impl_->what_message = oss.str();
+  impl_->what_formatted = true;
+}
+
+const char *
+RclcppException::what() const noexcept
+{
+  if (!impl_->what_formatted) {
+    try {
+      format_what_message();
+    } catch (...) {
+      return impl_->message.c_str();
+    }
+  }
+  return impl_->what_message.c_str();
+}
+
+std::string
+RclcppException::detailed_report() const
+{
+  std::ostringstream oss;
+
+  oss << "=== ROS 2 Exception Report ===" << "\n";
+  oss << "Error Code: " << static_cast<uint32_t>(impl_->code)
+      << " (" << get_error_code_name(impl_->code) << ")" << "\n";
+  oss << "Category: " << get_category_name(error_category()) << "\n";
+  oss << "Severity: " << get_severity_name(error_severity()) << "\n";
+  oss << "\n";
+  oss << "Message: " << impl_->message << "\n";
+
+  if (!impl_->context.empty()) {
+    oss << "\n";
+    oss << "Context:" << "\n";
+    for (const auto & [key, value] : impl_->context) {
+      oss << "  " << key << ": " << value << "\n";
+    }
+  }
+
+  if (!impl_->suggestion.empty()) {
+    oss << "\n";
+    oss << "Suggestion: " << impl_->suggestion.primary << "\n";
+    if (!impl_->suggestion.alternatives.empty()) {
+      oss << "Alternatives:" << "\n";
+      for (const auto & alt : impl_->suggestion.alternatives) {
+        oss << "  - " << alt << "\n";
+      }
+    }
+    if (!impl_->suggestion.documentation_url.empty()) {
+      oss << "Documentation: " << impl_->suggestion.documentation_url << "\n";
+    }
+  }
+
+  oss << "\n";
+  oss << "Location: " << location_string() << "\n";
+  oss << "==============================" << "\n";
+
+  return oss.str();
+}
+
+RclcppException &
+RclcppException::with_context(const std::string & key, const std::string & value)
+{
+  impl_->context[key] = value;
+  impl_->what_formatted = false;
+  return *this;
+}
+
+// ============================================================================
+// Specialized Exception Implementations
+// ============================================================================
+
+#if RCLCPP_HAS_SOURCE_LOCATION
+InvalidNodeNameError::InvalidNodeNameError(
+  const std::string & node_name,
+  const std::string & reason,
+  const std::source_location & location)
+: NodeException(
+    ErrorCode::NODE_NAME_INVALID,
+    "Invalid node name '" + node_name + "'" + (reason.empty() ? "" : ": " + reason),
+    ErrorSuggestion(
+      "Node names must start with a letter or underscore, and contain only "
+      "alphanumeric characters and underscores",
+      {"Avoid starting with numbers", "Avoid using reserved names starting with '_'"},
+      "https://docs.ros.org/en/rolling/Concepts/About-ROS-2-Names.html"
+    ),
+    location)
+{
+  with_context("node_name", node_name);
+}
+
+InvalidNamespaceError::InvalidNamespaceError(
+  const std::string & namespace_name,
+  const std::string & reason,
+  const std::source_location & location)
+: NodeException(
+    ErrorCode::NODE_NAMESPACE_INVALID,
+    "Invalid namespace '" + namespace_name + "'" + (reason.empty() ? "" : ": " + reason),
+    ErrorSuggestion(
+      "Namespaces must be absolute (start with '/') and follow ROS 2 naming conventions",
+      {"Ensure namespace starts with '/'", "Use only alphanumeric characters and underscores"},
+      "https://docs.ros.org/en/rolling/Concepts/About-ROS-2-Names.html"
+    ),
+    location)
+{
+  with_context("namespace", namespace_name);
+}
+
+NodeInitializationError::NodeInitializationError(
+  const std::string & node_name,
+  const std::string & reason,
+  const std::source_location & location)
+: NodeException(
+    ErrorCode::NODE_INIT_FAILED,
+    "Failed to initialize node '" + node_name + "': " + reason,
+    ErrorSuggestion(
+      "Check that ROS 2 is properly initialized with rclcpp::init() before creating nodes",
+      {"Verify rclcpp::init() was called", "Check for RMW implementation errors"}
+    ),
+    location)
+{
+  with_context("node_name", node_name);
+}
+
+InvalidTopicNameError::InvalidTopicNameError(
+  const std::string & topic_name,
+  const std::string & reason,
+  const std::source_location & location)
+: TopicException(
+    ErrorCode::TOPIC_NAME_INVALID,
+    "Invalid topic name '" + topic_name + "'" + (reason.empty() ? "" : ": " + reason),
+    ErrorSuggestion(
+      "Topic names should start with a letter and contain only alphanumeric characters, "
+      "underscores, and forward slashes",
+      {"Use absolute topic names starting with '/'", "Avoid special characters"},
+      "https://docs.ros.org/en/rolling/Concepts/About-ROS-2-Names.html"
+    ),
+    location)
+{
+  with_context("topic_name", topic_name);
+}
+
+InvalidServiceNameError::InvalidServiceNameError(
+  const std::string & service_name,
+  const std::string & reason,
+  const std::source_location & location)
+: ServiceException(
+    ErrorCode::SERVICE_NAME_INVALID,
+    "Invalid service name '" + service_name + "'" + (reason.empty() ? "" : ": " + reason),
+    ErrorSuggestion(
+      "Service names follow the same rules as topic names",
+      {"Use absolute service names starting with '/'", "Avoid special characters"},
+      "https://docs.ros.org/en/rolling/Concepts/About-ROS-2-Names.html"
+    ),
+    location)
+{
+  with_context("service_name", service_name);
+}
+
+ServiceNotAvailableError::ServiceNotAvailableError(
+  const std::string & service_name,
+  const std::source_location & location)
+: ServiceException(
+    ErrorCode::SERVICE_NOT_AVAILABLE,
+    "Service '" + service_name + "' is not available",
+    ErrorSuggestion(
+      "Ensure the service server is running and properly advertised",
+      {
+        "Check if the service server node is running",
+        "Use 'ros2 service list' to see available services",
+        "Verify the service name matches exactly"
+      }
+    ),
+    location)
+{
+  with_context("service_name", service_name);
+}
+
+ParameterNotDeclaredException::ParameterNotDeclaredException(
+  const std::string & parameter_name,
+  const std::source_location & location)
+: ParameterException(
+    ErrorCode::PARAMETER_NOT_DECLARED,
+    "Parameter '" + parameter_name + "' has not been declared",
+    ErrorSuggestion(
+      "Declare the parameter before use with declare_parameter<T>(name, default_value)",
+      {
+        "Use declare_parameter() in the node constructor",
+        "Set allow_undeclared_parameters to true in NodeOptions",
+        "Use has_parameter() to check existence first"
+      },
+      "https://docs.ros.org/en/rolling/Tutorials/Parameters/Understanding-ROS2-Parameters.html"
+    ),
+    location)
+{
+  with_context("parameter_name", parameter_name);
+}
+
+ParameterTypeMismatchException::ParameterTypeMismatchException(
+  const std::string & parameter_name,
+  const std::string & expected_type,
+  const std::string & actual_type,
+  const std::source_location & location)
+: ParameterException(
+    ErrorCode::PARAMETER_TYPE_MISMATCH,
+    "Parameter '" + parameter_name + "' type mismatch: expected " + expected_type +
+    ", got " + actual_type,
+    ErrorSuggestion(
+      "Use the correct type when getting the parameter value",
+      {"Check parameter declaration for the expected type", "Use get_parameter_or() for type-safe access"}
+    ),
+    location)
+{
+  with_context("parameter_name", parameter_name);
+  with_context("expected_type", expected_type);
+  with_context("actual_type", actual_type);
+}
+
+InvalidParameterValueException::InvalidParameterValueException(
+  const std::string & parameter_name,
+  const std::string & reason,
+  const std::source_location & location)
+: ParameterException(
+    ErrorCode::PARAMETER_INVALID_VALUE,
+    "Invalid value for parameter '" + parameter_name + "': " + reason,
+    ErrorSuggestion(
+      "Provide a valid value that meets the parameter's constraints",
+      {"Check parameter description for valid values", "Use describe_parameter() to see constraints"}
+    ),
+    location)
+{
+  with_context("parameter_name", parameter_name);
+}
+
+QoSIncompatibleError::QoSIncompatibleError(
+  const std::string & topic_name,
+  const std::string & publisher_qos,
+  const std::string & subscriber_qos,
+  const std::source_location & location)
+: QoSException(
+    ErrorCode::QOS_INCOMPATIBLE,
+    "QoS incompatibility on topic '" + topic_name + "'",
+    ErrorSuggestion(
+      "Ensure publisher and subscriber QoS settings are compatible",
+      {
+        "Use matching reliability settings (reliable/best_effort)",
+        "Use compatible durability settings",
+        "Consider using QoS profiles like rclcpp::SensorDataQoS() for consistent settings"
+      },
+      "https://docs.ros.org/en/rolling/Concepts/About-Quality-of-Service-Settings.html"
+    ),
+    location)
+{
+  with_context("topic_name", topic_name);
+  with_context("publisher_qos", publisher_qos);
+  with_context("subscriber_qos", subscriber_qos);
+}
+
+CallbackGroupError::CallbackGroupError(
+  const std::string & reason,
+  const std::source_location & location)
+: ExecutorException(
+    ErrorCode::CALLBACK_GROUP_ERROR,
+    "Callback group error: " + reason,
+    ErrorSuggestion(
+      "Review callback group configuration and ensure proper assignment",
+      {
+        "Check that callbacks are added to appropriate groups",
+        "Verify executor handles the callback group type (mutually exclusive vs reentrant)"
+      }
+    ),
+    location)
+{
+}
+
+#else
+// Fallback implementations for pre-C++20
+InvalidNodeNameError::InvalidNodeNameError(
+  const std::string & node_name,
+  const std::string & reason,
+  const SourceLocation & location)
+: NodeException(
+    ErrorCode::NODE_NAME_INVALID,
+    "Invalid node name '" + node_name + "'" + (reason.empty() ? "" : ": " + reason),
+    ErrorSuggestion(
+      "Node names must start with a letter or underscore, and contain only "
+      "alphanumeric characters and underscores",
+      {"Avoid starting with numbers", "Avoid using reserved names starting with '_'"},
+      "https://docs.ros.org/en/rolling/Concepts/About-ROS-2-Names.html"
+    ),
+    location)
+{
+  with_context("node_name", node_name);
+}
+
+InvalidNamespaceError::InvalidNamespaceError(
+  const std::string & namespace_name,
+  const std::string & reason,
+  const SourceLocation & location)
+: NodeException(
+    ErrorCode::NODE_NAMESPACE_INVALID,
+    "Invalid namespace '" + namespace_name + "'" + (reason.empty() ? "" : ": " + reason),
+    ErrorSuggestion(
+      "Namespaces must be absolute (start with '/') and follow ROS 2 naming conventions",
+      {"Ensure namespace starts with '/'", "Use only alphanumeric characters and underscores"},
+      "https://docs.ros.org/en/rolling/Concepts/About-ROS-2-Names.html"
+    ),
+    location)
+{
+  with_context("namespace", namespace_name);
+}
+
+NodeInitializationError::NodeInitializationError(
+  const std::string & node_name,
+  const std::string & reason,
+  const SourceLocation & location)
+: NodeException(
+    ErrorCode::NODE_INIT_FAILED,
+    "Failed to initialize node '" + node_name + "': " + reason,
+    ErrorSuggestion(
+      "Check that ROS 2 is properly initialized with rclcpp::init() before creating nodes",
+      {"Verify rclcpp::init() was called", "Check for RMW implementation errors"}
+    ),
+    location)
+{
+  with_context("node_name", node_name);
+}
+
+InvalidTopicNameError::InvalidTopicNameError(
+  const std::string & topic_name,
+  const std::string & reason,
+  const SourceLocation & location)
+: TopicException(
+    ErrorCode::TOPIC_NAME_INVALID,
+    "Invalid topic name '" + topic_name + "'" + (reason.empty() ? "" : ": " + reason),
+    ErrorSuggestion(
+      "Topic names should start with a letter and contain only alphanumeric characters, "
+      "underscores, and forward slashes",
+      {"Use absolute topic names starting with '/'", "Avoid special characters"},
+      "https://docs.ros.org/en/rolling/Concepts/About-ROS-2-Names.html"
+    ),
+    location)
+{
+  with_context("topic_name", topic_name);
+}
+
+InvalidServiceNameError::InvalidServiceNameError(
+  const std::string & service_name,
+  const std::string & reason,
+  const SourceLocation & location)
+: ServiceException(
+    ErrorCode::SERVICE_NAME_INVALID,
+    "Invalid service name '" + service_name + "'" + (reason.empty() ? "" : ": " + reason),
+    ErrorSuggestion(
+      "Service names follow the same rules as topic names",
+      {"Use absolute service names starting with '/'", "Avoid special characters"},
+      "https://docs.ros.org/en/rolling/Concepts/About-ROS-2-Names.html"
+    ),
+    location)
+{
+  with_context("service_name", service_name);
+}
+
+ServiceNotAvailableError::ServiceNotAvailableError(
+  const std::string & service_name,
+  const SourceLocation & location)
+: ServiceException(
+    ErrorCode::SERVICE_NOT_AVAILABLE,
+    "Service '" + service_name + "' is not available",
+    ErrorSuggestion(
+      "Ensure the service server is running and properly advertised",
+      {
+        "Check if the service server node is running",
+        "Use 'ros2 service list' to see available services",
+        "Verify the service name matches exactly"
+      }
+    ),
+    location)
+{
+  with_context("service_name", service_name);
+}
+
+ParameterNotDeclaredException::ParameterNotDeclaredException(
+  const std::string & parameter_name,
+  const SourceLocation & location)
+: ParameterException(
+    ErrorCode::PARAMETER_NOT_DECLARED,
+    "Parameter '" + parameter_name + "' has not been declared",
+    ErrorSuggestion(
+      "Declare the parameter before use with declare_parameter<T>(name, default_value)",
+      {
+        "Use declare_parameter() in the node constructor",
+        "Set allow_undeclared_parameters to true in NodeOptions",
+        "Use has_parameter() to check existence first"
+      },
+      "https://docs.ros.org/en/rolling/Tutorials/Parameters/Understanding-ROS2-Parameters.html"
+    ),
+    location)
+{
+  with_context("parameter_name", parameter_name);
+}
+
+ParameterTypeMismatchException::ParameterTypeMismatchException(
+  const std::string & parameter_name,
+  const std::string & expected_type,
+  const std::string & actual_type,
+  const SourceLocation & location)
+: ParameterException(
+    ErrorCode::PARAMETER_TYPE_MISMATCH,
+    "Parameter '" + parameter_name + "' type mismatch: expected " + expected_type +
+    ", got " + actual_type,
+    ErrorSuggestion(
+      "Use the correct type when getting the parameter value",
+      {"Check parameter declaration for the expected type", "Use get_parameter_or() for type-safe access"}
+    ),
+    location)
+{
+  with_context("parameter_name", parameter_name);
+  with_context("expected_type", expected_type);
+  with_context("actual_type", actual_type);
+}
+
+InvalidParameterValueException::InvalidParameterValueException(
+  const std::string & parameter_name,
+  const std::string & reason,
+  const SourceLocation & location)
+: ParameterException(
+    ErrorCode::PARAMETER_INVALID_VALUE,
+    "Invalid value for parameter '" + parameter_name + "': " + reason,
+    ErrorSuggestion(
+      "Provide a valid value that meets the parameter's constraints",
+      {"Check parameter description for valid values", "Use describe_parameter() to see constraints"}
+    ),
+    location)
+{
+  with_context("parameter_name", parameter_name);
+}
+
+QoSIncompatibleError::QoSIncompatibleError(
+  const std::string & topic_name,
+  const std::string & publisher_qos,
+  const std::string & subscriber_qos,
+  const SourceLocation & location)
+: QoSException(
+    ErrorCode::QOS_INCOMPATIBLE,
+    "QoS incompatibility on topic '" + topic_name + "'",
+    ErrorSuggestion(
+      "Ensure publisher and subscriber QoS settings are compatible",
+      {
+        "Use matching reliability settings (reliable/best_effort)",
+        "Use compatible durability settings",
+        "Consider using QoS profiles like rclcpp::SensorDataQoS() for consistent settings"
+      },
+      "https://docs.ros.org/en/rolling/Concepts/About-Quality-of-Service-Settings.html"
+    ),
+    location)
+{
+  with_context("topic_name", topic_name);
+  with_context("publisher_qos", publisher_qos);
+  with_context("subscriber_qos", subscriber_qos);
+}
+
+CallbackGroupError::CallbackGroupError(
+  const std::string & reason,
+  const SourceLocation & location)
+: ExecutorException(
+    ErrorCode::CALLBACK_GROUP_ERROR,
+    "Callback group error: " + reason,
+    ErrorSuggestion(
+      "Review callback group configuration and ensure proper assignment",
+      {
+        "Check that callbacks are added to appropriate groups",
+        "Verify executor handles the callback group type (mutually exclusive vs reentrant)"
+      }
+    ),
+    location)
+{
+}
+#endif
+
+}  // namespace exceptions
+}  // namespace rclcpp

--- a/rclcpp/src/exceptions/enhanced_exceptions.cpp
+++ b/rclcpp/src/exceptions/enhanced_exceptions.cpp
@@ -1002,7 +1002,10 @@ ParameterTypeMismatchException::ParameterTypeMismatchException(
     ", got " + actual_type,
     ErrorSuggestion(
       "Use the correct type when getting the parameter value",
-      {"Check parameter declaration for the expected type", "Use get_parameter_or() for type-safe access"}
+      {
+        "Check parameter declaration for the expected type",
+        "Use get_parameter_or() for type-safe access"
+      }
     ),
     location)
 {
@@ -1020,7 +1023,10 @@ InvalidParameterValueException::InvalidParameterValueException(
     "Invalid value for parameter '" + parameter_name + "': " + reason,
     ErrorSuggestion(
       "Provide a valid value that meets the parameter's constraints",
-      {"Check parameter description for valid values", "Use describe_parameter() to see constraints"}
+      {
+        "Check parameter description for valid values",
+        "Use describe_parameter() to see constraints"
+      }
     ),
     location)
 {
@@ -1206,7 +1212,10 @@ ParameterTypeMismatchException::ParameterTypeMismatchException(
     ", got " + actual_type,
     ErrorSuggestion(
       "Use the correct type when getting the parameter value",
-      {"Check parameter declaration for the expected type", "Use get_parameter_or() for type-safe access"}
+      {
+        "Check parameter declaration for the expected type",
+        "Use get_parameter_or() for type-safe access"
+      }
     ),
     location)
 {
@@ -1224,7 +1233,10 @@ InvalidParameterValueException::InvalidParameterValueException(
     "Invalid value for parameter '" + parameter_name + "': " + reason,
     ErrorSuggestion(
       "Provide a valid value that meets the parameter's constraints",
-      {"Check parameter description for valid values", "Use describe_parameter() to see constraints"}
+      {
+        "Check parameter description for valid values",
+        "Use describe_parameter() to see constraints"
+      }
     ),
     location)
 {

--- a/rclcpp/test/test_enhanced_exceptions.cpp
+++ b/rclcpp/test/test_enhanced_exceptions.cpp
@@ -23,7 +23,45 @@
 #include "rclcpp/exceptions/error_codes.hpp"
 #include "rclcpp/exceptions/error_macros.hpp"
 
-using namespace rclcpp::exceptions;
+using rclcpp::exceptions::ErrorCategory;
+using rclcpp::exceptions::ErrorCode;
+using rclcpp::exceptions::ErrorContext;
+using rclcpp::exceptions::ErrorSeverity;
+using rclcpp::exceptions::ErrorSuggestion;
+using rclcpp::exceptions::RclcppException;
+using rclcpp::exceptions::NodeException;
+using rclcpp::exceptions::TopicException;
+using rclcpp::exceptions::ServiceException;
+using rclcpp::exceptions::ParameterException;
+using rclcpp::exceptions::ExecutorException;
+using rclcpp::exceptions::QoSException;
+using rclcpp::exceptions::InvalidNodeNameError;
+using rclcpp::exceptions::InvalidNamespaceError;
+using rclcpp::exceptions::NodeInitializationError;
+using rclcpp::exceptions::InvalidTopicNameError;
+using rclcpp::exceptions::InvalidServiceNameError;
+using rclcpp::exceptions::ServiceNotAvailableError;
+using rclcpp::exceptions::ParameterNotDeclaredException;
+using rclcpp::exceptions::ParameterTypeMismatchException;
+using rclcpp::exceptions::InvalidParameterValueException;
+using rclcpp::exceptions::QoSIncompatibleError;
+using rclcpp::exceptions::CallbackGroupError;
+using rclcpp::exceptions::get_error_category;
+using rclcpp::exceptions::get_error_severity;
+using rclcpp::exceptions::get_error_code_name;
+using rclcpp::exceptions::get_error_code_description;
+using rclcpp::exceptions::get_category_name;
+using rclcpp::exceptions::get_severity_name;
+using rclcpp::exceptions::is_error_in_category;
+using rclcpp::exceptions::make_context;
+using rclcpp::exceptions::context_for_node;
+using rclcpp::exceptions::context_for_topic;
+using rclcpp::exceptions::context_for_service;
+using rclcpp::exceptions::context_for_parameter;
+using rclcpp::exceptions::make_suggestion;
+using rclcpp::exceptions::error_code_to_string;
+using rclcpp::exceptions::is_exception_category;
+using rclcpp::exceptions::is_exception_code;
 
 // ============================================================================
 // Error Code Tests

--- a/rclcpp/test/test_enhanced_exceptions.cpp
+++ b/rclcpp/test/test_enhanced_exceptions.cpp
@@ -1,0 +1,925 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "rclcpp/exceptions/enhanced_exceptions.hpp"
+#include "rclcpp/exceptions/error_codes.hpp"
+#include "rclcpp/exceptions/error_macros.hpp"
+
+using namespace rclcpp::exceptions;
+
+// ============================================================================
+// Error Code Tests
+// ============================================================================
+
+class ErrorCodeTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(ErrorCodeTest, GetErrorCategoryForNodeErrors)
+{
+  EXPECT_EQ(ErrorCategory::NODE, get_error_category(ErrorCode::NODE_NAME_INVALID));
+  EXPECT_EQ(ErrorCategory::NODE, get_error_category(ErrorCode::NODE_NAMESPACE_INVALID));
+  EXPECT_EQ(ErrorCategory::NODE, get_error_category(ErrorCode::NODE_INIT_FAILED));
+  EXPECT_EQ(ErrorCategory::NODE, get_error_category(ErrorCode::NODE_ALREADY_EXISTS));
+  EXPECT_EQ(ErrorCategory::NODE, get_error_category(ErrorCode::NODE_NOT_FOUND));
+}
+
+TEST_F(ErrorCodeTest, GetErrorCategoryForTopicErrors)
+{
+  EXPECT_EQ(ErrorCategory::TOPIC, get_error_category(ErrorCode::TOPIC_NAME_INVALID));
+  EXPECT_EQ(ErrorCategory::TOPIC, get_error_category(ErrorCode::TOPIC_NOT_AVAILABLE));
+  EXPECT_EQ(ErrorCategory::TOPIC, get_error_category(ErrorCode::PUBLISHER_CREATION_FAILED));
+  EXPECT_EQ(ErrorCategory::TOPIC, get_error_category(ErrorCode::SUBSCRIBER_CREATION_FAILED));
+}
+
+TEST_F(ErrorCodeTest, GetErrorCategoryForServiceErrors)
+{
+  EXPECT_EQ(ErrorCategory::SERVICE, get_error_category(ErrorCode::SERVICE_NAME_INVALID));
+  EXPECT_EQ(ErrorCategory::SERVICE, get_error_category(ErrorCode::SERVICE_NOT_AVAILABLE));
+  EXPECT_EQ(ErrorCategory::SERVICE, get_error_category(ErrorCode::SERVICE_TIMEOUT));
+}
+
+TEST_F(ErrorCodeTest, GetErrorCategoryForParameterErrors)
+{
+  EXPECT_EQ(ErrorCategory::PARAMETER, get_error_category(ErrorCode::PARAMETER_NOT_DECLARED));
+  EXPECT_EQ(ErrorCategory::PARAMETER, get_error_category(ErrorCode::PARAMETER_TYPE_MISMATCH));
+  EXPECT_EQ(ErrorCategory::PARAMETER, get_error_category(ErrorCode::PARAMETER_READ_ONLY));
+}
+
+TEST_F(ErrorCodeTest, GetErrorCategoryForQoSErrors)
+{
+  EXPECT_EQ(ErrorCategory::QOS, get_error_category(ErrorCode::QOS_INCOMPATIBLE));
+  EXPECT_EQ(ErrorCategory::QOS, get_error_category(ErrorCode::QOS_RELIABILITY_MISMATCH));
+  EXPECT_EQ(ErrorCategory::QOS, get_error_category(ErrorCode::QOS_DEADLINE_MISSED));
+}
+
+TEST_F(ErrorCodeTest, GetErrorCategoryForExecutorErrors)
+{
+  EXPECT_EQ(ErrorCategory::EXECUTOR, get_error_category(ErrorCode::EXECUTOR_NODE_ALREADY_ADDED));
+  EXPECT_EQ(ErrorCategory::EXECUTOR, get_error_category(ErrorCode::EXECUTOR_CALLBACK_ERROR));
+  EXPECT_EQ(ErrorCategory::EXECUTOR, get_error_category(ErrorCode::CALLBACK_GROUP_ERROR));
+}
+
+TEST_F(ErrorCodeTest, GetErrorCategoryForUnknown)
+{
+  EXPECT_EQ(ErrorCategory::UNKNOWN, get_error_category(ErrorCode::UNKNOWN));
+}
+
+TEST_F(ErrorCodeTest, GetErrorSeverity)
+{
+  EXPECT_EQ(ErrorSeverity::UNKNOWN, get_error_severity(ErrorCode::UNKNOWN));
+  EXPECT_EQ(ErrorSeverity::ERROR, get_error_severity(ErrorCode::NODE_NAME_INVALID));
+  EXPECT_EQ(ErrorSeverity::FATAL, get_error_severity(ErrorCode::ALLOCATION_FAILED));
+  EXPECT_EQ(ErrorSeverity::FATAL, get_error_severity(ErrorCode::INTERNAL_ERROR));
+}
+
+TEST_F(ErrorCodeTest, GetErrorCodeName)
+{
+  EXPECT_EQ("NODE_NAME_INVALID", get_error_code_name(ErrorCode::NODE_NAME_INVALID));
+  EXPECT_EQ("TOPIC_NOT_AVAILABLE", get_error_code_name(ErrorCode::TOPIC_NOT_AVAILABLE));
+  EXPECT_EQ("PARAMETER_NOT_DECLARED", get_error_code_name(ErrorCode::PARAMETER_NOT_DECLARED));
+  EXPECT_EQ("UNKNOWN", get_error_code_name(ErrorCode::UNKNOWN));
+}
+
+TEST_F(ErrorCodeTest, GetErrorCodeDescription)
+{
+  std::string desc = get_error_code_description(ErrorCode::NODE_NAME_INVALID);
+  EXPECT_FALSE(desc.empty());
+  EXPECT_NE(std::string::npos, desc.find("naming"));
+
+  desc = get_error_code_description(ErrorCode::PARAMETER_NOT_DECLARED);
+  EXPECT_FALSE(desc.empty());
+  EXPECT_NE(std::string::npos, desc.find("declared"));
+}
+
+TEST_F(ErrorCodeTest, IsErrorInCategory)
+{
+  EXPECT_TRUE(is_error_in_category(ErrorCode::NODE_NAME_INVALID, ErrorCategory::NODE));
+  EXPECT_FALSE(is_error_in_category(ErrorCode::NODE_NAME_INVALID, ErrorCategory::TOPIC));
+  EXPECT_TRUE(is_error_in_category(ErrorCode::TOPIC_NAME_INVALID, ErrorCategory::TOPIC));
+  EXPECT_FALSE(is_error_in_category(ErrorCode::TOPIC_NAME_INVALID, ErrorCategory::NODE));
+}
+
+TEST_F(ErrorCodeTest, GetCategoryName)
+{
+  EXPECT_EQ("Node", get_category_name(ErrorCategory::NODE));
+  EXPECT_EQ("Topic", get_category_name(ErrorCategory::TOPIC));
+  EXPECT_EQ("Service", get_category_name(ErrorCategory::SERVICE));
+  EXPECT_EQ("Parameter", get_category_name(ErrorCategory::PARAMETER));
+  EXPECT_EQ("QoS", get_category_name(ErrorCategory::QOS));
+  EXPECT_EQ("Unknown", get_category_name(ErrorCategory::UNKNOWN));
+}
+
+TEST_F(ErrorCodeTest, GetSeverityName)
+{
+  EXPECT_EQ("UNKNOWN", get_severity_name(ErrorSeverity::UNKNOWN));
+  EXPECT_EQ("INFO", get_severity_name(ErrorSeverity::INFO));
+  EXPECT_EQ("WARNING", get_severity_name(ErrorSeverity::WARNING));
+  EXPECT_EQ("ERROR", get_severity_name(ErrorSeverity::ERROR));
+  EXPECT_EQ("FATAL", get_severity_name(ErrorSeverity::FATAL));
+}
+
+// ============================================================================
+// Error Suggestion Tests
+// ============================================================================
+
+class ErrorSuggestionTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(ErrorSuggestionTest, DefaultConstruction)
+{
+  ErrorSuggestion suggestion;
+  EXPECT_TRUE(suggestion.empty());
+  EXPECT_TRUE(suggestion.primary.empty());
+  EXPECT_TRUE(suggestion.alternatives.empty());
+  EXPECT_TRUE(suggestion.documentation_url.empty());
+}
+
+TEST_F(ErrorSuggestionTest, ConstructWithPrimary)
+{
+  ErrorSuggestion suggestion("Try this instead");
+  EXPECT_FALSE(suggestion.empty());
+  EXPECT_EQ("Try this instead", suggestion.primary);
+  EXPECT_TRUE(suggestion.alternatives.empty());
+}
+
+TEST_F(ErrorSuggestionTest, ConstructWithAlternatives)
+{
+  ErrorSuggestion suggestion("Primary", {"Alt 1", "Alt 2"});
+  EXPECT_FALSE(suggestion.empty());
+  EXPECT_EQ("Primary", suggestion.primary);
+  EXPECT_EQ(2u, suggestion.alternatives.size());
+  EXPECT_EQ("Alt 1", suggestion.alternatives[0]);
+  EXPECT_EQ("Alt 2", suggestion.alternatives[1]);
+}
+
+TEST_F(ErrorSuggestionTest, ConstructWithDocUrl)
+{
+  ErrorSuggestion suggestion("Primary", {"Alt 1"}, "https://docs.ros.org");
+  EXPECT_EQ("https://docs.ros.org", suggestion.documentation_url);
+}
+
+TEST_F(ErrorSuggestionTest, Format)
+{
+  ErrorSuggestion suggestion("Fix this", {"Option A", "Option B"}, "https://docs.ros.org");
+  std::string formatted = suggestion.format();
+
+  EXPECT_NE(std::string::npos, formatted.find("Fix this"));
+  EXPECT_NE(std::string::npos, formatted.find("Option A"));
+  EXPECT_NE(std::string::npos, formatted.find("Option B"));
+  EXPECT_NE(std::string::npos, formatted.find("https://docs.ros.org"));
+}
+
+TEST_F(ErrorSuggestionTest, FormatEmpty)
+{
+  ErrorSuggestion suggestion;
+  EXPECT_EQ("", suggestion.format());
+}
+
+// ============================================================================
+// Error Context Tests
+// ============================================================================
+
+class ErrorContextTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(ErrorContextTest, DefaultConstruction)
+{
+  ErrorContext context;
+  EXPECT_TRUE(context.empty());
+  EXPECT_TRUE(context.as_map().empty());
+}
+
+TEST_F(ErrorContextTest, WithNodeName)
+{
+  ErrorContext context;
+  context.with_node_name("my_node");
+
+  EXPECT_FALSE(context.empty());
+  EXPECT_EQ(1u, context.as_map().size());
+  EXPECT_EQ("my_node", context.as_map().at("node_name"));
+}
+
+TEST_F(ErrorContextTest, WithTopicName)
+{
+  ErrorContext context;
+  context.with_topic_name("/chatter");
+
+  EXPECT_EQ("/chatter", context.as_map().at("topic_name"));
+}
+
+TEST_F(ErrorContextTest, WithServiceName)
+{
+  ErrorContext context;
+  context.with_service_name("/add_two_ints");
+
+  EXPECT_EQ("/add_two_ints", context.as_map().at("service_name"));
+}
+
+TEST_F(ErrorContextTest, WithParameterName)
+{
+  ErrorContext context;
+  context.with_parameter_name("max_speed");
+
+  EXPECT_EQ("max_speed", context.as_map().at("parameter_name"));
+}
+
+TEST_F(ErrorContextTest, WithTypes)
+{
+  ErrorContext context;
+  context.with_expected_type("int").with_actual_type("string");
+
+  EXPECT_EQ("int", context.as_map().at("expected_type"));
+  EXPECT_EQ("string", context.as_map().at("actual_type"));
+}
+
+TEST_F(ErrorContextTest, WithValues)
+{
+  ErrorContext context;
+  context.with_expected_value("42").with_actual_value("-1");
+
+  EXPECT_EQ("42", context.as_map().at("expected_value"));
+  EXPECT_EQ("-1", context.as_map().at("actual_value"));
+}
+
+TEST_F(ErrorContextTest, WithCustom)
+{
+  ErrorContext context;
+  context.with("custom_key", "custom_value");
+
+  EXPECT_EQ("custom_value", context.as_map().at("custom_key"));
+}
+
+TEST_F(ErrorContextTest, FluentInterface)
+{
+  ErrorContext context;
+  context
+  .with_node_name("node1")
+  .with_topic_name("/topic1")
+  .with_namespace("/ns");
+
+  EXPECT_EQ(3u, context.as_map().size());
+  EXPECT_EQ("node1", context.as_map().at("node_name"));
+  EXPECT_EQ("/topic1", context.as_map().at("topic_name"));
+  EXPECT_EQ("/ns", context.as_map().at("namespace"));
+}
+
+TEST_F(ErrorContextTest, Format)
+{
+  ErrorContext context;
+  context.with_node_name("my_node").with_topic_name("/chatter");
+
+  std::string formatted = context.format();
+  EXPECT_NE(std::string::npos, formatted.find("node_name"));
+  EXPECT_NE(std::string::npos, formatted.find("my_node"));
+  EXPECT_NE(std::string::npos, formatted.find("topic_name"));
+  EXPECT_NE(std::string::npos, formatted.find("/chatter"));
+}
+
+TEST_F(ErrorContextTest, CopyConstruction)
+{
+  ErrorContext original;
+  original.with_node_name("test_node");
+
+  ErrorContext copy(original);
+  EXPECT_EQ("test_node", copy.as_map().at("node_name"));
+
+  // Verify independence
+  copy.with_topic_name("/new_topic");
+  EXPECT_EQ(1u, original.as_map().size());
+  EXPECT_EQ(2u, copy.as_map().size());
+}
+
+TEST_F(ErrorContextTest, MoveConstruction)
+{
+  ErrorContext original;
+  original.with_node_name("test_node");
+
+  ErrorContext moved(std::move(original));
+  EXPECT_EQ("test_node", moved.as_map().at("node_name"));
+}
+
+// ============================================================================
+// RclcppException Tests
+// ============================================================================
+
+class RclcppExceptionTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(RclcppExceptionTest, BasicConstruction)
+{
+  RclcppException ex(ErrorCode::NODE_NAME_INVALID, "Test message");
+
+  EXPECT_EQ(ErrorCode::NODE_NAME_INVALID, ex.error_code());
+  EXPECT_EQ(ErrorCategory::NODE, ex.error_category());
+  EXPECT_EQ(ErrorSeverity::ERROR, ex.error_severity());
+  EXPECT_EQ("Test message", ex.message());
+}
+
+TEST_F(RclcppExceptionTest, ConstructionWithSuggestion)
+{
+  RclcppException ex(
+    ErrorCode::PARAMETER_NOT_DECLARED,
+    "Parameter not found",
+    "Declare the parameter first");
+
+  EXPECT_EQ("Declare the parameter first", ex.suggestion());
+  EXPECT_NE(nullptr, std::strstr(ex.what(), "Declare the parameter first"));
+}
+
+TEST_F(RclcppExceptionTest, ConstructionWithFullSuggestion)
+{
+  ErrorSuggestion suggestion("Primary fix", {"Alternative 1", "Alternative 2"});
+  RclcppException ex(ErrorCode::QOS_INCOMPATIBLE, "QoS error", suggestion);
+
+  EXPECT_EQ("Primary fix", ex.suggestion());
+  EXPECT_EQ(2u, ex.full_suggestion().alternatives.size());
+}
+
+TEST_F(RclcppExceptionTest, ConstructionWithContext)
+{
+  ErrorContext context;
+  context.with_node_name("test_node").with_topic_name("/test_topic");
+
+  RclcppException ex(
+    ErrorCode::TOPIC_NAME_INVALID,
+    "Invalid topic",
+    ErrorSuggestion("Fix the name"),
+    context);
+
+  EXPECT_EQ(2u, ex.context_map().size());
+  EXPECT_EQ("test_node", ex.context_map().at("node_name"));
+  EXPECT_EQ("/test_topic", ex.context_map().at("topic_name"));
+}
+
+TEST_F(RclcppExceptionTest, WhatMessageContainsErrorCode)
+{
+  RclcppException ex(ErrorCode::NODE_NAME_INVALID, "Test");
+  std::string what_msg = ex.what();
+
+  // Should contain the error code number
+  EXPECT_NE(std::string::npos, what_msg.find("1001"));
+}
+
+TEST_F(RclcppExceptionTest, WhatMessageContainsMessage)
+{
+  RclcppException ex(ErrorCode::NODE_NAME_INVALID, "My custom message");
+  std::string what_msg = ex.what();
+
+  EXPECT_NE(std::string::npos, what_msg.find("My custom message"));
+}
+
+TEST_F(RclcppExceptionTest, WhatMessageContainsSuggestion)
+{
+  RclcppException ex(
+    ErrorCode::NODE_NAME_INVALID,
+    "Error occurred",
+    "Try this fix");
+
+  std::string what_msg = ex.what();
+  EXPECT_NE(std::string::npos, what_msg.find("Try this fix"));
+}
+
+TEST_F(RclcppExceptionTest, SourceLocation)
+{
+  RclcppException ex(ErrorCode::NODE_NAME_INVALID, "Test");
+
+  // Source location should be captured
+  EXPECT_NE(nullptr, ex.file_name());
+  EXPECT_NE(0u, ex.line());
+
+  std::string loc = ex.location_string();
+  EXPECT_FALSE(loc.empty());
+}
+
+TEST_F(RclcppExceptionTest, DetailedReport)
+{
+  ErrorContext context;
+  context.with_node_name("my_node");
+
+  RclcppException ex(
+    ErrorCode::PARAMETER_NOT_DECLARED,
+    "Parameter error",
+    ErrorSuggestion("Declare parameter", {"Use declare_parameter()"}, "https://docs.ros.org"),
+    context);
+
+  std::string report = ex.detailed_report();
+
+  EXPECT_NE(std::string::npos, report.find("4001"));
+  EXPECT_NE(std::string::npos, report.find("PARAMETER_NOT_DECLARED"));
+  EXPECT_NE(std::string::npos, report.find("Parameter error"));
+  EXPECT_NE(std::string::npos, report.find("my_node"));
+  EXPECT_NE(std::string::npos, report.find("Declare parameter"));
+  EXPECT_NE(std::string::npos, report.find("https://docs.ros.org"));
+}
+
+TEST_F(RclcppExceptionTest, WithContextMethod)
+{
+  RclcppException ex(ErrorCode::NODE_NAME_INVALID, "Test");
+  ex.with_context("key1", "value1").with_context("key2", "value2");
+
+  EXPECT_EQ(2u, ex.context_map().size());
+  EXPECT_EQ("value1", ex.context_map().at("key1"));
+  EXPECT_EQ("value2", ex.context_map().at("key2"));
+}
+
+TEST_F(RclcppExceptionTest, CopyConstruction)
+{
+  RclcppException original(ErrorCode::NODE_NAME_INVALID, "Original message");
+  original.with_context("key", "value");
+
+  RclcppException copy(original);
+
+  EXPECT_EQ(original.error_code(), copy.error_code());
+  EXPECT_EQ(original.message(), copy.message());
+  EXPECT_EQ(original.context_map().at("key"), copy.context_map().at("key"));
+}
+
+TEST_F(RclcppExceptionTest, MoveConstruction)
+{
+  RclcppException original(ErrorCode::NODE_NAME_INVALID, "Original message");
+  RclcppException moved(std::move(original));
+
+  EXPECT_EQ(ErrorCode::NODE_NAME_INVALID, moved.error_code());
+  EXPECT_EQ("Original message", moved.message());
+}
+
+TEST_F(RclcppExceptionTest, CatchAsStdException)
+{
+  bool caught = false;
+  try {
+    throw RclcppException(ErrorCode::NODE_NAME_INVALID, "Test");
+  } catch (const std::exception & e) {
+    caught = true;
+    EXPECT_NE(nullptr, e.what());
+  }
+  EXPECT_TRUE(caught);
+}
+
+// ============================================================================
+// Specialized Exception Tests
+// ============================================================================
+
+class SpecializedExceptionTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(SpecializedExceptionTest, InvalidNodeNameError)
+{
+  InvalidNodeNameError ex("123_invalid");
+
+  EXPECT_EQ(ErrorCode::NODE_NAME_INVALID, ex.error_code());
+  EXPECT_NE(std::string::npos, std::string(ex.what()).find("123_invalid"));
+  EXPECT_EQ("123_invalid", ex.context_map().at("node_name"));
+  EXPECT_FALSE(ex.suggestion().empty());
+}
+
+TEST_F(SpecializedExceptionTest, InvalidNodeNameErrorWithReason)
+{
+  InvalidNodeNameError ex("bad_name", "starts with reserved character");
+
+  std::string what_msg = ex.what();
+  EXPECT_NE(std::string::npos, what_msg.find("reserved character"));
+}
+
+TEST_F(SpecializedExceptionTest, InvalidNamespaceError)
+{
+  InvalidNamespaceError ex("bad/namespace");
+
+  EXPECT_EQ(ErrorCode::NODE_NAMESPACE_INVALID, ex.error_code());
+  EXPECT_EQ("bad/namespace", ex.context_map().at("namespace"));
+}
+
+TEST_F(SpecializedExceptionTest, NodeInitializationError)
+{
+  NodeInitializationError ex("my_node", "RMW error");
+
+  EXPECT_EQ(ErrorCode::NODE_INIT_FAILED, ex.error_code());
+  EXPECT_NE(std::string::npos, std::string(ex.what()).find("RMW error"));
+}
+
+TEST_F(SpecializedExceptionTest, InvalidTopicNameError)
+{
+  InvalidTopicNameError ex("/bad topic");
+
+  EXPECT_EQ(ErrorCode::TOPIC_NAME_INVALID, ex.error_code());
+  EXPECT_EQ("/bad topic", ex.context_map().at("topic_name"));
+}
+
+TEST_F(SpecializedExceptionTest, InvalidServiceNameError)
+{
+  InvalidServiceNameError ex("/bad service");
+
+  EXPECT_EQ(ErrorCode::SERVICE_NAME_INVALID, ex.error_code());
+  EXPECT_EQ("/bad service", ex.context_map().at("service_name"));
+}
+
+TEST_F(SpecializedExceptionTest, ServiceNotAvailableError)
+{
+  ServiceNotAvailableError ex("/my_service");
+
+  EXPECT_EQ(ErrorCode::SERVICE_NOT_AVAILABLE, ex.error_code());
+  EXPECT_NE(std::string::npos, std::string(ex.what()).find("not available"));
+}
+
+TEST_F(SpecializedExceptionTest, ParameterNotDeclaredException)
+{
+  ParameterNotDeclaredException ex("my_param");
+
+  EXPECT_EQ(ErrorCode::PARAMETER_NOT_DECLARED, ex.error_code());
+  EXPECT_EQ("my_param", ex.context_map().at("parameter_name"));
+  EXPECT_NE(std::string::npos, std::string(ex.what()).find("declare"));
+}
+
+TEST_F(SpecializedExceptionTest, ParameterTypeMismatchException)
+{
+  ParameterTypeMismatchException ex("speed", "double", "string");
+
+  EXPECT_EQ(ErrorCode::PARAMETER_TYPE_MISMATCH, ex.error_code());
+  EXPECT_EQ("speed", ex.context_map().at("parameter_name"));
+  EXPECT_EQ("double", ex.context_map().at("expected_type"));
+  EXPECT_EQ("string", ex.context_map().at("actual_type"));
+}
+
+TEST_F(SpecializedExceptionTest, InvalidParameterValueException)
+{
+  InvalidParameterValueException ex("count", "must be positive");
+
+  EXPECT_EQ(ErrorCode::PARAMETER_INVALID_VALUE, ex.error_code());
+  EXPECT_NE(std::string::npos, std::string(ex.what()).find("must be positive"));
+}
+
+TEST_F(SpecializedExceptionTest, QoSIncompatibleError)
+{
+  QoSIncompatibleError ex("/topic", "reliable", "best_effort");
+
+  EXPECT_EQ(ErrorCode::QOS_INCOMPATIBLE, ex.error_code());
+  EXPECT_EQ("/topic", ex.context_map().at("topic_name"));
+  EXPECT_EQ("reliable", ex.context_map().at("publisher_qos"));
+  EXPECT_EQ("best_effort", ex.context_map().at("subscriber_qos"));
+}
+
+TEST_F(SpecializedExceptionTest, CallbackGroupError)
+{
+  CallbackGroupError ex("mutex violation");
+
+  EXPECT_EQ(ErrorCode::CALLBACK_GROUP_ERROR, ex.error_code());
+  EXPECT_NE(std::string::npos, std::string(ex.what()).find("mutex violation"));
+}
+
+TEST_F(SpecializedExceptionTest, CatchAsBaseClass)
+{
+  bool caught_as_node_exception = false;
+  bool caught_as_rclcpp_exception = false;
+
+  try {
+    throw InvalidNodeNameError("test");
+  } catch (const NodeException &) {
+    caught_as_node_exception = true;
+  } catch (const RclcppException &) {
+    caught_as_rclcpp_exception = true;
+  }
+
+  EXPECT_TRUE(caught_as_node_exception);
+  EXPECT_FALSE(caught_as_rclcpp_exception);
+}
+
+TEST_F(SpecializedExceptionTest, CatchParameterExceptionHierarchy)
+{
+  bool caught = false;
+
+  try {
+    throw ParameterNotDeclaredException("test_param");
+  } catch (const ParameterException &) {
+    caught = true;
+  }
+
+  EXPECT_TRUE(caught);
+}
+
+// ============================================================================
+// Error Macro Tests
+// ============================================================================
+
+class ErrorMacroTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(ErrorMacroTest, RclcppThrow)
+{
+  EXPECT_THROW(
+    RCLCPP_THROW(ErrorCode::NODE_NAME_INVALID, "Test error"),
+    RclcppException);
+}
+
+TEST_F(ErrorMacroTest, RclcppThrowWithSuggestion)
+{
+  try {
+    RCLCPP_THROW_WITH_SUGGESTION(
+      ErrorCode::PARAMETER_NOT_DECLARED,
+      "Parameter missing",
+      "Use declare_parameter()");
+    FAIL() << "Expected exception";
+  } catch (const RclcppException & ex) {
+    EXPECT_EQ("Use declare_parameter()", ex.suggestion());
+  }
+}
+
+TEST_F(ErrorMacroTest, RclcppThrowIf)
+{
+  bool condition = true;
+  EXPECT_THROW(
+    RCLCPP_THROW_IF(condition, ErrorCode::NODE_NAME_INVALID, "Condition was true"),
+    RclcppException);
+
+  condition = false;
+  EXPECT_NO_THROW(
+    RCLCPP_THROW_IF(condition, ErrorCode::NODE_NAME_INVALID, "Should not throw"));
+}
+
+TEST_F(ErrorMacroTest, RclcppThrowUnless)
+{
+  bool condition = false;
+  EXPECT_THROW(
+    RCLCPP_THROW_UNLESS(condition, ErrorCode::NODE_NAME_INVALID, "Condition was false"),
+    RclcppException);
+
+  condition = true;
+  EXPECT_NO_THROW(
+    RCLCPP_THROW_UNLESS(condition, ErrorCode::NODE_NAME_INVALID, "Should not throw"));
+}
+
+TEST_F(ErrorMacroTest, RclcppThrowIfNull)
+{
+  int * ptr = nullptr;
+  EXPECT_THROW(
+    RCLCPP_THROW_IF_NULL(ptr, ErrorCode::INTERNAL_ERROR, "Pointer is null"),
+    RclcppException);
+
+  int value = 42;
+  ptr = &value;
+  EXPECT_NO_THROW(
+    RCLCPP_THROW_IF_NULL(ptr, ErrorCode::INTERNAL_ERROR, "Should not throw"));
+}
+
+TEST_F(ErrorMacroTest, RclcppThrowInvalidNodeName)
+{
+  EXPECT_THROW(
+    RCLCPP_THROW_INVALID_NODE_NAME("123bad"),
+    InvalidNodeNameError);
+}
+
+TEST_F(ErrorMacroTest, RclcppThrowInvalidNodeNameWithReason)
+{
+  try {
+    RCLCPP_THROW_INVALID_NODE_NAME("bad", "starts with reserved");
+    FAIL() << "Expected exception";
+  } catch (const InvalidNodeNameError & ex) {
+    EXPECT_NE(std::string::npos, std::string(ex.what()).find("reserved"));
+  }
+}
+
+TEST_F(ErrorMacroTest, RclcppThrowParameterNotDeclared)
+{
+  try {
+    RCLCPP_THROW_PARAMETER_NOT_DECLARED("my_param");
+    FAIL() << "Expected exception";
+  } catch (const ParameterNotDeclaredException & ex) {
+    EXPECT_EQ("my_param", ex.context_map().at("parameter_name"));
+  }
+}
+
+TEST_F(ErrorMacroTest, RclcppThrowParameterTypeMismatch)
+{
+  try {
+    RCLCPP_THROW_PARAMETER_TYPE_MISMATCH("speed", "double", "int");
+    FAIL() << "Expected exception";
+  } catch (const ParameterTypeMismatchException & ex) {
+    EXPECT_EQ("speed", ex.context_map().at("parameter_name"));
+    EXPECT_EQ("double", ex.context_map().at("expected_type"));
+    EXPECT_EQ("int", ex.context_map().at("actual_type"));
+  }
+}
+
+TEST_F(ErrorMacroTest, RclcppThrowQoSIncompatible)
+{
+  try {
+    RCLCPP_THROW_QOS_INCOMPATIBLE("/topic", "reliable", "best_effort");
+    FAIL() << "Expected exception";
+  } catch (const QoSIncompatibleError & ex) {
+    EXPECT_EQ(ErrorCode::QOS_INCOMPATIBLE, ex.error_code());
+  }
+}
+
+TEST_F(ErrorMacroTest, RclcppErrorMsg)
+{
+  std::string msg = RCLCPP_ERROR_MSG("Value " << 42 << " is invalid");
+  EXPECT_EQ("Value 42 is invalid", msg);
+}
+
+TEST_F(ErrorMacroTest, RclcppThrowFmt)
+{
+  try {
+    int value = 42;
+    RCLCPP_THROW_FMT(ErrorCode::PARAMETER_INVALID_VALUE, "Value " << value << " is invalid");
+    FAIL() << "Expected exception";
+  } catch (const RclcppException & ex) {
+    EXPECT_NE(std::string::npos, std::string(ex.what()).find("Value 42 is invalid"));
+  }
+}
+
+// ============================================================================
+// Context Builder Helper Tests
+// ============================================================================
+
+class ContextBuilderHelperTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(ContextBuilderHelperTest, MakeContext)
+{
+  auto context = make_context().with_node_name("test").with_topic_name("/topic");
+  EXPECT_EQ(2u, context.as_map().size());
+}
+
+TEST_F(ContextBuilderHelperTest, ContextForNode)
+{
+  auto context = context_for_node("my_node");
+  EXPECT_EQ("my_node", context.as_map().at("node_name"));
+}
+
+TEST_F(ContextBuilderHelperTest, ContextForTopic)
+{
+  auto context = context_for_topic("/my_topic");
+  EXPECT_EQ("/my_topic", context.as_map().at("topic_name"));
+}
+
+TEST_F(ContextBuilderHelperTest, ContextForService)
+{
+  auto context = context_for_service("/my_service");
+  EXPECT_EQ("/my_service", context.as_map().at("service_name"));
+}
+
+TEST_F(ContextBuilderHelperTest, ContextForParameter)
+{
+  auto context = context_for_parameter("my_param");
+  EXPECT_EQ("my_param", context.as_map().at("parameter_name"));
+}
+
+TEST_F(ContextBuilderHelperTest, MakeSuggestion)
+{
+  auto suggestion = make_suggestion("Primary fix");
+  EXPECT_EQ("Primary fix", suggestion.primary);
+  EXPECT_TRUE(suggestion.alternatives.empty());
+}
+
+TEST_F(ContextBuilderHelperTest, MakeSuggestionWithAlternatives)
+{
+  auto suggestion = make_suggestion("Primary", {"Alt 1", "Alt 2"});
+  EXPECT_EQ(2u, suggestion.alternatives.size());
+}
+
+TEST_F(ContextBuilderHelperTest, MakeSuggestionWithDocUrl)
+{
+  auto suggestion = make_suggestion("Primary", {"Alt"}, "https://docs.ros.org");
+  EXPECT_EQ("https://docs.ros.org", suggestion.documentation_url);
+}
+
+TEST_F(ContextBuilderHelperTest, ErrorCodeToString)
+{
+  std::string str = error_code_to_string(ErrorCode::NODE_NAME_INVALID);
+  EXPECT_NE(std::string::npos, str.find("1001"));
+  EXPECT_NE(std::string::npos, str.find("NODE_NAME_INVALID"));
+}
+
+TEST_F(ContextBuilderHelperTest, IsExceptionCategory)
+{
+  InvalidNodeNameError ex("test");
+  EXPECT_TRUE(is_exception_category(ex, ErrorCategory::NODE));
+  EXPECT_FALSE(is_exception_category(ex, ErrorCategory::TOPIC));
+}
+
+TEST_F(ContextBuilderHelperTest, IsExceptionCode)
+{
+  ParameterNotDeclaredException ex("param");
+  EXPECT_TRUE(is_exception_code(ex, ErrorCode::PARAMETER_NOT_DECLARED));
+  EXPECT_FALSE(is_exception_code(ex, ErrorCode::PARAMETER_TYPE_MISMATCH));
+}
+
+// ============================================================================
+// Thread Safety Tests
+// ============================================================================
+
+class ThreadSafetyTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(ThreadSafetyTest, ConcurrentWhatCalls)
+{
+  RclcppException ex(ErrorCode::NODE_NAME_INVALID, "Test message", "Suggestion");
+
+  std::vector<std::thread> threads;
+  std::vector<std::string> results(10);
+
+  for (size_t i = 0; i < 10; ++i) {
+    threads.emplace_back([&ex, &results, i]() {
+        for (int j = 0; j < 100; ++j) {
+          results[i] = ex.what();
+        }
+      });
+  }
+
+  for (auto & t : threads) {
+    t.join();
+  }
+
+  // All threads should get the same result
+  for (const auto & result : results) {
+    EXPECT_EQ(results[0], result);
+  }
+}
+
+TEST_F(ThreadSafetyTest, ExceptionCopyInThreads)
+{
+  RclcppException original(ErrorCode::NODE_NAME_INVALID, "Original");
+  original.with_context("key", "value");
+
+  std::vector<std::thread> threads;
+  std::atomic<int> success_count{0};
+
+  for (size_t i = 0; i < 10; ++i) {
+    threads.emplace_back([&original, &success_count]() {
+        try {
+          RclcppException copy(original);
+          if (copy.error_code() == ErrorCode::NODE_NAME_INVALID &&
+          copy.context_map().at("key") == "value")
+          {
+            success_count++;
+          }
+        } catch (...) {
+          // Should not happen
+        }
+      });
+  }
+
+  for (auto & t : threads) {
+    t.join();
+  }
+
+  EXPECT_EQ(10, success_count.load());
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

This PR introduces an enhanced error handling system for rclcpp that provides more actionable and user-friendly error messages with structured error codes, contextual information, and recovery suggestions.

## Motivation

Current rclcpp error messages often lack the context and guidance needed:
- Cryptic messages like "rcl_node_init() failed" without explanation
- No suggestions for how to fix common mistakes
- No error codes for programmatic error handling

## Changes

### Exception Hierarchy

```
std::exception
└── RclcppException
    ├── NodeException (InvalidNodeNameError, InvalidNamespaceError, etc.)
    ├── TopicException (InvalidTopicNameError)
    ├── ServiceException (InvalidServiceNameError, ServiceNotAvailableError)
    ├── ParameterException (ParameterNotDeclaredException, etc.)
    ├── QoSException (QoSIncompatibleError)
    └── ExecutorException (CallbackGroupError)
```

### Error Code Categories

| Range | Category | Description |
|-------|----------|-------------|
| 1000-1999 | NODE | Node-related errors |
| 2000-2999 | TOPIC | Topic and pub/sub errors |
| 3000-3999 | SERVICE | Service-related errors |
| 4000-4999 | PARAMETER | Parameter handling errors |
| 5000-5999 | QOS | Quality of Service errors |

### Key Features

```cpp
// Recovery suggestions included
ParameterNotDeclaredException ex("speed");
// what() returns:
// "[4001] Parameter 'speed' has not been declared
//  | Suggestion: Declare the parameter before use with declare_parameter<T>()"

// Convenience macros
RCLCPP_THROW_IF(value < 0, ErrorCode::PARAMETER_INVALID_VALUE, "Value must be positive");
```

## Backward Compatibility

- All exceptions inherit from `std::exception`
- Existing `catch (const std::exception&)` blocks continue to work
- New features are opt-in

## Testing

88 comprehensive tests covering all error codes, exceptions, macros, and thread safety.

---

Signed-off-by: niveshdandyan <niveshdandyan@users.noreply.github.com>