### PR TITLE
Fix ASAN / valgrind warnings due to C / C++ allocator mismatch

### DIFF
--- a/rclcpp/include/rclcpp/message_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/message_memory_strategy.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <stdexcept>
 
+#include "rcl/allocator.h"
 #include "rcl/types.h"
 
 #include "rclcpp/allocator/allocator_common.hpp"
@@ -61,7 +62,7 @@ public:
     message_allocator_ = std::make_shared<MessageAlloc>();
     serialized_message_allocator_ = std::make_shared<SerializedMessageAlloc>();
     buffer_allocator_ = std::make_shared<BufferAlloc>();
-    rcutils_allocator_ = allocator::get_rcl_allocator<char, BufferAlloc>(*buffer_allocator_.get());
+    rcutils_allocator_ = rcl_get_default_allocator();
   }
 
   explicit MessageMemoryStrategy(std::shared_ptr<Alloc> allocator)
@@ -69,7 +70,7 @@ public:
     message_allocator_ = std::make_shared<MessageAlloc>(*allocator.get());
     serialized_message_allocator_ = std::make_shared<SerializedMessageAlloc>(*allocator.get());
     buffer_allocator_ = std::make_shared<BufferAlloc>(*allocator.get());
-    rcutils_allocator_ = allocator::get_rcl_allocator<char, BufferAlloc>(*buffer_allocator_.get());
+    rcutils_allocator_ = rcl_get_default_allocator();
   }
 
   virtual ~MessageMemoryStrategy() = default;

--- a/rclcpp/include/rclcpp/publisher_options.hpp
+++ b/rclcpp/include/rclcpp/publisher_options.hpp
@@ -20,6 +20,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "rcl/allocator.h"
 #include "rcl/publisher.h"
 
 #include "rclcpp/allocator/allocator_common.hpp"
@@ -81,7 +82,8 @@ struct PublisherOptionsWithAllocator : public PublisherOptionsBase
   /// Constructor using base class as input.
   explicit PublisherOptionsWithAllocator(const PublisherOptionsBase & publisher_options_base)
   : PublisherOptionsBase(publisher_options_base)
-  {}
+  {
+  }
 
   /// Convert this class, and a rclcpp::QoS, into an rcl_publisher_options_t.
   template<typename MessageT>
@@ -89,7 +91,7 @@ struct PublisherOptionsWithAllocator : public PublisherOptionsBase
   to_rcl_publisher_options(const rclcpp::QoS & qos) const
   {
     rcl_publisher_options_t result = rcl_publisher_get_default_options();
-    result.allocator = this->get_rcl_allocator();
+    result.allocator = rcl_get_default_allocator();
     result.qos = qos.get_rmw_qos_profile();
     result.rmw_publisher_options.require_unique_network_flow_endpoints =
       this->require_unique_network_flow_endpoints;
@@ -101,7 +103,6 @@ struct PublisherOptionsWithAllocator : public PublisherOptionsBase
 
     return result;
   }
-
 
   /// Get the allocator, creating one if needed.
   std::shared_ptr<Allocator>
@@ -127,7 +128,7 @@ private:
       plain_allocator_storage_ =
         std::make_shared<PlainAllocator>(*this->get_allocator());
     }
-    return rclcpp::allocator::get_rcl_allocator<char>(*plain_allocator_storage_);
+    return rcl_get_default_allocator();
   }
 
   // This is a temporal workaround, to make sure that get_allocator()

--- a/rclcpp/include/rclcpp/publisher_options.hpp
+++ b/rclcpp/include/rclcpp/publisher_options.hpp
@@ -75,13 +75,17 @@ struct PublisherOptionsWithAllocator : public PublisherOptionsBase
     "Publisher allocator value type must be void");
 
   /// Optional custom allocator.
-  std::shared_ptr<Allocator> allocator = nullptr;
+  std::shared_ptr<Allocator> allocator;
+  std::shared_ptr<rcutils_allocator_t> rcl_allocator;
 
-  PublisherOptionsWithAllocator() {}
+  PublisherOptionsWithAllocator()
+  :allocator(std::make_shared<Allocator>())
+  {}
 
   /// Constructor using base class as input.
   explicit PublisherOptionsWithAllocator(const PublisherOptionsBase & publisher_options_base)
-  : PublisherOptionsBase(publisher_options_base)
+  : PublisherOptionsBase(publisher_options_base),
+    allocator(std::make_shared<Allocator>())
   {
   }
 
