### PR TITLE
fix: Use default rcl allocator if allocator is std::allocator

### DIFF
--- a/rclcpp/include/rclcpp/allocator/allocator_common.hpp
+++ b/rclcpp/include/rclcpp/allocator/allocator_common.hpp
@@ -85,6 +85,8 @@ template<
   typename T,
   typename Alloc,
   typename std::enable_if<!std::is_same<Alloc, std::allocator<void>>::value>::type * = nullptr>
+[[deprecated("Conversion of C++ allocators to C style is not valid, as the size on deallocate"
+  "can not be determined. This will be remove in future versions of ros.")]]
 rcl_allocator_t get_rcl_allocator(Alloc & allocator)
 {
   rcl_allocator_t rcl_allocator = rcl_get_default_allocator();

--- a/rclcpp/include/rclcpp/allocator/allocator_common.hpp
+++ b/rclcpp/include/rclcpp/allocator/allocator_common.hpp
@@ -27,10 +27,39 @@ namespace rclcpp
 namespace allocator
 {
 
+template<typename T>
+using clean_t = std::remove_cv_t<std::remove_reference_t<T>>;
+
+// Primary template: false
+template<typename, typename = std::void_t<>>
+struct has_get_rcl_allocator : std::false_type {};
+
+// Specialization: true if expression is valid
+template<typename T>
+struct has_get_rcl_allocator<T,
+  std::void_t<
+    decltype(std::declval<clean_t<T> &>().get_rcl_allocator())
+  >
+>
+  : std::bool_constant<
+    std::is_same_v<
+      decltype(std::declval<clean_t<T> &>().get_rcl_allocator()),
+      rcl_allocator_t
+    >
+  >
+{};
+
+// Helper variable template
+template<typename T>
+inline constexpr bool has_get_rcl_allocator_v =
+  has_get_rcl_allocator<T>::value;
+
 template<typename T, typename Alloc>
 using AllocRebind = typename std::allocator_traits<Alloc>::template rebind_traits<T>;
 
 template<typename Alloc>
+[[deprecated("Conversion of C++ allocators to C style is not valid, as the size on deallocate"
+  "can not be determined. This will be remove in future versions of ros.")]]
 void * retyped_allocate(size_t size, void * untyped_allocator)
 {
   auto typed_allocator = static_cast<Alloc *>(untyped_allocator);
@@ -41,6 +70,8 @@ void * retyped_allocate(size_t size, void * untyped_allocator)
 }
 
 template<typename Alloc>
+[[deprecated("Conversion of C++ allocators to C style is not valid, as the size on deallocate"
+  "can not be determined. This will be remove in future versions of ros.")]]
 void * retyped_zero_allocate(size_t number_of_elem, size_t size_of_elem, void * untyped_allocator)
 {
   auto typed_allocator = static_cast<Alloc *>(untyped_allocator);
@@ -57,6 +88,8 @@ void * retyped_zero_allocate(size_t number_of_elem, size_t size_of_elem, void * 
 }
 
 template<typename T, typename Alloc>
+[[deprecated("Conversion of C++ allocators to C style is not valid, as the size on deallocate"
+  "can not be determined. This will be remove in future versions of ros.")]]
 void retyped_deallocate(void * untyped_pointer, void * untyped_allocator)
 {
   auto typed_allocator = static_cast<Alloc *>(untyped_allocator);
@@ -68,6 +101,8 @@ void retyped_deallocate(void * untyped_pointer, void * untyped_allocator)
 }
 
 template<typename T, typename Alloc>
+[[deprecated("Conversion of C++ allocators to C style is not valid, as the size on deallocate"
+  "can not be determined. This will be remove in future versions of ros.")]]
 void * retyped_reallocate(void * untyped_pointer, size_t size, void * untyped_allocator)
 {
   auto typed_allocator = static_cast<Alloc *>(untyped_allocator);
@@ -86,7 +121,8 @@ template<
   typename Alloc,
   typename std::enable_if<!std::is_same<Alloc, std::allocator<void>>::value>::type * = nullptr>
 [[deprecated("Conversion of C++ allocators to C style is not valid, as the size on deallocate"
-  "can not be determined. This will be remove in future versions of ros.")]]
+  "can not be determined. This will be remove in future versions of ros. To suppress this warning"
+  "define the method 'rcl_allocator_t get_rcl_allocator()' on your allocator")]]
 rcl_allocator_t get_rcl_allocator(Alloc & allocator)
 {
   rcl_allocator_t rcl_allocator = rcl_get_default_allocator();

--- a/rclcpp/include/rclcpp/message_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/message_memory_strategy.hpp
@@ -65,8 +65,12 @@ public:
     if constexpr (std::is_same_v<Alloc, std::allocator<void>>) {
       rcutils_allocator_ = rcl_get_default_allocator();
     } else {
-      rcutils_allocator_ = allocator::get_rcl_allocator<char,
-          BufferAlloc>(*buffer_allocator_.get());
+      if constexpr (rclcpp::allocator::has_get_rcl_allocator_v<Alloc>) {
+        rcutils_allocator_ = message_allocator_->get_rcl_allocator();
+      } else {
+        rcutils_allocator_ = allocator::get_rcl_allocator<char,
+            BufferAlloc>(*buffer_allocator_.get());
+      }
     }
   }
 
@@ -78,8 +82,12 @@ public:
     if constexpr (std::is_same_v<Alloc, std::allocator<void>>) {
       rcutils_allocator_ = rcl_get_default_allocator();
     } else {
-      rcutils_allocator_ = allocator::get_rcl_allocator<char,
-          BufferAlloc>(*buffer_allocator_.get());
+      if constexpr (rclcpp::allocator::has_get_rcl_allocator_v<Alloc>) {
+        rcutils_allocator_ = allocator->get_rcl_allocator();
+      } else {
+        rcutils_allocator_ = allocator::get_rcl_allocator<char,
+            BufferAlloc>(*buffer_allocator_.get());
+      }
     }
   }
 

