### PR TITLE
Fix incorrect internal clear inside `RingBufferImplementation`

### DIFF
--- a/rclcpp/include/rclcpp/experimental/buffers/ring_buffer_implementation.hpp
+++ b/rclcpp/include/rclcpp/experimental/buffers/ring_buffer_implementation.hpp
@@ -231,7 +231,6 @@ private:
 
   inline void clear_()
   {
-    ring_buffer_.clear();
     size_ = 0;
     read_index_ = 0;
     write_index_ = capacity_ - 1;

--- a/rclcpp/test/rclcpp/test_ring_buffer_implementation.cpp
+++ b/rclcpp/test/rclcpp/test_ring_buffer_implementation.cpp
@@ -165,6 +165,38 @@ TEST(TestRingBufferImplementation, test_buffer_clear) {
   EXPECT_EQ('d', d);
 }
 
+namespace detail
+{
+
+struct Tracked {
+  static int destroyed;
+  int value;
+
+  Tracked(int v) : value(v) {}
+  ~Tracked() { destroyed++; }
+};
+}  // detail namespace
+
+TEST(TestRingBufferImplementation, clear_is_non_destructive)
+{
+  detail::Tracked::destroyed = 0;
+
+  rclcpp::experimental::buffers::RingBufferImplementation<detail::Tracked> rb(2);
+
+  rb.enqueue(detail::Tracked(1));
+  rb.enqueue(detail::Tracked(2));
+
+  detail::Tracked::destroyed = 0;
+
+  rb.clear();
+
+  EXPECT_EQ(detail::Tracked::destroyed, 0);
+
+  // Outside buffer should be removed
+  rb.enqueue(detail::Tracked(3));
+  EXPECT_EQ(detail::Tracked::destroyed, 1);
+}
+
 TEST(TestRingBufferImplementation, handle_nullptr_deletion) {
   rclcpp::experimental::buffers::RingBufferImplementation<std::unique_ptr<int>> rb(3);
   rb.enqueue(std::make_unique<int>(42));

--- a/rclcpp/test/rclcpp/test_ring_buffer_implementation.cpp
+++ b/rclcpp/test/rclcpp/test_ring_buffer_implementation.cpp
@@ -169,7 +169,7 @@ namespace detail
 {
 
 struct Tracked {
-  static int destroyed;
+  inline static int destroyed = 0;
   int value;
 
   Tracked() : value(0) {}

--- a/rclcpp/test/rclcpp/test_ring_buffer_implementation.cpp
+++ b/rclcpp/test/rclcpp/test_ring_buffer_implementation.cpp
@@ -168,15 +168,18 @@ TEST(TestRingBufferImplementation, test_buffer_clear) {
 namespace detail
 {
 
-struct Tracked {
+struct Tracked
+{
   inline static int destroyed = 0;
   int value;
 
-  Tracked() : value(0) {}
-  Tracked(int v) : value(v) {}
-  ~Tracked() { destroyed++; }
+  Tracked()
+  : value(0) {}
+  explicit Tracked(int v)
+  : value(v) {}
+  ~Tracked() {destroyed++;}
 };
-}  // detail namespace
+}  // namespace detail
 
 TEST(TestRingBufferImplementation, clear_is_non_destructive)
 {

--- a/rclcpp/test/rclcpp/test_ring_buffer_implementation.cpp
+++ b/rclcpp/test/rclcpp/test_ring_buffer_implementation.cpp
@@ -198,7 +198,7 @@ TEST(TestRingBufferImplementation, clear_is_non_destructive)
 
   // Outside buffer should be removed
   rb.enqueue(detail::Tracked(3));
-  EXPECT_EQ(detail::Tracked::destroyed, 1);
+  EXPECT_GE(detail::Tracked::destroyed, 1);
 }
 
 TEST(TestRingBufferImplementation, handle_nullptr_deletion) {

--- a/rclcpp/test/rclcpp/test_ring_buffer_implementation.cpp
+++ b/rclcpp/test/rclcpp/test_ring_buffer_implementation.cpp
@@ -172,6 +172,7 @@ struct Tracked {
   static int destroyed;
   int value;
 
+  Tracked() : value(0) {}
   Tracked(int v) : value(v) {}
   ~Tracked() { destroyed++; }
 };


### PR DESCRIPTION
## Description

https://github.com/ros2/ci/issues/838#issuecomment-4118939903
Calling the internal clear could lead to index out of bounds. Caught with gcc15 on Ubuntu26.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
