### PR TITLE
[DRAFT] `GenericSubscription` support in `IntraProcessManager`

### DIFF
--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -148,6 +148,44 @@ public:
     return sub_id;
   }
 
+  template<
+    typename ROSMessageType,
+    typename Alloc = std::allocator<ROSMessageType>
+  >
+  uint64_t
+  add_generic_subscription(
+    rclcpp::experimental::SubscriptionIntraProcessBase::SharedPtr subscription)
+  {
+    std::unique_lock<std::shared_timed_mutex> lock(mutex_);
+
+    uint64_t sub_id = IntraProcessManager::get_next_unique_id();
+
+    generic_subscriptions_[sub_id] = subscription;
+
+    // adds the subscription id to all the matchable publishers
+    for (auto & pair : publishers_) {
+      auto publisher = pair.second.lock();
+      if (!publisher) {
+        continue;
+      }
+      if (can_communicate(publisher, subscription)) {
+        uint64_t pub_id = pair.first;
+        insert_generic_sub_id_for_pub(sub_id, pub_id, subscription->use_take_shared_method());
+        if (publisher->is_durability_transient_local() &&
+          subscription->is_durability_transient_local())
+        {
+          // FIXME PATRICK this shall be investigated
+          do_transient_local_publish<ROSMessageType, Alloc>(
+            pub_id, sub_id,
+            subscription->use_take_shared_method());
+        }
+      }
+    }
+
+    return sub_id;
+  }
+
+
   /// Unregister a subscription using the subscription's unique id.
   /**
    * This method does not allocate memory.
@@ -230,51 +268,148 @@ public:
 
     std::shared_lock<std::shared_timed_mutex> lock(mutex_);
 
-    auto publisher_it = pub_to_subs_.find(intra_process_publisher_id);
-    if (publisher_it == pub_to_subs_.end()) {
-      // Publisher is either invalid or no longer exists.
-      RCLCPP_WARN(
-        rclcpp::get_logger("rclcpp"),
-        "Calling do_intra_process_publish for invalid or no longer existing publisher id");
+    bool a = false;
+    bool b = false;
+
+    auto publisher_it = pub_to_generic_subs_.find(intra_process_publisher_id);
+    if (publisher_it != pub_to_generic_subs_.end()) {
+      const auto & sub_ids = publisher_it->second;
+      b = true;
+      using AllocatorT = std::allocator<void>;
+      using GMessageT = rclcpp::SerializedMessage;
+      using GSubscribedTypeAllocatorTraits = allocator::AllocRebind<GMessageT, AllocatorT>;
+      using GAlloc = typename GSubscribedTypeAllocatorTraits::allocator_type;
+      using GDeleter = allocator::Deleter<GAlloc, GMessageT>;
+      using ROSMessageTypeAllocatorTraits = allocator::AllocRebind<ROSMessageType, Alloc>;
+      using ROSMessageTypeAllocator = typename ROSMessageTypeAllocatorTraits::allocator_type;
+      using ROSMessageTypeDeleter = allocator::Deleter<ROSMessageTypeAllocator, ROSMessageType>;
+
+      GAlloc gallocator;
+
+      if (sub_ids.take_ownership_subscriptions.empty()) {
+        rclcpp::Serialization<ROSMessageType> serializer;
+        auto ser_msg = std::make_shared<rclcpp::SerializedMessage>();
+        if constexpr (rclcpp::TypeAdapter<MessageT, ROSMessageType>::is_specialized::value) {
+          ROSMessageTypeAllocator ros_message_alloc(allocator);
+          auto ptr = ROSMessageTypeAllocatorTraits::allocate(ros_message_alloc, 1);
+          ROSMessageTypeAllocatorTraits::construct(ros_message_alloc, ptr);
+          ROSMessageTypeDeleter deleter;
+          allocator::set_allocator_for_deleter(&deleter, &allocator);
+          rclcpp::TypeAdapter<MessageT, ROSMessageType>::convert_to_ros_message(*message, *ptr);
+          serializer.serialize_message(ptr, ser_msg.get());
+        } else {
+          serializer.serialize_message(message.get(), ser_msg.get());
+        }
+        this->template add_shared_msg_to_generic_buffers<GAlloc, GDeleter, ROSMessageType>(
+          ser_msg, sub_ids.take_shared_subscriptions);
+      } else if (!sub_ids.take_ownership_subscriptions.empty() && // NOLINT
+        sub_ids.take_shared_subscriptions.size() <= 1)
+      {
+        // There is at maximum 1 buffer that does not require ownership.
+        // So this case is equivalent to all the buffers requiring ownership
+
+        rclcpp::Serialization<ROSMessageType> serializer;
+        auto ser_msg = std::make_unique<rclcpp::SerializedMessage>();
+        if constexpr (rclcpp::TypeAdapter<MessageT, ROSMessageType>::is_specialized::value) {
+          ROSMessageTypeAllocator ros_message_alloc(allocator);
+          auto ptr = ROSMessageTypeAllocatorTraits::allocate(ros_message_alloc, 1);
+          ROSMessageTypeAllocatorTraits::construct(ros_message_alloc, ptr);
+          ROSMessageTypeDeleter deleter;
+          allocator::set_allocator_for_deleter(&deleter, &allocator);
+          rclcpp::TypeAdapter<MessageT, ROSMessageType>::convert_to_ros_message(*message, *ptr);
+          serializer.serialize_message(ptr, ser_msg.get());
+        } else {
+          serializer.serialize_message(message.get(), ser_msg.get());
+        }
+
+        // Merge the two vector of ids into a unique one
+        std::vector<uint64_t> concatenated_vector(
+          sub_ids.take_shared_subscriptions.begin(), sub_ids.take_shared_subscriptions.end());
+        concatenated_vector.insert(
+          concatenated_vector.end(),
+          sub_ids.take_ownership_subscriptions.begin(),
+          sub_ids.take_ownership_subscriptions.end());
+        this->template add_owned_msg_to_generic_buffers<GAlloc, GDeleter, ROSMessageType>(
+          std::move(ser_msg),
+          concatenated_vector,
+          gallocator);
+      } else if (!sub_ids.take_ownership_subscriptions.empty() && // NOLINT
+        sub_ids.take_shared_subscriptions.size() > 1)
+      {
+        // Construct a new shared pointer from the message
+        // for the buffers that do not require ownership
+        rclcpp::Serialization<ROSMessageType> serializer;
+        auto ser_msg = std::make_shared<rclcpp::SerializedMessage>();
+        auto ser_msg_u = std::make_unique<rclcpp::SerializedMessage>();
+        if constexpr (rclcpp::TypeAdapter<MessageT, ROSMessageType>::is_specialized::value) {
+          ROSMessageTypeAllocator ros_message_alloc(allocator);
+          auto ptr = ROSMessageTypeAllocatorTraits::allocate(ros_message_alloc, 1);
+          ROSMessageTypeAllocatorTraits::construct(ros_message_alloc, ptr);
+          ROSMessageTypeDeleter deleter;
+          allocator::set_allocator_for_deleter(&deleter, &allocator);
+          rclcpp::TypeAdapter<MessageT, ROSMessageType>::convert_to_ros_message(*message, *ptr);
+          serializer.serialize_message(ptr, ser_msg.get());
+          serializer.serialize_message(ptr, ser_msg_u.get());
+        } else {
+          serializer.serialize_message(message.get(), ser_msg.get());
+          serializer.serialize_message(message.get(), ser_msg_u.get());
+        }
+
+        this->template add_shared_msg_to_generic_buffers<GAlloc, GDeleter, ROSMessageType>(
+          ser_msg, sub_ids.take_shared_subscriptions);
+        this->template add_owned_msg_to_generic_buffers<GAlloc, GDeleter, ROSMessageType>(
+          std::move(ser_msg_u), sub_ids.take_ownership_subscriptions, gallocator);
+      }
+    }
+
+    publisher_it = pub_to_subs_.find(intra_process_publisher_id);
+    if (publisher_it != pub_to_subs_.end()) {
+      a = true;
+      const auto & sub_ids = publisher_it->second;
+
+      if (sub_ids.take_ownership_subscriptions.empty()) {
+        // None of the buffers require ownership, so we promote the pointer
+        std::shared_ptr<MessageT> msg = std::move(message);
+        this->template add_shared_msg_to_buffers<MessageT, Alloc, Deleter, ROSMessageType>(
+          msg, sub_ids.take_shared_subscriptions);
+      } else if (!sub_ids.take_ownership_subscriptions.empty() && // NOLINT
+        sub_ids.take_shared_subscriptions.size() <= 1)
+      {
+        // There is at maximum 1 buffer that does not require ownership.
+        // So this case is equivalent to all the buffers requiring ownership
+
+        // Merge the two vector of ids into a unique one
+        std::vector<uint64_t> concatenated_vector(
+          sub_ids.take_shared_subscriptions.begin(), sub_ids.take_shared_subscriptions.end());
+        concatenated_vector.insert(
+          concatenated_vector.end(),
+          sub_ids.take_ownership_subscriptions.begin(),
+          sub_ids.take_ownership_subscriptions.end());
+        this->template add_owned_msg_to_buffers<MessageT, Alloc, Deleter, ROSMessageType>(
+          std::move(message),
+          concatenated_vector,
+          allocator);
+      } else if (!sub_ids.take_ownership_subscriptions.empty() && // NOLINT
+        sub_ids.take_shared_subscriptions.size() > 1)
+      {
+        // Construct a new shared pointer from the message
+        // for the buffers that do not require ownership
+        auto shared_msg = std::allocate_shared<MessageT, MessageAllocatorT>(allocator, *message);
+
+        this->template add_shared_msg_to_buffers<MessageT, Alloc, Deleter, ROSMessageType>(
+          shared_msg, sub_ids.take_shared_subscriptions);
+        this->template add_owned_msg_to_buffers<MessageT, Alloc, Deleter, ROSMessageType>(
+          std::move(message), sub_ids.take_ownership_subscriptions, allocator);
+      }
+    }
+
+    if (a || b) {
       return;
     }
-    const auto & sub_ids = publisher_it->second;
-
-    if (sub_ids.take_ownership_subscriptions.empty()) {
-      // None of the buffers require ownership, so we promote the pointer
-      std::shared_ptr<MessageT> msg = std::move(message);
-
-      this->template add_shared_msg_to_buffers<MessageT, Alloc, Deleter, ROSMessageType>(
-        msg, sub_ids.take_shared_subscriptions);
-    } else if (!sub_ids.take_ownership_subscriptions.empty() && // NOLINT
-      sub_ids.take_shared_subscriptions.size() <= 1)
-    {
-      // There is at maximum 1 buffer that does not require ownership.
-      // So this case is equivalent to all the buffers requiring ownership
-
-      // Merge the two vector of ids into a unique one
-      std::vector<uint64_t> concatenated_vector(
-        sub_ids.take_shared_subscriptions.begin(), sub_ids.take_shared_subscriptions.end());
-      concatenated_vector.insert(
-        concatenated_vector.end(),
-        sub_ids.take_ownership_subscriptions.begin(),
-        sub_ids.take_ownership_subscriptions.end());
-      this->template add_owned_msg_to_buffers<MessageT, Alloc, Deleter, ROSMessageType>(
-        std::move(message),
-        concatenated_vector,
-        allocator);
-    } else if (!sub_ids.take_ownership_subscriptions.empty() && // NOLINT
-      sub_ids.take_shared_subscriptions.size() > 1)
-    {
-      // Construct a new shared pointer from the message
-      // for the buffers that do not require ownership
-      auto shared_msg = std::allocate_shared<MessageT, MessageAllocatorT>(allocator, *message);
-
-      this->template add_shared_msg_to_buffers<MessageT, Alloc, Deleter, ROSMessageType>(
-        shared_msg, sub_ids.take_shared_subscriptions);
-      this->template add_owned_msg_to_buffers<MessageT, Alloc, Deleter, ROSMessageType>(
-        std::move(message), sub_ids.take_ownership_subscriptions, allocator);
-    }
+    // Publisher is either invalid or no longer exists.
+    RCLCPP_WARN(
+      rclcpp::get_logger("rclcpp"),
+      "Calling do_intra_process_publish for invalid or no longer existing publisher id");
   }
 
   template<
@@ -294,7 +429,71 @@ public:
 
     std::shared_lock<std::shared_timed_mutex> lock(mutex_);
 
-    auto publisher_it = pub_to_subs_.find(intra_process_publisher_id);
+    auto publisher_it = pub_to_generic_subs_.find(intra_process_publisher_id);
+    if (publisher_it != pub_to_generic_subs_.end()) {
+      const auto & sub_ids = publisher_it->second;
+      using AllocatorT = std::allocator<void>;
+      using GMessageT = rclcpp::SerializedMessage;
+      using GSubscribedTypeAllocatorTraits = allocator::AllocRebind<GMessageT, AllocatorT>;
+      using GAlloc = typename GSubscribedTypeAllocatorTraits::allocator_type;
+      using GDeleter = allocator::Deleter<GAlloc, GMessageT>;
+      using ROSMessageTypeAllocatorTraits = allocator::AllocRebind<ROSMessageType, Alloc>;
+      using ROSMessageTypeAllocator = typename ROSMessageTypeAllocatorTraits::allocator_type;
+      using ROSMessageTypeDeleter = allocator::Deleter<ROSMessageTypeAllocator, ROSMessageType>;
+      GAlloc gallocator;
+
+      if (sub_ids.take_ownership_subscriptions.empty()) {
+        rclcpp::Serialization<ROSMessageType> serializer;
+        auto ser_msg = std::make_shared<rclcpp::SerializedMessage>();
+
+        if constexpr (rclcpp::TypeAdapter<MessageT, ROSMessageType>::is_specialized::value) {
+          ROSMessageTypeAllocator ros_message_alloc(allocator);
+          auto ptr = ROSMessageTypeAllocatorTraits::allocate(ros_message_alloc, 1);
+          ROSMessageTypeAllocatorTraits::construct(ros_message_alloc, ptr);
+          ROSMessageTypeDeleter deleter;
+          allocator::set_allocator_for_deleter(&deleter, &allocator);
+          rclcpp::TypeAdapter<MessageT, ROSMessageType>::convert_to_ros_message(message.get(),
+                *ptr);
+          serializer.serialize_message(ptr, ser_msg.get());
+        } else {
+          serializer.serialize_message(message.get(), ser_msg.get());
+        }
+
+        if (!sub_ids.take_shared_subscriptions.empty()) {
+          this->template add_shared_msg_to_generic_buffers<GAlloc, GDeleter, ROSMessageType>(
+            ser_msg, sub_ids.take_shared_subscriptions);
+        }
+      } else {
+        rclcpp::Serialization<ROSMessageType> serializer;
+        auto ser_msg = std::make_shared<rclcpp::SerializedMessage>();
+        auto ser_msg_u = std::make_unique<rclcpp::SerializedMessage>();
+        if constexpr (rclcpp::TypeAdapter<MessageT, ROSMessageType>::is_specialized::value) {
+          ROSMessageTypeAllocator ros_message_alloc(allocator);
+          auto ptr = ROSMessageTypeAllocatorTraits::allocate(ros_message_alloc, 1);
+          ROSMessageTypeAllocatorTraits::construct(ros_message_alloc, ptr);
+          ROSMessageTypeDeleter deleter;
+          allocator::set_allocator_for_deleter(&deleter, &allocator);
+          rclcpp::TypeAdapter<MessageT, ROSMessageType>::convert_to_ros_message(message.get(),
+                *ptr);
+          serializer.serialize_message(ptr, ser_msg.get());
+          serializer.serialize_message(ptr, ser_msg_u.get());
+        } else {
+          serializer.serialize_message(message.get(), ser_msg.get());
+          serializer.serialize_message(message.get(), ser_msg_u.get());
+        }
+
+        if (!sub_ids.take_shared_subscriptions.empty()) {
+          this->template add_shared_msg_to_generic_buffers<GAlloc, GDeleter, ROSMessageType>(
+            ser_msg, sub_ids.take_shared_subscriptions);
+        }
+        if (!sub_ids.take_ownership_subscriptions.empty()) {
+          this->template add_owned_msg_to_generic_buffers<GAlloc, GDeleter, ROSMessageType>(
+            std::move(ser_msg_u), sub_ids.take_ownership_subscriptions, gallocator);
+        }
+      }
+    }
+
+    publisher_it = pub_to_subs_.find(intra_process_publisher_id);
     if (publisher_it == pub_to_subs_.end()) {
       // Publisher is either invalid or no longer exists.
       RCLCPP_WARN(
@@ -406,6 +605,10 @@ private:
   RCLCPP_PUBLIC
   void
   insert_sub_id_for_pub(uint64_t sub_id, uint64_t pub_id, bool use_take_shared_method);
+
+  RCLCPP_PUBLIC
+  void
+  insert_generic_sub_id_for_pub(uint64_t sub_id, uint64_t pub_id, bool use_take_shared_method);
 
   RCLCPP_PUBLIC
   bool
@@ -636,8 +839,180 @@ private:
     }
   }
 
+
+  template<
+    typename Alloc,
+    typename Deleter,
+    typename ROSMessageType>
+  void
+  add_shared_msg_to_generic_buffers(
+    std::shared_ptr<const rclcpp::SerializedMessage> message,
+    std::vector<uint64_t> subscription_ids)
+  {
+    /*
+    using ROSMessageTypeAllocatorTraits = allocator::AllocRebind<ROSMessageType, Alloc>;
+    using ROSMessageTypeAllocator = typename ROSMessageTypeAllocatorTraits::allocator_type;
+    using ROSMessageTypeDeleter = allocator::Deleter<ROSMessageTypeAllocator, ROSMessageType>;
+    */
+    using MessageT = rclcpp::SerializedMessage;
+    using AllocatorT = std::allocator<void>;
+    using SubscribedTypeAllocatorTraits = allocator::AllocRebind<MessageT, AllocatorT>;
+    using SubscribedTypeAllocator = typename SubscribedTypeAllocatorTraits::allocator_type;
+    using SubscribedTypeDeleter = allocator::Deleter<SubscribedTypeAllocator, MessageT>;
+
+    for (auto id : subscription_ids) {
+      auto subscription_it = generic_subscriptions_.find(id);
+      if (subscription_it == generic_subscriptions_.end()) {
+        throw std::runtime_error("subscription has unexpectedly gone out of scope");
+      }
+      auto subscription_base = subscription_it->second.lock();
+      if (subscription_base == nullptr) {
+        generic_subscriptions_.erase(id);
+        continue;
+      }
+
+      auto subscription = std::dynamic_pointer_cast<
+        rclcpp::experimental::SubscriptionIntraProcessBuffer<
+          MessageT,
+          SubscribedTypeAllocator,
+          SubscribedTypeDeleter,
+          MessageT>
+        >(subscription_base);
+      if (subscription != nullptr) {
+        subscription->provide_intra_process_data(message);
+        continue;
+      } else {
+        throw std::runtime_error(
+                "failed to dynamic cast SubscriptionIntraProcessBase to "
+                "SubscriptionIntraProcessBuffer<MessageT, Alloc, Deleter> "
+                "which can happen when the publisher and "
+                "subscription use different allocator types, which is not supported");
+      }
+
+      /*
+      auto ros_message_subscription = std::dynamic_pointer_cast<
+        rclcpp::experimental::SubscriptionROSMsgIntraProcessBuffer<MessageT,
+        SubscribedTypeAllocator,
+        SubscribedTypeDeleter,
+        MessageT>
+        >(subscription_base);
+      if (nullptr == ros_message_subscription) {
+        throw std::runtime_error(
+                "failed to dynamic cast SubscriptionIntraProcessBase to "
+                "SubscriptionIntraProcessBuffer<MessageT, Alloc, Deleter>, or to "
+                "SubscriptionROSMsgIntraProcessBuffer<ROSMessageType,ROSMessageTypeAllocator,"
+                "ROSMessageTypeDeleter> which can happen when the publisher and "
+                "subscription use different allocator types, which is not supported");
+      }
+
+      ros_message_subscription->provide_intra_process_message(message);
+      */
+    }
+  }
+
+  template<
+    typename Alloc,
+    typename Deleter,
+    typename ROSMessageType>
+  void
+  add_owned_msg_to_generic_buffers(
+    std::unique_ptr<rclcpp::SerializedMessage, Deleter> message,
+    std::vector<uint64_t> subscription_ids,
+    typename allocator::AllocRebind<rclcpp::SerializedMessage, Alloc>::allocator_type & allocator)
+  {
+    using MessageT = rclcpp::SerializedMessage;
+    using MessageAllocTraits = allocator::AllocRebind<MessageT, Alloc>;
+    using MessageUniquePtr = std::unique_ptr<MessageT, Deleter>;
+    /*
+    using ROSMessageTypeAllocatorTraits = allocator::AllocRebind<ROSMessageType, Alloc>;
+    using ROSMessageTypeAllocator = typename ROSMessageTypeAllocatorTraits::allocator_type;
+    using ROSMessageTypeDeleter = allocator::Deleter<ROSMessageTypeAllocator, ROSMessageType>;
+    */
+    using AllocatorT = std::allocator<void>;
+    using SubscribedTypeAllocatorTraits = allocator::AllocRebind<MessageT, AllocatorT>;
+    using SubscribedTypeAllocator = typename SubscribedTypeAllocatorTraits::allocator_type;
+    using SubscribedTypeDeleter = allocator::Deleter<SubscribedTypeAllocator, MessageT>;
+
+    for (auto it = subscription_ids.begin(); it != subscription_ids.end(); it++) {
+      auto subscription_it = generic_subscriptions_.find(*it);
+      if (subscription_it == generic_subscriptions_.end()) {
+        throw std::runtime_error("subscription has unexpectedly gone out of scope");
+      }
+      auto subscription_base = subscription_it->second.lock();
+      if (subscription_base == nullptr) {
+        generic_subscriptions_.erase(subscription_it);
+        continue;
+      }
+
+      auto subscription = std::dynamic_pointer_cast<
+        rclcpp::experimental::SubscriptionIntraProcessBuffer<MessageT,
+        SubscribedTypeAllocator,
+        SubscribedTypeDeleter,
+        MessageT>
+        >(subscription_base);
+      if (subscription != nullptr) {
+        if (std::next(it) == subscription_ids.end()) {
+          // If this is the last subscription, give up ownership
+          subscription->provide_intra_process_data(std::move(message));
+          // Last message delivered, break from for loop
+          break;
+        } else {
+          // Copy the message since we have additional subscriptions to serve
+          Deleter deleter = message.get_deleter();
+          auto ptr = MessageAllocTraits::allocate(allocator, 1);
+          MessageAllocTraits::construct(allocator, ptr, *message);
+          subscription->provide_intra_process_data(MessageUniquePtr(ptr, deleter));
+        }
+
+        continue;
+      } else {
+        throw std::runtime_error(
+                "failed to dynamic cast SubscriptionIntraProcessBase to "
+                "SubscriptionIntraProcessBuffer<MessageT, Alloc, Deleter> "
+                "which can happen when the publisher and "
+                "subscription use different allocator types, which is not supported");
+      }
+
+      /*
+      auto ros_message_subscription = std::dynamic_pointer_cast<
+        rclcpp::experimental::SubscriptionROSMsgIntraProcessBuffer<MessageT,
+        SubscribedTypeAllocator,
+        SubscribedTypeDeleter,
+        MessageT>
+        >(subscription_base);
+      if (nullptr == ros_message_subscription) {
+        throw std::runtime_error(
+                "failed to dynamic cast SubscriptionIntraProcessBase to "
+                "SubscriptionIntraProcessBuffer<MessageT, Alloc, Deleter>, or to "
+                "SubscriptionROSMsgIntraProcessBuffer<ROSMessageType,ROSMessageTypeAllocator,"
+                "ROSMessageTypeDeleter> which can happen when the publisher and "
+                "subscription use different allocator types, which is not supported");
+      }
+
+      if (std::next(it) == subscription_ids.end()) {
+        // If this is the last subscription, give up ownership
+        ros_message_subscription->provide_intra_process_message(std::move(message));
+        // Last message delivered, break from for loop
+        break;
+      } else {
+        // Copy the message since we have additional subscriptions to serve
+        Deleter deleter = message.get_deleter();
+        allocator::set_allocator_for_deleter(&deleter, &allocator);
+        auto ptr = MessageAllocTraits::allocate(allocator, 1);
+        MessageAllocTraits::construct(allocator, ptr, *message);
+
+        ros_message_subscription->provide_intra_process_message(
+          MessageUniquePtr(ptr, deleter));
+      }
+      */
+    }
+  }
+
+
   PublisherToSubscriptionIdsMap pub_to_subs_;
