### PR TITLE
Add ConstRefCallback in `use_take_shared_method`

### DIFF
--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -1024,7 +1024,9 @@ public:
       std::holds_alternative<SharedConstPtrCallback>(callback_variant_) ||
       std::holds_alternative<SharedConstPtrWithInfoCallback>(callback_variant_) ||
       std::holds_alternative<ConstRefSharedConstPtrCallback>(callback_variant_) ||
-      std::holds_alternative<ConstRefSharedConstPtrWithInfoCallback>(callback_variant_);
+      std::holds_alternative<ConstRefSharedConstPtrWithInfoCallback>(callback_variant_) ||
+      std::holds_alternative<ConstRefCallback>(callback_variant_) ||
+      std::holds_alternative<ConstRefWithInfoCallback>(callback_variant_);
   }
 
   constexpr


### PR DESCRIPTION
Related to our discussion in https://discourse.openrobotics.org/t/performance-characteristics-subscription-callback-signatures-rmw-implementation-intra-process-communication-ipc/51454/7?u=mini-1235

it seems like `ConstRefCallback` is missing in `use_take_shared_method`