### PR TITLE
feat(rclcpp): add parameter validation helpers

### DIFF
--- a/rclcpp/include/rclcpp/parameter_builder.hpp
+++ b/rclcpp/include/rclcpp/parameter_builder.hpp
@@ -17,6 +17,7 @@
 
 #include <functional>
 #include <initializer_list>
+#include <limits>
 #include <map>
 #include <memory>
 #include <mutex>

--- a/rclcpp/include/rclcpp/parameter_builder.hpp
+++ b/rclcpp/include/rclcpp/parameter_builder.hpp
@@ -1,0 +1,537 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__PARAMETER_BUILDER_HPP_
+#define RCLCPP__PARAMETER_BUILDER_HPP_
+
+#include <functional>
+#include <initializer_list>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "rclcpp/node.hpp"
+#include "rclcpp/parameter.hpp"
+#include "rclcpp/parameter_validation.hpp"
+#include "rclcpp/parameter_validators.hpp"
+#include "rclcpp/visibility_control.hpp"
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
+
+namespace rclcpp
+{
+
+/// \brief Fluent builder for creating validated parameters.
+///
+/// ParameterBuilder provides a fluent API for declaring parameters with
+/// validation constraints. It allows you to specify the parameter name,
+/// description, default value, and one or more validators.
+///
+/// Example:
+/// \code{.cpp}
+/// auto builder = ParameterBuilder()
+///   .name("max_velocity")
+///   .description("Maximum robot velocity in m/s")
+///   .default_value(1.0)
+///   .range(0.0, 10.0);
+///
+/// // Declare the parameter with validation
+/// declare_validated_parameter(node, builder);
+/// \endcode
+class RCLCPP_PUBLIC ParameterBuilder
+{
+public:
+  /// \brief Default constructor.
+  ParameterBuilder() = default;
+
+  /// \brief Construct with parameter name.
+  /// \param param_name The name of the parameter.
+  explicit ParameterBuilder(const std::string & param_name);
+
+  /// \brief Set the parameter name.
+  /// \param param_name The name of the parameter.
+  /// \return Reference to this builder for chaining.
+  ParameterBuilder & name(const std::string & param_name);
+
+  /// \brief Set the parameter description.
+  /// \param desc Human-readable description of the parameter.
+  /// \return Reference to this builder for chaining.
+  ParameterBuilder & description(const std::string & desc);
+
+  /// \brief Set whether the parameter is read-only.
+  /// \param is_read_only True if parameter should be read-only.
+  /// \return Reference to this builder for chaining.
+  ParameterBuilder & read_only(bool is_read_only = true);
+
+  /// \brief Set the default value (template version).
+  /// \tparam T The value type.
+  /// \param value The default value.
+  /// \return Reference to this builder for chaining.
+  template<typename T>
+  ParameterBuilder & default_value(const T & value)
+  {
+    default_value_ = rclcpp::ParameterValue(value);
+    return *this;
+  }
+
+  /// \brief Set the default value from ParameterValue.
+  /// \param value The default value.
+  /// \return Reference to this builder for chaining.
+  ParameterBuilder & default_value(const rclcpp::ParameterValue & value);
+
+  /// \brief Add a custom validator.
+  /// \param v The validator to add.
+  /// \return Reference to this builder for chaining.
+  ParameterBuilder & validator(ParameterValidatorPtr v);
+
+  /// \brief Add a range validator for numeric parameters.
+  /// \tparam T The numeric type (int64_t or double).
+  /// \param min_val Minimum allowed value (inclusive).
+  /// \param max_val Maximum allowed value (inclusive).
+  /// \return Reference to this builder for chaining.
+  template<typename T>
+  ParameterBuilder & range(T min_val, T max_val)
+  {
+    validators_.push_back(std::make_shared<RangeValidator<T>>(min_val, max_val));
+    return *this;
+  }
+
+  /// \brief Add a minimum value validator.
+  /// \tparam T The numeric type.
+  /// \param min_val Minimum allowed value (inclusive).
+  /// \return Reference to this builder for chaining.
+  template<typename T>
+  ParameterBuilder & min(T min_val)
+  {
+    validators_.push_back(
+      std::make_shared<RangeValidator<T>>(RangeValidator<T>::min(min_val)));
+    return *this;
+  }
+
+  /// \brief Add a maximum value validator.
+  /// \tparam T The numeric type.
+  /// \param max_val Maximum allowed value (inclusive).
+  /// \return Reference to this builder for chaining.
+  template<typename T>
+  ParameterBuilder & max(T max_val)
+  {
+    validators_.push_back(
+      std::make_shared<RangeValidator<T>>(RangeValidator<T>::max(max_val)));
+    return *this;
+  }
+
+  /// \brief Add a one-of validator for enum-like constraints.
+  /// \tparam T The value type.
+  /// \param values The allowed values.
+  /// \return Reference to this builder for chaining.
+  template<typename T>
+  ParameterBuilder & one_of(std::initializer_list<T> values)
+  {
+    validators_.push_back(std::make_shared<OneOfValidator<T>>(values));
+    return *this;
+  }
+
+  /// \brief Add a regex pattern validator for strings.
+  /// \param pattern The regex pattern to match.
+  /// \param pattern_desc Optional description of the pattern.
+  /// \return Reference to this builder for chaining.
+  ParameterBuilder & matches(
+    const std::string & pattern,
+    const std::string & pattern_desc = "");
+
+  /// \brief Add a not-empty validator.
+  /// \return Reference to this builder for chaining.
+  ParameterBuilder & not_empty();
+
+  /// \brief Add a string length validator.
+  /// \param min_len Minimum string length.
+  /// \param max_len Maximum string length.
+  /// \return Reference to this builder for chaining.
+  ParameterBuilder & length(size_t min_len, size_t max_len);
+
+  /// \brief Get the parameter name.
+  /// \return The parameter name.
+  [[nodiscard]] const std::string &
+  get_name() const;
+
+  /// \brief Get the parameter description.
+  /// \return The description string.
+  [[nodiscard]] const std::string &
+  get_description() const;
+
+  /// \brief Check if parameter is read-only.
+  /// \return True if read-only.
+  [[nodiscard]] bool
+  is_read_only() const;
+
+  /// \brief Check if a default value is set.
+  /// \return True if default value is set.
+  [[nodiscard]] bool
+  has_default_value() const;
+
+  /// \brief Get the default value.
+  /// \return The default ParameterValue.
+  /// \throws std::runtime_error if no default value is set.
+  [[nodiscard]] const rclcpp::ParameterValue &
+  get_default_value() const;
+
+  /// \brief Build the parameter with current settings.
+  /// \return The constructed Parameter.
+  /// \throws std::runtime_error if name is not set.
+  [[nodiscard]] rclcpp::Parameter
+  build() const;
+
+  /// \brief Build a ParameterDescriptor with current settings.
+  ///
+  /// This creates a descriptor that includes the description, read-only flag,
+  /// and validation constraints as additional_constraints text.
+  ///
+  /// \return The constructed ParameterDescriptor.
+  [[nodiscard]] rcl_interfaces::msg::ParameterDescriptor
+  build_descriptor() const;
+
+  /// \brief Get the list of validators.
+  /// \return Vector of validator pointers.
+  [[nodiscard]] const std::vector<ParameterValidatorPtr> &
+  get_validators() const;
+
+  /// \brief Validate a parameter value against all validators.
+  /// \param param The parameter to validate.
+  /// \return ValidationResult indicating success or first failure.
+  [[nodiscard]] ValidationResult
+  validate(const rclcpp::Parameter & param) const;
+
+private:
+  std::string name_;
+  std::string description_;
+  bool read_only_ = false;
+  std::optional<rclcpp::ParameterValue> default_value_;
+  std::vector<ParameterValidatorPtr> validators_;
+};
+
+/// \brief Thread-safe registry for parameter validators.
+///
+/// This class manages the association between parameter names and their
+/// validators, allowing automatic validation when parameters change.
+class RCLCPP_PUBLIC ParameterValidatorRegistry
+{
+public:
+  /// \brief Default constructor.
+  ParameterValidatorRegistry() = default;
+
+  /// \brief Register validators for a parameter.
+  /// \param param_name The parameter name.
+  /// \param validators Vector of validators to register.
+  void register_validators(
+    const std::string & param_name,
+    std::vector<ParameterValidatorPtr> validators);
+
+  /// \brief Add a validator for a parameter.
+  /// \param param_name The parameter name.
+  /// \param validator The validator to add.
+  void add_validator(
+    const std::string & param_name,
+    ParameterValidatorPtr validator);
+
+  /// \brief Remove all validators for a parameter.
+  /// \param param_name The parameter name.
+  void clear_validators(const std::string & param_name);
+
+  /// \brief Check if a parameter has validators.
+  /// \param param_name The parameter name.
+  /// \return True if validators are registered.
+  [[nodiscard]] bool
+  has_validators(const std::string & param_name) const;
+
+  /// \brief Validate a parameter against its registered validators.
+  /// \param param The parameter to validate.
+  /// \return ValidationResult indicating success or first failure.
+  [[nodiscard]] ValidationResult
+  validate(const rclcpp::Parameter & param) const;
+
+  /// \brief Validate multiple parameters.
+  /// \param params Vector of parameters to validate.
+  /// \return ValidationResult indicating success or first failure.
+  [[nodiscard]] ValidationResult
+  validate(const std::vector<rclcpp::Parameter> & params) const;
+
+  /// \brief Create a parameter callback function for validation.
+  ///
+  /// Returns a callback suitable for use with add_on_set_parameters_callback().
+  ///
+  /// \return A callback function that validates parameters.
+  [[nodiscard]] std::function<rcl_interfaces::msg::SetParametersResult(
+      const std::vector<rclcpp::Parameter> &)>
+  create_callback() const;
+
+private:
+  mutable std::mutex mutex_;
+  std::map<std::string, std::vector<ParameterValidatorPtr>> validators_;
+};
+
+// =============================================================================
+// Free Functions for Node Integration
+// =============================================================================
+
+/// \brief Declare a parameter with validation using ParameterBuilder.
+///
+/// This function declares a parameter on a node, registering the validators
+/// from the builder and setting up automatic validation on parameter changes.
+///
+/// Example:
+/// \code{.cpp}
+/// auto param = declare_validated_parameter(
+///   *this,
+///   ParameterBuilder()
+///     .name("max_velocity")
+///     .description("Maximum velocity in m/s")
+///     .default_value(1.0)
+///     .range(0.0, 10.0)
+/// );
+/// \endcode
+///
+/// \tparam NodeT The node type (must have declare_parameter and
+///         add_on_set_parameters_callback methods).
+/// \param node The node to declare the parameter on.
+/// \param builder The ParameterBuilder with parameter configuration.
+/// \return The declared parameter value.
+/// \throws rclcpp::exceptions::ParameterAlreadyDeclaredException if parameter
+///         is already declared.
+/// \throws rclcpp::exceptions::InvalidParameterValueException if the default
+///         value fails validation.
+template<typename NodeT>
+rclcpp::Parameter
+declare_validated_parameter(
+  NodeT & node,
+  const ParameterBuilder & builder)
+{
+  // Validate default value first
+  if (builder.has_default_value()) {
+    rclcpp::Parameter temp_param(builder.get_name(), builder.get_default_value());
+    auto result = builder.validate(temp_param);
+    if (!result) {
+      throw rclcpp::exceptions::InvalidParameterValueException(result.reason());
+    }
+  }
+
+  // Build descriptor
+  auto descriptor = builder.build_descriptor();
+
+  // Declare the parameter
+  rclcpp::Parameter declared_param;
+  if (builder.has_default_value()) {
+    declared_param = rclcpp::Parameter(
+      builder.get_name(),
+      node.declare_parameter(
+        builder.get_name(),
+        builder.get_default_value(),
+        descriptor));
+  } else {
+    // Declare without default - will be PARAMETER_NOT_SET
+    declared_param = rclcpp::Parameter(
+      builder.get_name(),
+      node.declare_parameter(builder.get_name(), rclcpp::ParameterValue(), descriptor));
+  }
+
+  // Register validation callback if there are validators
+  if (!builder.get_validators().empty()) {
+    auto validators = builder.get_validators();
+    std::string param_name = builder.get_name();
+
+    auto callback = [validators, param_name](
+      const std::vector<rclcpp::Parameter> & params)
+      -> rcl_interfaces::msg::SetParametersResult {
+        rcl_interfaces::msg::SetParametersResult result;
+        result.successful = true;
+
+        for (const auto & param : params) {
+          if (param.get_name() == param_name) {
+            for (const auto & validator : validators) {
+              auto validation = validator->validate(param);
+              if (!validation) {
+                result.successful = false;
+                result.reason = validation.reason();
+                return result;
+              }
+            }
+          }
+        }
+
+        return result;
+      };
+
+    node.add_on_set_parameters_callback(callback);
+  }
+
+  return declared_param;
+}
+
+/// \brief Declare multiple validated parameters from a list of builders.
+///
+/// This is more efficient than calling declare_validated_parameter() multiple
+/// times because it creates a single combined callback for all validators.
+///
+/// \tparam NodeT The node type.
+/// \param node The node to declare parameters on.
+/// \param builders Vector of ParameterBuilder objects.
+/// \return Vector of declared parameters.
+template<typename NodeT>
+std::vector<rclcpp::Parameter>
+declare_validated_parameters(
+  NodeT & node,
+  const std::vector<ParameterBuilder> & builders)
+{
+  std::vector<rclcpp::Parameter> declared_params;
+  declared_params.reserve(builders.size());
+
+  // Collect all validators
+  std::map<std::string, std::vector<ParameterValidatorPtr>> all_validators;
+
+  for (const auto & builder : builders) {
+    // Validate default value first
+    if (builder.has_default_value()) {
+      rclcpp::Parameter temp_param(builder.get_name(), builder.get_default_value());
+      auto result = builder.validate(temp_param);
+      if (!result) {
+        throw rclcpp::exceptions::InvalidParameterValueException(result.reason());
+      }
+    }
+
+    // Build descriptor
+    auto descriptor = builder.build_descriptor();
+
+    // Declare the parameter
+    rclcpp::Parameter declared_param;
+    if (builder.has_default_value()) {
+      declared_param = rclcpp::Parameter(
+        builder.get_name(),
+        node.declare_parameter(
+          builder.get_name(),
+          builder.get_default_value(),
+          descriptor));
+    } else {
+      declared_param = rclcpp::Parameter(
+        builder.get_name(),
+        node.declare_parameter(builder.get_name(), rclcpp::ParameterValue(), descriptor));
+    }
+
+    declared_params.push_back(declared_param);
+
+    // Collect validators
+    if (!builder.get_validators().empty()) {
+      all_validators[builder.get_name()] = builder.get_validators();
+    }
+  }
+
+  // Register single combined callback
+  if (!all_validators.empty()) {
+    auto callback = [all_validators](
+      const std::vector<rclcpp::Parameter> & params)
+      -> rcl_interfaces::msg::SetParametersResult {
+        rcl_interfaces::msg::SetParametersResult result;
+        result.successful = true;
+
+        for (const auto & param : params) {
+          auto it = all_validators.find(param.get_name());
+          if (it != all_validators.end()) {
+            for (const auto & validator : it->second) {
+              auto validation = validator->validate(param);
+              if (!validation) {
+                result.successful = false;
+                result.reason = validation.reason();
+                return result;
+              }
+            }
+          }
+        }
+
+        return result;
+      };
+
+    node.add_on_set_parameters_callback(callback);
+  }
+
+  return declared_params;
+}
+
+/// \brief Create a validation callback for pre-existing parameters.
+///
+/// Use this when you need to add validation to parameters that were already
+/// declared through other means.
+///
+/// Example:
+/// \code{.cpp}
+/// std::map<std::string, std::vector<ParameterValidatorPtr>> validators;
+/// validators["velocity"] = {validators::range(0.0, 10.0)};
+/// validators["mode"] = {validators::one_of({"slow", "fast"})};
+///
+/// auto handle = create_validation_callback(node, validators);
+/// \endcode
+///
+/// \tparam NodeT The node type.
+/// \param node The node to register the callback on.
+/// \param validators Map of parameter names to their validators.
+/// \return The callback handle (store this to keep the callback active).
+template<typename NodeT>
+typename rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr
+create_validation_callback(
+  NodeT & node,
+  const std::map<std::string, std::vector<ParameterValidatorPtr>> & validators)
+{
+  auto callback = [validators](
+    const std::vector<rclcpp::Parameter> & params)
+    -> rcl_interfaces::msg::SetParametersResult {
+      rcl_interfaces::msg::SetParametersResult result;
+      result.successful = true;
+
+      for (const auto & param : params) {
+        auto it = validators.find(param.get_name());
+        if (it != validators.end()) {
+          for (const auto & validator : it->second) {
+            auto validation = validator->validate(param);
+            if (!validation) {
+              result.successful = false;
+              result.reason = validation.reason();
+              return result;
+            }
+          }
+        }
+      }
+
+      return result;
+    };
+
+  return node.add_on_set_parameters_callback(callback);
+}
+
+/// \brief Validate a parameter value programmatically.
+///
+/// This is useful for validating values before attempting to set them,
+/// or for validating values in custom logic.
+///
+/// \param param The parameter to validate.
+/// \param validators Vector of validators to apply.
+/// \return ValidationResult indicating success or first failure.
+RCLCPP_PUBLIC
+ValidationResult
+validate_parameter(
+  const rclcpp::Parameter & param,
+  const std::vector<ParameterValidatorPtr> & validators);
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__PARAMETER_BUILDER_HPP_

--- a/rclcpp/include/rclcpp/parameter_validation.hpp
+++ b/rclcpp/include/rclcpp/parameter_validation.hpp
@@ -1,0 +1,165 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__PARAMETER_VALIDATION_HPP_
+#define RCLCPP__PARAMETER_VALIDATION_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/parameter.hpp"
+#include "rclcpp/visibility_control.hpp"
+#include "rcl_interfaces/msg/set_parameters_result.hpp"
+
+namespace rclcpp
+{
+
+/// \brief Result of a parameter validation operation.
+///
+/// This class encapsulates the outcome of validating a parameter value,
+/// including whether the validation succeeded and a reason message if it failed.
+class RCLCPP_PUBLIC ValidationResult
+{
+public:
+  /// \brief Create a successful validation result.
+  /// \return A ValidationResult indicating success.
+  static ValidationResult success();
+
+  /// \brief Create a failed validation result.
+  /// \param reason A human-readable description of why validation failed.
+  /// \return A ValidationResult indicating failure with the given reason.
+  static ValidationResult failure(const std::string & reason);
+
+  /// \brief Check if the validation was successful.
+  /// \return true if validation succeeded, false otherwise.
+  [[nodiscard]] bool
+  successful() const noexcept;
+
+  /// \brief Boolean conversion operator.
+  /// \return true if validation succeeded, false otherwise.
+  [[nodiscard]] explicit
+  operator bool() const noexcept;
+
+  /// \brief Get the failure reason.
+  /// \return The reason string if validation failed, empty string if successful.
+  [[nodiscard]] const std::string &
+  reason() const noexcept;
+
+  /// \brief Convert to ROS message type for use with parameter callbacks.
+  /// \return A SetParametersResult message representing this validation result.
+  [[nodiscard]] rcl_interfaces::msg::SetParametersResult
+  to_msg() const;
+
+private:
+  ValidationResult(bool successful, std::string reason);
+
+  bool successful_;
+  std::string reason_;
+};
+
+/// \brief Abstract base class for parameter validators.
+///
+/// This class defines the interface that all parameter validators must implement.
+/// Validators are used to check if a parameter value meets certain constraints.
+///
+/// To create a custom validator, inherit from this class and implement the
+/// validate() and description() methods.
+///
+/// Example:
+/// \code{.cpp}
+/// class PositiveValidator : public rclcpp::ParameterValidator {
+/// public:
+///   ValidationResult validate(const rclcpp::Parameter& param) const override {
+///     if (param.as_double() > 0.0) {
+///       return ValidationResult::success();
+///     }
+///     return ValidationResult::failure("Value must be positive");
+///   }
+///
+///   std::string description() const override {
+///     return "positive number";
+///   }
+/// };
+/// \endcode
+class RCLCPP_PUBLIC ParameterValidator
+{
+public:
+  /// \brief Virtual destructor.
+  virtual ~ParameterValidator() = default;
+
+  /// \brief Validate a parameter value.
+  /// \param param The parameter to validate.
+  /// \return A ValidationResult indicating success or failure.
+  [[nodiscard]] virtual ValidationResult
+  validate(const rclcpp::Parameter & param) const = 0;
+
+  /// \brief Get a human-readable description of the validation constraint.
+  /// \return A string describing what this validator checks for.
+  [[nodiscard]] virtual std::string
+  description() const = 0;
+
+  /// \brief Get the expected parameter types for this validator.
+  ///
+  /// By default, returns an empty vector indicating any type is accepted.
+  /// Override this method to restrict which parameter types are valid.
+  ///
+  /// \return A vector of acceptable ParameterType values.
+  [[nodiscard]] virtual std::vector<rclcpp::ParameterType>
+  expected_types() const;
+};
+
+/// \brief Shared pointer type for ParameterValidator.
+using ParameterValidatorPtr = std::shared_ptr<ParameterValidator>;
+
+/// \brief Shared pointer to const type for ParameterValidator.
+using ParameterValidatorConstPtr = std::shared_ptr<const ParameterValidator>;
+
+/// \brief Format a validation error message with consistent structure.
+///
+/// Creates an error message in the format:
+/// "Parameter '<name>' validation failed: <reason>
+///   Expected: <expected>
+///   Got: <actual>"
+///
+/// \param param_name The name of the parameter that failed validation.
+/// \param reason Brief description of why validation failed.
+/// \param expected Description of what was expected.
+/// \param actual The actual value that was provided.
+/// \return A formatted error message string.
+RCLCPP_PUBLIC
+std::string
+format_validation_error(
+  const std::string & param_name,
+  const std::string & reason,
+  const std::string & expected,
+  const std::string & actual);
+
+/// \brief Convert a parameter value to string for error messages.
+/// \param param The parameter to convert.
+/// \return A string representation of the parameter value.
+RCLCPP_PUBLIC
+std::string
+parameter_value_to_string(const rclcpp::Parameter & param);
+
+/// \brief Get the string name of a parameter type.
+/// \param type The parameter type.
+/// \return A string name for the type.
+RCLCPP_PUBLIC
+std::string
+parameter_type_to_string(rclcpp::ParameterType type);
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__PARAMETER_VALIDATION_HPP_

--- a/rclcpp/include/rclcpp/parameter_validators.hpp
+++ b/rclcpp/include/rclcpp/parameter_validators.hpp
@@ -1,0 +1,775 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__PARAMETER_VALIDATORS_HPP_
+#define RCLCPP__PARAMETER_VALIDATORS_HPP_
+
+#include <algorithm>
+#include <initializer_list>
+#include <memory>
+#include <optional>
+#include <regex>
+#include <sstream>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "rclcpp/parameter_validation.hpp"
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+
+/// \brief Validates that a numeric parameter is within a specified range.
+///
+/// This validator checks that integer or double parameter values fall within
+/// specified minimum and/or maximum bounds. Bounds can be inclusive (default)
+/// or exclusive.
+///
+/// Example:
+/// \code{.cpp}
+/// // Value must be in [0.0, 100.0]
+/// auto validator = RangeValidator<double>(0.0, 100.0);
+///
+/// // Value must be in (0.0, 100.0) (exclusive bounds)
+/// auto validator = RangeValidator<double>(0.0, 100.0).exclusive();
+///
+/// // Value must be >= 0 (no upper bound)
+/// auto validator = RangeValidator<int64_t>::min(0);
+///
+/// // Value must be < 100 (exclusive upper bound only)
+/// auto validator = RangeValidator<int64_t>::max(100).exclusive_max();
+/// \endcode
+///
+/// \tparam T The numeric type (must be arithmetic: int64_t or double)
+template<typename T>
+class RangeValidator : public ParameterValidator
+{
+  static_assert(
+    std::is_arithmetic_v<T>,
+    "RangeValidator only supports arithmetic types (int64_t, double)"
+  );
+
+public:
+  /// \brief Construct a range validator with both min and max bounds.
+  /// \param min_value The minimum allowed value (inclusive by default).
+  /// \param max_value The maximum allowed value (inclusive by default).
+  RangeValidator(T min_value, T max_value)
+  : min_value_(min_value), max_value_(max_value),
+    min_exclusive_(false), max_exclusive_(false)
+  {
+  }
+
+  /// \brief Create a validator with only a minimum bound.
+  /// \param min_value The minimum allowed value.
+  /// \return A RangeValidator with no upper bound.
+  static RangeValidator<T> min(T min_value)
+  {
+    RangeValidator<T> v;
+    v.min_value_ = min_value;
+    return v;
+  }
+
+  /// \brief Create a validator with only a maximum bound.
+  /// \param max_value The maximum allowed value.
+  /// \return A RangeValidator with no lower bound.
+  static RangeValidator<T> max(T max_value)
+  {
+    RangeValidator<T> v;
+    v.max_value_ = max_value;
+    return v;
+  }
+
+  /// \brief Make the minimum bound exclusive.
+  /// \return Reference to this validator for chaining.
+  RangeValidator<T> & exclusive_min()
+  {
+    min_exclusive_ = true;
+    return *this;
+  }
+
+  /// \brief Make the maximum bound exclusive.
+  /// \return Reference to this validator for chaining.
+  RangeValidator<T> & exclusive_max()
+  {
+    max_exclusive_ = true;
+    return *this;
+  }
+
+  /// \brief Make both bounds exclusive.
+  /// \return Reference to this validator for chaining.
+  RangeValidator<T> & exclusive()
+  {
+    min_exclusive_ = true;
+    max_exclusive_ = true;
+    return *this;
+  }
+
+  /// \brief Validate the parameter value.
+  /// \param param The parameter to validate.
+  /// \return ValidationResult indicating success or failure.
+  [[nodiscard]] ValidationResult
+  validate(const rclcpp::Parameter & param) const override
+  {
+    T value;
+
+    // Extract value based on parameter type
+    if constexpr (std::is_integral_v<T>) {
+      if (param.get_type() != rclcpp::ParameterType::PARAMETER_INTEGER) {
+        return ValidationResult::failure(
+          format_validation_error(
+            param.get_name(),
+            "type mismatch",
+            "integer type",
+            parameter_type_to_string(param.get_type())));
+      }
+      value = static_cast<T>(param.as_int());
+    } else {
+      if (param.get_type() != rclcpp::ParameterType::PARAMETER_DOUBLE &&
+        param.get_type() != rclcpp::ParameterType::PARAMETER_INTEGER)
+      {
+        return ValidationResult::failure(
+          format_validation_error(
+            param.get_name(),
+            "type mismatch",
+            "numeric type (integer or double)",
+            parameter_type_to_string(param.get_type())));
+      }
+      if (param.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER) {
+        value = static_cast<T>(param.as_int());
+      } else {
+        value = static_cast<T>(param.as_double());
+      }
+    }
+
+    // Check minimum bound
+    if (min_value_.has_value()) {
+      bool min_ok = min_exclusive_ ?
+        (value > min_value_.value()) :
+        (value >= min_value_.value());
+      if (!min_ok) {
+        return ValidationResult::failure(
+          format_validation_error(
+            param.get_name(),
+            "value below minimum",
+            description(),
+            std::to_string(value)));
+      }
+    }
+
+    // Check maximum bound
+    if (max_value_.has_value()) {
+      bool max_ok = max_exclusive_ ?
+        (value < max_value_.value()) :
+        (value <= max_value_.value());
+      if (!max_ok) {
+        return ValidationResult::failure(
+          format_validation_error(
+            param.get_name(),
+            "value above maximum",
+            description(),
+            std::to_string(value)));
+      }
+    }
+
+    return ValidationResult::success();
+  }
+
+  /// \brief Get a description of this validator's constraints.
+  /// \return Human-readable description of the range constraint.
+  [[nodiscard]] std::string
+  description() const override
+  {
+    std::ostringstream ss;
+    ss << "value in ";
+
+    if (min_value_.has_value() && max_value_.has_value()) {
+      ss << (min_exclusive_ ? "(" : "[")
+         << min_value_.value()
+         << ", "
+         << max_value_.value()
+         << (max_exclusive_ ? ")" : "]");
+    } else if (min_value_.has_value()) {
+      ss << (min_exclusive_ ? "(" : "[")
+         << min_value_.value()
+         << ", +inf)";
+    } else if (max_value_.has_value()) {
+      ss << "(-inf, "
+         << max_value_.value()
+         << (max_exclusive_ ? ")" : "]");
+    } else {
+      ss << "(-inf, +inf)";
+    }
+
+    return ss.str();
+  }
+
+  /// \brief Get the expected parameter types.
+  /// \return Vector containing INTEGER and/or DOUBLE types.
+  [[nodiscard]] std::vector<rclcpp::ParameterType>
+  expected_types() const override
+  {
+    if constexpr (std::is_integral_v<T>) {
+      return {rclcpp::ParameterType::PARAMETER_INTEGER};
+    } else {
+      return {
+        rclcpp::ParameterType::PARAMETER_INTEGER,
+        rclcpp::ParameterType::PARAMETER_DOUBLE
+      };
+    }
+  }
+
+  /// \brief Get the minimum value if set.
+  /// \return Optional containing the minimum value, or nullopt.
+  [[nodiscard]] std::optional<T>
+  get_min() const
+  {
+    return min_value_;
+  }
+
+  /// \brief Get the maximum value if set.
+  /// \return Optional containing the maximum value, or nullopt.
+  [[nodiscard]] std::optional<T>
+  get_max() const
+  {
+    return max_value_;
+  }
+
+  /// \brief Check if minimum bound is exclusive.
+  /// \return true if minimum is exclusive, false if inclusive.
+  [[nodiscard]] bool
+  is_min_exclusive() const
+  {
+    return min_exclusive_;
+  }
+
+  /// \brief Check if maximum bound is exclusive.
+  /// \return true if maximum is exclusive, false if inclusive.
+  [[nodiscard]] bool
+  is_max_exclusive() const
+  {
+    return max_exclusive_;
+  }
+
+private:
+  RangeValidator()
+  : min_exclusive_(false), max_exclusive_(false)
+  {
+  }
+
+  std::optional<T> min_value_;
+  std::optional<T> max_value_;
+  bool min_exclusive_;
+  bool max_exclusive_;
+};
+
+/// \brief Type alias for integer range validator.
+using IntegerRangeValidator = RangeValidator<int64_t>;
+
+/// \brief Type alias for double range validator.
+using DoubleRangeValidator = RangeValidator<double>;
+
+/// \brief Validates that a parameter value is one of a set of allowed values.
+///
+/// This validator checks that the parameter value matches one of the predefined
+/// allowed values, similar to an enum constraint.
+///
+/// Example:
+/// \code{.cpp}
+/// // String must be one of the allowed modes
+/// auto validator = OneOfValidator<std::string>({"slow", "normal", "fast"});
+///
+/// // Integer must be a valid ID
+/// auto validator = OneOfValidator<int64_t>({1, 2, 4, 8, 16});
+/// \endcode
+///
+/// \tparam T The value type (string, int64_t, double, or bool)
+template<typename T>
+class OneOfValidator : public ParameterValidator
+{
+public:
+  /// \brief Construct from an initializer list of allowed values.
+  /// \param allowed_values The set of valid values.
+  OneOfValidator(std::initializer_list<T> allowed_values)
+  : allowed_values_(allowed_values)
+  {
+  }
+
+  /// \brief Construct from a container of allowed values.
+  /// \tparam Container A container type with begin/end iterators.
+  /// \param allowed_values Container of valid values.
+  template<typename Container>
+  explicit OneOfValidator(const Container & allowed_values)
+  : allowed_values_(allowed_values.begin(), allowed_values.end())
+  {
+  }
+
+  /// \brief Validate the parameter value.
+  /// \param param The parameter to validate.
+  /// \return ValidationResult indicating success or failure.
+  [[nodiscard]] ValidationResult
+  validate(const rclcpp::Parameter & param) const override
+  {
+    T value;
+
+    // Extract value based on type
+    if constexpr (std::is_same_v<T, std::string>) {
+      if (param.get_type() != rclcpp::ParameterType::PARAMETER_STRING) {
+        return ValidationResult::failure(
+          format_validation_error(
+            param.get_name(),
+            "type mismatch",
+            "string type",
+            parameter_type_to_string(param.get_type())));
+      }
+      value = param.as_string();
+    } else if constexpr (std::is_same_v<T, int64_t>) {
+      if (param.get_type() != rclcpp::ParameterType::PARAMETER_INTEGER) {
+        return ValidationResult::failure(
+          format_validation_error(
+            param.get_name(),
+            "type mismatch",
+            "integer type",
+            parameter_type_to_string(param.get_type())));
+      }
+      value = param.as_int();
+    } else if constexpr (std::is_same_v<T, double>) {
+      if (param.get_type() != rclcpp::ParameterType::PARAMETER_DOUBLE) {
+        return ValidationResult::failure(
+          format_validation_error(
+            param.get_name(),
+            "type mismatch",
+            "double type",
+            parameter_type_to_string(param.get_type())));
+      }
+      value = param.as_double();
+    } else if constexpr (std::is_same_v<T, bool>) {
+      if (param.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
+        return ValidationResult::failure(
+          format_validation_error(
+            param.get_name(),
+            "type mismatch",
+            "bool type",
+            parameter_type_to_string(param.get_type())));
+      }
+      value = param.as_bool();
+    }
+
+    // Check if value is in allowed set
+    auto it = std::find(allowed_values_.begin(), allowed_values_.end(), value);
+    if (it == allowed_values_.end()) {
+      return ValidationResult::failure(
+        format_validation_error(
+          param.get_name(),
+          "invalid value",
+          description(),
+          value_to_string(value)));
+    }
+
+    return ValidationResult::success();
+  }
+
+  /// \brief Get a description of allowed values.
+  /// \return Human-readable description of valid values.
+  [[nodiscard]] std::string
+  description() const override
+  {
+    std::ostringstream ss;
+    ss << "one of [";
+    for (size_t i = 0; i < allowed_values_.size(); ++i) {
+      if (i > 0) {
+        ss << ", ";
+      }
+      ss << value_to_string(allowed_values_[i]);
+    }
+    ss << "]";
+    return ss.str();
+  }
+
+  /// \brief Get the expected parameter type.
+  /// \return Vector with the expected type.
+  [[nodiscard]] std::vector<rclcpp::ParameterType>
+  expected_types() const override
+  {
+    if constexpr (std::is_same_v<T, std::string>) {
+      return {rclcpp::ParameterType::PARAMETER_STRING};
+    } else if constexpr (std::is_same_v<T, int64_t>) {
+      return {rclcpp::ParameterType::PARAMETER_INTEGER};
+    } else if constexpr (std::is_same_v<T, double>) {
+      return {rclcpp::ParameterType::PARAMETER_DOUBLE};
+    } else if constexpr (std::is_same_v<T, bool>) {
+      return {rclcpp::ParameterType::PARAMETER_BOOL};
+    }
+    return {};
+  }
+
+  /// \brief Get the list of allowed values.
+  /// \return Const reference to the allowed values vector.
+  [[nodiscard]] const std::vector<T> &
+  allowed_values() const
+  {
+    return allowed_values_;
+  }
+
+private:
+  template<typename U>
+  static std::string value_to_string(const U & val)
+  {
+    if constexpr (std::is_same_v<U, std::string>) {
+      return "\"" + val + "\"";
+    } else if constexpr (std::is_same_v<U, bool>) {
+      return val ? "true" : "false";
+    } else {
+      return std::to_string(val);
+    }
+  }
+
+  std::vector<T> allowed_values_;
+};
+
+/// \brief Type alias for string one-of validator.
+using StringOneOfValidator = OneOfValidator<std::string>;
+
+/// \brief Type alias for integer one-of validator.
+using IntegerOneOfValidator = OneOfValidator<int64_t>;
+
+/// \brief Validates that a string parameter matches a regex pattern.
+///
+/// This validator uses std::regex to check that string parameter values
+/// match the specified pattern.
+///
+/// Example:
+/// \code{.cpp}
+/// // Must be a valid identifier
+/// auto validator = RegexValidator("^[a-zA-Z_][a-zA-Z0-9_]*$", "valid identifier");
+///
+/// // Must be an IP address pattern
+/// auto validator = RegexValidator(R"(^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$)", "IPv4 address");
+/// \endcode
+class RCLCPP_PUBLIC RegexValidator : public ParameterValidator
+{
+public:
+  /// \brief Construct a regex validator.
+  /// \param pattern The regex pattern string.
+  /// \param pattern_description Optional human-readable description of what the pattern matches.
+  explicit RegexValidator(
+    const std::string & pattern,
+    const std::string & pattern_description = "");
+
+  /// \brief Validate the parameter value.
+  /// \param param The parameter to validate.
+  /// \return ValidationResult indicating success or failure.
+  [[nodiscard]] ValidationResult
+  validate(const rclcpp::Parameter & param) const override;
+
+  /// \brief Get a description of the pattern constraint.
+  /// \return Human-readable description.
+  [[nodiscard]] std::string
+  description() const override;
+
+  /// \brief Get the expected parameter type.
+  /// \return Vector containing STRING type.
+  [[nodiscard]] std::vector<rclcpp::ParameterType>
+  expected_types() const override;
+
+  /// \brief Get the regex pattern string.
+  /// \return The pattern string.
+  [[nodiscard]] const std::string &
+  pattern_string() const;
+
+private:
+  std::regex pattern_;
+  std::string pattern_str_;
+  std::string pattern_description_;
+};
+
+/// \brief Validates that a string or array parameter is not empty.
+///
+/// This validator checks that strings have at least one character,
+/// and arrays have at least one element.
+///
+/// Example:
+/// \code{.cpp}
+/// auto validator = NotEmptyValidator();
+/// \endcode
+class RCLCPP_PUBLIC NotEmptyValidator : public ParameterValidator
+{
+public:
+  NotEmptyValidator() = default;
+
+  /// \brief Validate the parameter value.
+  /// \param param The parameter to validate.
+  /// \return ValidationResult indicating success or failure.
+  [[nodiscard]] ValidationResult
+  validate(const rclcpp::Parameter & param) const override;
+
+  /// \brief Get a description of the constraint.
+  /// \return Human-readable description.
+  [[nodiscard]] std::string
+  description() const override;
+};
+
+/// \brief Validates string length is within specified bounds.
+///
+/// Example:
+/// \code{.cpp}
+/// // String must be 1-100 characters
+/// auto validator = StringLengthValidator(1, 100);
+///
+/// // String must be at least 3 characters
+/// auto validator = StringLengthValidator::min_length(3);
+/// \endcode
+class RCLCPP_PUBLIC StringLengthValidator : public ParameterValidator
+{
+public:
+  /// \brief Construct with min and max length bounds.
+  /// \param min_len Minimum string length (inclusive).
+  /// \param max_len Maximum string length (inclusive).
+  StringLengthValidator(size_t min_len, size_t max_len);
+
+  /// \brief Create a validator with only minimum length.
+  /// \param min_len Minimum string length.
+  /// \return A StringLengthValidator with no upper bound.
+  static StringLengthValidator min_length(size_t min_len);
+
+  /// \brief Create a validator with only maximum length.
+  /// \param max_len Maximum string length.
+  /// \return A StringLengthValidator with no lower bound.
+  static StringLengthValidator max_length(size_t max_len);
+
+  /// \brief Validate the parameter value.
+  /// \param param The parameter to validate.
+  /// \return ValidationResult indicating success or failure.
+  [[nodiscard]] ValidationResult
+  validate(const rclcpp::Parameter & param) const override;
+
+  /// \brief Get a description of the length constraint.
+  /// \return Human-readable description.
+  [[nodiscard]] std::string
+  description() const override;
+
+  /// \brief Get the expected parameter type.
+  /// \return Vector containing STRING type.
+  [[nodiscard]] std::vector<rclcpp::ParameterType>
+  expected_types() const override;
+
+private:
+  StringLengthValidator();
+
+  std::optional<size_t> min_length_;
+  std::optional<size_t> max_length_;
+};
+
+/// \brief Validates parameter type matches expected type(s).
+///
+/// Example:
+/// \code{.cpp}
+/// // Must be a double
+/// auto validator = TypeValidator(rclcpp::ParameterType::PARAMETER_DOUBLE);
+///
+/// // Must be numeric (int or double)
+/// auto validator = TypeValidator({
+///   rclcpp::ParameterType::PARAMETER_INTEGER,
+///   rclcpp::ParameterType::PARAMETER_DOUBLE
+/// });
+/// \endcode
+class RCLCPP_PUBLIC TypeValidator : public ParameterValidator
+{
+public:
+  /// \brief Construct with a single expected type.
+  /// \param expected_type The required parameter type.
+  explicit TypeValidator(rclcpp::ParameterType expected_type);
+
+  /// \brief Construct with multiple allowed types.
+  /// \param allowed_types List of acceptable parameter types.
+  TypeValidator(std::initializer_list<rclcpp::ParameterType> allowed_types);
+
+  /// \brief Validate the parameter value.
+  /// \param param The parameter to validate.
+  /// \return ValidationResult indicating success or failure.
+  [[nodiscard]] ValidationResult
+  validate(const rclcpp::Parameter & param) const override;
+
+  /// \brief Get a description of the type constraint.
+  /// \return Human-readable description.
+  [[nodiscard]] std::string
+  description() const override;
+
+  /// \brief Get the expected parameter types.
+  /// \return Vector of allowed types.
+  [[nodiscard]] std::vector<rclcpp::ParameterType>
+  expected_types() const override;
+
+private:
+  std::vector<rclcpp::ParameterType> allowed_types_;
+};
+
+/// \brief Combines multiple validators with AND or OR logic.
+///
+/// Example:
+/// \code{.cpp}
+/// // Value must pass ALL validators
+/// auto validator = CompositeValidator(CompositeValidator::Mode::ALL)
+///   .add(std::make_shared<RangeValidator<double>>(0.0, 100.0))
+///   .add(std::make_shared<CustomValidator>());
+///
+/// // Value must pass ANY validator
+/// auto validator = CompositeValidator(CompositeValidator::Mode::ANY)
+///   .add(validator1)
+///   .add(validator2);
+/// \endcode
+class RCLCPP_PUBLIC CompositeValidator : public ParameterValidator
+{
+public:
+  /// \brief Composition mode for combining validators.
+  enum class Mode
+  {
+    ALL,  ///< All validators must pass (AND logic)
+    ANY   ///< Any validator must pass (OR logic)
+  };
+
+  /// \brief Construct a composite validator.
+  /// \param mode The composition mode (default: ALL).
+  explicit CompositeValidator(Mode mode = Mode::ALL);
+
+  /// \brief Add a validator to the composition.
+  /// \param validator The validator to add.
+  /// \return Reference to this for chaining.
+  CompositeValidator & add(ParameterValidatorPtr validator);
+
+  /// \brief Alias for add() with AND semantics.
+  /// \param validator The validator to add.
+  /// \return Reference to this for chaining.
+  CompositeValidator & and_also(ParameterValidatorPtr validator);
+
+  /// \brief Add a validator and switch to ANY mode.
+  /// \param validator The validator to add.
+  /// \return Reference to this for chaining.
+  CompositeValidator & or_else(ParameterValidatorPtr validator);
+
+  /// \brief Validate the parameter value.
+  /// \param param The parameter to validate.
+  /// \return ValidationResult based on composition mode.
+  [[nodiscard]] ValidationResult
+  validate(const rclcpp::Parameter & param) const override;
+
+  /// \brief Get a description of all composed constraints.
+  /// \return Human-readable description.
+  [[nodiscard]] std::string
+  description() const override;
+
+  /// \brief Get the composition mode.
+  /// \return The current Mode.
+  [[nodiscard]] Mode
+  mode() const;
+
+  /// \brief Get the number of validators.
+  /// \return Count of composed validators.
+  [[nodiscard]] size_t
+  size() const;
+
+private:
+  Mode mode_;
+  std::vector<ParameterValidatorPtr> validators_;
+};
+
+/// \brief Convenience factory functions for creating validators.
+namespace validators
+{
+
+/// \brief Create a range validator with both bounds.
+/// \tparam T The numeric type.
+/// \param min_val Minimum value (inclusive).
+/// \param max_val Maximum value (inclusive).
+/// \return Shared pointer to the validator.
+template<typename T>
+ParameterValidatorPtr range(T min_val, T max_val)
+{
+  return std::make_shared<RangeValidator<T>>(min_val, max_val);
+}
+
+/// \brief Create a range validator with only minimum bound.
+/// \tparam T The numeric type.
+/// \param min_val Minimum value (inclusive).
+/// \return Shared pointer to the validator.
+template<typename T>
+ParameterValidatorPtr min(T min_val)
+{
+  return std::make_shared<RangeValidator<T>>(RangeValidator<T>::min(min_val));
+}
+
+/// \brief Create a range validator with only maximum bound.
+/// \tparam T The numeric type.
+/// \param max_val Maximum value (inclusive).
+/// \return Shared pointer to the validator.
+template<typename T>
+ParameterValidatorPtr max(T max_val)
+{
+  return std::make_shared<RangeValidator<T>>(RangeValidator<T>::max(max_val));
+}
+
+/// \brief Create a one-of validator from allowed values.
+/// \tparam T The value type.
+/// \param values Initializer list of allowed values.
+/// \return Shared pointer to the validator.
+template<typename T>
+ParameterValidatorPtr one_of(std::initializer_list<T> values)
+{
+  return std::make_shared<OneOfValidator<T>>(values);
+}
+
+/// \brief Create a regex validator.
+/// \param pattern The regex pattern.
+/// \param description Optional description of the pattern.
+/// \return Shared pointer to the validator.
+RCLCPP_PUBLIC
+ParameterValidatorPtr matches(
+  const std::string & pattern,
+  const std::string & description = "");
+
+/// \brief Create a not-empty validator.
+/// \return Shared pointer to the validator.
+RCLCPP_PUBLIC
+ParameterValidatorPtr not_empty();
+
+/// \brief Create a string length validator.
+/// \param min_len Minimum length.
+/// \param max_len Maximum length.
+/// \return Shared pointer to the validator.
+RCLCPP_PUBLIC
+ParameterValidatorPtr length(size_t min_len, size_t max_len);
+
+/// \brief Create a type validator.
+/// \param expected The expected parameter type.
+/// \return Shared pointer to the validator.
+RCLCPP_PUBLIC
+ParameterValidatorPtr type(rclcpp::ParameterType expected);
+
+/// \brief Create a composite validator requiring all validators to pass.
+/// \param validators List of validators to compose.
+/// \return Shared pointer to the composite validator.
+RCLCPP_PUBLIC
+ParameterValidatorPtr all_of(std::initializer_list<ParameterValidatorPtr> validators);
+
+/// \brief Create a composite validator requiring any validator to pass.
+/// \param validators List of validators to compose.
+/// \return Shared pointer to the composite validator.
+RCLCPP_PUBLIC
+ParameterValidatorPtr any_of(std::initializer_list<ParameterValidatorPtr> validators);
+
+}  // namespace validators
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__PARAMETER_VALIDATORS_HPP_

--- a/rclcpp/src/parameter_builder.cpp
+++ b/rclcpp/src/parameter_builder.cpp
@@ -1,0 +1,312 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/parameter_builder.hpp"
+
+#include <sstream>
+#include <stdexcept>
+
+namespace rclcpp
+{
+
+// =============================================================================
+// ParameterBuilder Implementation
+// =============================================================================
+
+ParameterBuilder::ParameterBuilder(const std::string & param_name)
+: name_(param_name)
+{
+}
+
+ParameterBuilder & ParameterBuilder::name(const std::string & param_name)
+{
+  name_ = param_name;
+  return *this;
+}
+
+ParameterBuilder & ParameterBuilder::description(const std::string & desc)
+{
+  description_ = desc;
+  return *this;
+}
+
+ParameterBuilder & ParameterBuilder::read_only(bool is_read_only)
+{
+  read_only_ = is_read_only;
+  return *this;
+}
+
+ParameterBuilder & ParameterBuilder::default_value(const rclcpp::ParameterValue & value)
+{
+  default_value_ = value;
+  return *this;
+}
+
+ParameterBuilder & ParameterBuilder::validator(ParameterValidatorPtr v)
+{
+  validators_.push_back(std::move(v));
+  return *this;
+}
+
+ParameterBuilder & ParameterBuilder::matches(
+  const std::string & pattern,
+  const std::string & pattern_desc)
+{
+  validators_.push_back(std::make_shared<RegexValidator>(pattern, pattern_desc));
+  return *this;
+}
+
+ParameterBuilder & ParameterBuilder::not_empty()
+{
+  validators_.push_back(std::make_shared<NotEmptyValidator>());
+  return *this;
+}
+
+ParameterBuilder & ParameterBuilder::length(size_t min_len, size_t max_len)
+{
+  validators_.push_back(std::make_shared<StringLengthValidator>(min_len, max_len));
+  return *this;
+}
+
+const std::string & ParameterBuilder::get_name() const
+{
+  return name_;
+}
+
+const std::string & ParameterBuilder::get_description() const
+{
+  return description_;
+}
+
+bool ParameterBuilder::is_read_only() const
+{
+  return read_only_;
+}
+
+bool ParameterBuilder::has_default_value() const
+{
+  return default_value_.has_value();
+}
+
+const rclcpp::ParameterValue & ParameterBuilder::get_default_value() const
+{
+  if (!default_value_.has_value()) {
+    throw std::runtime_error("No default value set for parameter '" + name_ + "'");
+  }
+  return default_value_.value();
+}
+
+rclcpp::Parameter ParameterBuilder::build() const
+{
+  if (name_.empty()) {
+    throw std::runtime_error("Parameter name must be set before building");
+  }
+
+  if (default_value_.has_value()) {
+    return rclcpp::Parameter(name_, default_value_.value());
+  }
+
+  return rclcpp::Parameter(name_);
+}
+
+rcl_interfaces::msg::ParameterDescriptor ParameterBuilder::build_descriptor() const
+{
+  rcl_interfaces::msg::ParameterDescriptor descriptor;
+  descriptor.description = description_;
+  descriptor.read_only = read_only_;
+
+  // Build additional_constraints from validator descriptions
+  if (!validators_.empty()) {
+    std::ostringstream ss;
+    ss << "Constraints: ";
+    for (size_t i = 0; i < validators_.size(); ++i) {
+      if (i > 0) {
+        ss << "; ";
+      }
+      ss << validators_[i]->description();
+    }
+    descriptor.additional_constraints = ss.str();
+  }
+
+  // Populate range info from RangeValidator if present
+  for (const auto & validator : validators_) {
+    // Check for double range validator
+    auto double_range = std::dynamic_pointer_cast<RangeValidator<double>>(validator);
+    if (double_range) {
+      auto min_val = double_range->get_min();
+      auto max_val = double_range->get_max();
+
+      if (min_val.has_value() || max_val.has_value()) {
+        rcl_interfaces::msg::FloatingPointRange range;
+        range.from_value = min_val.value_or(-std::numeric_limits<double>::infinity());
+        range.to_value = max_val.value_or(std::numeric_limits<double>::infinity());
+        range.step = 0.0;  // Any step
+        descriptor.floating_point_range.push_back(range);
+      }
+      break;  // Only use first range validator found
+    }
+
+    // Check for integer range validator
+    auto int_range = std::dynamic_pointer_cast<RangeValidator<int64_t>>(validator);
+    if (int_range) {
+      auto min_val = int_range->get_min();
+      auto max_val = int_range->get_max();
+
+      if (min_val.has_value() || max_val.has_value()) {
+        rcl_interfaces::msg::IntegerRange range;
+        range.from_value = min_val.value_or(std::numeric_limits<int64_t>::min());
+        range.to_value = max_val.value_or(std::numeric_limits<int64_t>::max());
+        range.step = 0;  // Any step
+        descriptor.integer_range.push_back(range);
+      }
+      break;
+    }
+  }
+
+  return descriptor;
+}
+
+const std::vector<ParameterValidatorPtr> & ParameterBuilder::get_validators() const
+{
+  return validators_;
+}
+
+ValidationResult ParameterBuilder::validate(const rclcpp::Parameter & param) const
+{
+  for (const auto & validator : validators_) {
+    auto result = validator->validate(param);
+    if (!result) {
+      return result;
+    }
+  }
+  return ValidationResult::success();
+}
+
+// =============================================================================
+// ParameterValidatorRegistry Implementation
+// =============================================================================
+
+void ParameterValidatorRegistry::register_validators(
+  const std::string & param_name,
+  std::vector<ParameterValidatorPtr> validators)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  validators_[param_name] = std::move(validators);
+}
+
+void ParameterValidatorRegistry::add_validator(
+  const std::string & param_name,
+  ParameterValidatorPtr validator)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  validators_[param_name].push_back(std::move(validator));
+}
+
+void ParameterValidatorRegistry::clear_validators(const std::string & param_name)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  validators_.erase(param_name);
+}
+
+bool ParameterValidatorRegistry::has_validators(const std::string & param_name) const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = validators_.find(param_name);
+  return it != validators_.end() && !it->second.empty();
+}
+
+ValidationResult ParameterValidatorRegistry::validate(const rclcpp::Parameter & param) const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = validators_.find(param.get_name());
+  if (it == validators_.end()) {
+    return ValidationResult::success();
+  }
+
+  for (const auto & validator : it->second) {
+    auto result = validator->validate(param);
+    if (!result) {
+      return result;
+    }
+  }
+
+  return ValidationResult::success();
+}
+
+ValidationResult ParameterValidatorRegistry::validate(
+  const std::vector<rclcpp::Parameter> & params) const
+{
+  for (const auto & param : params) {
+    auto result = validate(param);
+    if (!result) {
+      return result;
+    }
+  }
+  return ValidationResult::success();
+}
+
+std::function<rcl_interfaces::msg::SetParametersResult(
+    const std::vector<rclcpp::Parameter> &)>
+ParameterValidatorRegistry::create_callback() const
+{
+  // Capture a copy of the validators for thread safety
+  std::map<std::string, std::vector<ParameterValidatorPtr>> validators_copy;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    validators_copy = validators_;
+  }
+
+  return [validators_copy](
+    const std::vector<rclcpp::Parameter> & params)
+    -> rcl_interfaces::msg::SetParametersResult {
+      rcl_interfaces::msg::SetParametersResult result;
+      result.successful = true;
+
+      for (const auto & param : params) {
+        auto it = validators_copy.find(param.get_name());
+        if (it != validators_copy.end()) {
+          for (const auto & validator : it->second) {
+            auto validation = validator->validate(param);
+            if (!validation) {
+              result.successful = false;
+              result.reason = validation.reason();
+              return result;
+            }
+          }
+        }
+      }
+
+      return result;
+    };
+}
+
+// =============================================================================
+// Free Functions
+// =============================================================================
+
+ValidationResult validate_parameter(
+  const rclcpp::Parameter & param,
+  const std::vector<ParameterValidatorPtr> & validators)
+{
+  for (const auto & validator : validators) {
+    auto result = validator->validate(param);
+    if (!result) {
+      return result;
+    }
+  }
+  return ValidationResult::success();
+}
+
+}  // namespace rclcpp

