### PR TITLE
publish_feedback should effect only on executing state.

### DIFF
--- a/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
+++ b/rclcpp_action/include/rclcpp_action/server_goal_handle.hpp
@@ -151,13 +151,20 @@ public:
    * If execution of a goal is deferred then `ServerGoalHandle::set_executing()` must be called
    * first.
    *
-   * \throws std::runtime_error If the goal is in any state besides executing.
+   * If the goal is in any state besides executing, a warning will be logged and the feedback
+   * will not be published.
    *
    * \param[in] feedback_msg the message to publish to clients.
    */
   void
   publish_feedback(std::shared_ptr<typename ActionT::Feedback> feedback_msg)
   {
+    if (!is_executing()) {
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp_action"),
+        "publish_feedback() called on a goal handle not in executing state, ignoring");
+      return;
+    }
     auto feedback_message = std::make_shared<typename ActionT::Impl::FeedbackMessage>();
     feedback_message->goal_id.uuid = uuid_;
     feedback_message->feedback = *feedback_msg;

--- a/rclcpp_action/test/test_server_goal_handle.cpp
+++ b/rclcpp_action/test/test_server_goal_handle.cpp
@@ -174,6 +174,28 @@ TEST_F(TestServerGoalHandle, execute) {
   EXPECT_THROW(handle_->execute(), rclcpp::exceptions::RCLError);
 }
 
+TEST_F(TestServerGoalHandle, publish_feedback_not_executing) {
+  // Goal is in accepted (not executing) state, publish_feedback should warn and ignore
+  auto feedback = std::make_shared<test_msgs::action::Fibonacci::Feedback>();
+  EXPECT_NO_THROW(handle_->publish_feedback(feedback));
+}
+
+TEST_F(TestServerGoalHandle, publish_feedback_executing) {
+  // Goal is in executing state, publish_feedback should succeed
+  handle_->execute();
+  auto feedback = std::make_shared<test_msgs::action::Fibonacci::Feedback>();
+  EXPECT_NO_THROW(handle_->publish_feedback(feedback));
+}
+
+TEST_F(TestServerGoalHandle, publish_feedback_after_succeed) {
+  // Goal reached terminal state, publish_feedback should warn and ignore
+  handle_->execute();
+  auto result = std::make_shared<test_msgs::action::Fibonacci::Result>();
+  handle_->succeed(result);
+  auto feedback = std::make_shared<test_msgs::action::Fibonacci::Feedback>();
+  EXPECT_NO_THROW(handle_->publish_feedback(feedback));
+}
+
 TEST_F(TestServerGoalHandle, rcl_action_goal_handle_get_status_error) {
   auto mock = mocking_utils::patch_and_return(
     "lib:rclcpp_action", rcl_action_goal_handle_get_status, RCL_RET_ERROR);


### PR DESCRIPTION
## Description

Closes https://github.com/ros2/rclcpp/issues/3117

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?

Yes, only warning is going to be popped up that tells user application `publish_feedback` can be effective only executing state.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
