### PR TITLE
Fix component registering in subdirectories

### DIFF
--- a/rclcpp_components/cmake/rclcpp_components_package_hook.cmake
+++ b/rclcpp_components/cmake/rclcpp_components_package_hook.cmake
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 # register node plugins
+# The internal data is stored in a project directory scoped properties to allow
+# registering the components from nested scopes in CMake, where variables
+# would not propagate out.
 get_property(_rclcpp_components_package_resource_indices
   DIRECTORY "${PROJECT_SOURCE_DIR}"
   PROPERTY _RCLCPP_COMPONENTS_PACKAGE_RESOURCE_INDICES

--- a/rclcpp_components/cmake/rclcpp_components_package_hook.cmake
+++ b/rclcpp_components/cmake/rclcpp_components_package_hook.cmake
@@ -13,8 +13,16 @@
 # limitations under the License.
 
 # register node plugins
-list(REMOVE_DUPLICATES _RCLCPP_COMPONENTS_PACKAGE_RESOURCE_INDICES)
-foreach(resource_index ${_RCLCPP_COMPONENTS_PACKAGE_RESOURCE_INDICES})
+get_property(_rclcpp_components_package_resource_indices
+  DIRECTORY "${PROJECT_SOURCE_DIR}"
+  PROPERTY _RCLCPP_COMPONENTS_PACKAGE_RESOURCE_INDICES
+)
+list(REMOVE_DUPLICATES _rclcpp_components_package_resource_indices)
+foreach(resource_index ${_rclcpp_components_package_resource_indices})
+  get_property(_rclcpp_components_nodes
+    DIRECTORY "${PROJECT_SOURCE_DIR}"
+    PROPERTY "_RCLCPP_COMPONENTS_${resource_index}__NODES"
+  )
   ament_index_register_resource(
-    ${resource_index} CONTENT "${_RCLCPP_COMPONENTS_${resource_index}__NODES}")
+    ${resource_index} CONTENT "${_rclcpp_components_nodes}")
 endforeach()

--- a/rclcpp_components/cmake/rclcpp_components_register_node.cmake
+++ b/rclcpp_components/cmake/rclcpp_components_register_node.cmake
@@ -64,15 +64,19 @@ macro(rclcpp_components_register_node target)
   endif()
   set(component ${ARGS_PLUGIN})
   set(node ${ARGS_EXECUTABLE})
-  _rclcpp_components_register_package_hook()
   set(_path "lib")
   set(library_name "$<TARGET_FILE_NAME:${target}>")
   if(WIN32)
     set(_path "bin")
   endif()
-  set(_RCLCPP_COMPONENTS_${resource_index}__NODES
-    "${_RCLCPP_COMPONENTS_${resource_index}__NODES}${component};${_path}/$<TARGET_FILE_NAME:${target}>\n")
-  list(APPEND _RCLCPP_COMPONENTS_PACKAGE_RESOURCE_INDICES ${resource_index})
+  set_property(
+    DIRECTORY "${PROJECT_SOURCE_DIR}"
+    APPEND_STRING PROPERTY _RCLCPP_COMPONENTS_${resource_index}__NODES
+    "${component};${_path}/$<TARGET_FILE_NAME:${target}>\n")
+  set_property(
+    DIRECTORY "${PROJECT_SOURCE_DIR}"
+    APPEND PROPERTY _RCLCPP_COMPONENTS_PACKAGE_RESOURCE_INDICES
+    ${resource_index})
 
   if(ARGS_NO_UNDEFINED_SYMBOLS AND WIN32)
     message(WARNING "NO_UNDEFINED_SYMBOLS is enabled for target \"${target}\", but this is unsupported on windows.")

--- a/rclcpp_components/cmake/rclcpp_components_register_nodes.cmake
+++ b/rclcpp_components/cmake/rclcpp_components_register_nodes.cmake
@@ -47,7 +47,6 @@ macro(rclcpp_components_register_nodes target)
   endif()
 
   if(${ARGC} GREATER 0)
-    _rclcpp_components_register_package_hook()
     set(_unique_names)
     foreach(_arg ${ARGS_UNPARSED_ARGUMENTS})
       if(_arg IN_LIST _unique_names)
@@ -63,9 +62,14 @@ macro(rclcpp_components_register_nodes target)
       else()
         set(_path "lib")
       endif()
-      set(_RCLCPP_COMPONENTS_${resource_index}__NODES
-        "${_RCLCPP_COMPONENTS_${resource_index}__NODES}${_arg};${_path}/$<TARGET_FILE_NAME:${target}>\n")
-      list(APPEND _RCLCPP_COMPONENTS_PACKAGE_RESOURCE_INDICES ${resource_index})
+      set_property(
+        DIRECTORY "${PROJECT_SOURCE_DIR}"
+        APPEND_STRING PROPERTY _RCLCPP_COMPONENTS_${resource_index}__NODES
+        "${_arg};${_path}/$<TARGET_FILE_NAME:${target}>\n")
+      set_property(
+        DIRECTORY "${PROJECT_SOURCE_DIR}"
+        APPEND PROPERTY _RCLCPP_COMPONENTS_PACKAGE_RESOURCE_INDICES
+        ${resource_index})
     endforeach()
   endif()
 endmacro()

--- a/rclcpp_components/rclcpp_components-extras.cmake.in
+++ b/rclcpp_components/rclcpp_components-extras.cmake.in
@@ -25,6 +25,8 @@ macro(_rclcpp_components_register_package_hook)
   endif()
 endmacro()
 
+_rclcpp_components_register_package_hook()
+
 get_filename_component(@PROJECT_NAME@_SHARE_DIR "${@PROJECT_NAME@_DIR}" DIRECTORY)
 set(@PROJECT_NAME@_NODE_TEMPLATE "${@PROJECT_NAME@_SHARE_DIR}/node_main.cpp.in")
 


### PR DESCRIPTION
## Description

This PR allows using `rclcpp_components_register_node` and `rclcpp_components_register_nodes` functions in subdirectories added by `add_subdirectory` (and other non global scopes). This was done by storing the internal data in a property of the project directory instead of variable.

Fixes: #1698

### Is this user-facing behavior change?

Yes, users will be able to use the above mentioned functions inside nested scopes.

### Did you use Generative AI?

No
