### PR TITLE
Refactor component containers + Add option for CBG Executor

### DIFF
--- a/rclcpp_components/include/rclcpp_components/component_manager_isolated.hpp
+++ b/rclcpp_components/include/rclcpp_components/component_manager_isolated.hpp
@@ -40,7 +40,6 @@ namespace rclcpp_components
 template<typename ExecutorT = rclcpp::executors::SingleThreadedExecutor>
 class ComponentManagerIsolated : public rclcpp_components::ComponentManager
 {
-
   struct DedicatedExecutorWrapper
   {
     std::shared_ptr<rclcpp::Executor> executor;

--- a/rclcpp_components/include/rclcpp_components/component_manager_isolated.hpp
+++ b/rclcpp_components/include/rclcpp_components/component_manager_isolated.hpp
@@ -100,11 +100,6 @@ protected:
   {
     std::shared_ptr<ExecutorT> exec;
     if constexpr (std::is_same_v<ExecutorT, rclcpp::executors::SingleThreadedExecutor>) {
-      if (num_threads_ > 0) {
-        RCLCPP_WARN(
-          rclcpp::get_logger("rclcpp"),
-          "num_threads is not supported by SingleThreadedExecutor. Ignoring...");
-      }
       exec = std::make_shared<ExecutorT>(executor_options_);
     } else {
       exec = std::make_shared<ExecutorT>(executor_options_, num_threads_);

--- a/rclcpp_components/include/rclcpp_components/component_manager_isolated.hpp
+++ b/rclcpp_components/include/rclcpp_components/component_manager_isolated.hpp
@@ -21,11 +21,12 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <system_error>
 #include <thread>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#include <system_error>
 
 #include "rclcpp/executor.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
@@ -39,7 +40,6 @@ namespace rclcpp_components
 template<typename ExecutorT = rclcpp::executors::SingleThreadedExecutor>
 class ComponentManagerIsolated : public rclcpp_components::ComponentManager
 {
-  using rclcpp_components::ComponentManager::ComponentManager;
 
   struct DedicatedExecutorWrapper
   {
@@ -58,6 +58,29 @@ class ComponentManagerIsolated : public rclcpp_components::ComponentManager
   };
 
 public:
+  explicit ComponentManagerIsolated(
+    std::weak_ptr<rclcpp::Executor> executor = std::weak_ptr<rclcpp::Executor>(),
+    std::string node_name = "ComponentManager",
+    const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions()
+    .start_parameter_services(false)
+    .start_parameter_event_publisher(false))
+  : ComponentManager(executor, node_name, node_options)
+  {}
+
+  // Constructor with per-component executor configuration
+  ComponentManagerIsolated(
+    rclcpp::ExecutorOptions executor_options,
+    size_t num_threads,
+    std::weak_ptr<rclcpp::Executor> executor = std::weak_ptr<rclcpp::Executor>(),
+    std::string node_name = "ComponentManager",
+    const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions()
+    .start_parameter_services(false)
+    .start_parameter_event_publisher(false))
+  : ComponentManager(executor, node_name, node_options),
+    executor_options_(executor_options),
+    num_threads_(num_threads)
+  {}
+
   ~ComponentManagerIsolated()
   {
     if (node_wrappers_.size()) {
@@ -76,7 +99,17 @@ protected:
   void
   add_node_to_executor(uint64_t node_id) override
   {
-    auto exec = std::make_shared<ExecutorT>();
+    std::shared_ptr<ExecutorT> exec;
+    if constexpr (std::is_same_v<ExecutorT, rclcpp::executors::SingleThreadedExecutor>) {
+      if (num_threads_ > 0) {
+        RCLCPP_WARN(
+          rclcpp::get_logger("rclcpp"),
+          "num_threads is not supported by SingleThreadedExecutor. Ignoring...");
+      }
+      exec = std::make_shared<ExecutorT>(executor_options_);
+    } else {
+      exec = std::make_shared<ExecutorT>(executor_options_, num_threads_);
+    }
     exec->add_node(node_wrappers_[node_id].get_node_base_interface());
 
     // Emplace rather than std::move since move operations are deleted for atomics
@@ -143,6 +176,8 @@ private:
     executor_wrapper.thread.join();
   }
 
+  rclcpp::ExecutorOptions executor_options_;
+  size_t num_threads_{0};
   std::unordered_map<uint64_t, DedicatedExecutorWrapper> dedicated_executor_wrappers_;
 };
 

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -21,7 +21,7 @@
 #include "rcutils/logging_macros.h"
 #include "rclcpp/executors/multi_threaded_executor.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
-#include "rclcpp/experimental/executors/events_executor/events_executor.hpp"
+#include "rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp"
 #include "rclcpp/utilities.hpp"
 
 #include "rclcpp_components/component_manager.hpp"
@@ -31,21 +31,14 @@ enum class ExecutorType
 {
   SingleThreaded,
   MultiThreaded,
-  Events
+  EventsCBG
 };
-
-std::optional<ExecutorType>
+inline std::optional<ExecutorType>
 parse_executor_type(const std::string & arg)
 {
-  if (arg == "single-threaded") {
-    return ExecutorType::SingleThreaded;
-  }
-  if (arg == "multi-threaded") {
-    return ExecutorType::MultiThreaded;
-  }
-  if (arg == "events") {
-    return ExecutorType::Events;
-  }
+  if (arg == "single-threaded") {return ExecutorType::SingleThreaded;}
+  if (arg == "multi-threaded") {return ExecutorType::MultiThreaded;}
+  if (arg == "events-cbg") {return ExecutorType::EventsCBG;}
   return std::nullopt;
 }
 
@@ -58,7 +51,7 @@ struct ParsedArgs
   std::string error_message;
 };
 
-ParsedArgs
+inline ParsedArgs
 parse_args(const std::vector<std::string> & args)
 {
   ParsedArgs parsed;
@@ -68,15 +61,10 @@ parse_args(const std::vector<std::string> & args)
 
     if (arg == "--isolated") {
       parsed.isolated = true;
-      continue;
-    }
-
-    if (arg == "--help" || arg == "-h") {
+    } else if (arg == "--help" || arg == "-h") {
       parsed.help = true;
       return parsed;
-    }
-
-    if (arg == "--executor-type") {
+    } else if (arg == "--executor-type") {
       if (i + 1 >= args.size()) {
         parsed.invalid = true;
         parsed.error_message = "Missing value for --executor-type";

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -15,7 +15,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <thread>
 #include <vector>
 
 #include "rcutils/logging_macros.h"
@@ -87,9 +86,9 @@ parse_args(const std::vector<std::string> & args)
       try {
         parsed.num_threads = std::stol(args[++i]);
       } catch (const std::exception &) {
-    parsed.invalid = true;
+        parsed.invalid = true;
         parsed.error_message = "Invalid value for --num-threads: " + args[i];
-    return parsed;
+        return parsed;
       }
     }
   }
@@ -153,7 +152,7 @@ int main(int argc, char * argv[])
   if (args.isolated) {
     // The outer executor runs only the container manager's load/unload services.
     // Each loaded component gets its own dedicated executor of the requested type.
-      exec = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    exec = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
     switch (args.executor_type) {
       case ExecutorType::MultiThreaded:
         node = std::make_shared<

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -172,8 +172,7 @@ int main(int argc, char * argv[])
         break;
       default:
         node = std::make_shared<
-          rclcpp_components::ComponentManagerIsolated<rclcpp::executors::SingleThreadedExecutor>>(
-          rclcpp::ExecutorOptions(), num_threads);
+          rclcpp_components::ComponentManagerIsolated<rclcpp::executors::SingleThreadedExecutor>>();
         break;
     }
 

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -116,11 +116,11 @@ print_usage()
     "                           [--isolated]\n"
     "       component_container --help|-h\n"
     "Defaults: single-threaded, non-isolated\n"
-    "          if multi-threaded: thread_num<=0 means"
+    "          if multi-threaded: omitting thread_num means"
     " the executor will run with max available on system\n"
     "Examples: component_container --executor-type single-threaded\n"
     "          component_container --executor-type multi-threaded --ros_args -p thread_num:=4\n"
-    "          component_container --executor-type events-cbg --isolated --ros_args -p thread_num:=4");
+    "          component_container --executor-type events-cbg --isolated --ros_args -p thread_num:=1");
 }
 
 int main(int argc, char * argv[])

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -16,6 +16,7 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include <thread>
 
 #include "rcutils/logging_macros.h"
 #include "rclcpp/executors/multi_threaded_executor.hpp"
@@ -41,10 +42,17 @@ parse_executor_type(const std::string & arg)
   return std::nullopt;
 }
 
+inline std::string
+executor_type_to_string(const ExecutorType & type)
+{
+  if (type == ExecutorType::SingleThreaded) {return "single-threaded";}
+  if (type == ExecutorType::MultiThreaded) {return "multi-threaded";}
+  if (type == ExecutorType::EventsCBG) {return "events-cbg";}
+  return "unknown";
+}
 struct ParsedArgs
 {
   ExecutorType executor_type = ExecutorType::SingleThreaded;
-  int64_t num_threads = 0;
   bool isolated = false;
   bool help = false;
   bool invalid = false;
@@ -77,19 +85,6 @@ parse_args(const std::vector<std::string> & args)
         return parsed;
       }
       parsed.executor_type = option.value();
-    } else if (arg == "--num-threads") {
-      if (i + 1 >= args.size()) {
-        parsed.invalid = true;
-        parsed.error_message = "Missing value for --num-threads";
-        return parsed;
-      }
-      try {
-        parsed.num_threads = std::stol(args[++i]);
-      } catch (const std::exception &) {
-        parsed.invalid = true;
-        parsed.error_message = "Invalid value for --num-threads: " + args[i];
-        return parsed;
-      }
     }
   }
 
@@ -118,14 +113,14 @@ print_usage()
   RCUTILS_LOG_INFO_NAMED(
     "component_container",
     "Usage: component_container [--executor-type <single-threaded|multi-threaded|events-cbg>]\n"
-    "                           [--num-threads <N>] [--isolated]\n"
+    "                           [--isolated]\n"
     "       component_container --help|-h\n"
     "Defaults: single-threaded, non-isolated\n"
-    "          if multi-threaded: num_threads<=0 means"
+    "          if multi-threaded: thread_num<=0 means"
     " the executor will run with max available on system\n"
     "Examples: component_container --executor-type single-threaded\n"
-    "          component_container --executor-type multi-threaded --num-threads 4\n"
-    "          component_container --executor-type events-cbg --isolated --num-threads 2");
+    "          component_container --executor-type multi-threaded --ros_args -p thread_num:=4\n"
+    "          component_container --executor-type events-cbg --isolated --ros_args -p thread_num:=4");
 }
 
 int main(int argc, char * argv[])