--- a/rclcpp/src/parameter_builder.cpp
+++ b/rclcpp/src/parameter_builder.cpp
@@ -12,10 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "rclcpp/parameter_builder.hpp"
-
+#include <limits>
+#include <map>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "rclcpp/parameter_builder.hpp"
 
 namespace rclcpp
 {

--- a/rclcpp/src/parameter_validation.cpp
+++ b/rclcpp/src/parameter_validation.cpp
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "rclcpp/parameter_validation.hpp"
-#include "rclcpp/parameter_validators.hpp"
-
 #include <algorithm>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "rclcpp/parameter_validation.hpp"
+#include "rclcpp/parameter_validators.hpp"
 
 namespace rclcpp
 {

--- a/rclcpp/src/parameter_validation.cpp
+++ b/rclcpp/src/parameter_validation.cpp
@@ -1,0 +1,604 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/parameter_validation.hpp"
+#include "rclcpp/parameter_validators.hpp"
+
+#include <algorithm>
+#include <sstream>
+
+namespace rclcpp
+{
+
+// =============================================================================
+// ValidationResult Implementation
+// =============================================================================
+
+ValidationResult ValidationResult::success()
+{
+  return ValidationResult(true, "");
+}
+
+ValidationResult ValidationResult::failure(const std::string & reason)
+{
+  return ValidationResult(false, reason);
+}
+
+ValidationResult::ValidationResult(bool successful, std::string reason)
+: successful_(successful), reason_(std::move(reason))
+{
+}
+
+bool ValidationResult::successful() const noexcept
+{
+  return successful_;
+}
+
+ValidationResult::operator bool() const noexcept
+{
+  return successful_;
+}
+
+const std::string & ValidationResult::reason() const noexcept
+{
+  return reason_;
+}
+
+rcl_interfaces::msg::SetParametersResult ValidationResult::to_msg() const
+{
+  rcl_interfaces::msg::SetParametersResult msg;
+  msg.successful = successful_;
+  msg.reason = reason_;
+  return msg;
+}
+
+// =============================================================================
+// ParameterValidator Implementation
+// =============================================================================
+
+std::vector<rclcpp::ParameterType> ParameterValidator::expected_types() const
+{
+  return {};  // Empty means any type is accepted
+}
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+std::string format_validation_error(
+  const std::string & param_name,
+  const std::string & reason,
+  const std::string & expected,
+  const std::string & actual)
+{
+  std::ostringstream ss;
+  ss << "Parameter '" << param_name << "' validation failed: " << reason << "\n"
+     << "  Expected: " << expected << "\n"
+     << "  Got: " << actual;
+  return ss.str();
+}
+
+std::string parameter_value_to_string(const rclcpp::Parameter & param)
+{
+  switch (param.get_type()) {
+    case rclcpp::ParameterType::PARAMETER_NOT_SET:
+      return "<not set>";
+    case rclcpp::ParameterType::PARAMETER_BOOL:
+      return param.as_bool() ? "true" : "false";
+    case rclcpp::ParameterType::PARAMETER_INTEGER:
+      return std::to_string(param.as_int());
+    case rclcpp::ParameterType::PARAMETER_DOUBLE:
+      return std::to_string(param.as_double());
+    case rclcpp::ParameterType::PARAMETER_STRING:
+      return "\"" + param.as_string() + "\"";
+    case rclcpp::ParameterType::PARAMETER_BYTE_ARRAY:
+      {
+        auto arr = param.as_byte_array();
+        std::ostringstream ss;
+        ss << "[";
+        for (size_t i = 0; i < std::min(arr.size(), size_t(5)); ++i) {
+          if (i > 0) {ss << ", ";}
+          ss << static_cast<int>(arr[i]);
+        }
+        if (arr.size() > 5) {ss << ", ...";}
+        ss << "] (size=" << arr.size() << ")";
+        return ss.str();
+      }
+    case rclcpp::ParameterType::PARAMETER_BOOL_ARRAY:
+      {
+        auto arr = param.as_bool_array();
+        std::ostringstream ss;
+        ss << "[";
+        for (size_t i = 0; i < std::min(arr.size(), size_t(5)); ++i) {
+          if (i > 0) {ss << ", ";}
+          ss << (arr[i] ? "true" : "false");
+        }
+        if (arr.size() > 5) {ss << ", ...";}
+        ss << "] (size=" << arr.size() << ")";
+        return ss.str();
+      }
+    case rclcpp::ParameterType::PARAMETER_INTEGER_ARRAY:
+      {
+        auto arr = param.as_integer_array();
+        std::ostringstream ss;
+        ss << "[";
+        for (size_t i = 0; i < std::min(arr.size(), size_t(5)); ++i) {
+          if (i > 0) {ss << ", ";}
+          ss << arr[i];
+        }
+        if (arr.size() > 5) {ss << ", ...";}
+        ss << "] (size=" << arr.size() << ")";
+        return ss.str();
+      }
+    case rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY:
+      {
+        auto arr = param.as_double_array();
+        std::ostringstream ss;
+        ss << "[";
+        for (size_t i = 0; i < std::min(arr.size(), size_t(5)); ++i) {
+          if (i > 0) {ss << ", ";}
+          ss << arr[i];
+        }
+        if (arr.size() > 5) {ss << ", ...";}
+        ss << "] (size=" << arr.size() << ")";
+        return ss.str();
+      }
+    case rclcpp::ParameterType::PARAMETER_STRING_ARRAY:
+      {
+        auto arr = param.as_string_array();
+        std::ostringstream ss;
+        ss << "[";
+        for (size_t i = 0; i < std::min(arr.size(), size_t(5)); ++i) {
+          if (i > 0) {ss << ", ";}
+          ss << "\"" << arr[i] << "\"";
+        }
+        if (arr.size() > 5) {ss << ", ...";}
+        ss << "] (size=" << arr.size() << ")";
+        return ss.str();
+      }
+    default:
+      return "<unknown>";
+  }
+}
+
+std::string parameter_type_to_string(rclcpp::ParameterType type)
+{
+  switch (type) {
+    case rclcpp::ParameterType::PARAMETER_NOT_SET:
+      return "not_set";
+    case rclcpp::ParameterType::PARAMETER_BOOL:
+      return "bool";
+    case rclcpp::ParameterType::PARAMETER_INTEGER:
+      return "integer";
+    case rclcpp::ParameterType::PARAMETER_DOUBLE:
+      return "double";
+    case rclcpp::ParameterType::PARAMETER_STRING:
+      return "string";
+    case rclcpp::ParameterType::PARAMETER_BYTE_ARRAY:
+      return "byte_array";
+    case rclcpp::ParameterType::PARAMETER_BOOL_ARRAY:
+      return "bool_array";
+    case rclcpp::ParameterType::PARAMETER_INTEGER_ARRAY:
+      return "integer_array";
+    case rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY:
+      return "double_array";
+    case rclcpp::ParameterType::PARAMETER_STRING_ARRAY:
+      return "string_array";
+    default:
+      return "unknown";
+  }
+}
+
+// =============================================================================
+// RegexValidator Implementation
+// =============================================================================
+
+RegexValidator::RegexValidator(
+  const std::string & pattern,
+  const std::string & pattern_description)
+: pattern_(pattern, std::regex::ECMAScript),
+  pattern_str_(pattern),
+  pattern_description_(pattern_description)
+{
+}
+
+ValidationResult RegexValidator::validate(const rclcpp::Parameter & param) const
+{
+  if (param.get_type() != rclcpp::ParameterType::PARAMETER_STRING) {
+    return ValidationResult::failure(
+      format_validation_error(
+        param.get_name(),
+        "type mismatch",
+        "string type",
+        parameter_type_to_string(param.get_type())));
+  }
+
+  const std::string & value = param.as_string();
+  if (!std::regex_match(value, pattern_)) {
+    return ValidationResult::failure(
+      format_validation_error(
+        param.get_name(),
+        "pattern mismatch",
+        description(),
+        "\"" + value + "\""));
+  }
+
+  return ValidationResult::success();
+}
+
+std::string RegexValidator::description() const
+{
+  std::ostringstream ss;
+  ss << "string matching pattern \"" << pattern_str_ << "\"";
+  if (!pattern_description_.empty()) {
+    ss << " (" << pattern_description_ << ")";
+  }
+  return ss.str();
+}
+
+std::vector<rclcpp::ParameterType> RegexValidator::expected_types() const
+{
+  return {rclcpp::ParameterType::PARAMETER_STRING};
+}
+
+const std::string & RegexValidator::pattern_string() const
+{
+  return pattern_str_;
+}
+
+// =============================================================================
+// NotEmptyValidator Implementation
+// =============================================================================
+
+ValidationResult NotEmptyValidator::validate(const rclcpp::Parameter & param) const
+{
+  bool is_empty = false;
+  std::string type_name;
+
+  switch (param.get_type()) {
+    case rclcpp::ParameterType::PARAMETER_STRING:
+      is_empty = param.as_string().empty();
+      type_name = "string";
+      break;
+    case rclcpp::ParameterType::PARAMETER_BYTE_ARRAY:
+      is_empty = param.as_byte_array().empty();
+      type_name = "byte array";
+      break;
+    case rclcpp::ParameterType::PARAMETER_BOOL_ARRAY:
+      is_empty = param.as_bool_array().empty();
+      type_name = "bool array";
+      break;
+    case rclcpp::ParameterType::PARAMETER_INTEGER_ARRAY:
+      is_empty = param.as_integer_array().empty();
+      type_name = "integer array";
+      break;
+    case rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY:
+      is_empty = param.as_double_array().empty();
+      type_name = "double array";
+      break;
+    case rclcpp::ParameterType::PARAMETER_STRING_ARRAY:
+      is_empty = param.as_string_array().empty();
+      type_name = "string array";
+      break;
+    case rclcpp::ParameterType::PARAMETER_NOT_SET:
+      is_empty = true;
+      type_name = "parameter";
+      break;
+    default:
+      // For scalar types (bool, int, double), they are never "empty"
+      return ValidationResult::success();
+  }
+
+  if (is_empty) {
+    return ValidationResult::failure(
+      format_validation_error(
+        param.get_name(),
+        "empty " + type_name,
+        "non-empty " + type_name,
+        "empty"));
+  }
+
+  return ValidationResult::success();
+}
+
+std::string NotEmptyValidator::description() const
+{
+  return "non-empty value";
+}
+
+// =============================================================================
+// StringLengthValidator Implementation
+// =============================================================================
+
+StringLengthValidator::StringLengthValidator(size_t min_len, size_t max_len)
+: min_length_(min_len), max_length_(max_len)
+{
+}
+
+StringLengthValidator::StringLengthValidator()
+{
+}
+
+StringLengthValidator StringLengthValidator::min_length(size_t min_len)
+{
+  StringLengthValidator v;
+  v.min_length_ = min_len;
+  return v;
+}
+
+StringLengthValidator StringLengthValidator::max_length(size_t max_len)
+{
+  StringLengthValidator v;
+  v.max_length_ = max_len;
+  return v;
+}
+
+ValidationResult StringLengthValidator::validate(const rclcpp::Parameter & param) const
+{
+  if (param.get_type() != rclcpp::ParameterType::PARAMETER_STRING) {
+    return ValidationResult::failure(
+      format_validation_error(
+        param.get_name(),
+        "type mismatch",
+        "string type",
+        parameter_type_to_string(param.get_type())));
+  }
+
+  size_t len = param.as_string().length();
+
+  if (min_length_.has_value() && len < min_length_.value()) {
+    return ValidationResult::failure(
+      format_validation_error(
+        param.get_name(),
+        "string too short",
+        description(),
+        "length " + std::to_string(len)));
+  }
+
+  if (max_length_.has_value() && len > max_length_.value()) {
+    return ValidationResult::failure(
+      format_validation_error(
+        param.get_name(),
+        "string too long",
+        description(),
+        "length " + std::to_string(len)));
+  }
+
+  return ValidationResult::success();
+}
+
+std::string StringLengthValidator::description() const
+{
+  std::ostringstream ss;
+  ss << "string with length ";
+
+  if (min_length_.has_value() && max_length_.has_value()) {
+    ss << "in [" << min_length_.value() << ", " << max_length_.value() << "]";
+  } else if (min_length_.has_value()) {
+    ss << ">= " << min_length_.value();
+  } else if (max_length_.has_value()) {
+    ss << "<= " << max_length_.value();
+  } else {
+    ss << "any";
+  }
+
+  return ss.str();
+}
+
+std::vector<rclcpp::ParameterType> StringLengthValidator::expected_types() const
+{
+  return {rclcpp::ParameterType::PARAMETER_STRING};
+}
+
+// =============================================================================
+// TypeValidator Implementation
+// =============================================================================
+
+TypeValidator::TypeValidator(rclcpp::ParameterType expected_type)
+: allowed_types_({expected_type})
+{
+}
+
+TypeValidator::TypeValidator(std::initializer_list<rclcpp::ParameterType> allowed_types)
+: allowed_types_(allowed_types)
+{
+}
+
+ValidationResult TypeValidator::validate(const rclcpp::Parameter & param) const
+{
+  auto it = std::find(allowed_types_.begin(), allowed_types_.end(), param.get_type());
+  if (it == allowed_types_.end()) {
+    return ValidationResult::failure(
+      format_validation_error(
+        param.get_name(),
+        "type mismatch",
+        description(),
+        parameter_type_to_string(param.get_type())));
+  }
+
+  return ValidationResult::success();
+}
+
+std::string TypeValidator::description() const
+{
+  if (allowed_types_.size() == 1) {
+    return "type " + parameter_type_to_string(allowed_types_[0]);
+  }
+
+  std::ostringstream ss;
+  ss << "one of types [";
+  for (size_t i = 0; i < allowed_types_.size(); ++i) {
+    if (i > 0) {
+      ss << ", ";
+    }
+    ss << parameter_type_to_string(allowed_types_[i]);
+  }
+  ss << "]";
+  return ss.str();
+}
+
+std::vector<rclcpp::ParameterType> TypeValidator::expected_types() const
+{
+  return allowed_types_;
+}
+
+// =============================================================================
+// CompositeValidator Implementation
+// =============================================================================
+
+CompositeValidator::CompositeValidator(Mode mode)
+: mode_(mode)
+{
+}
+
+CompositeValidator & CompositeValidator::add(ParameterValidatorPtr validator)
+{
+  validators_.push_back(std::move(validator));
+  return *this;
+}
+
+CompositeValidator & CompositeValidator::and_also(ParameterValidatorPtr validator)
+{
+  return add(std::move(validator));
+}
+
+CompositeValidator & CompositeValidator::or_else(ParameterValidatorPtr validator)
+{
+  mode_ = Mode::ANY;
+  return add(std::move(validator));
+}
+
+ValidationResult CompositeValidator::validate(const rclcpp::Parameter & param) const
+{
+  if (validators_.empty()) {
+    return ValidationResult::success();
+  }
+
+  std::vector<std::string> failure_reasons;
+
+  for (const auto & validator : validators_) {
+    auto result = validator->validate(param);
+
+    if (mode_ == Mode::ALL) {
+      // ALL mode: fail on first failure
+      if (!result) {
+        return result;
+      }
+    } else {
+      // ANY mode: succeed on first success
+      if (result) {
+        return ValidationResult::success();
+      }
+      failure_reasons.push_back(result.reason());
+    }
+  }
+
+  if (mode_ == Mode::ALL) {
+    return ValidationResult::success();
+  } else {
+    // ALL validators failed in ANY mode
+    std::ostringstream ss;
+    ss << "Parameter '" << param.get_name() << "' validation failed: "
+       << "none of the validators passed\n";
+    for (size_t i = 0; i < failure_reasons.size(); ++i) {
+      ss << "  Validator " << (i + 1) << ": " << failure_reasons[i];
+      if (i < failure_reasons.size() - 1) {
+        ss << "\n";
+      }
+    }
+    return ValidationResult::failure(ss.str());
+  }
+}
+
+std::string CompositeValidator::description() const
+{
+  if (validators_.empty()) {
+    return "any value";
+  }
+
+  std::ostringstream ss;
+  std::string connector = (mode_ == Mode::ALL) ? " AND " : " OR ";
+
+  ss << "(";
+  for (size_t i = 0; i < validators_.size(); ++i) {
+    if (i > 0) {
+      ss << connector;
+    }
+    ss << validators_[i]->description();
+  }
+  ss << ")";
+
+  return ss.str();
+}
+
+CompositeValidator::Mode CompositeValidator::mode() const
+{
+  return mode_;
+}
+
+size_t CompositeValidator::size() const
+{
+  return validators_.size();
+}
+
+// =============================================================================
+// Factory Functions
+// =============================================================================
+
+namespace validators
+{
+
+ParameterValidatorPtr matches(
+  const std::string & pattern,
+  const std::string & description)
+{
+  return std::make_shared<RegexValidator>(pattern, description);
+}
+
+ParameterValidatorPtr not_empty()
+{
+  return std::make_shared<NotEmptyValidator>();
+}
+
+ParameterValidatorPtr length(size_t min_len, size_t max_len)
+{
+  return std::make_shared<StringLengthValidator>(min_len, max_len);
+}
+
+ParameterValidatorPtr type(rclcpp::ParameterType expected)
+{
+  return std::make_shared<TypeValidator>(expected);
+}
+
+ParameterValidatorPtr all_of(std::initializer_list<ParameterValidatorPtr> validators)
+{
+  auto composite = std::make_shared<CompositeValidator>(CompositeValidator::Mode::ALL);
+  for (const auto & v : validators) {
+    composite->add(v);
+  }
+  return composite;
+}
+
+ParameterValidatorPtr any_of(std::initializer_list<ParameterValidatorPtr> validators)
+{
+  auto composite = std::make_shared<CompositeValidator>(CompositeValidator::Mode::ANY);
+  for (const auto & v : validators) {
+    composite->add(v);
+  }
+  return composite;
+}
+
+}  // namespace validators
+
+}  // namespace rclcpp

--- a/rclcpp/test/test_parameter_validation.cpp
+++ b/rclcpp/test/test_parameter_validation.cpp
@@ -1,0 +1,1159 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/parameter_validation.hpp"
+#include "rclcpp/parameter_validators.hpp"
+#include "rclcpp/parameter_builder.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+using namespace rclcpp;
+
+// =============================================================================
+// ValidationResult Tests
+// =============================================================================
+
+class ValidationResultTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(ValidationResultTest, SuccessResult)
+{
+  auto result = ValidationResult::success();
+  EXPECT_TRUE(result.successful());
+  EXPECT_TRUE(static_cast<bool>(result));
+  EXPECT_TRUE(result.reason().empty());
+}
+
+TEST_F(ValidationResultTest, FailureResult)
+{
+  auto result = ValidationResult::failure("Something went wrong");
+  EXPECT_FALSE(result.successful());
+  EXPECT_FALSE(static_cast<bool>(result));
+  EXPECT_EQ(result.reason(), "Something went wrong");
+}
+
+TEST_F(ValidationResultTest, ToMsg)
+{
+  auto success = ValidationResult::success();
+  auto success_msg = success.to_msg();
+  EXPECT_TRUE(success_msg.successful);
+  EXPECT_TRUE(success_msg.reason.empty());
+
+  auto failure = ValidationResult::failure("Error message");
+  auto failure_msg = failure.to_msg();
+  EXPECT_FALSE(failure_msg.successful);
+  EXPECT_EQ(failure_msg.reason, "Error message");
+}
+
+// =============================================================================
+// RangeValidator Tests
+// =============================================================================
+
+class RangeValidatorTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(RangeValidatorTest, DoubleRangeInclusive)
+{
+  RangeValidator<double> validator(0.0, 100.0);
+
+  // Valid values
+  EXPECT_TRUE(validator.validate(Parameter("p", 0.0)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("p", 50.0)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("p", 100.0)).successful());
+
+  // Invalid values
+  EXPECT_FALSE(validator.validate(Parameter("p", -0.001)).successful());
+  EXPECT_FALSE(validator.validate(Parameter("p", 100.001)).successful());
+  EXPECT_FALSE(validator.validate(Parameter("p", -1000.0)).successful());
+}
+
+TEST_F(RangeValidatorTest, DoubleRangeExclusive)
+{
+  auto validator = RangeValidator<double>(0.0, 100.0).exclusive();
+
+  // Boundaries should fail
+  EXPECT_FALSE(validator.validate(Parameter("p", 0.0)).successful());
+  EXPECT_FALSE(validator.validate(Parameter("p", 100.0)).successful());
+
+  // Values inside should pass
+  EXPECT_TRUE(validator.validate(Parameter("p", 0.001)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("p", 99.999)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("p", 50.0)).successful());
+}
+
+TEST_F(RangeValidatorTest, DoubleRangeExclusiveMin)
+{
+  auto validator = RangeValidator<double>(0.0, 100.0).exclusive_min();
+
+  EXPECT_FALSE(validator.validate(Parameter("p", 0.0)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("p", 100.0)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("p", 0.001)).successful());
+}
+
+TEST_F(RangeValidatorTest, DoubleRangeExclusiveMax)
+{
+  auto validator = RangeValidator<double>(0.0, 100.0).exclusive_max();
+
+  EXPECT_TRUE(validator.validate(Parameter("p", 0.0)).successful());
+  EXPECT_FALSE(validator.validate(Parameter("p", 100.0)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("p", 99.999)).successful());
+}
+
+TEST_F(RangeValidatorTest, DoubleMinOnly)
+{
+  auto validator = RangeValidator<double>::min(0.0);
+
+  EXPECT_TRUE(validator.validate(Parameter("p", 0.0)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("p", 1000000.0)).successful());
+  EXPECT_FALSE(validator.validate(Parameter("p", -0.001)).successful());
+}
+
+TEST_F(RangeValidatorTest, DoubleMaxOnly)
+{
+  auto validator = RangeValidator<double>::max(100.0);
+
+  EXPECT_TRUE(validator.validate(Parameter("p", 100.0)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("p", -1000000.0)).successful());
+  EXPECT_FALSE(validator.validate(Parameter("p", 100.001)).successful());
+}
+
+TEST_F(RangeValidatorTest, IntegerRange)
+{
+  RangeValidator<int64_t> validator(0, 100);
+
+  EXPECT_TRUE(validator.validate(Parameter("p", 0)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("p", 50)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("p", 100)).successful());
+  EXPECT_FALSE(validator.validate(Parameter("p", -1)).successful());
+  EXPECT_FALSE(validator.validate(Parameter("p", 101)).successful());
+}
+
+TEST_F(RangeValidatorTest, IntegerFromDouble)
+{
+  // Double validator should accept integer values
+  RangeValidator<double> validator(0.0, 100.0);
+
+  EXPECT_TRUE(validator.validate(Parameter("p", 50)).successful());
+}
+
+TEST_F(RangeValidatorTest, TypeMismatch)
+{
+  RangeValidator<int64_t> int_validator(0, 100);
+  RangeValidator<double> double_validator(0.0, 100.0);
+
+  // Integer validator should reject strings
+  EXPECT_FALSE(int_validator.validate(Parameter("p", "50")).successful());
+
+  // Double validator should reject strings
+  EXPECT_FALSE(double_validator.validate(Parameter("p", "50.0")).successful());
+}
+
+TEST_F(RangeValidatorTest, Description)
+{
+  RangeValidator<double> both(0.0, 100.0);
+  EXPECT_NE(both.description().find("[0"), std::string::npos);
+  EXPECT_NE(both.description().find("100]"), std::string::npos);
+
+  auto min_only = RangeValidator<double>::min(0.0);
+  EXPECT_NE(min_only.description().find("[0"), std::string::npos);
+  EXPECT_NE(min_only.description().find("+inf"), std::string::npos);
+
+  auto exclusive = RangeValidator<double>(0.0, 100.0).exclusive();
+  EXPECT_NE(exclusive.description().find("(0"), std::string::npos);
+  EXPECT_NE(exclusive.description().find("100)"), std::string::npos);
+}
+
+TEST_F(RangeValidatorTest, ErrorMessageContent)
+{
+  RangeValidator<double> validator(0.0, 100.0);
+  auto result = validator.validate(Parameter("max_velocity", 150.0));
+
+  EXPECT_FALSE(result.successful());
+  EXPECT_NE(result.reason().find("max_velocity"), std::string::npos);
+  EXPECT_NE(result.reason().find("150"), std::string::npos);
+}
+
+// =============================================================================
+// OneOfValidator Tests
+// =============================================================================
+
+class OneOfValidatorTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(OneOfValidatorTest, StringValues)
+{
+  OneOfValidator<std::string> validator({"slow", "normal", "fast"});
+
+  EXPECT_TRUE(validator.validate(Parameter("mode", "slow")).successful());
+  EXPECT_TRUE(validator.validate(Parameter("mode", "normal")).successful());
+  EXPECT_TRUE(validator.validate(Parameter("mode", "fast")).successful());
+
+  EXPECT_FALSE(validator.validate(Parameter("mode", "turbo")).successful());
+  EXPECT_FALSE(validator.validate(Parameter("mode", "")).successful());
+  EXPECT_FALSE(validator.validate(Parameter("mode", "SLOW")).successful());  // Case sensitive
+}
+
+TEST_F(OneOfValidatorTest, IntegerValues)
+{
+  OneOfValidator<int64_t> validator({1, 2, 4, 8, 16});
+
+  EXPECT_TRUE(validator.validate(Parameter("power", 1)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("power", 8)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("power", 16)).successful());
+
+  EXPECT_FALSE(validator.validate(Parameter("power", 3)).successful());
+  EXPECT_FALSE(validator.validate(Parameter("power", 0)).successful());
+}
+
+TEST_F(OneOfValidatorTest, DoubleValues)
+{
+  OneOfValidator<double> validator({0.0, 0.5, 1.0});
+
+  EXPECT_TRUE(validator.validate(Parameter("factor", 0.0)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("factor", 0.5)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("factor", 1.0)).successful());
+
+  EXPECT_FALSE(validator.validate(Parameter("factor", 0.25)).successful());
+}
+
+TEST_F(OneOfValidatorTest, BoolValues)
+{
+  OneOfValidator<bool> validator({true});
+
+  EXPECT_TRUE(validator.validate(Parameter("enabled", true)).successful());
+  EXPECT_FALSE(validator.validate(Parameter("enabled", false)).successful());
+}
+
+TEST_F(OneOfValidatorTest, TypeMismatch)
+{
+  OneOfValidator<std::string> validator({"a", "b", "c"});
+
+  EXPECT_FALSE(validator.validate(Parameter("p", 123)).successful());
+  EXPECT_FALSE(validator.validate(Parameter("p", 1.5)).successful());
+}
+
+TEST_F(OneOfValidatorTest, Description)
+{
+  OneOfValidator<std::string> validator({"slow", "fast"});
+  auto desc = validator.description();
+
+  EXPECT_NE(desc.find("one of"), std::string::npos);
+  EXPECT_NE(desc.find("slow"), std::string::npos);
+  EXPECT_NE(desc.find("fast"), std::string::npos);
+}
+
+TEST_F(OneOfValidatorTest, AllowedValues)
+{
+  OneOfValidator<std::string> validator({"a", "b", "c"});
+  auto values = validator.allowed_values();
+
+  EXPECT_EQ(values.size(), 3u);
+  EXPECT_EQ(values[0], "a");
+  EXPECT_EQ(values[1], "b");
+  EXPECT_EQ(values[2], "c");
+}
+
+// =============================================================================
+// RegexValidator Tests
+// =============================================================================
+
+class RegexValidatorTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(RegexValidatorTest, SimplePattern)
+{
+  RegexValidator validator("^[a-z]+$");
+
+  EXPECT_TRUE(validator.validate(Parameter("name", "hello")).successful());
+  EXPECT_TRUE(validator.validate(Parameter("name", "world")).successful());
+
+  EXPECT_FALSE(validator.validate(Parameter("name", "Hello")).successful());
+  EXPECT_FALSE(validator.validate(Parameter("name", "hello123")).successful());
+  EXPECT_FALSE(validator.validate(Parameter("name", "")).successful());
+}
+
+TEST_F(RegexValidatorTest, IdentifierPattern)
+{
+  RegexValidator validator("^[a-zA-Z_][a-zA-Z0-9_]*$", "valid identifier");
+
+  EXPECT_TRUE(validator.validate(Parameter("id", "my_var")).successful());
+  EXPECT_TRUE(validator.validate(Parameter("id", "_private")).successful());
+  EXPECT_TRUE(validator.validate(Parameter("id", "CamelCase123")).successful());
+
+  EXPECT_FALSE(validator.validate(Parameter("id", "123start")).successful());
+  EXPECT_FALSE(validator.validate(Parameter("id", "has-dash")).successful());
+}
+
+TEST_F(RegexValidatorTest, IPAddressPattern)
+{
+  RegexValidator validator(R"(^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$)", "IPv4 address");
+
+  EXPECT_TRUE(validator.validate(Parameter("ip", "192.168.1.1")).successful());
+  EXPECT_TRUE(validator.validate(Parameter("ip", "0.0.0.0")).successful());
+  EXPECT_TRUE(validator.validate(Parameter("ip", "255.255.255.255")).successful());
+
+  EXPECT_FALSE(validator.validate(Parameter("ip", "1234.1.1.1")).successful());
+  EXPECT_FALSE(validator.validate(Parameter("ip", "192.168.1")).successful());
+}
+
+TEST_F(RegexValidatorTest, TypeMismatch)
+{
+  RegexValidator validator(".*");
+
+  EXPECT_FALSE(validator.validate(Parameter("p", 123)).successful());
+  EXPECT_FALSE(validator.validate(Parameter("p", 1.5)).successful());
+}
+
+TEST_F(RegexValidatorTest, Description)
+{
+  RegexValidator validator("^test$", "test pattern");
+  auto desc = validator.description();
+
+  EXPECT_NE(desc.find("^test$"), std::string::npos);
+  EXPECT_NE(desc.find("test pattern"), std::string::npos);
+}
+
+TEST_F(RegexValidatorTest, PatternString)
+{
+  RegexValidator validator("^[a-z]+$");
+  EXPECT_EQ(validator.pattern_string(), "^[a-z]+$");
+}
+
+// =============================================================================
+// NotEmptyValidator Tests
+// =============================================================================
+
+class NotEmptyValidatorTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(NotEmptyValidatorTest, StringValidation)
+{
+  NotEmptyValidator validator;
+
+  EXPECT_TRUE(validator.validate(Parameter("s", "hello")).successful());
+  EXPECT_TRUE(validator.validate(Parameter("s", " ")).successful());  // Whitespace is not empty
+
+  EXPECT_FALSE(validator.validate(Parameter("s", "")).successful());
+}
+
+TEST_F(NotEmptyValidatorTest, ArrayValidation)
+{
+  NotEmptyValidator validator;
+
+  // Non-empty arrays
+  EXPECT_TRUE(validator.validate(Parameter("arr", std::vector<int64_t>{1})).successful());
+  EXPECT_TRUE(validator.validate(Parameter("arr", std::vector<double>{1.0, 2.0})).successful());
+  EXPECT_TRUE(validator.validate(
+      Parameter("arr", std::vector<std::string>{"a"})).successful());
+
+  // Empty arrays
+  EXPECT_FALSE(validator.validate(Parameter("arr", std::vector<int64_t>{})).successful());
+  EXPECT_FALSE(validator.validate(Parameter("arr", std::vector<double>{})).successful());
+  EXPECT_FALSE(validator.validate(Parameter("arr", std::vector<std::string>{})).successful());
+}
+
+TEST_F(NotEmptyValidatorTest, ScalarTypesAlwaysPass)
+{
+  NotEmptyValidator validator;
+
+  // Scalar types are never "empty"
+  EXPECT_TRUE(validator.validate(Parameter("p", true)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("p", false)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("p", 0)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("p", 0.0)).successful());
+}
+
+TEST_F(NotEmptyValidatorTest, Description)
+{
+  NotEmptyValidator validator;
+  EXPECT_NE(validator.description().find("non-empty"), std::string::npos);
+}
+
+// =============================================================================
+// StringLengthValidator Tests
+// =============================================================================
+
+class StringLengthValidatorTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(StringLengthValidatorTest, BothBounds)
+{
+  StringLengthValidator validator(2, 10);
+
+  EXPECT_TRUE(validator.validate(Parameter("s", "ab")).successful());
+  EXPECT_TRUE(validator.validate(Parameter("s", "hello")).successful());
+  EXPECT_TRUE(validator.validate(Parameter("s", "1234567890")).successful());
+
+  EXPECT_FALSE(validator.validate(Parameter("s", "a")).successful());
+  EXPECT_FALSE(validator.validate(Parameter("s", "12345678901")).successful());
+}
+
+TEST_F(StringLengthValidatorTest, MinLengthOnly)
+{
+  auto validator = StringLengthValidator::min_length(3);
+
+  EXPECT_TRUE(validator.validate(Parameter("s", "abc")).successful());
+  EXPECT_TRUE(validator.validate(Parameter("s", "very long string")).successful());
+
+  EXPECT_FALSE(validator.validate(Parameter("s", "ab")).successful());
+  EXPECT_FALSE(validator.validate(Parameter("s", "")).successful());
+}
+
+TEST_F(StringLengthValidatorTest, MaxLengthOnly)
+{
+  auto validator = StringLengthValidator::max_length(5);
+
+  EXPECT_TRUE(validator.validate(Parameter("s", "")).successful());
+  EXPECT_TRUE(validator.validate(Parameter("s", "12345")).successful());
+
+  EXPECT_FALSE(validator.validate(Parameter("s", "123456")).successful());
+}
+
+TEST_F(StringLengthValidatorTest, TypeMismatch)
+{
+  StringLengthValidator validator(1, 10);
+
+  EXPECT_FALSE(validator.validate(Parameter("p", 123)).successful());
+  EXPECT_FALSE(validator.validate(Parameter("p", 1.5)).successful());
+}
+
+// =============================================================================
+// TypeValidator Tests
+// =============================================================================
+
+class TypeValidatorTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(TypeValidatorTest, SingleType)
+{
+  TypeValidator validator(ParameterType::PARAMETER_DOUBLE);
+
+  EXPECT_TRUE(validator.validate(Parameter("p", 1.5)).successful());
+  EXPECT_FALSE(validator.validate(Parameter("p", 1)).successful());
+  EXPECT_FALSE(validator.validate(Parameter("p", "1.5")).successful());
+}
+
+TEST_F(TypeValidatorTest, MultipleTypes)
+{
+  TypeValidator validator({
+    ParameterType::PARAMETER_INTEGER,
+    ParameterType::PARAMETER_DOUBLE
+  });
+
+  EXPECT_TRUE(validator.validate(Parameter("p", 1)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("p", 1.5)).successful());
+  EXPECT_FALSE(validator.validate(Parameter("p", "1")).successful());
+}
+
+TEST_F(TypeValidatorTest, Description)
+{
+  TypeValidator single(ParameterType::PARAMETER_DOUBLE);
+  EXPECT_NE(single.description().find("double"), std::string::npos);
+
+  TypeValidator multiple({
+    ParameterType::PARAMETER_INTEGER,
+    ParameterType::PARAMETER_DOUBLE
+  });
+  EXPECT_NE(multiple.description().find("integer"), std::string::npos);
+  EXPECT_NE(multiple.description().find("double"), std::string::npos);
+}
+
+// =============================================================================
+// CompositeValidator Tests
+// =============================================================================
+
+class CompositeValidatorTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(CompositeValidatorTest, AllMode)
+{
+  CompositeValidator validator(CompositeValidator::Mode::ALL);
+  validator.add(std::make_shared<RangeValidator<double>>(0.0, 100.0));
+  validator.add(std::make_shared<RangeValidator<double>>(50.0, 150.0));
+
+  // Must pass both: [0, 100] AND [50, 150] = [50, 100]
+  EXPECT_TRUE(validator.validate(Parameter("p", 50.0)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("p", 100.0)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("p", 75.0)).successful());
+
+  EXPECT_FALSE(validator.validate(Parameter("p", 25.0)).successful());  // Fails second
+  EXPECT_FALSE(validator.validate(Parameter("p", 125.0)).successful());  // Fails first
+}
+
+TEST_F(CompositeValidatorTest, AnyMode)
+{
+  CompositeValidator validator(CompositeValidator::Mode::ANY);
+  validator.add(std::make_shared<RangeValidator<double>>(0.0, 10.0));
+  validator.add(std::make_shared<RangeValidator<double>>(90.0, 100.0));
+
+  // Must pass either: [0, 10] OR [90, 100]
+  EXPECT_TRUE(validator.validate(Parameter("p", 5.0)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("p", 95.0)).successful());
+
+  EXPECT_FALSE(validator.validate(Parameter("p", 50.0)).successful());  // Fails both
+}
+
+TEST_F(CompositeValidatorTest, FluentAPI)
+{
+  CompositeValidator validator;
+  validator
+    .and_also(std::make_shared<RangeValidator<double>>(0.0, 100.0))
+    .and_also(std::make_shared<TypeValidator>(ParameterType::PARAMETER_DOUBLE));
+
+  EXPECT_TRUE(validator.validate(Parameter("p", 50.0)).successful());
+  EXPECT_FALSE(validator.validate(Parameter("p", 50)).successful());  // Wrong type
+}
+
+TEST_F(CompositeValidatorTest, OrElseChangesMode)
+{
+  CompositeValidator validator;
+  validator
+    .add(std::make_shared<RangeValidator<double>>(0.0, 10.0))
+    .or_else(std::make_shared<RangeValidator<double>>(90.0, 100.0));
+
+  EXPECT_EQ(validator.mode(), CompositeValidator::Mode::ANY);
+  EXPECT_TRUE(validator.validate(Parameter("p", 5.0)).successful());
+  EXPECT_TRUE(validator.validate(Parameter("p", 95.0)).successful());
+}
+
+TEST_F(CompositeValidatorTest, EmptyComposite)
+{
+  CompositeValidator validator;
+  EXPECT_TRUE(validator.validate(Parameter("p", "anything")).successful());
+}
+
+TEST_F(CompositeValidatorTest, Description)
+{
+  CompositeValidator all_validator(CompositeValidator::Mode::ALL);
+  all_validator.add(std::make_shared<NotEmptyValidator>());
+  all_validator.add(std::make_shared<StringLengthValidator>(1, 10));
+
+  auto desc = all_validator.description();
+  EXPECT_NE(desc.find("AND"), std::string::npos);
+
+  CompositeValidator any_validator(CompositeValidator::Mode::ANY);
+  any_validator.add(std::make_shared<NotEmptyValidator>());
+  any_validator.add(std::make_shared<StringLengthValidator>(1, 10));
+
+  desc = any_validator.description();
+  EXPECT_NE(desc.find("OR"), std::string::npos);
+}
+
+// =============================================================================
+// Factory Functions Tests
+// =============================================================================
+
+class FactoryFunctionsTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(FactoryFunctionsTest, RangeFactory)
+{
+  auto validator = validators::range(0.0, 100.0);
+  EXPECT_TRUE(validator->validate(Parameter("p", 50.0)).successful());
+  EXPECT_FALSE(validator->validate(Parameter("p", 150.0)).successful());
+}
+
+TEST_F(FactoryFunctionsTest, MinMaxFactory)
+{
+  auto min_validator = validators::min(0.0);
+  EXPECT_TRUE(min_validator->validate(Parameter("p", 0.0)).successful());
+  EXPECT_FALSE(min_validator->validate(Parameter("p", -1.0)).successful());
+
+  auto max_validator = validators::max(100.0);
+  EXPECT_TRUE(max_validator->validate(Parameter("p", 100.0)).successful());
+  EXPECT_FALSE(max_validator->validate(Parameter("p", 101.0)).successful());
+}
+
+TEST_F(FactoryFunctionsTest, OneOfFactory)
+{
+  auto validator = validators::one_of<std::string>({"a", "b", "c"});
+  EXPECT_TRUE(validator->validate(Parameter("p", "a")).successful());
+  EXPECT_FALSE(validator->validate(Parameter("p", "d")).successful());
+}
+
+TEST_F(FactoryFunctionsTest, MatchesFactory)
+{
+  auto validator = validators::matches("^[a-z]+$");
+  EXPECT_TRUE(validator->validate(Parameter("p", "hello")).successful());
+  EXPECT_FALSE(validator->validate(Parameter("p", "Hello")).successful());
+}
+
+TEST_F(FactoryFunctionsTest, NotEmptyFactory)
+{
+  auto validator = validators::not_empty();
+  EXPECT_TRUE(validator->validate(Parameter("p", "hello")).successful());
+  EXPECT_FALSE(validator->validate(Parameter("p", "")).successful());
+}
+
+TEST_F(FactoryFunctionsTest, LengthFactory)
+{
+  auto validator = validators::length(1, 10);
+  EXPECT_TRUE(validator->validate(Parameter("p", "hello")).successful());
+  EXPECT_FALSE(validator->validate(Parameter("p", "")).successful());
+}
+
+TEST_F(FactoryFunctionsTest, TypeFactory)
+{
+  auto validator = validators::type(ParameterType::PARAMETER_DOUBLE);
+  EXPECT_TRUE(validator->validate(Parameter("p", 1.5)).successful());
+  EXPECT_FALSE(validator->validate(Parameter("p", 1)).successful());
+}
+
+TEST_F(FactoryFunctionsTest, AllOfFactory)
+{
+  auto validator = validators::all_of({
+    validators::range(0.0, 100.0),
+    validators::type(ParameterType::PARAMETER_DOUBLE)
+  });
+
+  EXPECT_TRUE(validator->validate(Parameter("p", 50.0)).successful());
+  EXPECT_FALSE(validator->validate(Parameter("p", 50)).successful());  // Wrong type
+  EXPECT_FALSE(validator->validate(Parameter("p", 150.0)).successful());  // Out of range
+}
+
+TEST_F(FactoryFunctionsTest, AnyOfFactory)
+{
+  auto validator = validators::any_of({
+    validators::one_of<std::string>({"yes"}),
+    validators::one_of<std::string>({"no"})
+  });
+
+  EXPECT_TRUE(validator->validate(Parameter("p", "yes")).successful());
+  EXPECT_TRUE(validator->validate(Parameter("p", "no")).successful());
+  EXPECT_FALSE(validator->validate(Parameter("p", "maybe")).successful());
+}
+
+// =============================================================================
+// ParameterBuilder Tests
+// =============================================================================
+
+class ParameterBuilderTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(ParameterBuilderTest, BasicConstruction)
+{
+  auto builder = ParameterBuilder()
+    .name("test_param")
+    .description("A test parameter")
+    .default_value(42.0)
+    .read_only(true);
+
+  EXPECT_EQ(builder.get_name(), "test_param");
+  EXPECT_EQ(builder.get_description(), "A test parameter");
+  EXPECT_TRUE(builder.has_default_value());
+  EXPECT_TRUE(builder.is_read_only());
+}
+
+TEST_F(ParameterBuilderTest, ConstructWithName)
+{
+  ParameterBuilder builder("my_param");
+  EXPECT_EQ(builder.get_name(), "my_param");
+}
+
+TEST_F(ParameterBuilderTest, BuildParameter)
+{
+  auto param = ParameterBuilder()
+    .name("velocity")
+    .default_value(1.5)
+    .build();
+
+  EXPECT_EQ(param.get_name(), "velocity");
+  EXPECT_EQ(param.as_double(), 1.5);
+}
+
+TEST_F(ParameterBuilderTest, BuildDescriptor)
+{
+  auto builder = ParameterBuilder()
+    .name("velocity")
+    .description("Robot velocity")
+    .read_only(true)
+    .range(0.0, 10.0);
+
+  auto descriptor = builder.build_descriptor();
+
+  EXPECT_EQ(descriptor.description, "Robot velocity");
+  EXPECT_TRUE(descriptor.read_only);
+  EXPECT_FALSE(descriptor.additional_constraints.empty());
+  EXPECT_EQ(descriptor.floating_point_range.size(), 1u);
+  EXPECT_EQ(descriptor.floating_point_range[0].from_value, 0.0);
+  EXPECT_EQ(descriptor.floating_point_range[0].to_value, 10.0);
+}
+
+TEST_F(ParameterBuilderTest, IntegerRangeDescriptor)
+{
+  auto builder = ParameterBuilder()
+    .name("count")
+    .range<int64_t>(0, 100);
+
+  auto descriptor = builder.build_descriptor();
+
+  EXPECT_EQ(descriptor.integer_range.size(), 1u);
+  EXPECT_EQ(descriptor.integer_range[0].from_value, 0);
+  EXPECT_EQ(descriptor.integer_range[0].to_value, 100);
+}
+
+TEST_F(ParameterBuilderTest, FluentValidators)
+{
+  auto builder = ParameterBuilder()
+    .name("config")
+    .default_value("default")
+    .not_empty()
+    .matches("^[a-z]+$")
+    .length(1, 20);
+
+  auto validators = builder.get_validators();
+  EXPECT_EQ(validators.size(), 3u);
+}
+
+TEST_F(ParameterBuilderTest, Validation)
+{
+  auto builder = ParameterBuilder()
+    .name("velocity")
+    .range(0.0, 10.0);
+
+  EXPECT_TRUE(builder.validate(Parameter("velocity", 5.0)).successful());
+  EXPECT_FALSE(builder.validate(Parameter("velocity", 15.0)).successful());
+}
+
+TEST_F(ParameterBuilderTest, CustomValidator)
+{
+  class EvenValidator : public ParameterValidator
+  {
+  public:
+    ValidationResult validate(const Parameter & param) const override
+    {
+      if (param.as_int() % 2 == 0) {
+        return ValidationResult::success();
+      }
+      return ValidationResult::failure("Value must be even");
+    }
+    std::string description() const override {return "even integer";}
+  };
+
+  auto builder = ParameterBuilder()
+    .name("even_number")
+    .validator(std::make_shared<EvenValidator>());
+
+  EXPECT_TRUE(builder.validate(Parameter("even_number", 4)).successful());
+  EXPECT_FALSE(builder.validate(Parameter("even_number", 3)).successful());
+}
+
+TEST_F(ParameterBuilderTest, BuildWithoutName)
+{
+  ParameterBuilder builder;
+  EXPECT_THROW(builder.build(), std::runtime_error);
+}
+
+TEST_F(ParameterBuilderTest, GetDefaultValueWithoutSetting)
+{
+  ParameterBuilder builder;
+  builder.name("test");
+  EXPECT_THROW(builder.get_default_value(), std::runtime_error);
+}
+
+// =============================================================================
+// ParameterValidatorRegistry Tests
+// =============================================================================
+
+class ParameterValidatorRegistryTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(ParameterValidatorRegistryTest, RegisterAndValidate)
+{
+  ParameterValidatorRegistry registry;
+
+  registry.register_validators("velocity", {
+    std::make_shared<RangeValidator<double>>(0.0, 10.0)
+  });
+
+  EXPECT_TRUE(registry.has_validators("velocity"));
+  EXPECT_FALSE(registry.has_validators("other"));
+
+  EXPECT_TRUE(registry.validate(Parameter("velocity", 5.0)).successful());
+  EXPECT_FALSE(registry.validate(Parameter("velocity", 15.0)).successful());
+
+  // Unregistered parameter always passes
+  EXPECT_TRUE(registry.validate(Parameter("other", 100.0)).successful());
+}
+
+TEST_F(ParameterValidatorRegistryTest, AddValidator)
+{
+  ParameterValidatorRegistry registry;
+
+  registry.add_validator("param", std::make_shared<RangeValidator<double>>(0.0, 100.0));
+  registry.add_validator("param", std::make_shared<RangeValidator<double>>(50.0, 150.0));
+
+  // Both must pass
+  EXPECT_TRUE(registry.validate(Parameter("param", 75.0)).successful());
+  EXPECT_FALSE(registry.validate(Parameter("param", 25.0)).successful());
+}
+
+TEST_F(ParameterValidatorRegistryTest, ClearValidators)
+{
+  ParameterValidatorRegistry registry;
+
+  registry.register_validators("param", {
+    std::make_shared<RangeValidator<double>>(0.0, 10.0)
+  });
+
+  EXPECT_TRUE(registry.has_validators("param"));
+
+  registry.clear_validators("param");
+
+  EXPECT_FALSE(registry.has_validators("param"));
+}
+
+TEST_F(ParameterValidatorRegistryTest, ValidateMultiple)
+{
+  ParameterValidatorRegistry registry;
+
+  registry.register_validators("a", {
+    std::make_shared<RangeValidator<double>>(0.0, 10.0)
+  });
+  registry.register_validators("b", {
+    std::make_shared<RangeValidator<double>>(0.0, 100.0)
+  });
+
+  std::vector<Parameter> valid_params = {
+    Parameter("a", 5.0),
+    Parameter("b", 50.0)
+  };
+  EXPECT_TRUE(registry.validate(valid_params).successful());
+
+  std::vector<Parameter> invalid_params = {
+    Parameter("a", 15.0),  // Invalid
+    Parameter("b", 50.0)
+  };
+  EXPECT_FALSE(registry.validate(invalid_params).successful());
+}
+
+TEST_F(ParameterValidatorRegistryTest, CreateCallback)
+{
+  ParameterValidatorRegistry registry;
+
+  registry.register_validators("velocity", {
+    std::make_shared<RangeValidator<double>>(0.0, 10.0)
+  });
+
+  auto callback = registry.create_callback();
+
+  auto result = callback({Parameter("velocity", 5.0)});
+  EXPECT_TRUE(result.successful);
+
+  result = callback({Parameter("velocity", 15.0)});
+  EXPECT_FALSE(result.successful);
+}
+
+// =============================================================================
+// Utility Functions Tests
+// =============================================================================
+
+class UtilityFunctionsTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(UtilityFunctionsTest, FormatValidationError)
+{
+  auto error = format_validation_error(
+    "max_velocity",
+    "value out of range",
+    "value in [0.0, 10.0]",
+    "15.5");
+
+  EXPECT_NE(error.find("max_velocity"), std::string::npos);
+  EXPECT_NE(error.find("value out of range"), std::string::npos);
+  EXPECT_NE(error.find("[0.0, 10.0]"), std::string::npos);
+  EXPECT_NE(error.find("15.5"), std::string::npos);
+}
+
+TEST_F(UtilityFunctionsTest, ParameterValueToString)
+{
+  EXPECT_NE(parameter_value_to_string(Parameter("p", true)).find("true"), std::string::npos);
+  EXPECT_NE(parameter_value_to_string(Parameter("p", 42)).find("42"), std::string::npos);
+  EXPECT_NE(parameter_value_to_string(Parameter("p", 3.14)).find("3.14"), std::string::npos);
+  EXPECT_NE(parameter_value_to_string(Parameter("p", "hello")).find("hello"), std::string::npos);
+}
+
+TEST_F(UtilityFunctionsTest, ParameterTypeToString)
+{
+  EXPECT_EQ(parameter_type_to_string(ParameterType::PARAMETER_BOOL), "bool");
+  EXPECT_EQ(parameter_type_to_string(ParameterType::PARAMETER_INTEGER), "integer");
+  EXPECT_EQ(parameter_type_to_string(ParameterType::PARAMETER_DOUBLE), "double");
+  EXPECT_EQ(parameter_type_to_string(ParameterType::PARAMETER_STRING), "string");
+  EXPECT_EQ(parameter_type_to_string(ParameterType::PARAMETER_NOT_SET), "not_set");
+}
+
+TEST_F(UtilityFunctionsTest, ValidateParameterFunction)
+{
+  std::vector<ParameterValidatorPtr> validators = {
+    std::make_shared<RangeValidator<double>>(0.0, 100.0),
+    std::make_shared<RangeValidator<double>>(50.0, 150.0)
+  };
+
+  EXPECT_TRUE(validate_parameter(Parameter("p", 75.0), validators).successful());
+  EXPECT_FALSE(validate_parameter(Parameter("p", 25.0), validators).successful());
+}
+
+// =============================================================================
+// Node Integration Tests
+// =============================================================================
+
+class NodeIntegrationTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    node_ = std::make_shared<rclcpp::Node>("test_node");
+  }
+
+  void TearDown() override
+  {
+    node_.reset();
+    rclcpp::shutdown();
+  }
+
+  std::shared_ptr<rclcpp::Node> node_;
+};
+
+TEST_F(NodeIntegrationTest, DeclareValidatedParameter)
+{
+  auto param = declare_validated_parameter(
+    *node_,
+    ParameterBuilder()
+      .name("velocity")
+      .description("Robot velocity")
+      .default_value(1.0)
+      .range(0.0, 10.0)
+  );
+
+  EXPECT_EQ(param.get_name(), "velocity");
+  EXPECT_EQ(param.as_double(), 1.0);
+
+  // Try to set valid value
+  auto result = node_->set_parameter(Parameter("velocity", 5.0));
+  EXPECT_TRUE(result.successful);
+
+  // Try to set invalid value
+  result = node_->set_parameter(Parameter("velocity", 15.0));
+  EXPECT_FALSE(result.successful);
+}
+
+TEST_F(NodeIntegrationTest, DeclareValidatedParameterInvalidDefault)
+{
+  EXPECT_THROW(
+    declare_validated_parameter(
+      *node_,
+      ParameterBuilder()
+        .name("invalid_default")
+        .default_value(100.0)  // Outside range
+        .range(0.0, 10.0)
+    ),
+    rclcpp::exceptions::InvalidParameterValueException
+  );
+}
+
+TEST_F(NodeIntegrationTest, DeclareMultipleValidatedParameters)
+{
+  std::vector<ParameterBuilder> builders = {
+    ParameterBuilder()
+      .name("velocity")
+      .default_value(1.0)
+      .range(0.0, 10.0),
+    ParameterBuilder()
+      .name("mode")
+      .default_value("normal")
+      .one_of<std::string>({"slow", "normal", "fast"})
+  };
+
+  auto params = declare_validated_parameters(*node_, builders);
+
+  EXPECT_EQ(params.size(), 2u);
+  EXPECT_EQ(params[0].get_name(), "velocity");
+  EXPECT_EQ(params[1].get_name(), "mode");
+
+  // Test validation
+  EXPECT_TRUE(node_->set_parameter(Parameter("velocity", 5.0)).successful);
+  EXPECT_FALSE(node_->set_parameter(Parameter("velocity", 15.0)).successful);
+
+  EXPECT_TRUE(node_->set_parameter(Parameter("mode", "fast")).successful);
+  EXPECT_FALSE(node_->set_parameter(Parameter("mode", "turbo")).successful);
+}
+
+TEST_F(NodeIntegrationTest, CreateValidationCallback)
+{
+  // Declare parameters normally
+  node_->declare_parameter("legacy_param", 5.0);
+
+  // Add validation later
+  std::map<std::string, std::vector<ParameterValidatorPtr>> validators;
+  validators["legacy_param"] = {
+    std::make_shared<RangeValidator<double>>(0.0, 10.0)
+  };
+
+  auto handle = create_validation_callback(*node_, validators);
+
+  // Test validation
+  EXPECT_TRUE(node_->set_parameter(Parameter("legacy_param", 5.0)).successful);
+  EXPECT_FALSE(node_->set_parameter(Parameter("legacy_param", 15.0)).successful);
+}
+
+TEST_F(NodeIntegrationTest, ReadOnlyParameter)
+{
+  declare_validated_parameter(
+    *node_,
+    ParameterBuilder()
+      .name("constant")
+      .default_value(42)
+      .read_only(true)
+  );
+
+  // Should fail to change read-only parameter
+  auto result = node_->set_parameter(Parameter("constant", 100));
+  EXPECT_FALSE(result.successful);
+}
+
+TEST_F(NodeIntegrationTest, ParameterDescriptorPopulated)
+{
+  declare_validated_parameter(
+    *node_,
+    ParameterBuilder()
+      .name("documented_param")
+      .description("A well documented parameter")
+      .default_value(5.0)
+      .range(0.0, 10.0)
+  );
+
+  auto descriptor = node_->describe_parameter("documented_param");
+  EXPECT_EQ(descriptor.description, "A well documented parameter");
+  EXPECT_FALSE(descriptor.additional_constraints.empty());
+  EXPECT_EQ(descriptor.floating_point_range.size(), 1u);
+}
+
+// =============================================================================
+// Error Message Tests
+// =============================================================================
+
+class ErrorMessageTest : public ::testing::Test
+{
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(ErrorMessageTest, RangeErrorMessage)
+{
+  RangeValidator<double> validator(0.0, 100.0);
+  auto result = validator.validate(Parameter("max_speed", 150.0));
+
+  EXPECT_FALSE(result.successful());
+  EXPECT_NE(result.reason().find("max_speed"), std::string::npos);
+  EXPECT_NE(result.reason().find("150"), std::string::npos);
+  EXPECT_NE(result.reason().find("above maximum"), std::string::npos);
+}
+
+TEST_F(ErrorMessageTest, OneOfErrorMessage)
+{
+  OneOfValidator<std::string> validator({"a", "b", "c"});
+  auto result = validator.validate(Parameter("choice", "invalid"));
+
+  EXPECT_FALSE(result.successful());
+  EXPECT_NE(result.reason().find("choice"), std::string::npos);
+  EXPECT_NE(result.reason().find("invalid"), std::string::npos);
+}
+
+TEST_F(ErrorMessageTest, RegexErrorMessage)
+{
+  RegexValidator validator("^[a-z]+$", "lowercase letters");
+  auto result = validator.validate(Parameter("identifier", "Invalid123"));
+
+  EXPECT_FALSE(result.successful());
+  EXPECT_NE(result.reason().find("identifier"), std::string::npos);
+  EXPECT_NE(result.reason().find("Invalid123"), std::string::npos);
+  EXPECT_NE(result.reason().find("pattern"), std::string::npos);
+}
+
+TEST_F(ErrorMessageTest, CompositeAnyModeErrorMessage)
+{
+  CompositeValidator validator(CompositeValidator::Mode::ANY);
+  validator.add(std::make_shared<RangeValidator<double>>(0.0, 10.0));
+  validator.add(std::make_shared<RangeValidator<double>>(90.0, 100.0));
+
+  auto result = validator.validate(Parameter("value", 50.0));
+
+  EXPECT_FALSE(result.successful());
+  EXPECT_NE(result.reason().find("none of the validators"), std::string::npos);
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/rclcpp/test/test_parameter_validation.cpp
+++ b/rclcpp/test/test_parameter_validation.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -22,8 +23,6 @@
 #include "rclcpp/parameter_validators.hpp"
 #include "rclcpp/parameter_builder.hpp"
 #include "rclcpp/rclcpp.hpp"
-
-using namespace rclcpp;
 
 // =============================================================================
 // ValidationResult Tests
@@ -38,7 +37,7 @@ protected:
 
 TEST_F(ValidationResultTest, SuccessResult)
 {
-  auto result = ValidationResult::success();
+  auto result = rclcpp::ValidationResult::success();
   EXPECT_TRUE(result.successful());
   EXPECT_TRUE(static_cast<bool>(result));
   EXPECT_TRUE(result.reason().empty());
@@ -46,7 +45,7 @@ TEST_F(ValidationResultTest, SuccessResult)
 
 TEST_F(ValidationResultTest, FailureResult)
 {
-  auto result = ValidationResult::failure("Something went wrong");
+  auto result = rclcpp::ValidationResult::failure("Something went wrong");
   EXPECT_FALSE(result.successful());
   EXPECT_FALSE(static_cast<bool>(result));
   EXPECT_EQ(result.reason(), "Something went wrong");
@@ -54,12 +53,12 @@ TEST_F(ValidationResultTest, FailureResult)
 
 TEST_F(ValidationResultTest, ToMsg)
 {
-  auto success = ValidationResult::success();
+  auto success = rclcpp::ValidationResult::success();
   auto success_msg = success.to_msg();
   EXPECT_TRUE(success_msg.successful);
   EXPECT_TRUE(success_msg.reason.empty());
 
-  auto failure = ValidationResult::failure("Error message");
+  auto failure = rclcpp::ValidationResult::failure("Error message");
   auto failure_msg = failure.to_msg();
   EXPECT_FALSE(failure_msg.successful);
   EXPECT_EQ(failure_msg.reason, "Error message");
@@ -78,119 +77,119 @@ protected:
 
 TEST_F(RangeValidatorTest, DoubleRangeInclusive)
 {
-  RangeValidator<double> validator(0.0, 100.0);
+  rclcpp::RangeValidator<double> validator(0.0, 100.0);
 
   // Valid values
-  EXPECT_TRUE(validator.validate(Parameter("p", 0.0)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("p", 50.0)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("p", 100.0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 0.0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 50.0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 100.0)).successful());
 
   // Invalid values
-  EXPECT_FALSE(validator.validate(Parameter("p", -0.001)).successful());
-  EXPECT_FALSE(validator.validate(Parameter("p", 100.001)).successful());
-  EXPECT_FALSE(validator.validate(Parameter("p", -1000.0)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", -0.001)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", 100.001)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", -1000.0)).successful());
 }
 
 TEST_F(RangeValidatorTest, DoubleRangeExclusive)
 {
-  auto validator = RangeValidator<double>(0.0, 100.0).exclusive();
+  auto validator = rclcpp::RangeValidator<double>(0.0, 100.0).exclusive();
 
   // Boundaries should fail
-  EXPECT_FALSE(validator.validate(Parameter("p", 0.0)).successful());
-  EXPECT_FALSE(validator.validate(Parameter("p", 100.0)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", 0.0)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", 100.0)).successful());
 
   // Values inside should pass
-  EXPECT_TRUE(validator.validate(Parameter("p", 0.001)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("p", 99.999)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("p", 50.0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 0.001)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 99.999)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 50.0)).successful());
 }
 
 TEST_F(RangeValidatorTest, DoubleRangeExclusiveMin)
 {
-  auto validator = RangeValidator<double>(0.0, 100.0).exclusive_min();
+  auto validator = rclcpp::RangeValidator<double>(0.0, 100.0).exclusive_min();
 
-  EXPECT_FALSE(validator.validate(Parameter("p", 0.0)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("p", 100.0)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("p", 0.001)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", 0.0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 100.0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 0.001)).successful());
 }
 
 TEST_F(RangeValidatorTest, DoubleRangeExclusiveMax)
 {
-  auto validator = RangeValidator<double>(0.0, 100.0).exclusive_max();
+  auto validator = rclcpp::RangeValidator<double>(0.0, 100.0).exclusive_max();
 
-  EXPECT_TRUE(validator.validate(Parameter("p", 0.0)).successful());
-  EXPECT_FALSE(validator.validate(Parameter("p", 100.0)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("p", 99.999)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 0.0)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", 100.0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 99.999)).successful());
 }
 
 TEST_F(RangeValidatorTest, DoubleMinOnly)
 {
-  auto validator = RangeValidator<double>::min(0.0);
+  auto validator = rclcpp::RangeValidator<double>::min(0.0);
 
-  EXPECT_TRUE(validator.validate(Parameter("p", 0.0)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("p", 1000000.0)).successful());
-  EXPECT_FALSE(validator.validate(Parameter("p", -0.001)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 0.0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 1000000.0)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", -0.001)).successful());
 }
 
 TEST_F(RangeValidatorTest, DoubleMaxOnly)
 {
-  auto validator = RangeValidator<double>::max(100.0);
+  auto validator = rclcpp::RangeValidator<double>::max(100.0);
 
-  EXPECT_TRUE(validator.validate(Parameter("p", 100.0)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("p", -1000000.0)).successful());
-  EXPECT_FALSE(validator.validate(Parameter("p", 100.001)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 100.0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", -1000000.0)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", 100.001)).successful());
 }
 
 TEST_F(RangeValidatorTest, IntegerRange)
 {
-  RangeValidator<int64_t> validator(0, 100);
+  rclcpp::RangeValidator<int64_t> validator(0, 100);
 
-  EXPECT_TRUE(validator.validate(Parameter("p", 0)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("p", 50)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("p", 100)).successful());
-  EXPECT_FALSE(validator.validate(Parameter("p", -1)).successful());
-  EXPECT_FALSE(validator.validate(Parameter("p", 101)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 50)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 100)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", -1)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", 101)).successful());
 }
 
 TEST_F(RangeValidatorTest, IntegerFromDouble)
 {
   // Double validator should accept integer values
-  RangeValidator<double> validator(0.0, 100.0);
+  rclcpp::RangeValidator<double> validator(0.0, 100.0);
 
-  EXPECT_TRUE(validator.validate(Parameter("p", 50)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 50)).successful());
 }
 
 TEST_F(RangeValidatorTest, TypeMismatch)
 {
-  RangeValidator<int64_t> int_validator(0, 100);
-  RangeValidator<double> double_validator(0.0, 100.0);
+  rclcpp::RangeValidator<int64_t> int_validator(0, 100);
+  rclcpp::RangeValidator<double> double_validator(0.0, 100.0);
 
   // Integer validator should reject strings
-  EXPECT_FALSE(int_validator.validate(Parameter("p", "50")).successful());
+  EXPECT_FALSE(int_validator.validate(rclcpp::Parameter("p", "50")).successful());
 
   // Double validator should reject strings
-  EXPECT_FALSE(double_validator.validate(Parameter("p", "50.0")).successful());
+  EXPECT_FALSE(double_validator.validate(rclcpp::Parameter("p", "50.0")).successful());
 }
 
 TEST_F(RangeValidatorTest, Description)
 {
-  RangeValidator<double> both(0.0, 100.0);
+  rclcpp::RangeValidator<double> both(0.0, 100.0);
   EXPECT_NE(both.description().find("[0"), std::string::npos);
   EXPECT_NE(both.description().find("100]"), std::string::npos);
 
-  auto min_only = RangeValidator<double>::min(0.0);
+  auto min_only = rclcpp::RangeValidator<double>::min(0.0);
   EXPECT_NE(min_only.description().find("[0"), std::string::npos);
   EXPECT_NE(min_only.description().find("+inf"), std::string::npos);
 
-  auto exclusive = RangeValidator<double>(0.0, 100.0).exclusive();
+  auto exclusive = rclcpp::RangeValidator<double>(0.0, 100.0).exclusive();
   EXPECT_NE(exclusive.description().find("(0"), std::string::npos);
   EXPECT_NE(exclusive.description().find("100)"), std::string::npos);
 }
 
 TEST_F(RangeValidatorTest, ErrorMessageContent)
 {
-  RangeValidator<double> validator(0.0, 100.0);
-  auto result = validator.validate(Parameter("max_velocity", 150.0));
+  rclcpp::RangeValidator<double> validator(0.0, 100.0);
+  auto result = validator.validate(rclcpp::Parameter("max_velocity", 150.0));
 
   EXPECT_FALSE(result.successful());
   EXPECT_NE(result.reason().find("max_velocity"), std::string::npos);
@@ -210,59 +209,59 @@ protected:
 
 TEST_F(OneOfValidatorTest, StringValues)
 {
-  OneOfValidator<std::string> validator({"slow", "normal", "fast"});
+  rclcpp::OneOfValidator<std::string> validator({"slow", "normal", "fast"});
 
-  EXPECT_TRUE(validator.validate(Parameter("mode", "slow")).successful());
-  EXPECT_TRUE(validator.validate(Parameter("mode", "normal")).successful());
-  EXPECT_TRUE(validator.validate(Parameter("mode", "fast")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("mode", "slow")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("mode", "normal")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("mode", "fast")).successful());
 
-  EXPECT_FALSE(validator.validate(Parameter("mode", "turbo")).successful());
-  EXPECT_FALSE(validator.validate(Parameter("mode", "")).successful());
-  EXPECT_FALSE(validator.validate(Parameter("mode", "SLOW")).successful());  // Case sensitive
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("mode", "turbo")).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("mode", "")).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("mode", "SLOW")).successful());  // Case sensitive
 }
 
 TEST_F(OneOfValidatorTest, IntegerValues)
 {
-  OneOfValidator<int64_t> validator({1, 2, 4, 8, 16});
+  rclcpp::OneOfValidator<int64_t> validator({1, 2, 4, 8, 16});
 
-  EXPECT_TRUE(validator.validate(Parameter("power", 1)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("power", 8)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("power", 16)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("power", 1)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("power", 8)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("power", 16)).successful());
 
-  EXPECT_FALSE(validator.validate(Parameter("power", 3)).successful());
-  EXPECT_FALSE(validator.validate(Parameter("power", 0)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("power", 3)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("power", 0)).successful());
 }
 
 TEST_F(OneOfValidatorTest, DoubleValues)
 {
-  OneOfValidator<double> validator({0.0, 0.5, 1.0});
+  rclcpp::OneOfValidator<double> validator({0.0, 0.5, 1.0});
 
-  EXPECT_TRUE(validator.validate(Parameter("factor", 0.0)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("factor", 0.5)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("factor", 1.0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("factor", 0.0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("factor", 0.5)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("factor", 1.0)).successful());
 
-  EXPECT_FALSE(validator.validate(Parameter("factor", 0.25)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("factor", 0.25)).successful());
 }
 
 TEST_F(OneOfValidatorTest, BoolValues)
 {
-  OneOfValidator<bool> validator({true});
+  rclcpp::OneOfValidator<bool> validator({true});
 
-  EXPECT_TRUE(validator.validate(Parameter("enabled", true)).successful());
-  EXPECT_FALSE(validator.validate(Parameter("enabled", false)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("enabled", true)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("enabled", false)).successful());
 }
 
 TEST_F(OneOfValidatorTest, TypeMismatch)
 {
-  OneOfValidator<std::string> validator({"a", "b", "c"});
+  rclcpp::OneOfValidator<std::string> validator({"a", "b", "c"});
 
-  EXPECT_FALSE(validator.validate(Parameter("p", 123)).successful());
-  EXPECT_FALSE(validator.validate(Parameter("p", 1.5)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", 123)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", 1.5)).successful());
 }
 
 TEST_F(OneOfValidatorTest, Description)
 {
-  OneOfValidator<std::string> validator({"slow", "fast"});
+  rclcpp::OneOfValidator<std::string> validator({"slow", "fast"});
   auto desc = validator.description();
 
   EXPECT_NE(desc.find("one of"), std::string::npos);
@@ -272,7 +271,7 @@ TEST_F(OneOfValidatorTest, Description)
 
 TEST_F(OneOfValidatorTest, AllowedValues)
 {
-  OneOfValidator<std::string> validator({"a", "b", "c"});
+  rclcpp::OneOfValidator<std::string> validator({"a", "b", "c"});
   auto values = validator.allowed_values();
 
   EXPECT_EQ(values.size(), 3u);
@@ -294,51 +293,51 @@ protected:
 
 TEST_F(RegexValidatorTest, SimplePattern)
 {
-  RegexValidator validator("^[a-z]+$");
+  rclcpp::RegexValidator validator("^[a-z]+$");
 
-  EXPECT_TRUE(validator.validate(Parameter("name", "hello")).successful());
-  EXPECT_TRUE(validator.validate(Parameter("name", "world")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("name", "hello")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("name", "world")).successful());
 
-  EXPECT_FALSE(validator.validate(Parameter("name", "Hello")).successful());
-  EXPECT_FALSE(validator.validate(Parameter("name", "hello123")).successful());
-  EXPECT_FALSE(validator.validate(Parameter("name", "")).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("name", "Hello")).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("name", "hello123")).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("name", "")).successful());
 }
 
 TEST_F(RegexValidatorTest, IdentifierPattern)
 {
-  RegexValidator validator("^[a-zA-Z_][a-zA-Z0-9_]*$", "valid identifier");
+  rclcpp::RegexValidator validator("^[a-zA-Z_][a-zA-Z0-9_]*$", "valid identifier");
 
-  EXPECT_TRUE(validator.validate(Parameter("id", "my_var")).successful());
-  EXPECT_TRUE(validator.validate(Parameter("id", "_private")).successful());
-  EXPECT_TRUE(validator.validate(Parameter("id", "CamelCase123")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("id", "my_var")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("id", "_private")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("id", "CamelCase123")).successful());
 
-  EXPECT_FALSE(validator.validate(Parameter("id", "123start")).successful());
-  EXPECT_FALSE(validator.validate(Parameter("id", "has-dash")).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("id", "123start")).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("id", "has-dash")).successful());
 }
 
 TEST_F(RegexValidatorTest, IPAddressPattern)
 {
-  RegexValidator validator(R"(^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$)", "IPv4 address");
+  rclcpp::RegexValidator validator(R"(^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$)", "IPv4 address");
 
-  EXPECT_TRUE(validator.validate(Parameter("ip", "192.168.1.1")).successful());
-  EXPECT_TRUE(validator.validate(Parameter("ip", "0.0.0.0")).successful());
-  EXPECT_TRUE(validator.validate(Parameter("ip", "255.255.255.255")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("ip", "192.168.1.1")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("ip", "0.0.0.0")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("ip", "255.255.255.255")).successful());
 
-  EXPECT_FALSE(validator.validate(Parameter("ip", "1234.1.1.1")).successful());
-  EXPECT_FALSE(validator.validate(Parameter("ip", "192.168.1")).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("ip", "1234.1.1.1")).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("ip", "192.168.1")).successful());
 }
 
 TEST_F(RegexValidatorTest, TypeMismatch)
 {
-  RegexValidator validator(".*");
+  rclcpp::RegexValidator validator(".*");
 
-  EXPECT_FALSE(validator.validate(Parameter("p", 123)).successful());
-  EXPECT_FALSE(validator.validate(Parameter("p", 1.5)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", 123)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", 1.5)).successful());
 }
 
 TEST_F(RegexValidatorTest, Description)
 {
-  RegexValidator validator("^test$", "test pattern");
+  rclcpp::RegexValidator validator("^test$", "test pattern");
   auto desc = validator.description();
 
   EXPECT_NE(desc.find("^test$"), std::string::npos);
@@ -347,7 +346,7 @@ TEST_F(RegexValidatorTest, Description)
 
 TEST_F(RegexValidatorTest, PatternString)
 {
-  RegexValidator validator("^[a-z]+$");
+  rclcpp::RegexValidator validator("^[a-z]+$");
   EXPECT_EQ(validator.pattern_string(), "^[a-z]+$");
 }
 
@@ -364,44 +363,44 @@ protected:
 
 TEST_F(NotEmptyValidatorTest, StringValidation)
 {
-  NotEmptyValidator validator;
+  rclcpp::NotEmptyValidator validator;
 
-  EXPECT_TRUE(validator.validate(Parameter("s", "hello")).successful());
-  EXPECT_TRUE(validator.validate(Parameter("s", " ")).successful());  // Whitespace is not empty
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("s", "hello")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("s", " ")).successful());  // Whitespace is not empty
 
