### PR TITLE
Expose ServiceType in Service public API

### DIFF
--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -287,6 +287,7 @@ class Service
   public std::enable_shared_from_this<Service<ServiceT>>
 {
 public:
+  using ServiceType = ServiceT;
   using CallbackType = std::function<
     void (
       const std::shared_ptr<typename ServiceT::Request>,


### PR DESCRIPTION
## Description

The PR exposes `ServiceType` in  `rclcpp::Service` public API.

### Is this user-facing behavior change?

Yes, the change unlocks deduction of the `ServiceType` of an already declared `rclcpp::Service` instance, thus avoiding duplicating type information.
Here is an example:

```cpp
auto init_service = []<typename T>(T& service, const std::string& name, const auto& cb) {
  service = create_service<typename T::element_type::ServiceType>(name, cb);
};
```

Usage:
```cpp
rclcpp::Service<long_namespace::MyServiceType>::SharedPtr my_service_; // usually a class member
...
init_service(my_service_, "my_service", my_service_callback); // usually happens in constructor
// my_service_ = create_service<long_namespace::MyServiceType>("my_service", my_service_callback); // current practice
```

### Did you use Generative AI?

No