@@ -147,8 +142,15 @@ int main(int argc, char * argv[])
   }
 
   std::shared_ptr<rclcpp::Executor> exec;
-  std::shared_ptr<rclcpp_components::ComponentManager> node;
+  std::shared_ptr<rclcpp_components::ComponentManager> node = std::make_shared<rclcpp_components::ComponentManager>();
+  const int64_t num_threads = (node->has_parameter("thread_num")) ?
+      node->get_parameter("thread_num").as_int() :
+      std::thread::hardware_concurrency();
+  std::string debug_msg;
 
+  if (args.executor_type == ExecutorType::SingleThreaded && num_threads < std::thread::hardware_concurrency()) {
+    RCUTILS_LOG_WARN_NAMED("component_container", "num_threads is not supported by the SingleThreadedExecutor. Ignoring...");
+  }
   if (args.isolated) {
     // The outer executor runs only the container manager's load/unload services.
     // Each loaded component gets its own dedicated executor of the requested type.
@@ -157,28 +159,35 @@ int main(int argc, char * argv[])
       case ExecutorType::MultiThreaded:
         node = std::make_shared<
           rclcpp_components::ComponentManagerIsolated<rclcpp::executors::MultiThreadedExecutor>>(
-          rclcpp::ExecutorOptions(), args.num_threads);
+          rclcpp::ExecutorOptions(), num_threads);
         break;
       case ExecutorType::EventsCBG:
         node = std::make_shared<
           rclcpp_components::ComponentManagerIsolated<rclcpp::executors::EventsCBGExecutor>>(
-          rclcpp::ExecutorOptions(), args.num_threads);
+          rclcpp::ExecutorOptions(), num_threads);
         break;
       default:
         node = std::make_shared<
           rclcpp_components::ComponentManagerIsolated<rclcpp::executors::SingleThreadedExecutor>>(
-          rclcpp::ExecutorOptions(), args.num_threads);
+          rclcpp::ExecutorOptions(), num_threads);
         break;
     }
