### PR TITLE
Improve error message when parameter value is missing

### DIFF
--- a/rclcpp/src/rclcpp/parameter_map.cpp
+++ b/rclcpp/src/rclcpp/parameter_map.cpp
@@ -152,7 +152,7 @@ rclcpp::parameter_value_from(const rcl_variant_t * const c_param_value)
     return ParameterValue(strings);
   }
 
-  throw InvalidParameterValueException("No parameter value set");
+  throw InvalidParameterValueException("Invalid parameter value: rcl parameter strucure contains no value");
 }
 
 ParameterMap

--- a/rclcpp/src/rclcpp/parameter_map.cpp
+++ b/rclcpp/src/rclcpp/parameter_map.cpp
@@ -153,8 +153,8 @@ rclcpp::parameter_value_from(const rcl_variant_t * const c_param_value)
   }
 
   throw InvalidParameterValueException(
-	"Invalid parameter value: rcl parameter structure"
-	" contains no value");
+        "Invalid parameter value: rcl parameter structure"
+        "Contains no value");
 }
 
 ParameterMap

--- a/rclcpp/src/rclcpp/parameter_map.cpp
+++ b/rclcpp/src/rclcpp/parameter_map.cpp
@@ -153,7 +153,8 @@ rclcpp::parameter_value_from(const rcl_variant_t * const c_param_value)
   }
 
   throw InvalidParameterValueException(
-	"Invalid parameter value: rcl parameter strucure contains no value");
+	"Invalid parameter value: rcl parameter structure"
+	" contains no value");
 }
 
 ParameterMap

--- a/rclcpp/src/rclcpp/parameter_map.cpp
+++ b/rclcpp/src/rclcpp/parameter_map.cpp
@@ -152,7 +152,8 @@ rclcpp::parameter_value_from(const rcl_variant_t * const c_param_value)
     return ParameterValue(strings);
   }
 
-  throw InvalidParameterValueException("Invalid parameter value: rcl parameter strucure contains no value");
+  throw InvalidParameterValueException(
+	"Invalid parameter value: rcl parameter strucure contains no value");
 }
 
 ParameterMap


### PR DESCRIPTION
## Description

This pull request improves the error message thrown when a parameter value is missing during parameter value conversion in `parameter_map.cpp`.

Previously, the exception message was:

```
"No parameter value set"
```

This message did not clearly indicate the source of the problem.
The updated message clarifies that the issue originates from the underlying `rcl` parameter structure when no value is present.

This improves debugging and provides clearer feedback when invalid parameter configurations are encountered.

Fixes # (issue)

### Is this user-facing behavior change?

Yes.
The error message shown when a parameter value is missing has been made more descriptive to improve debugging and clarity for users.

### Did you use Generative AI?

No.

### Additional Information

This change only updates the exception message and does not modify any logic or behavior in parameter parsing.
