### PR TITLE
Revert "improve lookup time for matches_any_publishers(). (#3068)"

### DIFF
--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -386,40 +386,6 @@ private:
     std::vector<uint64_t> take_ownership_subscriptions;
   };
 
-  /// Hash function for rmw_gid_t to enable use in unordered_map
-  struct rmw_gid_hash
-  {
-    std::size_t operator()(const rmw_gid_t & gid) const noexcept
-    {
-      // Using the FNV-1a hash algorithm on the gid data
-      constexpr std::size_t FNV_prime = 1099511628211u;
-      std::size_t result = 14695981039346656037u;
-
-      for (std::size_t i = 0; i < RMW_GID_STORAGE_SIZE; ++i) {
-        result ^= gid.data[i];
-        result *= FNV_prime;
-      }
-      return result;
-    }
-  };
-
-  /// Equality comparison for rmw_gid_t to enable use in unordered_map
-  struct rmw_gid_equal
-  {
-    bool operator()(const rmw_gid_t & lhs, const rmw_gid_t & rhs) const noexcept
-    {
-      // Compare implementation identifier first for fast rejection
-      if (lhs.implementation_identifier != rhs.implementation_identifier) {
-        return false;
-      }
-      // Compare the data bytes
-      return std::equal(
-        std::begin(lhs.data),
-        std::end(lhs.data),
-        std::begin(rhs.data));
-    }
-  };
-
   using SubscriptionMap =
     std::unordered_map<uint64_t, rclcpp::experimental::SubscriptionIntraProcessBase::WeakPtr>;
 
@@ -431,16 +397,6 @@ private:
 
   using PublisherToSubscriptionIdsMap =
     std::unordered_map<uint64_t, SplittedSubscriptions>;
-
-  /// Structure to store publisher information in GID lookup map
-  struct PublisherInfo
-  {
-    uint64_t pub_id;
-    rclcpp::PublisherBase::WeakPtr publisher;
-  };
-
-  using GidToPublisherInfoMap =
-    std::unordered_map<rmw_gid_t, PublisherInfo, rmw_gid_hash, rmw_gid_equal>;
 
   RCLCPP_PUBLIC
   static
@@ -684,7 +640,6 @@ private:
   SubscriptionMap subscriptions_;
   PublisherMap publishers_;
   PublisherBufferMap publisher_buffers_;
-  GidToPublisherInfoMap gid_to_publisher_info_;
 
   mutable std::shared_timed_mutex mutex_;
 };

--- a/rclcpp/src/rclcpp/intra_process_manager.cpp
+++ b/rclcpp/src/rclcpp/intra_process_manager.cpp
@@ -51,9 +51,6 @@ IntraProcessManager::add_publisher(
     }
   }
 
-  // Add GID to publisher info mapping for fast lookups (stores both ID and weak_ptr)
-  gid_to_publisher_info_[publisher->get_gid()] = {pub_id, publisher};
-
   // Initialize the subscriptions storage for this publisher.
   pub_to_subs_[pub_id] = SplittedSubscriptions();
 
@@ -101,15 +98,6 @@ IntraProcessManager::remove_publisher(uint64_t intra_process_publisher_id)
 {
   std::unique_lock<std::shared_timed_mutex> lock(mutex_);
 
-  // Remove GID to publisher info mapping
-  auto pub_it = publishers_.find(intra_process_publisher_id);
-  if (pub_it != publishers_.end()) {
-    auto publisher = pub_it->second.lock();
-    if (publisher) {
-      gid_to_publisher_info_.erase(publisher->get_gid());
-    }
-  }
-
   publishers_.erase(intra_process_publisher_id);
   publisher_buffers_.erase(intra_process_publisher_id);
   pub_to_subs_.erase(intra_process_publisher_id);
@@ -120,15 +108,16 @@ IntraProcessManager::matches_any_publishers(const rmw_gid_t * id) const
 {
   std::shared_lock<std::shared_timed_mutex> lock(mutex_);
 
-  // Single O(1) hash map lookup - struct contains both ID and weak_ptr
-  auto it = gid_to_publisher_info_.find(*id);
-  if (it == gid_to_publisher_info_.end()) {
-    return false;
+  for (auto & publisher_pair : publishers_) {
+    auto publisher = publisher_pair.second.lock();
+    if (!publisher) {
+      continue;
+    }
+    if (*publisher.get() == id) {
+      return true;
+    }
   }
-
-  // Verify the publisher still exists by checking the weak_ptr
-  auto publisher = it->second.publisher.lock();
-  return publisher != nullptr;
+  return false;
 }
 
 size_t

--- a/rclcpp/test/rclcpp/test_intra_process_manager.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager.cpp
@@ -162,14 +162,7 @@ public:
   explicit PublisherBase(const std::string & topic, const rclcpp::QoS & qos)
   : topic_name(topic),
     qos_profile(qos)
-  {
-    // Initialize a mock GID with unique data based on this pointer
-    gid_.implementation_identifier = "mock_rmw";
-    auto ptr_value = reinterpret_cast<std::uintptr_t>(this);
-    for (size_t i = 0; i < RMW_GID_STORAGE_SIZE; ++i) {
-      gid_.data[i] = static_cast<uint8_t>((ptr_value >> (i * 8)) & 0xFF);
-    }
-  }
+  {}
 
   virtual ~PublisherBase()
   {}
@@ -199,12 +192,6 @@ public:
     return qos_profile.durability() == rclcpp::DurabilityPolicy::TransientLocal;
   }
 
-  const rmw_gid_t &
-  get_gid() const
-  {
-    return gid_;
-  }
-
   bool
   operator==([[maybe_unused]] const rmw_gid_t & gid) const
   {
@@ -223,7 +210,6 @@ public:
 private:
   std::string topic_name;
   rclcpp::QoS qos_profile;
-  rmw_gid_t gid_;
 };
 
 template<typename T, typename Alloc = std::allocator<void>>


### PR DESCRIPTION
This reverts commit b6730f9d4e659bcaa54e7740ff9ecdcc09042884.

it looks like this generates the regression https://github.com/ros2/rclcpp/pull/3068#issuecomment-3921867144.
although we are not sure what the root cause is, i suggest to revert the fix (performance improvement) to avoid breaking the userspace.

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Revert https://github.com/ros2/rclcpp/pull/3068

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