@@ -91,7 +95,7 @@ struct PublisherOptionsWithAllocator : public PublisherOptionsBase
   to_rcl_publisher_options(const rclcpp::QoS & qos) const
   {
     rcl_publisher_options_t result = rcl_publisher_get_default_options();
-    result.allocator = rcl_get_default_allocator();
+    result.allocator = get_rcl_allocator();
     result.qos = qos.get_rmw_qos_profile();
     result.rmw_publisher_options.require_unique_network_flow_endpoints =
       this->require_unique_network_flow_endpoints;
@@ -108,37 +112,20 @@ struct PublisherOptionsWithAllocator : public PublisherOptionsBase
   std::shared_ptr<Allocator>
   get_allocator() const
   {
-    if (!this->allocator) {
-      if (!allocator_storage_) {
-        allocator_storage_ = std::make_shared<Allocator>();
-      }
-      return allocator_storage_;
-    }
     return this->allocator;
   }
 
 private:
-  using PlainAllocator =
-    typename std::allocator_traits<Allocator>::template rebind_alloc<char>;
-
   rcl_allocator_t
   get_rcl_allocator() const
   {
-    if (!plain_allocator_storage_) {
-      plain_allocator_storage_ =
-        std::make_shared<PlainAllocator>(*this->get_allocator());
+    if(rcl_allocator) {
+      return *rcl_allocator;
     }
     return rcl_get_default_allocator();
   }
-
-  // This is a temporal workaround, to make sure that get_allocator()
-  // always returns a copy of the same allocator.
-  mutable std::shared_ptr<Allocator> allocator_storage_;
-
-  // This is a temporal workaround, to keep the plain allocator that backs
-  // up the rcl allocator returned in rcl_publisher_options_t alive.
-  mutable std::shared_ptr<PlainAllocator> plain_allocator_storage_;
 };
+
 
 using PublisherOptions = PublisherOptionsWithAllocator<std::allocator<void>>;
 

--- a/rclcpp/include/rclcpp/publisher_options.hpp
+++ b/rclcpp/include/rclcpp/publisher_options.hpp
@@ -122,10 +122,22 @@ private:
     if(rcl_allocator) {
       return *rcl_allocator;
     }
+
+    RCUTILS_LOG_ERROR_NAMED("rclcpp",
+        "Warning, custom C++ allocator specified, but custom rcl allocator was set. Note, " \
+        "that due to a bug fix rcl allocators are not automatically generated from the C++ " \
+        "allocator any more.");
+
     return rcl_get_default_allocator();
   }
 };
 
+template<>
+inline rcl_allocator_t
+PublisherOptionsWithAllocator<std::allocator<void>>::get_rcl_allocator() const
+{
+  return rcl_get_default_allocator();
+}
 
 using PublisherOptions = PublisherOptionsWithAllocator<std::allocator<void>>;
 

--- a/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
@@ -515,7 +515,7 @@ public:
 
   rcl_allocator_t get_allocator() override
   {
-    return rclcpp::allocator::get_rcl_allocator<void *, VoidAlloc>(*allocator_.get());
+    return rcl_get_default_allocator();
   }
 
   size_t number_of_ready_subscriptions() const override

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -21,6 +21,8 @@
 #include <type_traits>
 #include <vector>
 
+#include "rcl/allocator.h"
+
 #include "rclcpp/callback_group.hpp"
 #include "rclcpp/detail/rmw_implementation_specific_subscription_payload.hpp"
 #include "rclcpp/intra_process_buffer_type.hpp"
@@ -108,7 +110,8 @@ struct SubscriptionOptionsWithAllocator : public SubscriptionOptionsBase
   explicit SubscriptionOptionsWithAllocator(
     const SubscriptionOptionsBase & subscription_options_base)
   : SubscriptionOptionsBase(subscription_options_base)
