### PR TITLE
chore: fix typo in test_time_source.cpp

### DIFF
--- a/rclcpp/test/rclcpp/test_time_source.cpp
+++ b/rclcpp/test/rclcpp/test_time_source.cpp
@@ -171,7 +171,7 @@ void set_use_sim_time_parameter(
     EXPECT_TRUE(result.successful);
   }
 
-  // Same as above - workaround for a little bit of asynchronus behavior.  The sim_time paramater
+  // Same as above - workaround for a little bit of asynchronus behavior.  The sim_time parameter
   // is set synchronously, but the way the ros clock gets notified involves a pub/sub that happens
   // AFTER the synchronous notification that the parameter was set.  This may also get fixed
   // upstream


### PR DESCRIPTION
## Description
Fixed a small typo (`paramater` -> `parameter`) in the comments of `test_time_source.cpp` to improve code readability.

### Is this user-facing behavior change?
No

### Did you use Generative AI?
No

### Additional Information