+
+    debug_msg = "Creating isolated component container with the following per-node settings: "
+    "executor_type: " + executor_type_to_string(args.executor_type);
+    if (args.executor_type != ExecutorType::SingleThreaded) {
+    debug_msg += ", num_threads: " + std::to_string(num_threads);
+    }
   } else {
-    node = std::make_shared<rclcpp_components::ComponentManager>();
-    // --num-threads CLI arg takes precedence; fall back to thread_num ROS parameter
-    // for backwards compatibility
-    const int64_t num_threads = (args.num_threads == 0 && node->has_parameter("thread_num")) ?
-      node->get_parameter("thread_num").as_int() :
-      args.num_threads;
     exec = make_executor(args.executor_type, rclcpp::ExecutorOptions(), num_threads);
+
+    debug_msg = "Creating non-isolated component container with executor_type: " + executor_type_to_string(args.executor_type);
+    if (args.executor_type != ExecutorType::SingleThreaded) {
+    debug_msg += ", num_threads: " + std::to_string(num_threads);
+    }
   }
+
+  RCUTILS_LOG_DEBUG_NAMED("component_container", debug_msg.c_str());
 
   node->set_executor(exec);
   exec->add_node(node);

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -118,11 +118,15 @@ print_usage()
 {
   RCUTILS_LOG_INFO_NAMED(
     "component_container",
-    "Usage: component_container [--executor-type <single-threaded|multi-threaded|events>] [--isolated]\n"
+    "Usage: component_container [--executor-type <single-threaded|multi-threaded|events-cbg>]\n"
+    "                           [--num-threads <N>] [--isolated]\n"
     "       component_container --help|-h\n"
     "Defaults: single-threaded, non-isolated\n"
-    "Examples: component_container --executor-type multi-threaded\n"
-    "          component_container --executor-type single-threaded --isolated");
+    "          if multi-threaded: num_threads<=0 means"
+    " the executor will run with max available on system\n"
+    "Examples: component_container --executor-type single-threaded\n"
+    "          component_container --executor-type multi-threaded --num-threads 4\n"
+    "          component_container --executor-type events-cbg --isolated --num-threads 2");
 }
 
 int main(int argc, char * argv[])

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -152,7 +152,7 @@ int main(int argc, char * argv[])
 
   if (args.executor_type == ExecutorType::SingleThreaded &&
     num_threads > 0 &&
-    num_threads < std::thread::hardware_concurrency())
+    num_threads != std::thread::hardware_concurrency())
   {
     RCUTILS_LOG_WARN_NAMED("component_container",
       "thread_num is not supported by the SingleThreadedExecutor. Ignoring...");

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -120,7 +120,8 @@ print_usage()
     " the executor will run with max available on system\n"
     "Examples: component_container --executor-type single-threaded\n"
     "          component_container --executor-type multi-threaded --ros_args -p thread_num:=4\n"
-    "          component_container --executor-type events-cbg --isolated --ros_args -p thread_num:=1");
+    "          component_container --executor-type events-cbg "
+    "--isolated --ros_args -p thread_num:=1");
 }
 
 int main(int argc, char * argv[])
