### PR TITLE
Remove duplicate test cases in TestAnySubscriptionCallback::is_serialized_message_callback

### DIFF
--- a/rclcpp/test/rclcpp/test_any_subscription_callback.cpp
+++ b/rclcpp/test/rclcpp/test_any_subscription_callback.cpp
@@ -113,15 +113,6 @@ TEST_F(TestAnySubscriptionCallback, is_serialized_message_callback) {
   }
   {
     rclcpp::AnySubscriptionCallback<test_msgs::msg::Empty> asc;
-    asc.set([](const rclcpp::SerializedMessage &, const rclcpp::MessageInfo &) {});
-    EXPECT_TRUE(asc.is_serialized_message_callback());
-    EXPECT_NO_THROW(
-      asc.dispatch(
-        std::make_shared<rclcpp::SerializedMessage>(),
-        rclcpp::MessageInfo{}));
-  }
-  {
-    rclcpp::AnySubscriptionCallback<test_msgs::msg::Empty> asc;
     asc.set([](std::unique_ptr<rclcpp::SerializedMessage>) {});
     EXPECT_TRUE(asc.is_serialized_message_callback());
     EXPECT_NO_THROW(
@@ -171,24 +162,6 @@ TEST_F(TestAnySubscriptionCallback, is_serialized_message_callback) {
       [](
         const std::shared_ptr<const rclcpp::SerializedMessage> &,
         const rclcpp::MessageInfo &) {});
-    EXPECT_TRUE(asc.is_serialized_message_callback());
-    EXPECT_NO_THROW(
-      asc.dispatch(
-        std::make_shared<rclcpp::SerializedMessage>(),
-        rclcpp::MessageInfo{}));
-  }
-  {
-    rclcpp::AnySubscriptionCallback<test_msgs::msg::Empty> asc;
-    asc.set([](std::shared_ptr<const rclcpp::SerializedMessage>) {});
-    EXPECT_TRUE(asc.is_serialized_message_callback());
-    EXPECT_NO_THROW(
-      asc.dispatch(
-        std::make_shared<rclcpp::SerializedMessage>(),
-        rclcpp::MessageInfo{}));
-  }
-  {
-    rclcpp::AnySubscriptionCallback<test_msgs::msg::Empty> asc;
-    asc.set([](std::shared_ptr<const rclcpp::SerializedMessage>, const rclcpp::MessageInfo &) {});
     EXPECT_TRUE(asc.is_serialized_message_callback());
     EXPECT_NO_THROW(
       asc.dispatch(


### PR DESCRIPTION
## Description
I found some test cases that were implemented twice, so I removed them. So this us just a bit of "cleanup".

### Is this user-facing behavior change?
No

### Did you use Generative AI?
No