### PR TITLE
node_parameters: reject non-finite values in floating-point range check

### DIFF
--- a/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_parameters.cpp
@@ -180,6 +180,9 @@ RCLCPP_LOCAL
 bool
 __are_doubles_equal(double x, double y, double ulp = 100.0)
 {
+  if (!std::isfinite(x) || !std::isfinite(y)) {
+    return x == y;
+  }
   return std::abs(x - y) <= std::numeric_limits<double>::epsilon() * std::abs(x + y) * ulp;
 }
 
@@ -234,7 +237,7 @@ __check_double_range(
   {
     return result;
   }
-  if ((value < fp_range.from_value) || (value > fp_range.to_value)) {
+  if (!(value >= fp_range.from_value && value <= fp_range.to_value)) {
     result.successful = false;
     result.reason = format_range_reason(descriptor.name, "floating point");
     return result;

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -1733,6 +1733,26 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     EXPECT_EQ(node->get_parameter(name).get_value<double>(), 11.0);
   }
   {
+    // setting a parameter to non-finite values with floating point range descriptor
+    auto name = "parameter"_unq;
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    descriptor.floating_point_range.resize(1);
+    auto & floating_point_range = descriptor.floating_point_range.at(0);
+    floating_point_range.from_value = 0.0;
+    floating_point_range.to_value = 100.0;
+    floating_point_range.step = 0.0;
+    node->declare_parameter(name, 50.0, descriptor);
+
+    constexpr double inf = std::numeric_limits<double>::infinity();
+    constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, inf)).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<double>(), 50.0);
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, -inf)).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<double>(), 50.0);
+    EXPECT_FALSE(node->set_parameter(rclcpp::Parameter(name, nan)).successful);
+    EXPECT_EQ(node->get_parameter(name).get_value<double>(), 50.0);
+  }
+  {
     // setting an array parameter with floating point range descriptor
     auto name = "parameter"_unq;
     rcl_interfaces::msg::ParameterDescriptor descriptor;
@@ -1969,7 +1989,7 @@ TEST_F(TestNode, set_parameter_undeclared_parameters_not_allowed) {
     RCPPUTILS_SCOPE_EXIT(
       {node->remove_pre_set_parameters_callback(handler.get());});  // always reset
   }
-}
+}  // NOLINT(readability/fn_size)
 
 TEST_F(TestNode, set_parameter_undeclared_parameters_allowed) {
   rclcpp::NodeOptions no;


### PR DESCRIPTION
## Description

Fixes #2898. `__check_double_range` accepted `+inf`, `-inf`, and `NaN` for parameters declared with a `floating_point_range`. Fix guards `__are_doubles_equal` against non-finite operands and rewrites the bound check so `NaN` is rejected.

### Is this user-facing behavior change?

Yes. `set_parameter` with `+inf`, `-inf`, or `NaN` on a parameter with a `floating_point_range` now returns `successful=false`.

### Did you use Generative AI?

Yes — Claude Opus 4.7.

### Additional Information

Adds a regression test in `test_node.cpp` for the three non-finite cases. The new scope block pushes the existing `TEST_F` over cpplint's 800-line limit, so a `// NOLINT(readability/fn_size)` is added on its closing brace — same pattern other ROS 2 packages use for this case.