@@ -142,7 +143,8 @@ int main(int argc, char * argv[])
   }
 
   std::shared_ptr<rclcpp::Executor> exec;
-  std::shared_ptr<rclcpp_components::ComponentManager> node = std::make_shared<rclcpp_components::ComponentManager>();
+  std::shared_ptr<rclcpp_components::ComponentManager> node =
+    std::make_shared<rclcpp_components::ComponentManager>();
   const int64_t num_threads = (node->has_parameter("thread_num")) ?
     node->get_parameter("thread_num").as_int() :
     std::thread::hardware_concurrency();

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -129,50 +129,52 @@ int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
 
-  std::vector<std::string> args = rclcpp::remove_ros_arguments(argc, argv);
-  ParsedArgs parsed = parse_args(args);
+  std::vector<std::string> arg_strs = rclcpp::remove_ros_arguments(argc, argv);
+  auto args = parse_args(arg_strs);
 
-  if (parsed.help) {
+  if (args.help) {
     print_usage();
     return 0;
   }
 
-  if (parsed.invalid) {
-    RCUTILS_LOG_ERROR_NAMED("component_container", "%s", parsed.error_message.c_str());
+  if (args.invalid) {
+    RCUTILS_LOG_ERROR_NAMED("component_container", "%s", args.error_message.c_str());
     print_usage();
     return 1;
   }
 
-  ExecutorType executor_type = parsed.executor_type;
-  bool isolated = parsed.isolated;
+  std::shared_ptr<rclcpp::Executor> exec;
+  std::shared_ptr<rclcpp_components::ComponentManager> node;
 
-  std::shared_ptr<rclcpp::Executor> exec = nullptr;
-  std::shared_ptr<rclcpp_components::ComponentManager> node = nullptr;
-
-  if (executor_type == ExecutorType::MultiThreaded) {
-    if (isolated) {
+  if (args.isolated) {
+    // The outer executor runs only the container manager's load/unload services.
+    // Each loaded component gets its own dedicated executor of the requested type.
       exec = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-      node = std::make_shared<rclcpp_components::ComponentManagerIsolated<rclcpp::executors::MultiThreadedExecutor>>();
-    } else {
-      node = std::make_shared<rclcpp_components::ComponentManager>();
-      if (node->has_parameter("thread_num")) {
-        const auto thread_num = node->get_parameter("thread_num").as_int();
-        exec = std::make_shared<rclcpp::executors::MultiThreadedExecutor>(
-          rclcpp::ExecutorOptions(), thread_num);
-      } else {
-        exec = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
-      }
+    switch (args.executor_type) {
+      case ExecutorType::MultiThreaded:
+        node = std::make_shared<
+          rclcpp_components::ComponentManagerIsolated<rclcpp::executors::MultiThreadedExecutor>>(
+          rclcpp::ExecutorOptions(), args.num_threads);
+        break;
+      case ExecutorType::EventsCBG:
+        node = std::make_shared<
+          rclcpp_components::ComponentManagerIsolated<rclcpp::executors::EventsCBGExecutor>>(
+          rclcpp::ExecutorOptions(), args.num_threads);
+        break;
+      default:
+        node = std::make_shared<
+          rclcpp_components::ComponentManagerIsolated<rclcpp::executors::SingleThreadedExecutor>>(
+          rclcpp::ExecutorOptions(), args.num_threads);
+        break;
     }
-  } else if (executor_type == ExecutorType::Events) {
-    exec = std::make_shared<rclcpp::experimental::executors::EventsExecutor>();
-    node = std::make_shared<rclcpp_components::ComponentManager>();
   } else {
-    exec = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-    if (isolated) {
-      node = std::make_shared<rclcpp_components::ComponentManagerIsolated<rclcpp::executors::SingleThreadedExecutor>>();
-    } else {
-      node = std::make_shared<rclcpp_components::ComponentManager>();
-    }
+    node = std::make_shared<rclcpp_components::ComponentManager>();
+    // --num-threads CLI arg takes precedence; fall back to thread_num ROS parameter
+    // for backwards compatibility
+    const int64_t num_threads = (args.num_threads == 0 && node->has_parameter("thread_num")) ?
+      node->get_parameter("thread_num").as_int() :
+      args.num_threads;
+    exec = make_executor(args.executor_type, rclcpp::ExecutorOptions(), num_threads);
   }
 
   node->set_executor(exec);

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -13,18 +13,156 @@
 // limitations under the License.
 
 #include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
 
+#include "rcutils/logging_macros.h"
+#include "rclcpp/executors/multi_threaded_executor.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rclcpp/experimental/executors/events_executor/events_executor.hpp"
 #include "rclcpp/utilities.hpp"
 
 #include "rclcpp_components/component_manager.hpp"
+#include "rclcpp_components/component_manager_isolated.hpp"
+
+enum class ExecutorType
+{
+  SingleThreaded,
+  MultiThreaded,
+  Events
+};
+
+std::optional<ExecutorType>
+parse_executor_type(const std::string & arg)
+{
+  if (arg == "single-threaded") {
+    return ExecutorType::SingleThreaded;
+  }
+  if (arg == "multi-threaded") {
+    return ExecutorType::MultiThreaded;
+  }
+  if (arg == "events") {
+    return ExecutorType::Events;
+  }
+  return std::nullopt;
+}
+
+struct ParsedArgs
+{
+  ExecutorType executor_type = ExecutorType::SingleThreaded;
+  bool isolated = false;
+  bool help = false;
+  bool invalid = false;
+  std::string error_message;
+};
+
+ParsedArgs
+parse_args(const std::vector<std::string> & args)
+{
+  ParsedArgs parsed;
+
+  for (size_t i = 1; i < args.size(); ++i) {
+    const std::string & arg = args[i];
+
+    if (arg == "--isolated") {
+      parsed.isolated = true;
+      continue;
+    }
+
+    if (arg == "--help" || arg == "-h") {
+      parsed.help = true;
+      return parsed;
+    }
+
+    if (arg == "--executor-type") {
+      if (i + 1 >= args.size()) {
+        parsed.invalid = true;
+        parsed.error_message = "Missing value for --executor-type";
+        return parsed;
+      }
+      auto option = parse_executor_type(args[++i]);
+      if (!option) {
+        parsed.invalid = true;
+        parsed.error_message = "Invalid executor type: " + args[i];
+        return parsed;
+      }
+      parsed.executor_type = option.value();
+      continue;
+    }
+
+    parsed.invalid = true;
+    parsed.error_message = "Unknown argument: " + arg;
+    return parsed;
+  }
+
+  return parsed;
+}
+
+void
+print_usage()
+{
+  RCUTILS_LOG_INFO_NAMED(
+    "component_container",
+    "Usage: component_container [--executor-type <single-threaded|multi-threaded|events>] [--isolated]\n"
+    "       component_container --help|-h\n"
+    "Defaults: single-threaded, non-isolated\n"
+    "Examples: component_container --executor-type multi-threaded\n"
+    "          component_container --executor-type single-threaded --isolated\n");
+}
 
 int main(int argc, char * argv[])
 {
-  /// Component container with a single-threaded executor.
   rclcpp::init(argc, argv);
-  auto exec = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-  auto node = std::make_shared<rclcpp_components::ComponentManager>(exec);
+
+  std::vector<std::string> args = rclcpp::remove_ros_arguments(argc, argv);
+  ParsedArgs parsed = parse_args(args);
+
+  if (parsed.help) {
+    print_usage();
+    return 0;
+  }
+
+  if (parsed.invalid) {
+    RCUTILS_LOG_ERROR_NAMED("component_container", "%s", parsed.error_message.c_str());
+    print_usage();
+    return 1;
+  }
+
+  ExecutorType executor_type = parsed.executor_type;
+  bool isolated = parsed.isolated;
+
+  std::shared_ptr<rclcpp::Executor> exec = nullptr;
+  std::shared_ptr<rclcpp_components::ComponentManager> node = nullptr;
+
+  if (executor_type == ExecutorType::MultiThreaded) {
+    if (isolated) {
+      exec = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+      node = std::make_shared<rclcpp_components::ComponentManagerIsolated<rclcpp::executors::MultiThreadedExecutor>>();
+    } else {
+      node = std::make_shared<rclcpp_components::ComponentManager>();
+      if (node->has_parameter("thread_num")) {
+        const auto thread_num = node->get_parameter("thread_num").as_int();
+        exec = std::make_shared<rclcpp::executors::MultiThreadedExecutor>(
+          rclcpp::ExecutorOptions(), thread_num);
+      } else {
+        exec = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
+      }
+    }
+  } else if (executor_type == ExecutorType::Events) {
+    exec = std::make_shared<rclcpp::experimental::executors::EventsExecutor>();
+    node = std::make_shared<rclcpp_components::ComponentManager>();
+  } else {
+    exec = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    if (isolated) {
+      node = std::make_shared<rclcpp_components::ComponentManagerIsolated<rclcpp::executors::SingleThreadedExecutor>>();
+    } else {
+      node = std::make_shared<rclcpp_components::ComponentManager>();
+    }
+  }
+
+  node->set_executor(exec);
   exec->add_node(node);
   exec->spin();
 

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -109,7 +109,7 @@ print_usage()
     "       component_container --help|-h\n"
     "Defaults: single-threaded, non-isolated\n"
     "Examples: component_container --executor-type multi-threaded\n"
-    "          component_container --executor-type single-threaded --isolated\n");
+    "          component_container --executor-type single-threaded --isolated");
 }
 
 int main(int argc, char * argv[])

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -153,7 +153,7 @@ int main(int argc, char * argv[])
     num_threads < std::thread::hardware_concurrency())
   {
     RCUTILS_LOG_WARN_NAMED("component_container",
-      "num_threads is not supported by the SingleThreadedExecutor. Ignoring...");
+      "thread_num is not supported by the SingleThreadedExecutor. Ignoring...");
   }
   if (args.isolated) {
     // The outer executor runs only the container manager's load/unload services.

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -158,6 +158,12 @@ int main(int argc, char * argv[])
       "thread_num is not supported by the SingleThreadedExecutor. Ignoring...");
   }
   if (args.isolated) {
+    // we use the ComponentManager node initially to get the `thread_num` parameter,
+    // but temporarily delete it here before re-assigning it
+    // if running with a ComponentManagerIsolated.
+    // This is to avoid a possible race condition
+    // where the 2 nodes may be briefly alive at the same time,
+    node = nullptr;
     // The outer executor runs only the container manager's load/unload services.
     // Each loaded component gets its own dedicated executor of the requested type.
     exec = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -45,6 +45,7 @@ parse_executor_type(const std::string & arg)
 struct ParsedArgs
 {
   ExecutorType executor_type = ExecutorType::SingleThreaded;
+  int64_t num_threads = 0;
   bool isolated = false;
   bool help = false;
   bool invalid = false;
@@ -77,12 +78,20 @@ parse_args(const std::vector<std::string> & args)
         return parsed;
       }
       parsed.executor_type = option.value();
-      continue;
-    }
-
+    } else if (arg == "--num-threads") {
+      if (i + 1 >= args.size()) {
+        parsed.invalid = true;
+        parsed.error_message = "Missing value for --num-threads";
+        return parsed;
+      }
+      try {
+        parsed.num_threads = std::stol(args[++i]);
+      } catch (const std::exception &) {
     parsed.invalid = true;
-    parsed.error_message = "Unknown argument: " + arg;
+        parsed.error_message = "Invalid value for --num-threads: " + args[i];
     return parsed;
+      }
+    }
   }
 
   return parsed;

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -88,6 +88,22 @@ parse_args(const std::vector<std::string> & args)
   return parsed;
 }
 
