### PR TITLE
Initialize GenericClient result response offsets (backport #2790)

### DIFF
--- a/rclcpp_action/src/generic_client.cpp
+++ b/rclcpp_action/src/generic_client.cpp
@@ -420,8 +420,8 @@ GenericClient::make_result_aware(typename GenericClientGoalHandle::SharedPtr goa
         WrappedResult wrapped_result;
 
         // Get the offsets for the status and result fields
-        size_t status_offset;
-        size_t result_offset;
+        size_t status_offset{0};
+        size_t result_offset{0};
         for (uint32_t i = 0; i < result_service_response_type_members_->member_count_; i++) {
           if (!std::strcmp(result_service_response_type_members_->members_[i].name_, "result")) {
             result_offset = result_service_response_type_members_->members_[i].offset_;


### PR DESCRIPTION
## Summary

Fixes ros2/rclcpp#3128.

Backport of ros2/rclcpp#2790 to `jazzy`.

- Initialize `GenericClient` result response field offsets with `{0}`.
- Keep the patch scoped to the already-merged rolling/kilted fix.

### Did you use Generative AI?

Yes. I used OpenAI Codex (GPT-5) to help prepare this backport PR, including drafting the PR description and checking the backport diff. The code change itself is limited to the already-merged upstream fix from ros2/rclcpp#2790.

## Before / After

<details>
<summary>Before</summary>

Command:

```bash
git show upstream/jazzy:rclcpp_action/src/generic_client.cpp | sed -n '420,434p'
```

Output:

```text
        WrappedResult wrapped_result;

        // Get the offsets for the status and result fields
        size_t status_offset;
        size_t result_offset;
        for (uint32_t i = 0; i < result_service_response_type_members_->member_count_; i++) {
          if (!std::strcmp(result_service_response_type_members_->members_[i].name_, "result")) {
            result_offset = result_service_response_type_members_->members_[i].offset_;
            continue;
          }
          if (!std::strcmp(result_service_response_type_members_->members_[i].name_, "status")) {
            status_offset = result_service_response_type_members_->members_[i].offset_;
            continue;
          }
        }
```

</details>

<details>
<summary>After</summary>

Command:

```bash
git diff -- rclcpp_action/src/generic_client.cpp
```

Output:

```diff
diff --git a/rclcpp_action/src/generic_client.cpp b/rclcpp_action/src/generic_client.cpp
index a3f77206..e3a5a3ad 100644
--- a/rclcpp_action/src/generic_client.cpp
+++ b/rclcpp_action/src/generic_client.cpp
@@ -420,8 +420,8 @@ GenericClient::make_result_aware(typename GenericClientGoalHandle::SharedPtr goa
         WrappedResult wrapped_result;
 
         // Get the offsets for the status and result fields
-        size_t status_offset;
-        size_t result_offset;
+        size_t status_offset{0};
+        size_t result_offset{0};
         for (uint32_t i = 0; i < result_service_response_type_members_->member_count_; i++) {
           if (!std::strcmp(result_service_response_type_members_->members_[i].name_, "result")) {
             result_offset = result_service_response_type_members_->members_[i].offset_;
```

</details>

## Tests

Note: the local host is Ubuntu 22.04 and does not have a `/opt/ros/jazzy` binary underlay available. I validated this Jazzy backport with a Jazzy source overlay for `rcl`/`rclcpp` on the available Rolling underlay, with tests disabled for the dependency build.

Command:

```bash
env -i HOME=$HOME USER=$USER PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin bash -c 'source /opt/ros/rolling/setup.bash && colcon --log-base log_pr build --paths $WORKSPACE/public-oss/ros2-prs/deps/rcl-jazzy/rcl $WORKSPACE/public-oss/ros2-prs/deps/rcl-jazzy/rcl_action $WORKSPACE/public-oss/ros2-prs/deps/rcl-jazzy/rcl_lifecycle $WORKSPACE/public-oss/ros2-prs/deps/rcl-jazzy/rcl_yaml_param_parser rclcpp rclcpp_action --packages-up-to rclcpp_action --allow-overriding rcl rcl_action rcl_lifecycle rcl_yaml_param_parser rclcpp rclcpp_action --event-handlers console_direct+ --build-base build_pr --install-base install_pr --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=OFF -DCMAKE_CXX_FLAGS="-O2 -Wall -Wextra -Wmaybe-uninitialized"'
```

Result:

```text
Summary: 5 packages finished [0.79s]
```

Warning check:

```bash
rg -n "warning:" log_pr/build_*/**/stdout_stderr.log log_pr/build_*/**/stderr.log 2>/dev/null || true
```

Output:

```text
```