-  EXPECT_FALSE(validator.validate(Parameter("s", "")).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("s", "")).successful());
 }
 
 TEST_F(NotEmptyValidatorTest, ArrayValidation)
 {
-  NotEmptyValidator validator;
+  rclcpp::NotEmptyValidator validator;
 
   // Non-empty arrays
-  EXPECT_TRUE(validator.validate(Parameter("arr", std::vector<int64_t>{1})).successful());
-  EXPECT_TRUE(validator.validate(Parameter("arr", std::vector<double>{1.0, 2.0})).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("arr", std::vector<int64_t>{1})).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("arr", std::vector<double>{1.0, 2.0})).successful());
   EXPECT_TRUE(validator.validate(
-      Parameter("arr", std::vector<std::string>{"a"})).successful());
+    rclcpp::Parameter("arr", std::vector<std::string>{"a"})).successful());
 
   // Empty arrays
-  EXPECT_FALSE(validator.validate(Parameter("arr", std::vector<int64_t>{})).successful());
-  EXPECT_FALSE(validator.validate(Parameter("arr", std::vector<double>{})).successful());
-  EXPECT_FALSE(validator.validate(Parameter("arr", std::vector<std::string>{})).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("arr", std::vector<int64_t>{})).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("arr", std::vector<double>{})).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("arr", std::vector<std::string>{})).successful());
 }
 
 TEST_F(NotEmptyValidatorTest, ScalarTypesAlwaysPass)
 {
-  NotEmptyValidator validator;
+  rclcpp::NotEmptyValidator validator;
 
   // Scalar types are never "empty"
-  EXPECT_TRUE(validator.validate(Parameter("p", true)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("p", false)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("p", 0)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("p", 0.0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", true)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", false)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 0.0)).successful());
 }
 
 TEST_F(NotEmptyValidatorTest, Description)
 {
-  NotEmptyValidator validator;
+  rclcpp::NotEmptyValidator validator;
   EXPECT_NE(validator.description().find("non-empty"), std::string::npos);
 }
 
