### PR TITLE
Added tracepoint for rclcpp_take event when message loaning is used

### DIFF
--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -580,6 +580,7 @@ Executor::execute_subscription(const rclcpp::SubscriptionBase::SharedPtr & subsc
                 &loaned_msg,
                 &message_info.get_rmw_message_info(),
                 nullptr);
+              TRACETOOLS_TRACEPOINT(rclcpp_take, static_cast<const void *>(loaned_msg));
               if (RCL_RET_SUBSCRIPTION_TAKE_FAILED == ret) {
                 return false;
               } else if (RCL_RET_OK != ret) {


### PR DESCRIPTION
## Description

It's difficult to fully trace a system when using zero-copy because the rclcpp_take tracepoint is not invoked. This corrects for that.

### Is this user-facing behavior change?

No

### Did you use Generative AI?
No

### Additional Information