--- a/rclcpp/include/rclcpp/message_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/message_memory_strategy.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <stdexcept>
 
+#include "rcl/allocator.h"
 #include "rcl/types.h"
 
 #include "rclcpp/allocator/allocator_common.hpp"
@@ -61,7 +62,12 @@ public:
     message_allocator_ = std::make_shared<MessageAlloc>();
     serialized_message_allocator_ = std::make_shared<SerializedMessageAlloc>();
     buffer_allocator_ = std::make_shared<BufferAlloc>();
-    rcutils_allocator_ = allocator::get_rcl_allocator<char, BufferAlloc>(*buffer_allocator_.get());
+    if constexpr (std::is_same_v<Alloc, std::allocator<void>>) {
+      rcutils_allocator_ = rcl_get_default_allocator();
+    } else {
+      rcutils_allocator_ = allocator::get_rcl_allocator<char,
+          BufferAlloc>(*buffer_allocator_.get());
+    }
   }
 
   explicit MessageMemoryStrategy(std::shared_ptr<Alloc> allocator)
@@ -69,7 +75,12 @@ public:
     message_allocator_ = std::make_shared<MessageAlloc>(*allocator.get());
     serialized_message_allocator_ = std::make_shared<SerializedMessageAlloc>(*allocator.get());
     buffer_allocator_ = std::make_shared<BufferAlloc>(*allocator.get());
-    rcutils_allocator_ = allocator::get_rcl_allocator<char, BufferAlloc>(*buffer_allocator_.get());
+    if constexpr (std::is_same_v<Alloc, std::allocator<void>>) {
+      rcutils_allocator_ = rcl_get_default_allocator();
+    } else {
+      rcutils_allocator_ = allocator::get_rcl_allocator<char,
+          BufferAlloc>(*buffer_allocator_.get());
+    }
   }
 
   virtual ~MessageMemoryStrategy() = default;