+  PublisherToSubscriptionIdsMap pub_to_generic_subs_;
   SubscriptionMap subscriptions_;
+  SubscriptionMap generic_subscriptions_;
   PublisherMap publishers_;
   PublisherBufferMap publisher_buffers_;
 

--- a/rclcpp/include/rclcpp/generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/generic_subscription.hpp
@@ -87,6 +87,57 @@ public:
     any_callback_(callback),
     ts_lib_(ts_lib)
   {
+        // Setup intra process publishing if requested.
+    if (rclcpp::detail::resolve_use_intra_process(options, *node_base)) {
+      using rclcpp::detail::resolve_intra_process_buffer_type;
+
+      // Check if the QoS is compatible with intra-process.
+      auto qos_profile = get_actual_qos();
+      if (qos_profile.history() != rclcpp::HistoryPolicy::KeepLast) {
+        throw std::invalid_argument(
+                "intraprocess communication on topic '" + topic_name +
+                "' allowed only with keep last history qos policy");
+      }
+      if (qos_profile.depth() == 0) {
+        throw std::invalid_argument(
+                "intraprocess communication on topic '" + topic_name +
+                "' is not allowed with 0 depth qos policy");
+      }
+      using MessageT = rclcpp::SerializedMessage;
+      using SubscribedTypeAllocatorTraits = allocator::AllocRebind<MessageT, AllocatorT>;
+      using SubscribedTypeAllocator = typename SubscribedTypeAllocatorTraits::allocator_type;
+      using SubscribedTypeDeleter = allocator::Deleter<SubscribedTypeAllocator, MessageT>;
+
+      using SubscriptionIntraProcessT = rclcpp::experimental::SubscriptionIntraProcess<
+        MessageT,
+        MessageT,
+        SubscribedTypeAllocator,
+        SubscribedTypeDeleter,
+        MessageT,
+        AllocatorT>;
+
+      // First create a SubscriptionIntraProcess which will be given to the intra-process manager.
+      auto context = node_base->get_context();
+      subscription_intra_process_ = std::make_shared<SubscriptionIntraProcessT>(
+        callback,
+        options.get_allocator(),
+        context,
+        this->get_topic_name(),  // important to get like this, as it has the fully-qualified name
+        qos_profile,
+        resolve_intra_process_buffer_type(options.intra_process_buffer_type, callback));
+      TRACETOOLS_TRACEPOINT(
+        rclcpp_subscription_init,
+        static_cast<const void *>(get_subscription_handle().get()),
+        static_cast<const void *>(subscription_intra_process_.get()));
+
+      // Add it to the intra process manager.
+      using rclcpp::experimental::IntraProcessManager;
+      auto ipm = context->get_sub_context<IntraProcessManager>();
+      uint64_t intra_process_subscription_id = ipm->template add_generic_subscription<
+        MessageT, SubscribedTypeAllocator>(subscription_intra_process_);
+      this->setup_intra_process(intra_process_subscription_id, ipm);
+    }
+
     TRACETOOLS_TRACEPOINT(
       rclcpp_subscription_init,
       static_cast<const void *>(get_subscription_handle().get()),

--- a/rclcpp/src/rclcpp/generic_subscription.cpp
+++ b/rclcpp/src/rclcpp/generic_subscription.cpp
@@ -75,6 +75,12 @@ GenericSubscription::handle_serialized_message(
   const std::shared_ptr<rclcpp::SerializedMessage> & message,
   const rclcpp::MessageInfo & message_info)
 {
+  if (matches_any_intra_process_publishers(&message_info.get_rmw_message_info().publisher_gid)) {
+    // In this case, the message will be delivered via intra process and
+    // we should ignore this copy of the message.
+    return;
+  }
+
   any_callback_.dispatch(message, message_info);
 }
 

--- a/rclcpp/src/rclcpp/intra_process_manager.cpp
+++ b/rclcpp/src/rclcpp/intra_process_manager.cpp
@@ -53,6 +53,7 @@ IntraProcessManager::add_publisher(
 
   // Initialize the subscriptions storage for this publisher.
   pub_to_subs_[pub_id] = SplittedSubscriptions();
+  pub_to_generic_subs_[pub_id] = SplittedSubscriptions();
 
   // create an entry for the publisher id and populate with already existing subscriptions
   for (auto & pair : subscriptions_) {
@@ -66,6 +67,19 @@ IntraProcessManager::add_publisher(
     }
   }
 
+  // create an entry for the publisher id and populate with already existing subscriptions
+  for (auto & pair : generic_subscriptions_) {
+    auto subscription = pair.second.lock();
+    if (!subscription) {
+      continue;
+    }
+    if (can_communicate(publisher, subscription)) {
+      uint64_t sub_id = pair.first;
+      insert_generic_sub_id_for_pub(sub_id, pub_id, subscription->use_take_shared_method());
+    }
+  }
+
+
   return pub_id;
 }
 
@@ -75,8 +89,25 @@ IntraProcessManager::remove_subscription(uint64_t intra_process_subscription_id)
   std::unique_lock<std::shared_timed_mutex> lock(mutex_);
 
   subscriptions_.erase(intra_process_subscription_id);
+  generic_subscriptions_.erase(intra_process_subscription_id);
 
   for (auto & pair : pub_to_subs_) {
+    pair.second.take_shared_subscriptions.erase(
+      std::remove(
+        pair.second.take_shared_subscriptions.begin(),
+        pair.second.take_shared_subscriptions.end(),
+        intra_process_subscription_id),
+      pair.second.take_shared_subscriptions.end());
+
+    pair.second.take_ownership_subscriptions.erase(
+      std::remove(
+        pair.second.take_ownership_subscriptions.begin(),
+        pair.second.take_ownership_subscriptions.end(),
+        intra_process_subscription_id),
+      pair.second.take_ownership_subscriptions.end());
+  }
+
+  for (auto & pair : pub_to_generic_subs_) {
     pair.second.take_shared_subscriptions.erase(
       std::remove(
         pair.second.take_shared_subscriptions.begin(),
@@ -101,6 +132,7 @@ IntraProcessManager::remove_publisher(uint64_t intra_process_publisher_id)
   publishers_.erase(intra_process_publisher_id);
   publisher_buffers_.erase(intra_process_publisher_id);
   pub_to_subs_.erase(intra_process_publisher_id);
+  pub_to_generic_subs_.erase(intra_process_publisher_id);
 }
 
 bool
@@ -113,6 +145,7 @@ IntraProcessManager::matches_any_publishers(const rmw_gid_t * id) const
     if (!publisher) {
       continue;
     }
+    // publisher is of type "rclcpp::PublisherBase::WeakPtr"
     if (*publisher.get() == id) {
       return true;
     }
@@ -125,8 +158,11 @@ IntraProcessManager::get_subscription_count(uint64_t intra_process_publisher_id)
 {
   std::shared_lock<std::shared_timed_mutex> lock(mutex_);
 
+  size_t count = 0;
+
   auto publisher_it = pub_to_subs_.find(intra_process_publisher_id);
-  if (publisher_it == pub_to_subs_.end()) {
+  auto publisher_g_it = pub_to_generic_subs_.find(intra_process_publisher_id);
+  if (publisher_it == pub_to_subs_.end() && publisher_g_it == pub_to_generic_subs_.end() ) {
     // Publisher is either invalid or no longer exists.
     RCLCPP_WARN(
       rclcpp::get_logger("rclcpp"),
@@ -134,10 +170,15 @@ IntraProcessManager::get_subscription_count(uint64_t intra_process_publisher_id)
     return 0;
   }
 
-  auto count =
-    publisher_it->second.take_shared_subscriptions.size() +
-    publisher_it->second.take_ownership_subscriptions.size();
+  if (publisher_it != pub_to_subs_.end()) {
+    count += publisher_it->second.take_shared_subscriptions.size();
+    count += publisher_it->second.take_ownership_subscriptions.size();
+  }
 
+  if (publisher_g_it != pub_to_generic_subs_.end()) {
+    count += publisher_g_it->second.take_shared_subscriptions.size();
+    count += publisher_g_it->second.take_ownership_subscriptions.size();
+  }
   return count;
 }
 
@@ -147,9 +188,14 @@ IntraProcessManager::get_subscription_intra_process(uint64_t intra_process_subsc
   std::shared_lock<std::shared_timed_mutex> lock(mutex_);
 
   auto subscription_it = subscriptions_.find(intra_process_subscription_id);
-  if (subscription_it == subscriptions_.end()) {
+  auto subscription_g_it = generic_subscriptions_.find(intra_process_subscription_id);
+  if (subscription_it == subscriptions_.end() &&
+    subscription_g_it == generic_subscriptions_.end())
+  {
     return nullptr;
-  } else {
+  }
+
+  if (subscription_it != subscriptions_.end()) {
     auto subscription = subscription_it->second.lock();
     if (subscription) {
       return subscription;
@@ -158,6 +204,18 @@ IntraProcessManager::get_subscription_intra_process(uint64_t intra_process_subsc
       return nullptr;
     }
   }
+
+  if (subscription_g_it != generic_subscriptions_.end()) {
+    auto subscription = subscription_g_it->second.lock();
+    if (subscription) {
+      return subscription;
+    } else {
+      generic_subscriptions_.erase(subscription_g_it);
+      return nullptr;
+    }
+  }
+
+  return nullptr;
 }
 
 uint64_t
@@ -195,6 +253,19 @@ IntraProcessManager::insert_sub_id_for_pub(
   }
 }
 
+void
+IntraProcessManager::insert_generic_sub_id_for_pub(
+  uint64_t sub_id,
+  uint64_t pub_id,
+  bool use_take_shared_method)
+{
+  if (use_take_shared_method) {
+    pub_to_generic_subs_[pub_id].take_shared_subscriptions.push_back(sub_id);
+  } else {
+    pub_to_generic_subs_[pub_id].take_ownership_subscriptions.push_back(sub_id);
+  }
+}
+
 bool
 IntraProcessManager::can_communicate(
   rclcpp::PublisherBase::SharedPtr pub,
@@ -219,7 +290,8 @@ IntraProcessManager::lowest_available_capacity(const uint64_t intra_process_publ
   size_t capacity = std::numeric_limits<size_t>::max();
 
   auto publisher_it = pub_to_subs_.find(intra_process_publisher_id);
-  if (publisher_it == pub_to_subs_.end()) {
+  auto publisher_g_it = pub_to_generic_subs_.find(intra_process_publisher_id);
+  if (publisher_it == pub_to_subs_.end() && publisher_g_it == pub_to_generic_subs_.end()) {
     // Publisher is either invalid or no longer exists.
     RCLCPP_WARN(
       rclcpp::get_logger("rclcpp"),
@@ -227,9 +299,19 @@ IntraProcessManager::lowest_available_capacity(const uint64_t intra_process_publ
     return 0u;
   }
 
-  if (publisher_it->second.take_shared_subscriptions.empty() &&
-    publisher_it->second.take_ownership_subscriptions.empty())
-  {
+  bool a = false;
+  bool b = false;
+  if (publisher_it != pub_to_subs_.end()) {
+    a = publisher_it->second.take_shared_subscriptions.empty() &&
+      publisher_it->second.take_ownership_subscriptions.empty();
+  }
+
+  if (publisher_g_it != pub_to_generic_subs_.end()) {
+    b = publisher_g_it->second.take_shared_subscriptions.empty() &&
+      publisher_g_it->second.take_ownership_subscriptions.empty();
+  }
+
+  if (!(a || b)) {
     // no subscriptions available
     return 0u;
   }
@@ -250,12 +332,42 @@ IntraProcessManager::lowest_available_capacity(const uint64_t intra_process_publ
       }
     };
 
-  for (const auto sub_id : publisher_it->second.take_shared_subscriptions) {
-    available_capacity(sub_id);
+  auto available_g_capacity = [this, &capacity](const uint64_t intra_process_subscription_id)
+    {
+      auto subscription_it = generic_subscriptions_.find(intra_process_subscription_id);
+      if (subscription_it != generic_subscriptions_.end()) {
+        auto subscription = subscription_it->second.lock();
+        if (subscription) {
+          capacity = std::min(capacity, subscription->available_capacity());
+        }
+      } else {
+        // Subscription is either invalid or no longer exists.
+        RCLCPP_WARN(
+          rclcpp::get_logger("rclcpp"),
+          "Calling available_capacity for invalid or no longer existing subscription id");
+      }
+    };
+
+
+  if (publisher_it != pub_to_subs_.end()) {
+    for (const auto sub_id : publisher_it->second.take_shared_subscriptions) {
+      available_capacity(sub_id);
+    }
+
+    for (const auto sub_id : publisher_it->second.take_ownership_subscriptions) {
+      available_capacity(sub_id);
+    }
   }
 
-  for (const auto sub_id : publisher_it->second.take_ownership_subscriptions) {
-    available_capacity(sub_id);
+  if (publisher_g_it != pub_to_generic_subs_.end()) {
+
+    for (const auto sub_id : publisher_g_it->second.take_shared_subscriptions) {
+      available_g_capacity(sub_id);
+    }
+
+    for (const auto sub_id : publisher_g_it->second.take_ownership_subscriptions) {
+      available_g_capacity(sub_id);
+    }
   }
 
   return capacity;

--- a/rclcpp/test/rclcpp/test_generic_pubsub.cpp
+++ b/rclcpp/test/rclcpp/test_generic_pubsub.cpp
@@ -44,10 +44,12 @@ class RclcppGenericNodeFixture : public Test
 public:
   RclcppGenericNodeFixture()
   {
-    node_ = std::make_shared<rclcpp::Node>("pubsub");
+    node_ = std::make_shared<rclcpp::Node>(
+      "pubsub",
+      rclcpp::NodeOptions().start_parameter_event_publisher(false).use_intra_process_comms(true));
     publisher_node_ = std::make_shared<rclcpp::Node>(
       "publisher_node",
-      rclcpp::NodeOptions().start_parameter_event_publisher(false));
+      rclcpp::NodeOptions().start_parameter_event_publisher(false).use_intra_process_comms(true));
   }
 
   static void SetUpTestCase()
@@ -181,6 +183,82 @@ TEST_F(RclcppGenericNodeFixture, publisher_and_subscriber_work)
 
   for (const auto & message : test_messages) {
     publisher->publish(serialize_message<std::string, test_msgs::msg::Strings>(message));
+  }
+
+  auto subscribed_messages = subscriber_future_.get();
+  EXPECT_THAT(subscribed_messages, SizeIs(Not(0)));
+  EXPECT_THAT(subscribed_messages[0], StrEq("Hello World"));
+}
+
+TEST_F(RclcppGenericNodeFixture, publisher_and_subscriber_intra_unique)
+{
+  // We currently publish more messages because they can get lost
+  std::vector<std::string> test_messages = {"Hello World", "Hello World"};
+  std::string topic_name = "/string_topic_intra";
+  std::string type = "test_msgs/msg/Strings";
+
+  auto publisher = node_->create_publisher<test_msgs::msg::Strings>(topic_name, rclcpp::QoS(1));
+
+  auto subscriber_future_ = std::async(
+    std::launch::async, [this, topic_name, type] {
+      return subscribe_raw_messages<std::string, test_msgs::msg::Strings>(1, topic_name, type);
+    });
+
+  // TODO(karsten1987): Port 'wait_for_sub' to rclcpp
+  auto allocator = node_->get_node_options().allocator();
+  auto success = false;
+  auto ret = rcl_wait_for_subscribers(
+    node_->get_node_base_interface()->get_rcl_node_handle(),
+    &allocator,
+    topic_name.c_str(),
+    1u,
+    static_cast<rcutils_duration_value_t>(1e9),  // timeout in ns
+    &success);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ASSERT_TRUE(success);
+
+  for (const auto & message : test_messages) {
+    auto msg1 = std::make_unique<test_msgs::msg::Strings>();
+    msg1->string_value = message;
+    publisher->publish(std::move(msg1));
+  }
+
+  auto subscribed_messages = subscriber_future_.get();
+  EXPECT_THAT(subscribed_messages, SizeIs(Not(0)));
+  EXPECT_THAT(subscribed_messages[0], StrEq("Hello World"));
+}
+
+TEST_F(RclcppGenericNodeFixture, publisher_and_subscriber_intra_shared)
+{
+  // We currently publish more messages because they can get lost
+  std::vector<std::string> test_messages = {"Hello World", "Hello World"};
+  std::string topic_name = "/string_topic_intra";
+  std::string type = "test_msgs/msg/Strings";
+
+  auto publisher = node_->create_publisher<test_msgs::msg::Strings>(topic_name, rclcpp::QoS(1));
+
+  auto subscriber_future_ = std::async(
+    std::launch::async, [this, topic_name, type] {
+      return subscribe_raw_messages<std::string, test_msgs::msg::Strings>(1, topic_name, type);
+    });
+
+  // TODO(karsten1987): Port 'wait_for_sub' to rclcpp
+  auto allocator = node_->get_node_options().allocator();
+  auto success = false;
+  auto ret = rcl_wait_for_subscribers(
+    node_->get_node_base_interface()->get_rcl_node_handle(),
+    &allocator,
+    topic_name.c_str(),
+    1u,
+    static_cast<rcutils_duration_value_t>(1e9),  // timeout in ns
+    &success);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ASSERT_TRUE(success);
+
+  for (const auto & message : test_messages) {
+    test_msgs::msg::Strings msg2;
+    msg2.string_value = message;
+    publisher->publish(msg2);
   }
 
   auto subscribed_messages = subscriber_future_.get();


### PR DESCRIPTION
## Description

`GenericSubscription` is extensively used by `rosbag2`. However, this means that currently, intra-process communication is not leveraged. Even when composing `rosbag2::Recorder`, topics are subscribed in the traditional way - `IntraProcessManager` does not handle the data exchange towards the recorder's subscribers, as the `GenericSubscrition` does not register itself as capable of intra-process comms (no `SubscriptionIntraProcess` is created).

Of course, at some point serialization *needs* to happen. So there will always some cost in using a `GenericSubscription`. This gets even more valid when dealing with `rosbag2`, that currently stores data in serialized format. The point here is to avoid RMW / data transmission on loopback when not needed.

This PR allows `GenericSubscription` to create a `SubscriptionIntraProcess` whose template type is `rclcpp::SerializedMessage`. `IntraProcessManager` gets new internal collections and methods specifically used to track and manage these new subscribers - instead of mixing them in existing structures, they are collected in separate collections so that the added logic can easily treat normal subscribers and generic subscribers in different ways (if needed).

See https://github.com/ros2/rosbag2/issues/2267 for motivation & further context.

### Is this user-facing behavior change?

No outstanding changes in API - in theory stuff like `rosbag2` needs just to be rebuilt against this branch of `rclcpp`. Everything happens "under the hood" in the constructor of `GenericSubscrition` and the `IntraProcessManager`.

### Did you use Generative AI?

No

### Additional Information

- Still WIP - next step is to build `rosbag2` on top of this.
- `test_generic_pubsub` has been modified to run with intra-process enabled and two additional test cases. It runs green!


Feel free to provide your feedbacks on this - I'll may let sink this here for a while before polishing in greater detail. 