### PR TITLE
Add deprecation control macros and update MemoryStrategy class

### DIFF
--- a/rclcpp/include/rclcpp/deprecation_control.hpp
+++ b/rclcpp/include/rclcpp/deprecation_control.hpp
@@ -1,0 +1,59 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__DEPRECATION_CONTROL_HPP_
+#define RCLCPP__DEPRECATION_CONTROL_HPP_
+
+/*! \file deprecation_control.hpp
+ * \brief Cross-platform macros for marking declarations as deprecated.
+ *
+ * The C++14 standard attribute [[deprecated]] is correctly accepted by
+ * all major compilers when applied to functions, variables, type
+ * aliases, and enumerators. However, when applied to a class declaration
+ * that also carries a visibility/export macro (such as RCLCPP_PUBLIC),
+ * the accepted attribute placement differs between GCC, Clang, and MSVC,
+ * and no single placement of [[deprecated]] works on all three.
+ *
+ * These macros expand to the vendor-specific attribute syntax
+ * (__attribute__((deprecated(msg))) on GCC/Clang,
+ *  __declspec(deprecated(msg)) on MSVC), which can be placed immediately
+ * after the class-key alongside other vendor attributes in a consistent,
+ * portable way.
+ *
+ * Example:
+ * \code
+ *   class RCLCPP_PUBLIC
+ *         RCLCPP_DEPRECATED_WITH_MSG("Use NewClass instead") OldClass
+ *   {
+ *     // ...
+ *   };
+ * \endcode
+ *
+ * For functions, variables, and other declarations where the standard
+ * [[deprecated]] attribute works portably, prefer the standard attribute
+ * directly.
+ */
+
+#if defined(_MSC_VER)
+#  define RCLCPP_DEPRECATED            __declspec(deprecated)
+#  define RCLCPP_DEPRECATED_WITH_MSG(msg) __declspec(deprecated(msg))
+#elif defined(__GNUC__) || defined(__clang__)
+#  define RCLCPP_DEPRECATED            __attribute__((deprecated))
+#  define RCLCPP_DEPRECATED_WITH_MSG(msg) __attribute__((deprecated(msg)))
+#else
+#  define RCLCPP_DEPRECATED
+#  define RCLCPP_DEPRECATED_WITH_MSG(msg)
+#endif
+
+#endif  // RCLCPP__DEPRECATION_CONTROL_HPP_

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -26,6 +26,7 @@
 #include "rclcpp/macros.hpp"
 #include "rclcpp/node_interfaces/node_base_interface.hpp"
 #include "rclcpp/visibility_control.hpp"
+#include "rclcpp/deprecation_control.hpp"
 #include "rclcpp/waitable.hpp"
 
 namespace rclcpp
@@ -39,7 +40,7 @@ namespace memory_strategy
  * the rmw implementation after the executor waits for work, based on the number of entities that
  * come through.
  */
-class RCLCPP_PUBLIC [[deprecated("The executor does not used this anymore")]] MemoryStrategy
+class RCLCPP_PUBLIC RCLCPP_DEPRECATED_WITH_MSG("The executor does not used this anymore") MemoryStrategy
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(MemoryStrategy)


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Introduces a new deprecation_control.hpp header that provides cross-platform macros (RCLCPP_DEPRECATED and RCLCPP_DEPRECATED_WITH_MSG) for marking class declarations as deprecated, and updates MemoryStrategy to use them.

Background: The standard C++14 [[deprecated]] attribute works portably on functions, variables, and type aliases, but its placement on a class declaration that also carries a visibility macro (e.g., RCLCPP_PUBLIC) is inconsistent across GCC, Clang, and MSVC — no single placement satisfies all three compilers. This was exposed by #3136, which added [[deprecated(...)]] directly to MemoryStrategy.

[Minimize code verification](https://github.com/EricX-Zhao/rclcpp/actions/runs/25671778285)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
No behavioral change. Compiler deprecation warnings for MemoryStrategy now work correctly on MSVC in addition to GCC and Clang.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
With Claude Sonnet 4.6 via Claude Code.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
#3142 