### PR TITLE
feat: Add per-node log level support via NodeOptions

### DIFF
--- a/rclcpp/include/rclcpp/node_options.hpp
+++ b/rclcpp/include/rclcpp/node_options.hpp
@@ -52,6 +52,7 @@ public:
    *   - clock_qos = rclcpp::ClockQoS()
    *   - use_clock_thread = true
    *   - enable_logger_service = false
+   *   - log_level = rclcpp::Logger::Level::Unset
    *   - rosout_qos = rclcpp::RosoutQoS()
    *   - parameter_event_qos = rclcpp::ParameterEventQoS
    *     - with history setting and depth from rmw_qos_profile_parameter_events
@@ -260,6 +261,22 @@ public:
   NodeOptions &
   enable_logger_service(bool enable_log_service);
 
+  /// Return the log_level option.
+  RCLCPP_PUBLIC
+  rclcpp::Logger::Level
+  log_level() const;
+
+  /// Set the log_level option, return this for logger idiom.
+  /**
+   * This allows to set the initial log level for this node, makes it different
+   * from global context.
+   *
+   * \param[in] log_level A rclcpp::Logger::Level value.
+   */
+  RCLCPP_PUBLIC
+  NodeOptions &
+  log_level(rclcpp::Logger::Level log_level);
+
   /// Return the start_parameter_event_publisher flag.
   RCLCPP_PUBLIC
   bool
@@ -450,6 +467,8 @@ private:
   bool use_clock_thread_ {true};
 
   bool enable_logger_service_ {false};
+
+  rclcpp::Logger::Level log_level_ {rclcpp::Logger::Level::Unset};
 
   rclcpp::QoS parameter_event_qos_ = rclcpp::ParameterEventsQoS(
     rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_parameter_events)

--- a/rclcpp/src/rclcpp/node.cpp
+++ b/rclcpp/src/rclcpp/node.cpp
@@ -250,6 +250,9 @@ Node::Node(
     options.parameter_event_qos(),
     rclcpp::detail::PublisherQosParametersTraits{});
 
+  if (options.log_level() != rclcpp::Logger::Level::Unset) {
+    node_logging_->get_logger().set_level(options.log_level());
+  }
   if (options.enable_logger_service()) {
     node_logging_->create_logger_services(node_services_);
   }

--- a/rclcpp/src/rclcpp/node_options.cpp
+++ b/rclcpp/src/rclcpp/node_options.cpp
@@ -81,6 +81,7 @@ NodeOptions::operator=(const NodeOptions & other)
     this->clock_qos_ = other.clock_qos_;
     this->use_clock_thread_ = other.use_clock_thread_;
     this->enable_logger_service_ = other.enable_logger_service_;
+    this->log_level_ = other.log_level_;
     this->parameter_event_qos_ = other.parameter_event_qos_;
     this->rosout_qos_ = other.rosout_qos_;
     this->parameter_event_publisher_options_ = other.parameter_event_publisher_options_;
@@ -259,6 +260,19 @@ NodeOptions &
 NodeOptions::enable_logger_service(bool enable_logger_service)
 {
   this->enable_logger_service_ = enable_logger_service;
+  return *this;
+}
+
+rclcpp::Logger::Level
+NodeOptions::log_level() const
+{
+  return this->log_level_;
+}
+
+NodeOptions &
+NodeOptions::log_level(rclcpp::Logger::Level log_level)
+{
+  this->log_level_ = log_level;
   return *this;
 }
 

--- a/rclcpp_components/src/component_manager.cpp
+++ b/rclcpp_components/src/component_manager.cpp
@@ -177,6 +177,20 @@ ComponentManager::create_node_options(const std::shared_ptr<LoadNode::Request> r
     .parameter_overrides(parameters)
     .arguments(remap_rules);
 
+  if (request->log_level != static_cast<uint8_t>(rclcpp::Logger::Level::Unset)) {
+    if (request->log_level != static_cast<uint8_t>(rclcpp::Logger::Level::Debug) &&
+      request->log_level != static_cast<uint8_t>(rclcpp::Logger::Level::Info) &&
+      request->log_level != static_cast<uint8_t>(rclcpp::Logger::Level::Warn) &&
+      request->log_level != static_cast<uint8_t>(rclcpp::Logger::Level::Error) &&
+      request->log_level != static_cast<uint8_t>(rclcpp::Logger::Level::Fatal))
+    {
+      throw ComponentManagerException(
+        "Invalid log_level value: " + std::to_string(request->log_level) +
+        ". Valid values are DEBUG (10), INFO (20), WARN (30), ERROR (40), FATAL (50).");
+    }
+    options.log_level(static_cast<rclcpp::Logger::Level>(request->log_level));
+  }
+
   for (const auto & a : request->extra_arguments) {
     const rclcpp::Parameter extra_argument = rclcpp::Parameter::from_parameter_msg(a);
     if (extra_argument.get_name() == "forward_global_arguments") {


### PR DESCRIPTION
Add a log_level option to NodeOptions that allows setting the initial log severity for a node at construction time, enabling per-component log level customization in component containers.

## Description

Fixes (https://github.com/ros2/rclcpp/issues/3091)

User could set log level for single node and component.

- Set component log_level with CLI:
```bash
ros2 component load /ComponentManager <PKG> <PLUGIN> --log-level debug
```

- Set component log_level with launch:
```python
def generate_launch_description():
    return LaunchDescription([ComposableNodeContainer(
        name='component_demo_container',
        namespace='',
        package='rclcpp_components',
        executable='component_container',
        composable_node_descriptions=[
            ComposableNode(
                package='<PKG>',
                plugin='<PLUGIN>',
                log_level='DEBUG',  # component log level
            ),
        ],
        arguments=['--ros-args', '--log-level', 'DEBUG'],  # container log level
    )])
```

### Is this user-facing behavior change?

No, the additional log level option is optional and default back to the current behavior.

### Did you use Generative AI?

Partially with Claude Sonnet 4.6

### Additional Information

Look at: https://github.com/ros2/rclcpp/issues/3091