@@ -418,43 +417,43 @@ protected:
 
 TEST_F(StringLengthValidatorTest, BothBounds)
 {
-  StringLengthValidator validator(2, 10);
+  rclcpp::StringLengthValidator validator(2, 10);
 
-  EXPECT_TRUE(validator.validate(Parameter("s", "ab")).successful());
-  EXPECT_TRUE(validator.validate(Parameter("s", "hello")).successful());
-  EXPECT_TRUE(validator.validate(Parameter("s", "1234567890")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("s", "ab")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("s", "hello")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("s", "1234567890")).successful());
 
-  EXPECT_FALSE(validator.validate(Parameter("s", "a")).successful());
-  EXPECT_FALSE(validator.validate(Parameter("s", "12345678901")).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("s", "a")).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("s", "12345678901")).successful());
 }
 
 TEST_F(StringLengthValidatorTest, MinLengthOnly)
 {
-  auto validator = StringLengthValidator::min_length(3);
+  auto validator = rclcpp::StringLengthValidator::min_length(3);
 
-  EXPECT_TRUE(validator.validate(Parameter("s", "abc")).successful());
-  EXPECT_TRUE(validator.validate(Parameter("s", "very long string")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("s", "abc")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("s", "very long string")).successful());
 
-  EXPECT_FALSE(validator.validate(Parameter("s", "ab")).successful());
-  EXPECT_FALSE(validator.validate(Parameter("s", "")).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("s", "ab")).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("s", "")).successful());
 }
 
 TEST_F(StringLengthValidatorTest, MaxLengthOnly)
 {
-  auto validator = StringLengthValidator::max_length(5);
+  auto validator = rclcpp::StringLengthValidator::max_length(5);
 
-  EXPECT_TRUE(validator.validate(Parameter("s", "")).successful());
-  EXPECT_TRUE(validator.validate(Parameter("s", "12345")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("s", "")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("s", "12345")).successful());
 
-  EXPECT_FALSE(validator.validate(Parameter("s", "123456")).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("s", "123456")).successful());
 }
 
 TEST_F(StringLengthValidatorTest, TypeMismatch)
 {
-  StringLengthValidator validator(1, 10);
+  rclcpp::StringLengthValidator validator(1, 10);
 
-  EXPECT_FALSE(validator.validate(Parameter("p", 123)).successful());
-  EXPECT_FALSE(validator.validate(Parameter("p", 1.5)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", 123)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", 1.5)).successful());
 }
 
 // =============================================================================
