### PR TITLE
test: remove unnecessary sleep in waitable test

### DIFF
--- a/rclcpp/test/rclcpp/executors/test_waitable.cpp
+++ b/rclcpp/test/rclcpp/executors/test_waitable.cpp
@@ -78,8 +78,6 @@ TestWaitable::execute(const std::shared_ptr<void> &)
   count_++;
   if (nullptr != on_execute_callback_) {
     on_execute_callback_();
-  } else {
-    // Removed unnecessary sleep based on TODO comment; tests should rely on explicit synchronization instead
   }
 }
 

--- a/rclcpp/test/rclcpp/executors/test_waitable.cpp
+++ b/rclcpp/test/rclcpp/executors/test_waitable.cpp
@@ -79,10 +79,7 @@ TestWaitable::execute(const std::shared_ptr<void> &)
   if (nullptr != on_execute_callback_) {
     on_execute_callback_();
   } else {
-    // TODO(wjwwood): I don't know why this was here, but probably it should
-    //   not be there, or test cases where that is important should use the
-    //   on_execute_callback?
-    std::this_thread::sleep_for(3ms);
+    // Removed unnecessary sleep based on TODO comment; tests should rely on explicit synchronization instead
   }
 }
 


### PR DESCRIPTION
## Description
Removes an unnecessary sleep from `test_waitable.cpp`.

The test contained a TODO comment questioning the purpose of a `std::this_thread::sleep_for(3ms)` call. The sleep has been removed to simplify the test and avoid unnecessary delays.

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
No.

### Additional Information

This change is limited to test code and should not affect runtime behavior.

Note: A local build was attempted but failed due to a version mismatch between the rclcpp source and the installed ROS rolling binaries. CI should validate this change in the correct environment.