### PR TITLE
Add documentation clarifying FAILURE vs ERROR in CallbackReturn

### DIFF
--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
@@ -64,13 +64,8 @@ enum class CallbackReturn : uint8_t
 
   /// An error occurred during the callback execution.
   /// The node may transition to an error handling state.
-  ERROR = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR
+  ERROR = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR,
 };
-
-  /// Callback function for configure transition
-  /*
-   * \return SUCCESS by default
-   */
   RCLCPP_LIFECYCLE_PUBLIC
   virtual CallbackReturn
   on_configure(const State & previous_state);

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
@@ -53,6 +53,15 @@ protected:
   LifecycleNodeInterface() {}
 
 public:
+/// Return values for lifecycle transition callbacks.
+  ///
+  /// SUCCESS: The callback completed successfully and the transition can proceed.
+  ///
+  /// FAILURE: The callback did not succeed, and the transition will not proceed.
+  /// The node remains in its current state.
+  ///
+  /// ERROR: An error occurred during the callback execution.
+  /// The node may transition to an error handling state.
   enum class CallbackReturn : uint8_t
   {
     SUCCESS = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS,

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
@@ -53,21 +53,19 @@ protected:
   LifecycleNodeInterface() {}
 
 public:
-/// Return values for lifecycle transition callbacks.
-  ///
-  /// SUCCESS: The callback completed successfully and the transition can proceed.
-  ///
-  /// FAILURE: The callback did not succeed, and the transition will not proceed.
+enum class CallbackReturn : uint8_t
+{
+  /// The callback completed successfully and the transition can proceed.
+  SUCCESS = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS,
+
+  /// The callback did not succeed, and the transition will not proceed.
   /// The node remains in its current state.
-  ///
-  /// ERROR: An error occurred during the callback execution.
+  FAILURE = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE,
+
+  /// An error occurred during the callback execution.
   /// The node may transition to an error handling state.
-  enum class CallbackReturn : uint8_t
-  {
-    SUCCESS = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS,
-    FAILURE = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE,
-    ERROR = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR
-  };
+  ERROR = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR
+};
 
   /// Callback function for configure transition
   /*

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
@@ -63,7 +63,7 @@ enum class CallbackReturn : uint8_t
   FAILURE = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE,
 
   /// An error occurred during the callback execution.
-  /// The node may transition to an error handling state.
+  /// The node transitions to an error handling state.
   ERROR = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR,
 };
   RCLCPP_LIFECYCLE_PUBLIC


### PR DESCRIPTION
Adds documentation explaining the difference between FAILURE and ERROR return values for lifecycle callbacks.

Closes #3086