### PR TITLE
Add acceptable_buffer_backends field in SubscriptionOptionsBase

### DIFF
--- a/rclcpp/include/rclcpp/generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/generic_subscription.hpp
@@ -80,7 +80,7 @@ public:
       node_base,
       *rclcpp::get_message_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *ts_lib),
       topic_name,
-      options.to_rcl_subscription_options(qos),
+      force_cpu_buffer_backend_(options).to_rcl_subscription_options(qos),
       options.event_callbacks,
       options.use_default_callbacks,
       DeliveredMessageKind::SERIALIZED_MESSAGE),
@@ -182,6 +182,17 @@ public:
 
 private:
   RCLCPP_DISABLE_COPY(GenericSubscription)
+
+  template<typename AllocatorT>
+  static rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>
+  force_cpu_buffer_backend_(
+    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options)
+  {
+    auto opts = options;
+    opts.acceptable_buffer_backends = "cpu";
+    return opts;
+  }
+
   AnySubscriptionCallback<rclcpp::SerializedMessage, std::allocator<void>> any_callback_;
   // The type support library should stay loaded, so it is stored in the GenericSubscription
   std::shared_ptr<rcpputils::SharedLibrary> ts_lib_;

--- a/rclcpp/include/rclcpp/generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/generic_subscription.hpp
@@ -80,7 +80,7 @@ public:
       node_base,
       *rclcpp::get_message_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *ts_lib),
       topic_name,
-      force_cpu_buffer_backend_(options).to_rcl_subscription_options(qos),
+      force_cpu_buffer_backend(options).to_rcl_subscription_options(qos),
       options.event_callbacks,
       options.use_default_callbacks,
       DeliveredMessageKind::SERIALIZED_MESSAGE),
@@ -185,7 +185,7 @@ private:
 
   template<typename AllocatorT>
   static rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>
-  force_cpu_buffer_backend_(
+  force_cpu_buffer_backend(
     const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options)
   {
     auto opts = options;

--- a/rclcpp/include/rclcpp/generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/generic_subscription.hpp
@@ -80,7 +80,7 @@ public:
       node_base,
       *rclcpp::get_message_typesupport_handle(topic_type, "rosidl_typesupport_cpp", *ts_lib),
       topic_name,
-      force_cpu_buffer_backend(options).to_rcl_subscription_options(qos),
+      options.to_rcl_subscription_options(qos),
       options.event_callbacks,
       options.use_default_callbacks,
       DeliveredMessageKind::SERIALIZED_MESSAGE),
@@ -182,17 +182,6 @@ public:
 
 private:
   RCLCPP_DISABLE_COPY(GenericSubscription)
-
-  template<typename AllocatorT>
-  static rclcpp::SubscriptionOptionsWithAllocator<AllocatorT>
-  force_cpu_buffer_backend(
-    const rclcpp::SubscriptionOptionsWithAllocator<AllocatorT> & options)
-  {
-    auto opts = options;
-    opts.acceptable_buffer_backends = "cpu";
-    return opts;
-  }
-
   AnySubscriptionCallback<rclcpp::SerializedMessage, std::allocator<void>> any_callback_;
   // The type support library should stay loaded, so it is stored in the GenericSubscription
   std::shared_ptr<rcpputils::SharedLibrary> ts_lib_;

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -89,6 +89,15 @@ struct SubscriptionOptionsBase
   QosOverridingOptions qos_overriding_options;
 
   ContentFilterOptions content_filter_options;
+
+  /// Acceptable buffer backend names for this subscription.
+  /**
+   * Empty string or "cpu" means CPU-only (default for backward compatibility).
+   * "any" means all installed backends are acceptable.
+   * Comma-separated for specific backends, e.g. "cuda,demo".
+   * CPU is always implicitly acceptable regardless of this value.
+   */
+  std::string acceptable_buffer_backends{"cpu"};
 };
 
 /// Structure containing optional configuration for Subscriptions.
@@ -143,6 +152,11 @@ struct SubscriptionOptionsWithAllocator : public SubscriptionOptionsBase
         rclcpp::exceptions::throw_from_rcl_error(
           ret, "failed to set content_filter_options");
       }
+    }
+
+    if (!acceptable_buffer_backends.empty()) {
+      result.rmw_subscription_options.acceptable_buffer_backends =
+        acceptable_buffer_backends.c_str();
     }
 
     return result;

--- a/rclcpp/include/rclcpp/subscription_options.hpp
+++ b/rclcpp/include/rclcpp/subscription_options.hpp
@@ -155,8 +155,13 @@ struct SubscriptionOptionsWithAllocator : public SubscriptionOptionsBase
     }
 
     if (!acceptable_buffer_backends.empty()) {
-      result.rmw_subscription_options.acceptable_buffer_backends =
-        acceptable_buffer_backends.c_str();
+      rcl_ret_t ret = rcl_subscription_options_set_acceptable_buffer_backends(
+        acceptable_buffer_backends.c_str(),
+        &result);
+      if (RCL_RET_OK != ret) {
+        rclcpp::exceptions::throw_from_rcl_error(
+          ret, "failed to set acceptable_buffer_backends");
+      }
     }
 
     return result;


### PR DESCRIPTION
## Description

This pull request adds the `acceptable_buffer_backends` subscription option in rclcpp, which corresponds to the subscription field with the same name introduced in rmw in https://github.com/ros2/rmw/pull/416. This option allows subscribers to control which buffer backends they accept, with a backward-compatible default of CPU-only.

This pull request consists of the following key changes:

- **`rclcpp`** (`subscription_options.hpp`): `SubscriptionOptionsBase` adds `acceptable_buffer_backends` (std::string, default `"cpu"`). `to_rcl_subscription_options()` copies it into `rmw_subscription_options.acceptable_buffer_backends` when non-empty.
- **Generic subscription** (`generic_subscription.hpp`): Constructor forces `acceptable_buffer_backends` to `"cpu"` ensuring serialized messages received by generic subscriptions are always CPU-based, which will be used by ros2 bag record for direct storage in bag files.

### Is this user-facing behavior change?

The default value `"cpu"` preserves existing behavior -- subscriptions only accept CPU-backed data unless explicitly opting in. This is a new API surface but is additive and backward-compatible. Existing code that does not pass `acceptable_buffer_backends` will behave identically to before.

### Did you use Generative AI?
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

This PR is part of the broader ROS 2 native buffer feature introduced in this [post](https://discourse.openrobotics.org/t/working-prototype-of-native-buffers-accelerated-memory-transport/52399).
It depends on the subscription field with the same name introduced in rmw in https://github.com/ros2/rmw/pull/416.