--- a/rclcpp/include/rclcpp/publisher_options.hpp
+++ b/rclcpp/include/rclcpp/publisher_options.hpp
@@ -123,6 +123,10 @@ private:
   rcl_allocator_t
   get_rcl_allocator() const
   {
+    if constexpr (std::is_same_v<Allocator, std::allocator<void>>) {
+      return rcl_get_default_allocator();
+    }
+
     if (!plain_allocator_storage_) {
       plain_allocator_storage_ =
         std::make_shared<PlainAllocator>(*this->get_allocator());
@@ -138,6 +142,13 @@ private:
   // up the rcl allocator returned in rcl_publisher_options_t alive.
   mutable std::shared_ptr<PlainAllocator> plain_allocator_storage_;
 };
+
+template<>
+inline rcl_allocator_t
+PublisherOptionsWithAllocator<std::allocator<void>>::get_rcl_allocator() const
+{
+  return rcl_get_default_allocator();
+}
 
 using PublisherOptions = PublisherOptionsWithAllocator<std::allocator<void>>;
 

--- a/rclcpp/include/rclcpp/publisher_options.hpp
+++ b/rclcpp/include/rclcpp/publisher_options.hpp
@@ -125,13 +125,18 @@ private:
   {
     if constexpr (std::is_same_v<Allocator, std::allocator<void>>) {
       return rcl_get_default_allocator();
-    }
+    } else {
+      if constexpr (rclcpp::allocator::has_get_rcl_allocator_v<Allocator>) {
+        return get_allocator()->get_rcl_allocator();
+      } else {
+        if (!plain_allocator_storage_) {
+          plain_allocator_storage_ =
+            std::make_shared<PlainAllocator>(*this->get_allocator());
+        }
 
-    if (!plain_allocator_storage_) {
-      plain_allocator_storage_ =
-        std::make_shared<PlainAllocator>(*this->get_allocator());
+        return rclcpp::allocator::get_rcl_allocator<char>(*plain_allocator_storage_);
+      }
     }
-    return rclcpp::allocator::get_rcl_allocator<char>(*plain_allocator_storage_);
   }
 
   // This is a temporal workaround, to make sure that get_allocator()
@@ -142,13 +147,6 @@ private:
   // up the rcl allocator returned in rcl_publisher_options_t alive.
   mutable std::shared_ptr<PlainAllocator> plain_allocator_storage_;
 };
-
-template<>
-inline rcl_allocator_t
-PublisherOptionsWithAllocator<std::allocator<void>>::get_rcl_allocator() const
-{
-  return rcl_get_default_allocator();
-}
 
 using PublisherOptions = PublisherOptionsWithAllocator<std::allocator<void>>;
 

--- a/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
@@ -515,7 +515,11 @@ public:
 
   rcl_allocator_t get_allocator() override
   {
-    return rclcpp::allocator::get_rcl_allocator<void *, VoidAlloc>(*allocator_.get());
+    if constexpr (std::is_same_v<Alloc, std::allocator<void>>) {
+      return rcl_get_default_allocator();
+    } else {
+      return rclcpp::allocator::get_rcl_allocator<void *, VoidAlloc>(*allocator_.get());
+    }
   }
 
   size_t number_of_ready_subscriptions() const override

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -167,11 +167,15 @@ private:
   rcl_allocator_t
   get_rcl_allocator() const
   {
-    if (!plain_allocator_storage_) {
-      plain_allocator_storage_ =
-        std::make_shared<PlainAllocator>(*this->get_allocator());
+    if constexpr (std::is_same_v<Allocator, std::allocator<void>>) {
+      return rcl_get_default_allocator();
+    } else {
+      if (!plain_allocator_storage_) {
+        plain_allocator_storage_ =
+          std::make_shared<PlainAllocator>(*this->get_allocator());
+      }
+      return rclcpp::allocator::get_rcl_allocator<char>(*plain_allocator_storage_);
     }
-    return rclcpp::allocator::get_rcl_allocator<char>(*plain_allocator_storage_);
   }
 
   // This is a temporal workaround, to make sure that get_allocator()

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -170,11 +170,16 @@ private:
     if constexpr (std::is_same_v<Allocator, std::allocator<void>>) {
       return rcl_get_default_allocator();
     } else {
-      if (!plain_allocator_storage_) {
-        plain_allocator_storage_ =
-          std::make_shared<PlainAllocator>(*this->get_allocator());
+      if constexpr (rclcpp::allocator::has_get_rcl_allocator_v<Allocator>) {
+        return get_allocator()->get_rcl_allocator();
+      } else {
+        if (!plain_allocator_storage_) {
+          plain_allocator_storage_ =
+            std::make_shared<PlainAllocator>(*this->get_allocator());
+        }
+
+        return rclcpp::allocator::get_rcl_allocator<char>(*plain_allocator_storage_);
       }
-      return rclcpp::allocator::get_rcl_allocator<char>(*plain_allocator_storage_);
     }
   }
 

--- a/rclcpp/test/rclcpp/allocator/test_allocator_common.cpp
+++ b/rclcpp/test/rclcpp/allocator/test_allocator_common.cpp
@@ -16,11 +16,17 @@
 
 #include <memory>
 
-#include "rclcpp/allocator/allocator_common.hpp"
+#include "rcpputils/compile_warnings.hpp"
 
-TEST(TestAllocatorCommon, retyped_allocate) {
+RCPPUTILS_DEPRECATION_WARNING_OFF_START
+#include "rclcpp/allocator/allocator_common.hpp"
+RCPPUTILS_DEPRECATION_WARNING_OFF_STOP
+
+TEST(TestAllocatorCommon, retyped_allocate)
+{
   std::allocator<int> allocator;
   void * untyped_allocator = &allocator;
+  RCPPUTILS_DEPRECATION_WARNING_OFF_START
   void * allocated_mem =
     rclcpp::allocator::retyped_allocate<std::allocator<char>>(1u, untyped_allocator);
   // The more natural check here is ASSERT_NE(nullptr, ptr), but clang static
@@ -49,9 +55,12 @@ TEST(TestAllocatorCommon, retyped_allocate) {
         reallocated_mem, untyped_allocator);
     };
   EXPECT_NO_THROW(code2());
+
+  RCPPUTILS_DEPRECATION_WARNING_OFF_STOP
 }
 
 TEST(TestAllocatorCommon, retyped_zero_allocate_basic) {
+RCPPUTILS_DEPRECATION_WARNING_OFF_START
   std::allocator<int> allocator;
   void * untyped_allocator = &allocator;
   void * allocated_mem =
@@ -63,9 +72,11 @@ TEST(TestAllocatorCommon, retyped_zero_allocate_basic) {
         allocated_mem, untyped_allocator);
     };
   EXPECT_NO_THROW(code());
+RCPPUTILS_DEPRECATION_WARNING_OFF_STOP
 }
 
 TEST(TestAllocatorCommon, retyped_zero_allocate) {
+RCPPUTILS_DEPRECATION_WARNING_OFF_START
   std::allocator<int> allocator;
   void * untyped_allocator = &allocator;
   void * allocated_mem =
@@ -96,9 +107,11 @@ TEST(TestAllocatorCommon, retyped_zero_allocate) {
         reallocated_mem, untyped_allocator);
     };
   EXPECT_NO_THROW(code2());
