### PR TITLE
fix(executor): wake executor when future is set by non-executor thread (#1916)

### DIFF
--- a/rclcpp/include/rclcpp/executor.hpp
+++ b/rclcpp/include/rclcpp/executor.hpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "rcl/guard_condition.h"
@@ -375,9 +376,6 @@ public:
    *   If the time spent inside the blocking loop exceeds this timeout, return a TIMEOUT return
    *   code.
    * \return The return code, one of `SUCCESS`, `INTERRUPTED`, or `TIMEOUT`.
-   * \note This method will check the future and the timeout only when the executor is woken up.
-   *   If this future is unrelated to an executor's entity, this method will not correctly detect
-   *   when it's completed and therefore may wait forever and never time out.
    */
   template<typename FutureT, typename TimeRepT = int64_t, typename TimeT = std::milli>
   FutureReturnCode
@@ -385,12 +383,42 @@ public:
     const FutureT & future,
     std::chrono::duration<TimeRepT, TimeT> timeout = std::chrono::duration<TimeRepT, TimeT>(-1))
   {
+    // When a future is fulfilled by a non-executor thread, spin_until_future_complete_impl
+    // blocks indefinitely in wait_for_work() because nothing in the wait set becomes ready.
+    // A watcher thread triggers interrupt_guard_condition_ the moment the future is set,
+    // immediately waking the executor. See ros2/rclcpp#1916.
+    std::atomic<bool> stop_watcher{false};
+    // Copy the shared_ptr so the watcher keeps the guard condition alive
+    // even if this executor is destroyed before the watcher exits.
+    std::shared_ptr<rclcpp::GuardCondition> watcher_gc = interrupt_guard_condition_;
+
+    std::thread watcher_thread(
+      [&future, &stop_watcher, watcher_gc]() {
+        // Use wait_for with a short interval rather than wait() so the thread
+        // can observe stop_watcher after spin_until_future_complete returns
+        // (on timeout or cancel), enabling a clean join() without blocking.
+        while (!stop_watcher.load(std::memory_order_relaxed)) {
+          if (future.wait_for(std::chrono::milliseconds(100)) ==
+            std::future_status::ready)
+          {
+            try {
+              watcher_gc->trigger();
+            } catch (const std::exception &) {}
+            return;
+          }
+        }
+      });
+
+    RCPPUTILS_SCOPE_EXIT(
+      stop_watcher.store(true, std::memory_order_relaxed);
+      watcher_thread.join();
+    );
+
     return spin_until_future_complete_impl(
       std::chrono::duration_cast<std::chrono::nanoseconds>(timeout),
       [&future](std::chrono::nanoseconds wait_time) {
         return future.wait_for(wait_time);
-      }
-    );
+      });
   }
 
   /// Cancel any running spin* function, causing it to return.

--- a/rclcpp/test/rclcpp/executors/test_executors.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors.cpp
@@ -293,6 +293,32 @@ TYPED_TEST(TestExecutors, testSpinUntilFutureCompleteNoTimeout)
   spinner.join();
 }
 
+// Regression test for ros2/rclcpp#1916:
+// spin_until_future_complete must return when a future is fulfilled by a non-executor thread,
+// even if no executor-registered entities (subscriptions, timers, etc.) become ready.
+// Without the watcher thread fix, this test hangs indefinitely.
+TYPED_TEST(TestExecutors, testSpinUntilFutureCompleteExternalThread)
+{
+  using ExecutorType = TypeParam;
+  ExecutorType executor;
+  // No node added: nothing in the wait set becomes ready except the watcher's guard condition.
+
+  std::promise<bool> promise;
+  std::shared_future<bool> future = promise.get_future().share();
+
+  // Fulfill the future from a non-executor thread after a short delay.
+  std::thread setter([&promise]() {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      promise.set_value(true);
+    });
+
+  // spin_until_future_complete with no timeout — previously blocked forever (ros2/rclcpp#1916).
+  auto ret = executor.spin_until_future_complete(future);
+  EXPECT_EQ(rclcpp::FutureReturnCode::SUCCESS, ret);
+  EXPECT_TRUE(future.get());
+  setter.join();
+}
+
 // Check spin_until_future_complete timeout works as expected
 TYPED_TEST(TestExecutors, testSpinUntilFutureCompleteWithTimeout)
 {


### PR DESCRIPTION
## Problem

`spin_until_future_complete` with no timeout (`-1`) blocks indefinitely when the
future is fulfilled by a thread that is not part of the executor.

**Root cause** (`executor.hpp` / `executor.cpp`):
- `spin_until_future_complete_impl(-1ns)` passes the full remaining timeout to
  `spin_once_impl`, which calls `wait_for_work(-1ns)` → `wait_set_.wait(-1ns)`
- `wait_set_.wait` blocks until a registered entity (subscription, timer, service,
  client, or guard condition) becomes ready
- A future fulfilled by an external thread triggers none of these entities
- The executor never wakes; `wait_for_work` never returns

This was originally reported alongside a potential `GuardCondition` callback bug
(#1917), but that path was subsequently fixed. The remaining issue is that the
executor has no mechanism to learn the future is ready when it is set externally.

## Fix

Spawn a watcher thread inside `spin_until_future_complete` that monitors the
future and triggers `interrupt_guard_condition_` the moment the future is set.
This immediately unblocks `wait_for_work` without busy-waiting in the executor's
main loop.

The watcher uses `future.wait_for(100ms)` in a loop (rather than `future.wait()`)
so it can observe a `stop_watcher` flag set on all exit paths — enabling a clean
`join()` whether the spin returns by success, timeout, cancel, or exception.

**Files changed**:
- `rclcpp/include/rclcpp/executor.hpp` — expand `spin_until_future_complete`
  template; add `#include <thread>`
- `rclcpp/test/rclcpp/executors/test_executors.cpp` — add
  `testSpinUntilFutureCompleteExternalThread` regression test

## Prior work consulted

- #1916 — original issue (spin_until_future_complete blocks forever)
- #1917 — GuardCondition callback enhancement; executor wakeup discussion
- ros2/demos#558 — wjwwood's suggested user-level workaround
- #3114 — related: ExecutorEntitiesCollector guard condition lifetime fix

The watcher-thread approach is consistent with the `interrupt_guard_condition_`
pattern already used in `Executor::cancel()` (`executor.cpp` L472) and
`Executor::handle_updated_entities()` (`executor.cpp` L146).

## Source reading

- `rclcpp/include/rclcpp/executor.hpp` L571 — `interrupt_guard_condition_` declaration
- `rclcpp/src/rclcpp/executor.cpp` L265–314 — `spin_until_future_complete_impl`
- `rclcpp/src/rclcpp/executor.cpp` L913–930 — `get_next_executable` → `wait_for_work`
- `rclcpp/src/rclcpp/executor.cpp` L758–787 — `wait_for_work` → `wait_set_.wait`
- `rclcpp/src/rclcpp/guard_condition.cpp` L69–85 — `trigger()` already calls
  `rcl_trigger_guard_condition` before callback (sloretz's 2022 bug was separately fixed)

*AI-assisted — authored with Claude, reviewed by Komada.*