-  {}
+  {
+  }
 
   /// Convert this class, with a rclcpp::QoS, into an rcl_subscription_options_t.
   /**
@@ -119,7 +122,7 @@ struct SubscriptionOptionsWithAllocator : public SubscriptionOptionsBase
   to_rcl_subscription_options(const rclcpp::QoS & qos) const
   {
     rcl_subscription_options_t result = rcl_subscription_get_default_options();
-    result.allocator = this->get_rcl_allocator();
+    result.allocator = rcl_get_default_allocator();
     result.qos = qos.get_rmw_qos_profile();
     result.rmw_subscription_options.ignore_local_publications = this->ignore_local_publications;
     result.rmw_subscription_options.require_unique_network_flow_endpoints =
@@ -171,7 +174,7 @@ private:
       plain_allocator_storage_ =
         std::make_shared<PlainAllocator>(*this->get_allocator());
     }
-    return rclcpp::allocator::get_rcl_allocator<char>(*plain_allocator_storage_);
+    return rcl_get_default_allocator();
   }
 
   // This is a temporal workaround, to make sure that get_allocator()

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -102,14 +102,18 @@ struct SubscriptionOptionsWithAllocator : public SubscriptionOptionsBase
     "Subscription allocator value type must be void");
 
   /// Optional custom allocator.
-  std::shared_ptr<Allocator> allocator = nullptr;
+  std::shared_ptr<Allocator> allocator;
+  std::shared_ptr<rcutils_allocator_t> rcl_allocator;
 
-  SubscriptionOptionsWithAllocator() {}
+  SubscriptionOptionsWithAllocator()
+  :allocator(std::make_shared<Allocator>())
+  {}
 
   /// Constructor using base class as input.
   explicit SubscriptionOptionsWithAllocator(
     const SubscriptionOptionsBase & subscription_options_base)
-  : SubscriptionOptionsBase(subscription_options_base)
+  : SubscriptionOptionsBase(subscription_options_base),
+    allocator(std::make_shared<Allocator>())
   {
   }
 
@@ -154,36 +158,18 @@ struct SubscriptionOptionsWithAllocator : public SubscriptionOptionsBase
   std::shared_ptr<Allocator>
   get_allocator() const
   {
-    if (!this->allocator) {
-      if (!allocator_storage_) {
-        allocator_storage_ = std::make_shared<Allocator>();
-      }
-      return allocator_storage_;
-    }
     return this->allocator;
   }
 
 private:
-  using PlainAllocator =
-    typename std::allocator_traits<Allocator>::template rebind_alloc<char>;
-
   rcl_allocator_t
   get_rcl_allocator() const
   {
-    if (!plain_allocator_storage_) {
-      plain_allocator_storage_ =
-        std::make_shared<PlainAllocator>(*this->get_allocator());
+    if(rcl_allocator) {
+      return *rcl_allocator;
     }
     return rcl_get_default_allocator();
   }
-
-  // This is a temporal workaround, to make sure that get_allocator()
-  // always returns a copy of the same allocator.
-  mutable std::shared_ptr<Allocator> allocator_storage_;
-
-  // This is a temporal workaround, to keep the plain allocator that backs
-  // up the rcl allocator returned in rcl_subscription_options_t alive.
-  mutable std::shared_ptr<PlainAllocator> plain_allocator_storage_;
 };
 
 using SubscriptionOptions = SubscriptionOptionsWithAllocator<std::allocator<void>>;

--- a/rclcpp/test/rclcpp/allocator/test_allocator_common.cpp
+++ b/rclcpp/test/rclcpp/allocator/test_allocator_common.cpp
@@ -18,54 +18,17 @@
 
 #include "rclcpp/allocator/allocator_common.hpp"
 
-TEST(TestAllocatorCommon, retyped_allocate) {
-  std::allocator<int> allocator;
-  void * untyped_allocator = &allocator;
-  void * allocated_mem =
-    rclcpp::allocator::retyped_allocate<std::allocator<char>>(1u, untyped_allocator);
-  // The more natural check here is ASSERT_NE(nullptr, ptr), but clang static
-  // analysis throws a false-positive memory leak warning.  Use ASSERT_TRUE instead.
-  ASSERT_TRUE(nullptr != allocated_mem);
-
-  auto code = [&untyped_allocator, allocated_mem]() {
-      rclcpp::allocator::retyped_deallocate<int, std::allocator<int>>(
-        allocated_mem, untyped_allocator);
-    };
-  EXPECT_NO_THROW(code());
-
-  allocated_mem = allocator.allocate(1);
-  // The more natural check here is ASSERT_NE(nullptr, ptr), but clang static
-  // analysis throws a false-positive memory leak warning.  Use ASSERT_TRUE instead.
-  ASSERT_TRUE(nullptr != allocated_mem);
-  void * reallocated_mem =
-    rclcpp::allocator::retyped_reallocate<int, std::allocator<int>>(
-    allocated_mem, 2u, untyped_allocator);
-  // The more natural check here is ASSERT_NE(nullptr, ptr), but clang static
-  // analysis throws a false-positive memory leak warning.  Use ASSERT_TRUE instead.
-  ASSERT_TRUE(nullptr != reallocated_mem);
-
-  auto code2 = [&untyped_allocator, reallocated_mem]() {
-      rclcpp::allocator::retyped_deallocate<int, std::allocator<int>>(
-        reallocated_mem, untyped_allocator);
-    };
-  EXPECT_NO_THROW(code2());
-}
-
-TEST(TestAllocatorCommon, retyped_zero_allocate_basic) {
+TEST(TestAllocatorCommon, retyped_zero_allocate_basic)
+{
   std::allocator<int> allocator;
   void * untyped_allocator = &allocator;
   void * allocated_mem =
     rclcpp::allocator::retyped_zero_allocate<std::allocator<char>>(20u, 1u, untyped_allocator);
   ASSERT_TRUE(nullptr != allocated_mem);
-
-  auto code = [&untyped_allocator, allocated_mem]() {
-      rclcpp::allocator::retyped_deallocate<char, std::allocator<char>>(
-        allocated_mem, untyped_allocator);
-    };
-  EXPECT_NO_THROW(code());
 }
 
-TEST(TestAllocatorCommon, retyped_zero_allocate) {
+TEST(TestAllocatorCommon, retyped_zero_allocate)
+{
   std::allocator<int> allocator;
   void * untyped_allocator = &allocator;
   void * allocated_mem =
@@ -73,34 +36,12 @@ TEST(TestAllocatorCommon, retyped_zero_allocate) {
   // The more natural check here is ASSERT_NE(nullptr, ptr), but clang static
   // analysis throws a false-positive memory leak warning.  Use ASSERT_TRUE instead.
   ASSERT_TRUE(nullptr != allocated_mem);
-
-  auto code = [&untyped_allocator, allocated_mem]() {
-      rclcpp::allocator::retyped_deallocate<int, std::allocator<int>>(
-        allocated_mem, untyped_allocator);
-    };
-  EXPECT_NO_THROW(code());
-
-  allocated_mem = allocator.allocate(1);
-  // The more natural check here is ASSERT_NE(nullptr, ptr), but clang static
-  // analysis throws a false-positive memory leak warning.  Use ASSERT_TRUE instead.
-  ASSERT_TRUE(nullptr != allocated_mem);
-  void * reallocated_mem =
-    rclcpp::allocator::retyped_reallocate<int, std::allocator<int>>(
-    allocated_mem, 2u, untyped_allocator);
-  // The more natural check here is ASSERT_NE(nullptr, ptr), but clang static
-  // analysis throws a false-positive memory leak warning.  Use ASSERT_TRUE instead.
-  ASSERT_TRUE(nullptr != reallocated_mem);
-
-  auto code2 = [&untyped_allocator, reallocated_mem]() {
-      rclcpp::allocator::retyped_deallocate<int, std::allocator<int>>(
-        reallocated_mem, untyped_allocator);
-    };
-  EXPECT_NO_THROW(code2());
 }
 
-TEST(TestAllocatorCommon, get_rcl_allocator) {
+TEST(TestAllocatorCommon, get_rcl_allocator)
+{
   std::allocator<int> allocator;
-  auto rcl_allocator = rclcpp::allocator::get_rcl_allocator<int>(allocator);
+  auto rcl_allocator = rclcpp::allocator::get_rcl_allocator(allocator);
   EXPECT_NE(nullptr, rcl_allocator.allocate);
   EXPECT_NE(nullptr, rcl_allocator.deallocate);
   EXPECT_NE(nullptr, rcl_allocator.reallocate);
@@ -108,10 +49,10 @@ TEST(TestAllocatorCommon, get_rcl_allocator) {
   // Not testing state as that may or may not be null depending on platform
 }
 
-TEST(TestAllocatorCommon, get_void_rcl_allocator) {
+TEST(TestAllocatorCommon, get_void_rcl_allocator)
+{
   std::allocator<void> allocator;
-  auto rcl_allocator =
-    rclcpp::allocator::get_rcl_allocator<void, std::allocator<void>>(allocator);
+  auto rcl_allocator = rclcpp::allocator::get_rcl_allocator(allocator);
   EXPECT_NE(nullptr, rcl_allocator.allocate);
   EXPECT_NE(nullptr, rcl_allocator.deallocate);
   EXPECT_NE(nullptr, rcl_allocator.reallocate);

--- a/rclcpp/test/rclcpp/test_node_options.cpp
+++ b/rclcpp/test/rclcpp/test_node_options.cpp
@@ -372,7 +372,7 @@ TEST(TestNodeOptions, set_get_allocator) {
   EXPECT_EQ(fake_allocator.state, options.allocator().state);
 
   // Check invalid allocator
-  EXPECT_THROW(options.get_rcl_node_options(), std::bad_alloc);
+  EXPECT_THROW(options.get_rcl_node_options(), rclcpp::exceptions::RCLBadAlloc);
 }
 
 TEST(TestNodeOptions, clock_type) {


### PR DESCRIPTION
## Description

rclcpp passes down C++ style allocators down to rcl, that then uses them.
Due to the missing / wrong size on the deallocation, all the memory checkers
complain about it in newer ubuntu versions (>= 24.04).
This PR is a rebase / rework of https://github.com/ros2/rclcpp/pull/2046

### Did you use Generative AI?
No