+RCPPUTILS_DEPRECATION_WARNING_OFF_STOP
 }
 
 TEST(TestAllocatorCommon, get_rcl_allocator) {
+RCPPUTILS_DEPRECATION_WARNING_OFF_START
   std::allocator<int> allocator;
   auto rcl_allocator = rclcpp::allocator::get_rcl_allocator<int>(allocator);
   EXPECT_NE(nullptr, rcl_allocator.allocate);
@@ -106,9 +119,12 @@ TEST(TestAllocatorCommon, get_rcl_allocator) {
   EXPECT_NE(nullptr, rcl_allocator.reallocate);
   EXPECT_NE(nullptr, rcl_allocator.zero_allocate);
   // Not testing state as that may or may not be null depending on platform
+RCPPUTILS_DEPRECATION_WARNING_OFF_STOP
 }
 
 TEST(TestAllocatorCommon, get_void_rcl_allocator) {
+RCPPUTILS_DEPRECATION_WARNING_OFF_START
+
   std::allocator<void> allocator;
   auto rcl_allocator =
     rclcpp::allocator::get_rcl_allocator<void, std::allocator<void>>(allocator);
@@ -117,4 +133,5 @@ TEST(TestAllocatorCommon, get_void_rcl_allocator) {
   EXPECT_NE(nullptr, rcl_allocator.reallocate);
   EXPECT_NE(nullptr, rcl_allocator.zero_allocate);
   // Not testing state as that may or may not be null depending on platform
+RCPPUTILS_DEPRECATION_WARNING_OFF_STOP
 }

--- a/rclcpp/test/rclcpp/test_intra_process_manager_with_allocators.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager_with_allocators.cpp
@@ -75,6 +75,11 @@ public:
   {
     typedef MyAllocator<U> other;
   };
+
+  rcl_allocator_t get_rcl_allocator()
+  {
+    return rcl_get_default_allocator();
+  }
 };
 
 // Explicit specialization for void
@@ -102,6 +107,11 @@ public:
   {
     typedef MyAllocator<U> other;
   };
+
+  rcl_allocator_t get_rcl_allocator()
+  {
+    return rcl_get_default_allocator();
+  }
 };
 
 template<typename T, typename U>


### PR DESCRIPTION
This fixes a bunch of warnings if using ASAN / valgrind on newer OS versions. It also fixed a real bug, as giving the wrong size on deallocate is undefined behavior according to the C++ standard.

This version of the patch keeps the behavior for users that specified an own allocator the same and in therefore back portable.

Alternative to https://github.com/ros2/rclcpp/pull/3054

USED AI:
Yes, chatgpt to generate the template methods to check for the existence of a method on a class in c++17.