### PR TITLE
Include EventsCBGExecutor

### DIFF
--- a/rclcpp/include/rclcpp/executors.hpp
+++ b/rclcpp/include/rclcpp/executors.hpp
@@ -21,6 +21,7 @@
 #include "rclcpp/executors/multi_threaded_executor.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
 #include "rclcpp/experimental/executors/events_executor/events_executor.hpp"
+#include "rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp"
 #include "rclcpp/node.hpp"
 #include "rclcpp/utilities.hpp"
 #include "rclcpp/visibility_control.hpp"
@@ -123,6 +124,7 @@ namespace executors
 
 using rclcpp::executors::MultiThreadedExecutor;
 using rclcpp::executors::SingleThreadedExecutor;
+using rclcpp::executors::EventsCBGExecutor;
 
 /// Spin (blocking) until the future is complete, it times out waiting, or rclcpp is interrupted.
 /**

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -74,10 +74,14 @@
  *   - rclcpp::executors::MultiThreadedExecutor
  *   - rclcpp::executors::MultiThreadedExecutor::add_node()
  *   - rclcpp::executors::MultiThreadedExecutor::spin()
+ *   - rclcpp::executors::EventsCBGExecutor
+ *   - rclcpp::executors::EventsCBGExecutor::add_node()
+ *   - rclcpp::executors::EventsCBGExecutor::spin()
  *   - rclcpp/executor.hpp
  *   - rclcpp/executors.hpp
  *   - rclcpp/executors/single_threaded_executor.hpp
  *   - rclcpp/executors/multi_threaded_executor.hpp
+ *   - rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp
  * - CallbackGroups (mechanism for enforcing concurrency rules for callbacks):
  *   - rclcpp::Node::create_callback_group()
  *   - rclcpp::CallbackGroup


### PR DESCRIPTION
## Description

Similar to other executors, this PR includes EventsCBGExecutor to executors.hpp and rclcpp.hpp


### Is this user-facing behavior change?

Yes, users should be able to find EventsCBGExecutor when including rclcpp.hpp now

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
