### PR TITLE
Avoid unecessary creation of MultiThreadedExecutor

### DIFF
--- a/rclcpp_components/src/component_container_mt.cpp
+++ b/rclcpp_components/src/component_container_mt.cpp
@@ -24,16 +24,16 @@ int main(int argc, char * argv[])
   /// Component container with a multi-threaded executor.
   rclcpp::init(argc, argv);
 
-  auto exec = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
-  auto node = std::make_shared<rclcpp_components::ComponentManager>();
+  rclcpp::executors::MultiThreadedExecutor::SharedPtr exec;
+  const auto node = std::make_shared<rclcpp_components::ComponentManager>();
   if (node->has_parameter("thread_num")) {
     const auto thread_num = node->get_parameter("thread_num").as_int();
     exec = std::make_shared<rclcpp::executors::MultiThreadedExecutor>(
       rclcpp::ExecutorOptions{}, thread_num);
-    node->set_executor(exec);
   } else {
-    node->set_executor(exec);
+    exec = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
   }
+  node->set_executor(exec);
   exec->add_node(node);
   exec->spin();
 

--- a/rclcpp_components/src/component_container_mt.cpp
+++ b/rclcpp_components/src/component_container_mt.cpp
@@ -24,7 +24,7 @@ int main(int argc, char * argv[])
   /// Component container with a multi-threaded executor.
   rclcpp::init(argc, argv);
 
-  rclcpp::executors::MultiThreadedExecutor::SharedPtr exec;
+  rclcpp::executors::MultiThreadedExecutor::SharedPtr exec = nullptr;
   const auto node = std::make_shared<rclcpp_components::ComponentManager>();
   if (node->has_parameter("thread_num")) {
     const auto thread_num = node->get_parameter("thread_num").as_int();


### PR DESCRIPTION
## Description

Avoids the unecessary creation of a `MultiThreadedExecutor` in the `component_container_mt` node.

The overhead of creating an unecessary `MultiThreadedExecutor` here is quite minimal, but there is *some* amount of overhead due to `Executor`'s constructor.
I just noticed this and thought I'd contribute this, even though quite minor.

Also, I added `const` to `node`, as afaik there's no reason not to here.

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No. I don't use slop bots.
