### PR TITLE
fix: Fix data race in CallbackGroup::size()

### DIFF
--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -59,6 +59,7 @@ CallbackGroup::type() const
 size_t
 CallbackGroup::size() const
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   return
     subscription_ptrs_.size() +
     service_ptrs_.size() +


### PR DESCRIPTION
The computation of the size was not protected by a mutex, leading to possible data races.

### Did you use Generative AI?

No

### Additional Information

Discovered using helgrind