@@ -470,33 +469,33 @@ protected:
 
 TEST_F(TypeValidatorTest, SingleType)
 {
-  TypeValidator validator(ParameterType::PARAMETER_DOUBLE);
+  rclcpp::TypeValidator validator(rclcpp::ParameterType::PARAMETER_DOUBLE);
 
-  EXPECT_TRUE(validator.validate(Parameter("p", 1.5)).successful());
-  EXPECT_FALSE(validator.validate(Parameter("p", 1)).successful());
-  EXPECT_FALSE(validator.validate(Parameter("p", "1.5")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 1.5)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", 1)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", "1.5")).successful());
 }
 
 TEST_F(TypeValidatorTest, MultipleTypes)
 {
-  TypeValidator validator({
-    ParameterType::PARAMETER_INTEGER,
-    ParameterType::PARAMETER_DOUBLE
+  rclcpp::TypeValidator validator({
+    rclcpp::ParameterType::PARAMETER_INTEGER,
+    rclcpp::ParameterType::PARAMETER_DOUBLE
   });
 
-  EXPECT_TRUE(validator.validate(Parameter("p", 1)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("p", 1.5)).successful());
-  EXPECT_FALSE(validator.validate(Parameter("p", "1")).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 1)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 1.5)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", "1")).successful());
 }
 
 TEST_F(TypeValidatorTest, Description)
 {
-  TypeValidator single(ParameterType::PARAMETER_DOUBLE);
+  rclcpp::TypeValidator single(rclcpp::ParameterType::PARAMETER_DOUBLE);
   EXPECT_NE(single.description().find("double"), std::string::npos);
 
-  TypeValidator multiple({
-    ParameterType::PARAMETER_INTEGER,
-    ParameterType::PARAMETER_DOUBLE
+  rclcpp::TypeValidator multiple({
+    rclcpp::ParameterType::PARAMETER_INTEGER,
+    rclcpp::ParameterType::PARAMETER_DOUBLE
   });
   EXPECT_NE(multiple.description().find("integer"), std::string::npos);
   EXPECT_NE(multiple.description().find("double"), std::string::npos);
@@ -515,73 +514,73 @@ protected:
 
 TEST_F(CompositeValidatorTest, AllMode)
 {
-  CompositeValidator validator(CompositeValidator::Mode::ALL);
-  validator.add(std::make_shared<RangeValidator<double>>(0.0, 100.0));
-  validator.add(std::make_shared<RangeValidator<double>>(50.0, 150.0));
+  rclcpp::CompositeValidator validator(rclcpp::CompositeValidator::Mode::ALL);
+  validator.add(std::make_shared<rclcpp::RangeValidator<double>>(0.0, 100.0));
+  validator.add(std::make_shared<rclcpp::RangeValidator<double>>(50.0, 150.0));
 
   // Must pass both: [0, 100] AND [50, 150] = [50, 100]
-  EXPECT_TRUE(validator.validate(Parameter("p", 50.0)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("p", 100.0)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("p", 75.0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 50.0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 100.0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 75.0)).successful());
 
-  EXPECT_FALSE(validator.validate(Parameter("p", 25.0)).successful());  // Fails second
-  EXPECT_FALSE(validator.validate(Parameter("p", 125.0)).successful());  // Fails first
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", 25.0)).successful());  // Fails second
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", 125.0)).successful());  // Fails first
 }
 
 TEST_F(CompositeValidatorTest, AnyMode)
 {
-  CompositeValidator validator(CompositeValidator::Mode::ANY);
-  validator.add(std::make_shared<RangeValidator<double>>(0.0, 10.0));
-  validator.add(std::make_shared<RangeValidator<double>>(90.0, 100.0));
+  rclcpp::CompositeValidator validator(rclcpp::CompositeValidator::Mode::ANY);
+  validator.add(std::make_shared<rclcpp::RangeValidator<double>>(0.0, 10.0));
+  validator.add(std::make_shared<rclcpp::RangeValidator<double>>(90.0, 100.0));
 
   // Must pass either: [0, 10] OR [90, 100]
-  EXPECT_TRUE(validator.validate(Parameter("p", 5.0)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("p", 95.0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 5.0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 95.0)).successful());
 
-  EXPECT_FALSE(validator.validate(Parameter("p", 50.0)).successful());  // Fails both
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", 50.0)).successful());  // Fails both
 }
 
 TEST_F(CompositeValidatorTest, FluentAPI)
 {
-  CompositeValidator validator;
+  rclcpp::CompositeValidator validator;
   validator
-    .and_also(std::make_shared<RangeValidator<double>>(0.0, 100.0))
-    .and_also(std::make_shared<TypeValidator>(ParameterType::PARAMETER_DOUBLE));
+    .and_also(std::make_shared<rclcpp::RangeValidator<double>>(0.0, 100.0))
+    .and_also(std::make_shared<rclcpp::TypeValidator>(rclcpp::ParameterType::PARAMETER_DOUBLE));
 
-  EXPECT_TRUE(validator.validate(Parameter("p", 50.0)).successful());
-  EXPECT_FALSE(validator.validate(Parameter("p", 50)).successful());  // Wrong type
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 50.0)).successful());
+  EXPECT_FALSE(validator.validate(rclcpp::Parameter("p", 50)).successful());  // Wrong type
 }
 
 TEST_F(CompositeValidatorTest, OrElseChangesMode)
 {
-  CompositeValidator validator;
+  rclcpp::CompositeValidator validator;
   validator
-    .add(std::make_shared<RangeValidator<double>>(0.0, 10.0))
-    .or_else(std::make_shared<RangeValidator<double>>(90.0, 100.0));
+    .add(std::make_shared<rclcpp::RangeValidator<double>>(0.0, 10.0))
+    .or_else(std::make_shared<rclcpp::RangeValidator<double>>(90.0, 100.0));
 
-  EXPECT_EQ(validator.mode(), CompositeValidator::Mode::ANY);
-  EXPECT_TRUE(validator.validate(Parameter("p", 5.0)).successful());
-  EXPECT_TRUE(validator.validate(Parameter("p", 95.0)).successful());
+  EXPECT_EQ(validator.mode(), rclcpp::CompositeValidator::Mode::ANY);
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 5.0)).successful());
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", 95.0)).successful());
 }
 
 TEST_F(CompositeValidatorTest, EmptyComposite)
 {
-  CompositeValidator validator;
-  EXPECT_TRUE(validator.validate(Parameter("p", "anything")).successful());
+  rclcpp::CompositeValidator validator;
+  EXPECT_TRUE(validator.validate(rclcpp::Parameter("p", "anything")).successful());
 }
 
 TEST_F(CompositeValidatorTest, Description)
 {
-  CompositeValidator all_validator(CompositeValidator::Mode::ALL);
-  all_validator.add(std::make_shared<NotEmptyValidator>());
-  all_validator.add(std::make_shared<StringLengthValidator>(1, 10));
+  rclcpp::CompositeValidator all_validator(rclcpp::CompositeValidator::Mode::ALL);
+  all_validator.add(std::make_shared<rclcpp::NotEmptyValidator>());
+  all_validator.add(std::make_shared<rclcpp::StringLengthValidator>(1, 10));
 
   auto desc = all_validator.description();
   EXPECT_NE(desc.find("AND"), std::string::npos);
 
-  CompositeValidator any_validator(CompositeValidator::Mode::ANY);
-  any_validator.add(std::make_shared<NotEmptyValidator>());
-  any_validator.add(std::make_shared<StringLengthValidator>(1, 10));
+  rclcpp::CompositeValidator any_validator(rclcpp::CompositeValidator::Mode::ANY);
+  any_validator.add(std::make_shared<rclcpp::NotEmptyValidator>());
+  any_validator.add(std::make_shared<rclcpp::StringLengthValidator>(1, 10));
 
   desc = any_validator.description();
   EXPECT_NE(desc.find("OR"), std::string::npos);
@@ -600,79 +599,79 @@ protected:
 
 TEST_F(FactoryFunctionsTest, RangeFactory)
 {
-  auto validator = validators::range(0.0, 100.0);
-  EXPECT_TRUE(validator->validate(Parameter("p", 50.0)).successful());
-  EXPECT_FALSE(validator->validate(Parameter("p", 150.0)).successful());
+  auto validator = rclcpp::validators::range(0.0, 100.0);
+  EXPECT_TRUE(validator->validate(rclcpp::Parameter("p", 50.0)).successful());
+  EXPECT_FALSE(validator->validate(rclcpp::Parameter("p", 150.0)).successful());
 }
 
 TEST_F(FactoryFunctionsTest, MinMaxFactory)
 {
-  auto min_validator = validators::min(0.0);
-  EXPECT_TRUE(min_validator->validate(Parameter("p", 0.0)).successful());
-  EXPECT_FALSE(min_validator->validate(Parameter("p", -1.0)).successful());
+  auto min_validator = rclcpp::validators::min(0.0);
+  EXPECT_TRUE(min_validator->validate(rclcpp::Parameter("p", 0.0)).successful());
+  EXPECT_FALSE(min_validator->validate(rclcpp::Parameter("p", -1.0)).successful());
 
-  auto max_validator = validators::max(100.0);
-  EXPECT_TRUE(max_validator->validate(Parameter("p", 100.0)).successful());
-  EXPECT_FALSE(max_validator->validate(Parameter("p", 101.0)).successful());
+  auto max_validator = rclcpp::validators::max(100.0);
+  EXPECT_TRUE(max_validator->validate(rclcpp::Parameter("p", 100.0)).successful());
+  EXPECT_FALSE(max_validator->validate(rclcpp::Parameter("p", 101.0)).successful());
 }
 
 TEST_F(FactoryFunctionsTest, OneOfFactory)
 {
-  auto validator = validators::one_of<std::string>({"a", "b", "c"});
-  EXPECT_TRUE(validator->validate(Parameter("p", "a")).successful());
-  EXPECT_FALSE(validator->validate(Parameter("p", "d")).successful());
+  auto validator = rclcpp::validators::one_of<std::string>({"a", "b", "c"});
+  EXPECT_TRUE(validator->validate(rclcpp::Parameter("p", "a")).successful());
+  EXPECT_FALSE(validator->validate(rclcpp::Parameter("p", "d")).successful());
 }
 
 TEST_F(FactoryFunctionsTest, MatchesFactory)
 {
-  auto validator = validators::matches("^[a-z]+$");
-  EXPECT_TRUE(validator->validate(Parameter("p", "hello")).successful());
-  EXPECT_FALSE(validator->validate(Parameter("p", "Hello")).successful());
+  auto validator = rclcpp::validators::matches("^[a-z]+$");
+  EXPECT_TRUE(validator->validate(rclcpp::Parameter("p", "hello")).successful());
+  EXPECT_FALSE(validator->validate(rclcpp::Parameter("p", "Hello")).successful());
 }
 
 TEST_F(FactoryFunctionsTest, NotEmptyFactory)
 {
-  auto validator = validators::not_empty();
-  EXPECT_TRUE(validator->validate(Parameter("p", "hello")).successful());
-  EXPECT_FALSE(validator->validate(Parameter("p", "")).successful());
+  auto validator = rclcpp::validators::not_empty();
+  EXPECT_TRUE(validator->validate(rclcpp::Parameter("p", "hello")).successful());
+  EXPECT_FALSE(validator->validate(rclcpp::Parameter("p", "")).successful());
 }
 
 TEST_F(FactoryFunctionsTest, LengthFactory)
 {
-  auto validator = validators::length(1, 10);
-  EXPECT_TRUE(validator->validate(Parameter("p", "hello")).successful());
-  EXPECT_FALSE(validator->validate(Parameter("p", "")).successful());
+  auto validator = rclcpp::validators::length(1, 10);
+  EXPECT_TRUE(validator->validate(rclcpp::Parameter("p", "hello")).successful());
+  EXPECT_FALSE(validator->validate(rclcpp::Parameter("p", "")).successful());
 }
 
 TEST_F(FactoryFunctionsTest, TypeFactory)
 {
-  auto validator = validators::type(ParameterType::PARAMETER_DOUBLE);
-  EXPECT_TRUE(validator->validate(Parameter("p", 1.5)).successful());
-  EXPECT_FALSE(validator->validate(Parameter("p", 1)).successful());
+  auto validator = rclcpp::validators::type(rclcpp::ParameterType::PARAMETER_DOUBLE);
+  EXPECT_TRUE(validator->validate(rclcpp::Parameter("p", 1.5)).successful());
+  EXPECT_FALSE(validator->validate(rclcpp::Parameter("p", 1)).successful());
 }
 
 TEST_F(FactoryFunctionsTest, AllOfFactory)
 {
-  auto validator = validators::all_of({
-    validators::range(0.0, 100.0),
-    validators::type(ParameterType::PARAMETER_DOUBLE)
+  auto validator = rclcpp::validators::all_of({
+    rclcpp::validators::range(0.0, 100.0),
+    rclcpp::validators::type(rclcpp::ParameterType::PARAMETER_DOUBLE)
   });
 
-  EXPECT_TRUE(validator->validate(Parameter("p", 50.0)).successful());
-  EXPECT_FALSE(validator->validate(Parameter("p", 50)).successful());  // Wrong type
-  EXPECT_FALSE(validator->validate(Parameter("p", 150.0)).successful());  // Out of range
+  EXPECT_TRUE(validator->validate(rclcpp::Parameter("p", 50.0)).successful());
+  EXPECT_FALSE(validator->validate(rclcpp::Parameter("p", 50)).successful());  // Wrong type
+  EXPECT_FALSE(validator->validate(rclcpp::Parameter("p", 150.0)).successful());  // Out of range
 }
 
 TEST_F(FactoryFunctionsTest, AnyOfFactory)
 {
-  auto validator = validators::any_of({
-    validators::one_of<std::string>({"yes"}),
-    validators::one_of<std::string>({"no"})
+  auto validator = rclcpp::validators::any_of({
+    rclcpp::validators::one_of<std::string>({"yes"}),
+    rclcpp::validators::one_of<std::string>({"no"})
   });
 
-  EXPECT_TRUE(validator->validate(Parameter("p", "yes")).successful());
-  EXPECT_TRUE(validator->validate(Parameter("p", "no")).successful());
-  EXPECT_FALSE(validator->validate(Parameter("p", "maybe")).successful());
+  EXPECT_TRUE(validator->validate(rclcpp::Parameter("p", "yes")).successful());
+  EXPECT_TRUE(validator->validate(rclcpp::Parameter("p", "no")).successful());
+  EXPECT_FALSE(validator->validate(rclcpp::Parameter("p", "maybe")).successful());
 }
 
 // =============================================================================
@@ -688,7 +687,7 @@ protected:
 
 TEST_F(ParameterBuilderTest, BasicConstruction)
 {
-  auto builder = ParameterBuilder()
+  auto builder = rclcpp::ParameterBuilder()
     .name("test_param")
     .description("A test parameter")
     .default_value(42.0)
@@ -702,13 +701,13 @@ TEST_F(ParameterBuilderTest, BasicConstruction)
 
 TEST_F(ParameterBuilderTest, ConstructWithName)
 {
-  ParameterBuilder builder("my_param");
+  rclcpp::ParameterBuilder builder("my_param");
   EXPECT_EQ(builder.get_name(), "my_param");
 }
 
 TEST_F(ParameterBuilderTest, BuildParameter)
 {
-  auto param = ParameterBuilder()
+  auto param = rclcpp::ParameterBuilder()
     .name("velocity")
     .default_value(1.5)
     .build();
@@ -719,7 +718,7 @@ TEST_F(ParameterBuilderTest, BuildParameter)
 
 TEST_F(ParameterBuilderTest, BuildDescriptor)
 {
-  auto builder = ParameterBuilder()
+  auto builder = rclcpp::ParameterBuilder()
     .name("velocity")
     .description("Robot velocity")
     .read_only(true)
@@ -737,7 +736,7 @@ TEST_F(ParameterBuilderTest, BuildDescriptor)
 
 TEST_F(ParameterBuilderTest, IntegerRangeDescriptor)
 {
-  auto builder = ParameterBuilder()
+  auto builder = rclcpp::ParameterBuilder()
     .name("count")
     .range<int64_t>(0, 100);
 
@@ -750,7 +749,7 @@ TEST_F(ParameterBuilderTest, IntegerRangeDescriptor)
 
 TEST_F(ParameterBuilderTest, FluentValidators)
 {
-  auto builder = ParameterBuilder()
+  auto builder = rclcpp::ParameterBuilder()
     .name("config")
     .default_value("default")
     .not_empty()
@@ -763,46 +762,46 @@ TEST_F(ParameterBuilderTest, FluentValidators)
 
 TEST_F(ParameterBuilderTest, Validation)
 {
-  auto builder = ParameterBuilder()
+  auto builder = rclcpp::ParameterBuilder()
     .name("velocity")
     .range(0.0, 10.0);
 
-  EXPECT_TRUE(builder.validate(Parameter("velocity", 5.0)).successful());
-  EXPECT_FALSE(builder.validate(Parameter("velocity", 15.0)).successful());
+  EXPECT_TRUE(builder.validate(rclcpp::Parameter("velocity", 5.0)).successful());
+  EXPECT_FALSE(builder.validate(rclcpp::Parameter("velocity", 15.0)).successful());
 }
 
 TEST_F(ParameterBuilderTest, CustomValidator)
 {
-  class EvenValidator : public ParameterValidator
+  class EvenValidator : public rclcpp::ParameterValidator
   {
   public:
-    ValidationResult validate(const Parameter & param) const override
+    rclcpp::ValidationResult validate(const rclcpp::Parameter & param) const override
     {
       if (param.as_int() % 2 == 0) {
-        return ValidationResult::success();
+        return rclcpp::ValidationResult::success();
       }
-      return ValidationResult::failure("Value must be even");
+      return rclcpp::ValidationResult::failure("Value must be even");
     }
     std::string description() const override {return "even integer";}
   };
 
-  auto builder = ParameterBuilder()
+  auto builder = rclcpp::ParameterBuilder()
     .name("even_number")
     .validator(std::make_shared<EvenValidator>());
 
-  EXPECT_TRUE(builder.validate(Parameter("even_number", 4)).successful());
-  EXPECT_FALSE(builder.validate(Parameter("even_number", 3)).successful());
+  EXPECT_TRUE(builder.validate(rclcpp::Parameter("even_number", 4)).successful());
+  EXPECT_FALSE(builder.validate(rclcpp::Parameter("even_number", 3)).successful());
 }
 
 TEST_F(ParameterBuilderTest, BuildWithoutName)
 {
-  ParameterBuilder builder;
+  rclcpp::ParameterBuilder builder;
   EXPECT_THROW(builder.build(), std::runtime_error);
 }
 
 TEST_F(ParameterBuilderTest, GetDefaultValueWithoutSetting)
 {
-  ParameterBuilder builder;
+  rclcpp::ParameterBuilder builder;
   builder.name("test");
   EXPECT_THROW(builder.get_default_value(), std::runtime_error);
 }
@@ -820,40 +819,40 @@ protected:
 
 TEST_F(ParameterValidatorRegistryTest, RegisterAndValidate)
 {
-  ParameterValidatorRegistry registry;
+  rclcpp::ParameterValidatorRegistry registry;
 
   registry.register_validators("velocity", {
-    std::make_shared<RangeValidator<double>>(0.0, 10.0)
+    std::make_shared<rclcpp::RangeValidator<double>>(0.0, 10.0)
   });
 
   EXPECT_TRUE(registry.has_validators("velocity"));
   EXPECT_FALSE(registry.has_validators("other"));
 
-  EXPECT_TRUE(registry.validate(Parameter("velocity", 5.0)).successful());
-  EXPECT_FALSE(registry.validate(Parameter("velocity", 15.0)).successful());
+  EXPECT_TRUE(registry.validate(rclcpp::Parameter("velocity", 5.0)).successful());
+  EXPECT_FALSE(registry.validate(rclcpp::Parameter("velocity", 15.0)).successful());
 
   // Unregistered parameter always passes
-  EXPECT_TRUE(registry.validate(Parameter("other", 100.0)).successful());
+  EXPECT_TRUE(registry.validate(rclcpp::Parameter("other", 100.0)).successful());
 }
 
 TEST_F(ParameterValidatorRegistryTest, AddValidator)
 {
-  ParameterValidatorRegistry registry;
+  rclcpp::ParameterValidatorRegistry registry;
 
-  registry.add_validator("param", std::make_shared<RangeValidator<double>>(0.0, 100.0));
-  registry.add_validator("param", std::make_shared<RangeValidator<double>>(50.0, 150.0));
+  registry.add_validator("param", std::make_shared<rclcpp::RangeValidator<double>>(0.0, 100.0));
+  registry.add_validator("param", std::make_shared<rclcpp::RangeValidator<double>>(50.0, 150.0));
 
   // Both must pass
-  EXPECT_TRUE(registry.validate(Parameter("param", 75.0)).successful());
-  EXPECT_FALSE(registry.validate(Parameter("param", 25.0)).successful());
+  EXPECT_TRUE(registry.validate(rclcpp::Parameter("param", 75.0)).successful());
+  EXPECT_FALSE(registry.validate(rclcpp::Parameter("param", 25.0)).successful());
 }
 
 TEST_F(ParameterValidatorRegistryTest, ClearValidators)
 {
-  ParameterValidatorRegistry registry;
+  rclcpp::ParameterValidatorRegistry registry;
 
   registry.register_validators("param", {
-    std::make_shared<RangeValidator<double>>(0.0, 10.0)
+    std::make_shared<rclcpp::RangeValidator<double>>(0.0, 10.0)
   });
 
   EXPECT_TRUE(registry.has_validators("param"));
@@ -865,42 +864,42 @@ TEST_F(ParameterValidatorRegistryTest, ClearValidators)
 
 TEST_F(ParameterValidatorRegistryTest, ValidateMultiple)
 {
-  ParameterValidatorRegistry registry;
+  rclcpp::ParameterValidatorRegistry registry;
 
   registry.register_validators("a", {
-    std::make_shared<RangeValidator<double>>(0.0, 10.0)
+    std::make_shared<rclcpp::RangeValidator<double>>(0.0, 10.0)
   });
   registry.register_validators("b", {
-    std::make_shared<RangeValidator<double>>(0.0, 100.0)
+    std::make_shared<rclcpp::RangeValidator<double>>(0.0, 100.0)
   });
 
-  std::vector<Parameter> valid_params = {
-    Parameter("a", 5.0),
-    Parameter("b", 50.0)
+  std::vector<rclcpp::Parameter> valid_params = {
+    rclcpp::Parameter("a", 5.0),
+    rclcpp::Parameter("b", 50.0)
   };
   EXPECT_TRUE(registry.validate(valid_params).successful());
 
-  std::vector<Parameter> invalid_params = {
-    Parameter("a", 15.0),  // Invalid
-    Parameter("b", 50.0)
+  std::vector<rclcpp::Parameter> invalid_params = {
+    rclcpp::Parameter("a", 15.0),  // Invalid
+    rclcpp::Parameter("b", 50.0)
   };
   EXPECT_FALSE(registry.validate(invalid_params).successful());
 }
 
 TEST_F(ParameterValidatorRegistryTest, CreateCallback)
 {
-  ParameterValidatorRegistry registry;
+  rclcpp::ParameterValidatorRegistry registry;
 
   registry.register_validators("velocity", {
-    std::make_shared<RangeValidator<double>>(0.0, 10.0)
+    std::make_shared<rclcpp::RangeValidator<double>>(0.0, 10.0)
   });
 
   auto callback = registry.create_callback();
 
-  auto result = callback({Parameter("velocity", 5.0)});
+  auto result = callback({rclcpp::Parameter("velocity", 5.0)});
   EXPECT_TRUE(result.successful);
 
-  result = callback({Parameter("velocity", 15.0)});
+  result = callback({rclcpp::Parameter("velocity", 15.0)});
   EXPECT_FALSE(result.successful);
 }
 
@@ -917,7 +916,7 @@ protected:
 
 TEST_F(UtilityFunctionsTest, FormatValidationError)
 {
-  auto error = format_validation_error(
+  auto error = rclcpp::format_validation_error(
     "max_velocity",
     "value out of range",
     "value in [0.0, 10.0]",
@@ -931,30 +930,38 @@ TEST_F(UtilityFunctionsTest, FormatValidationError)
 
 TEST_F(UtilityFunctionsTest, ParameterValueToString)
 {
-  EXPECT_NE(parameter_value_to_string(Parameter("p", true)).find("true"), std::string::npos);
-  EXPECT_NE(parameter_value_to_string(Parameter("p", 42)).find("42"), std::string::npos);
-  EXPECT_NE(parameter_value_to_string(Parameter("p", 3.14)).find("3.14"), std::string::npos);
-  EXPECT_NE(parameter_value_to_string(Parameter("p", "hello")).find("hello"), std::string::npos);
+  EXPECT_NE(
+    rclcpp::parameter_value_to_string(rclcpp::Parameter("p", true)).find("true"),
+    std::string::npos);
+  EXPECT_NE(
+    rclcpp::parameter_value_to_string(rclcpp::Parameter("p", 42)).find("42"),
+    std::string::npos);
+  EXPECT_NE(
+    rclcpp::parameter_value_to_string(rclcpp::Parameter("p", 3.14)).find("3.14"),
+    std::string::npos);
+  EXPECT_NE(
+    rclcpp::parameter_value_to_string(rclcpp::Parameter("p", "hello")).find("hello"),
+    std::string::npos);
 }
 
 TEST_F(UtilityFunctionsTest, ParameterTypeToString)
 {
-  EXPECT_EQ(parameter_type_to_string(ParameterType::PARAMETER_BOOL), "bool");
-  EXPECT_EQ(parameter_type_to_string(ParameterType::PARAMETER_INTEGER), "integer");
-  EXPECT_EQ(parameter_type_to_string(ParameterType::PARAMETER_DOUBLE), "double");
-  EXPECT_EQ(parameter_type_to_string(ParameterType::PARAMETER_STRING), "string");
-  EXPECT_EQ(parameter_type_to_string(ParameterType::PARAMETER_NOT_SET), "not_set");
+  EXPECT_EQ(rclcpp::parameter_type_to_string(rclcpp::ParameterType::PARAMETER_BOOL), "bool");
+  EXPECT_EQ(rclcpp::parameter_type_to_string(rclcpp::ParameterType::PARAMETER_INTEGER), "integer");
+  EXPECT_EQ(rclcpp::parameter_type_to_string(rclcpp::ParameterType::PARAMETER_DOUBLE), "double");
+  EXPECT_EQ(rclcpp::parameter_type_to_string(rclcpp::ParameterType::PARAMETER_STRING), "string");
+  EXPECT_EQ(rclcpp::parameter_type_to_string(rclcpp::ParameterType::PARAMETER_NOT_SET), "not_set");
 }
 
 TEST_F(UtilityFunctionsTest, ValidateParameterFunction)
 {
-  std::vector<ParameterValidatorPtr> validators = {
-    std::make_shared<RangeValidator<double>>(0.0, 100.0),
-    std::make_shared<RangeValidator<double>>(50.0, 150.0)
+  std::vector<rclcpp::ParameterValidatorPtr> validators = {
+    std::make_shared<rclcpp::RangeValidator<double>>(0.0, 100.0),
+    std::make_shared<rclcpp::RangeValidator<double>>(50.0, 150.0)
   };
 
-  EXPECT_TRUE(validate_parameter(Parameter("p", 75.0), validators).successful());
-  EXPECT_FALSE(validate_parameter(Parameter("p", 25.0), validators).successful());
+  EXPECT_TRUE(rclcpp::validate_parameter(rclcpp::Parameter("p", 75.0), validators).successful());
+  EXPECT_FALSE(rclcpp::validate_parameter(rclcpp::Parameter("p", 25.0), validators).successful());
 }
 
 // =============================================================================
@@ -981,9 +988,9 @@ protected:
 
 TEST_F(NodeIntegrationTest, DeclareValidatedParameter)
 {
-  auto param = declare_validated_parameter(
+  auto param = rclcpp::declare_validated_parameter(
     *node_,
-    ParameterBuilder()
+    rclcpp::ParameterBuilder()
       .name("velocity")
       .description("Robot velocity")
       .default_value(1.0)
@@ -994,20 +1001,20 @@ TEST_F(NodeIntegrationTest, DeclareValidatedParameter)
   EXPECT_EQ(param.as_double(), 1.0);
 
   // Try to set valid value
-  auto result = node_->set_parameter(Parameter("velocity", 5.0));
+  auto result = node_->set_parameter(rclcpp::Parameter("velocity", 5.0));
   EXPECT_TRUE(result.successful);
 
   // Try to set invalid value
-  result = node_->set_parameter(Parameter("velocity", 15.0));
+  result = node_->set_parameter(rclcpp::Parameter("velocity", 15.0));
   EXPECT_FALSE(result.successful);
 }
 
 TEST_F(NodeIntegrationTest, DeclareValidatedParameterInvalidDefault)
 {
   EXPECT_THROW(
-    declare_validated_parameter(
+    rclcpp::declare_validated_parameter(
       *node_,
-      ParameterBuilder()
+      rclcpp::ParameterBuilder()
         .name("invalid_default")
         .default_value(100.0)  // Outside range
         .range(0.0, 10.0)
@@ -1018,29 +1025,29 @@ TEST_F(NodeIntegrationTest, DeclareValidatedParameterInvalidDefault)
 
 TEST_F(NodeIntegrationTest, DeclareMultipleValidatedParameters)
 {
-  std::vector<ParameterBuilder> builders = {
-    ParameterBuilder()
+  std::vector<rclcpp::ParameterBuilder> builders = {
+    rclcpp::ParameterBuilder()
       .name("velocity")
       .default_value(1.0)
       .range(0.0, 10.0),
-    ParameterBuilder()
+    rclcpp::ParameterBuilder()
       .name("mode")
       .default_value("normal")
       .one_of<std::string>({"slow", "normal", "fast"})
   };
 
-  auto params = declare_validated_parameters(*node_, builders);
+  auto params = rclcpp::declare_validated_parameters(*node_, builders);
 
   EXPECT_EQ(params.size(), 2u);
   EXPECT_EQ(params[0].get_name(), "velocity");
   EXPECT_EQ(params[1].get_name(), "mode");
 
   // Test validation
-  EXPECT_TRUE(node_->set_parameter(Parameter("velocity", 5.0)).successful);
-  EXPECT_FALSE(node_->set_parameter(Parameter("velocity", 15.0)).successful);
+  EXPECT_TRUE(node_->set_parameter(rclcpp::Parameter("velocity", 5.0)).successful);
+  EXPECT_FALSE(node_->set_parameter(rclcpp::Parameter("velocity", 15.0)).successful);
 
-  EXPECT_TRUE(node_->set_parameter(Parameter("mode", "fast")).successful);
-  EXPECT_FALSE(node_->set_parameter(Parameter("mode", "turbo")).successful);
+  EXPECT_TRUE(node_->set_parameter(rclcpp::Parameter("mode", "fast")).successful);
+  EXPECT_FALSE(node_->set_parameter(rclcpp::Parameter("mode", "turbo")).successful);
 }
 
 TEST_F(NodeIntegrationTest, CreateValidationCallback)
@@ -1049,38 +1056,38 @@ TEST_F(NodeIntegrationTest, CreateValidationCallback)
   node_->declare_parameter("legacy_param", 5.0);
 
   // Add validation later
-  std::map<std::string, std::vector<ParameterValidatorPtr>> validators;
+  std::map<std::string, std::vector<rclcpp::ParameterValidatorPtr>> validators;
   validators["legacy_param"] = {
-    std::make_shared<RangeValidator<double>>(0.0, 10.0)
+    std::make_shared<rclcpp::RangeValidator<double>>(0.0, 10.0)
   };
 
-  auto handle = create_validation_callback(*node_, validators);
+  auto handle = rclcpp::create_validation_callback(*node_, validators);
 
   // Test validation
-  EXPECT_TRUE(node_->set_parameter(Parameter("legacy_param", 5.0)).successful);
-  EXPECT_FALSE(node_->set_parameter(Parameter("legacy_param", 15.0)).successful);
+  EXPECT_TRUE(node_->set_parameter(rclcpp::Parameter("legacy_param", 5.0)).successful);
+  EXPECT_FALSE(node_->set_parameter(rclcpp::Parameter("legacy_param", 15.0)).successful);
 }
 
 TEST_F(NodeIntegrationTest, ReadOnlyParameter)
 {
-  declare_validated_parameter(
+  rclcpp::declare_validated_parameter(
     *node_,
-    ParameterBuilder()
+    rclcpp::ParameterBuilder()
       .name("constant")
       .default_value(42)
       .read_only(true)
   );
 
   // Should fail to change read-only parameter
-  auto result = node_->set_parameter(Parameter("constant", 100));
+  auto result = node_->set_parameter(rclcpp::Parameter("constant", 100));
   EXPECT_FALSE(result.successful);
 }
 
 TEST_F(NodeIntegrationTest, ParameterDescriptorPopulated)
 {
-  declare_validated_parameter(
+  rclcpp::declare_validated_parameter(
     *node_,
-    ParameterBuilder()
+    rclcpp::ParameterBuilder()
       .name("documented_param")
       .description("A well documented parameter")
       .default_value(5.0)
@@ -1106,8 +1113,8 @@ protected:
 
 TEST_F(ErrorMessageTest, RangeErrorMessage)
 {
-  RangeValidator<double> validator(0.0, 100.0);
-  auto result = validator.validate(Parameter("max_speed", 150.0));
+  rclcpp::RangeValidator<double> validator(0.0, 100.0);
+  auto result = validator.validate(rclcpp::Parameter("max_speed", 150.0));
 
   EXPECT_FALSE(result.successful());
   EXPECT_NE(result.reason().find("max_speed"), std::string::npos);
@@ -1117,8 +1124,8 @@ TEST_F(ErrorMessageTest, RangeErrorMessage)
 
 TEST_F(ErrorMessageTest, OneOfErrorMessage)
 {
-  OneOfValidator<std::string> validator({"a", "b", "c"});
-  auto result = validator.validate(Parameter("choice", "invalid"));
+  rclcpp::OneOfValidator<std::string> validator({"a", "b", "c"});
+  auto result = validator.validate(rclcpp::Parameter("choice", "invalid"));
 
   EXPECT_FALSE(result.successful());
   EXPECT_NE(result.reason().find("choice"), std::string::npos);
@@ -1127,8 +1134,8 @@ TEST_F(ErrorMessageTest, OneOfErrorMessage)
 
 TEST_F(ErrorMessageTest, RegexErrorMessage)
 {
-  RegexValidator validator("^[a-z]+$", "lowercase letters");
-  auto result = validator.validate(Parameter("identifier", "Invalid123"));
+  rclcpp::RegexValidator validator("^[a-z]+$", "lowercase letters");
+  auto result = validator.validate(rclcpp::Parameter("identifier", "Invalid123"));
 
   EXPECT_FALSE(result.successful());
   EXPECT_NE(result.reason().find("identifier"), std::string::npos);
@@ -1138,11 +1145,11 @@ TEST_F(ErrorMessageTest, RegexErrorMessage)
 
 TEST_F(ErrorMessageTest, CompositeAnyModeErrorMessage)
 {
-  CompositeValidator validator(CompositeValidator::Mode::ANY);
-  validator.add(std::make_shared<RangeValidator<double>>(0.0, 10.0));
-  validator.add(std::make_shared<RangeValidator<double>>(90.0, 100.0));
+  rclcpp::CompositeValidator validator(rclcpp::CompositeValidator::Mode::ANY);
+  validator.add(std::make_shared<rclcpp::RangeValidator<double>>(0.0, 10.0));
+  validator.add(std::make_shared<rclcpp::RangeValidator<double>>(90.0, 100.0));
 
-  auto result = validator.validate(Parameter("value", 50.0));
+  auto result = validator.validate(rclcpp::Parameter("value", 50.0));
 
   EXPECT_FALSE(result.successful());
   EXPECT_NE(result.reason().find("none of the validators"), std::string::npos);


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive parameter validation system for rclcpp that enables declarative validation of ROS 2 parameters, reducing boilerplate and providing consistent error messages.

## Motivation

Currently, validating ROS 2 parameters requires manually writing callback functions with custom validation logic for each parameter. This leads to:
- Significant boilerplate code duplication
- Inconsistent validation patterns and error messages
- Easy-to-miss edge cases

## Changes

### Built-in Validators

| Validator | Description |
|-----------|-------------|
| `RangeValidator<T>` | Numeric range with optional exclusive bounds |
| `OneOfValidator<T>` | Enum-like constraint for allowed values |
| `RegexValidator` | String pattern matching |
| `NotEmptyValidator` | Non-empty strings and arrays |
| `StringLengthValidator` | String length bounds |
| `CompositeValidator` | AND/OR composition of validators |

### API Example

```cpp
#include <rclcpp/parameter_builder.hpp>

class MyNode : public rclcpp::Node {
public:
  MyNode() : Node("my_node") {
    // Declare parameter with validation
    declare_validated_parameter(
      *this,
      rclcpp::ParameterBuilder()
        .name("max_velocity")
        .description("Maximum velocity in m/s")
        .default_value(1.0)
        .range(0.0, 10.0)
    );

    // String enum validation
    declare_validated_parameter(
      *this,
      rclcpp::ParameterBuilder()
        .name("mode")
        .default_value("normal")
        .one_of<std::string>({"slow", "normal", "fast"})
    );
  }
};
```

### Error Message Format

```
Parameter 'max_velocity' validation failed: value above maximum
  Expected: value in [0.000000, 10.000000]
  Got: 15.500000
```

## Backward Compatibility

- All changes are additive; existing code continues to work unchanged
- Validation is opt-in through `declare_validated_parameter()`

## Testing

60+ comprehensive GTest cases covering all validators, builder API, and node integration.

---

Signed-off-by: niveshdandyan <niveshdandyan@users.noreply.github.com>