+inline std::shared_ptr<rclcpp::Executor>
+make_executor(
+  ExecutorType type,
+  const rclcpp::ExecutorOptions & opts,
+  int64_t num_threads)
+{
+  switch (type) {
+    case ExecutorType::MultiThreaded:
+      return std::make_shared<rclcpp::executors::MultiThreadedExecutor>(opts, num_threads);
+    case ExecutorType::EventsCBG:
+      return std::make_shared<rclcpp::executors::EventsCBGExecutor>(opts, num_threads);
+    default:
+      return std::make_shared<rclcpp::executors::SingleThreadedExecutor>(opts);
+  }
+}
+
 void
 print_usage()
 {

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -144,12 +144,16 @@ int main(int argc, char * argv[])
   std::shared_ptr<rclcpp::Executor> exec;
   std::shared_ptr<rclcpp_components::ComponentManager> node = std::make_shared<rclcpp_components::ComponentManager>();
   const int64_t num_threads = (node->has_parameter("thread_num")) ?
-      node->get_parameter("thread_num").as_int() :
-      std::thread::hardware_concurrency();
+    node->get_parameter("thread_num").as_int() :
+    std::thread::hardware_concurrency();
   std::string debug_msg;
 
-  if (args.executor_type == ExecutorType::SingleThreaded && num_threads < std::thread::hardware_concurrency()) {
-    RCUTILS_LOG_WARN_NAMED("component_container", "num_threads is not supported by the SingleThreadedExecutor. Ignoring...");
+  if (args.executor_type == ExecutorType::SingleThreaded &&
+    num_threads > 0 &&
+    num_threads < std::thread::hardware_concurrency())
+  {
+    RCUTILS_LOG_WARN_NAMED("component_container",
+      "num_threads is not supported by the SingleThreadedExecutor. Ignoring...");
   }
   if (args.isolated) {
     // The outer executor runs only the container manager's load/unload services.
@@ -174,16 +178,17 @@ int main(int argc, char * argv[])
     }
 
     debug_msg = "Creating isolated component container with the following per-node settings: "
-    "executor_type: " + executor_type_to_string(args.executor_type);
+      "executor_type: " + executor_type_to_string(args.executor_type);
     if (args.executor_type != ExecutorType::SingleThreaded) {
-    debug_msg += ", num_threads: " + std::to_string(num_threads);
+      debug_msg += ", num_threads: " + std::to_string(num_threads);
     }
   } else {
     exec = make_executor(args.executor_type, rclcpp::ExecutorOptions(), num_threads);
 
-    debug_msg = "Creating non-isolated component container with executor_type: " + executor_type_to_string(args.executor_type);
+    debug_msg = "Creating non-isolated component container with executor_type: " +
+      executor_type_to_string(args.executor_type);
     if (args.executor_type != ExecutorType::SingleThreaded) {
-    debug_msg += ", num_threads: " + std::to_string(num_threads);
+      debug_msg += ", num_threads: " + std::to_string(num_threads);
     }
   }
 

--- a/rclcpp_components/src/component_container_event.cpp
+++ b/rclcpp_components/src/component_container_event.cpp
@@ -21,6 +21,10 @@
 
 int main(int argc, char * argv[])
 {
+  RCUTILS_LOG_WARN_NAMED("component_container_event",
+    "This executable is deprecated and will be removed in M-turtle.\n"
+    "Use 'component_container --executor-type events' instead.\n");
+
   /// Component container with an events executor.
   rclcpp::init(argc, argv);
   auto exec = std::make_shared<rclcpp::experimental::executors::EventsExecutor>();

--- a/rclcpp_components/src/component_container_event.cpp
+++ b/rclcpp_components/src/component_container_event.cpp
@@ -23,7 +23,7 @@ int main(int argc, char * argv[])
 {
   RCUTILS_LOG_WARN_NAMED("component_container_event",
     "This executable is deprecated and will be removed in M-turtle.\n"
-    "Use 'component_container --executor-type events' instead.");
+    "Use 'component_container --executor-type events-cbg' instead.");
 
   /// Component container with an events executor.
   rclcpp::init(argc, argv);

--- a/rclcpp_components/src/component_container_event.cpp
+++ b/rclcpp_components/src/component_container_event.cpp
@@ -23,7 +23,7 @@ int main(int argc, char * argv[])
 {
   RCUTILS_LOG_WARN_NAMED("component_container_event",
     "This executable is deprecated and will be removed in M-turtle.\n"
-    "Use 'component_container --executor-type events' instead.\n");
+    "Use 'component_container --executor-type events' instead.");
 
   /// Component container with an events executor.
   rclcpp::init(argc, argv);

--- a/rclcpp_components/src/component_container_isolated.cpp
+++ b/rclcpp_components/src/component_container_isolated.cpp
@@ -27,7 +27,8 @@ int main(int argc, char * argv[])
   RCUTILS_LOG_WARN_NAMED("component_container_isolated",
     "This executable is deprecated and will be removed in M-turtle.\n"
     "Use 'component_container --executor-type single-threaded --isolated' instead.\n"
-    "For a multi-threaded isolated setup, use 'component_container --executor-type multi-threaded --isolated'.");
+    "For a multi-threaded isolated setup,"
+    " use 'component_container --executor-type multi-threaded --isolated'.");
 
   /// Component container with dedicated single-threaded executors for each components.
   rclcpp::init(argc, argv);

--- a/rclcpp_components/src/component_container_isolated.cpp
+++ b/rclcpp_components/src/component_container_isolated.cpp
@@ -24,6 +24,11 @@
 
 int main(int argc, char * argv[])
 {
+  RCUTILS_LOG_WARN_NAMED("component_container_isolated",
+    "This executable is deprecated and will be removed in M-turtle.\n"
+    "Use 'component_container --executor-type single-threaded --isolated' instead.\n"
+    "For a multi-threaded isolated setup, use 'component_container --executor-type multi-threaded --isolated'.\n");
+
   /// Component container with dedicated single-threaded executors for each components.
   rclcpp::init(argc, argv);
   // parse arguments

--- a/rclcpp_components/src/component_container_isolated.cpp
+++ b/rclcpp_components/src/component_container_isolated.cpp
@@ -27,7 +27,7 @@ int main(int argc, char * argv[])
   RCUTILS_LOG_WARN_NAMED("component_container_isolated",
     "This executable is deprecated and will be removed in M-turtle.\n"
     "Use 'component_container --executor-type single-threaded --isolated' instead.\n"
-    "For a multi-threaded isolated setup, use 'component_container --executor-type multi-threaded --isolated'.\n");
+    "For a multi-threaded isolated setup, use 'component_container --executor-type multi-threaded --isolated'.");
 
   /// Component container with dedicated single-threaded executors for each components.
   rclcpp::init(argc, argv);

--- a/rclcpp_components/src/component_container_mt.cpp
+++ b/rclcpp_components/src/component_container_mt.cpp
@@ -22,7 +22,7 @@
 int main(int argc, char * argv[])
 {
   RCUTILS_LOG_WARN_NAMED("component_container_mt",
-    "This executable is deprecated and will be removed in M-turtle. "
+    "This executable is deprecated and will be removed in M-turtle.\n"
     "Use 'component_container --executor-type multi-threaded' instead.");
   /// Component container with a multi-threaded executor.
   rclcpp::init(argc, argv);

--- a/rclcpp_components/src/component_container_mt.cpp
+++ b/rclcpp_components/src/component_container_mt.cpp
@@ -21,6 +21,9 @@
 
 int main(int argc, char * argv[])
 {
+  RCUTILS_LOG_WARN_NAMED("component_container_mt",
+    "This executable is deprecated and will be removed in M-turtle. "
+    "Use 'component_container --executor-type multi-threaded' instead.");
   /// Component container with a multi-threaded executor.
   rclcpp::init(argc, argv);
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Refactors `component_container.cpp` to be the single entrypoint for launching component managers of all types.
 - CLI parsing of executor type and isolated mode
 - Added new constructor to `ComponentManagerIsolated` which consumes an `ExecutorOptions` and `num_threads`. these are stored in the class and used when spawning new nodes in isolated executors
 - Defaults to SingleThreadedExecutor in non-isolated mode
 - Adds support for the new Callback Group Events Executor introduced in https://github.com/ros2/rclcpp/pull/3097
 - Adds a debug message detailing what executor the component container was spawned with, if it's in isolated mode, and the number of threads if applicable

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

 When users use component_container_mt/component_container_event/component_container_isolated, they will see a warning message
When using component_container without any arguments, it will default to non isolated + single threaded, so users will probably not notice this change
Users will be able to use the Callback Group Events Executor in component containers
 Users will be able to specify the number of threads used for MT / CBG executors in isolated component containers, making the refactored executable more featureful than `component_container_isolated.cpp` which just uses the max possible threads for each isolated executor

### Did you use Generative AI?
@mini-1235 's changes were generated by github copilot. My subsequent changes were initially generated by Claude Sonnet 4.6, and then manually cleaned up afterwards.
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
Depends on https://github.com/ros2/rclcpp/pull/3097
Successor PR to https://github.com/ros2/rclcpp/pull/3129
Supersedes https://github.com/ros2/rclcpp/pull/3055
Companion PR which adds frontend tests to launch_ros: https://github.com/ros2/launch_ros/pull/536