### PR TITLE
[DRAFT] Keep executor collector guard conditions alive with shared ownership

### DIFF
--- a/rclcpp/include/rclcpp/executors/executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/executor_entities_collector.hpp
@@ -160,12 +160,12 @@ protected:
 
   using WeakNodesToGuardConditionsMap = std::map<
     rclcpp::node_interfaces::NodeBaseInterface::WeakPtr,
-    rclcpp::GuardCondition::WeakPtr,
+    rclcpp::GuardCondition::SharedPtr,
     std::owner_less<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr>>;
 
   using WeakGroupsToGuardConditionsMap = std::map<
     rclcpp::CallbackGroup::WeakPtr,
-    rclcpp::GuardCondition::WeakPtr,
+    rclcpp::GuardCondition::SharedPtr,
     std::owner_less<rclcpp::CallbackGroup::WeakPtr>>;
 
   /// Implementation of removing a node from the collector.


### PR DESCRIPTION
## Description
This pull request updates the `ExecutorEntitiesCollector` class to improve the management of guard condition pointers. The most important change is switching from weak pointers to shared pointers for guard conditions in internal maps, which helps prevent premature destruction and potential use-after-free errors.

**Pointer management improvements:**

* Changed the value type in both `WeakNodesToGuardConditionsMap` and `WeakGroupsToGuardConditionsMap` from `rclcpp::GuardCondition::WeakPtr` to `rclcpp::GuardCondition::SharedPtr` in `executor_entities_collector.hpp`. This ensures guard conditions remain alive as long as they're needed by the executor.

Fixes #2163

### Is this user-facing behavior change?
This breaks the downstream ABI. All libraries must be rebuilt. 

### Did you use Generative AI?
I used GitHub Copilot model Claude-Opus: 4.6
