### PR TITLE
Fix expiration of action goals when EventsExecutors are used (Kilted backport)

### DIFF
--- a/rclcpp_action/include/rclcpp_action/server.hpp
+++ b/rclcpp_action/include/rclcpp_action/server.hpp
@@ -205,6 +205,10 @@ public:
     const rclcpp::QoS & qos_service_event_pub,
     rcl_service_introspection_state_t introspection_state);
 
+  RCLCPP_ACTION_PUBLIC
+  size_t
+  get_number_of_goal_handles();
+
 protected:
   RCLCPP_ACTION_PUBLIC
   ServerBase(

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -158,8 +158,8 @@ ServerBase::ServerBase(
   rcl_node_t * rcl_node = node_base->get_rcl_node_handle();
 
   std::function<void()> timer_callback = [this] () {
-    execute_check_expired_goals();
-  };
+      execute_check_expired_goals();
+    };
   pimpl_->expire_timer_ = std::make_shared<rclcpp::GenericTimer<decltype (timer_callback)>>(
       node_clock->get_clock(), std::chrono::nanoseconds(options.result_timeout.nanoseconds),
       std::move(timer_callback), node_base->get_context(), false);
@@ -637,6 +637,13 @@ ServerBase::execute_result_request_received(
       rclcpp::exceptions::throw_from_rcl_error(rcl_ret);
     }
   }
+}
+
+size_t
+ServerBase::get_number_of_goal_handles()
+{
+  std::lock_guard<std::recursive_mutex> lock(pimpl_->unordered_map_mutex_);
+  return pimpl_->goal_handles_.size();
 }
 
 void

--- a/rclcpp_action/src/server.cpp
+++ b/rclcpp_action/src/server.cpp
@@ -157,9 +157,9 @@ ServerBase::ServerBase(
 
   rcl_node_t * rcl_node = node_base->get_rcl_node_handle();
 
-  // This timer callback will never be called, we are only interested in
-  // weather the timer itself becomes ready or not.
-  std::function<void()> timer_callback = [] () {};
+  std::function<void()> timer_callback = [this] () {
+    execute_check_expired_goals();
+  };
   pimpl_->expire_timer_ = std::make_shared<rclcpp::GenericTimer<decltype (timer_callback)>>(
       node_clock->get_clock(), std::chrono::nanoseconds(options.result_timeout.nanoseconds),
       std::move(timer_callback), node_base->get_context(), false);

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -1049,10 +1049,8 @@ TEST_F(TestServer, goals_expired_with_events_executor)
   rclcpp::ExecutorOptions opts;
   opts.context = node->get_node_base_interface()->get_context();
 
-  rclcpp::experimental::executors::EventsQueue::UniquePtr events_queue =
-    std::make_unique<rclcpp::experimental::executors::SimpleEventsQueue>();
   rclcpp::experimental::executors::EventsExecutor executor
-    (std::move(events_queue), false, opts);
+    (std::make_unique<rclcpp::experimental::executors::SimpleEventsQueue>(), false, opts);
   executor.add_node(node);
   const std::vector<GoalUUID> uuids{
     {{1, 2, 3, 40, 5, 6, 70, 8, 9, 1, 11, 120, 13, 140, 15, 160}},

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -50,7 +50,8 @@ protected:
   send_goal_request(
     rclcpp::Node::SharedPtr node, GoalUUID uuid,
     rclcpp::Executor & executor,
-    std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
+    std::chrono::milliseconds timeout = std::chrono::milliseconds(-1),
+    bool executor_owns_node = false)
   {
     auto client = node->create_client<Fibonacci::Impl::SendGoalService>(
       "fibonacci/_action/send_goal");
@@ -60,7 +61,9 @@ protected:
     auto request = std::make_shared<Fibonacci::Impl::SendGoalService::Request>();
     request->goal_id.uuid = uuid;
     auto future = client->async_send_request(request);
-    auto return_code = rclcpp::executors::spin_node_until_future_complete(executor,
+    auto return_code = (executor_owns_node) ?
+      executor.spin_until_future_complete(future, timeout) :
+      rclcpp::executors::spin_node_until_future_complete(executor,
       node->get_node_base_interface(), future, timeout);
     if (rclcpp::FutureReturnCode::SUCCESS == return_code) {
       return request;
@@ -76,15 +79,19 @@ protected:
     rclcpp::Node::SharedPtr node, GoalUUID uuid,
     std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
   {
-    rclcpp::executors::SingleThreadedExecutor ex;
-    return send_goal_request(node, uuid, ex, timeout);
+    rclcpp::ExecutorOptions options;
+    options.context = node->get_node_base_interface()->get_context();
+    rclcpp::executors::SingleThreadedExecutor executor(options);
+    auto ret = send_goal_request(node, uuid, executor, timeout);
+    return ret;
   }
 
   CancelResponse::SharedPtr
   send_cancel_request(
     rclcpp::Node::SharedPtr node, GoalUUID uuid,
     rclcpp::Executor & executor,
-    std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
+    std::chrono::milliseconds timeout = std::chrono::milliseconds(-1),
+    bool executor_owns_node = false)
   {
     auto cancel_client = node->create_client<Fibonacci::Impl::CancelGoalService>(
       "fibonacci/_action/cancel_goal");
@@ -94,7 +101,9 @@ protected:
     auto request = std::make_shared<Fibonacci::Impl::CancelGoalService::Request>();
     request->goal_info.goal_id.uuid = uuid;
     auto future = cancel_client->async_send_request(request);
-    auto return_code = rclcpp::executors::spin_node_until_future_complete(executor,
+    auto return_code = (executor_owns_node) ?
+      executor.spin_until_future_complete(future, timeout) :
+      rclcpp::executors::spin_node_until_future_complete(executor,
       node->get_node_base_interface(), future, timeout);
     if (rclcpp::FutureReturnCode::SUCCESS == return_code) {
       return future.get();
@@ -110,8 +119,11 @@ protected:
     rclcpp::Node::SharedPtr node, GoalUUID uuid,
     std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
   {
-    rclcpp::executors::SingleThreadedExecutor ex;
-    return send_cancel_request(node, uuid, ex, timeout);
+    rclcpp::ExecutorOptions options;
+    options.context = node->get_node_base_interface()->get_context();
+    rclcpp::executors::SingleThreadedExecutor executor(options);
+    auto ret = send_cancel_request(node, uuid, executor, timeout);
+    return ret;
   }
 };
 
@@ -1028,17 +1040,17 @@ TEST_F(TestServer, deferred_execution)
 
 TEST_F(TestServer, goals_expired_with_events_executor)
 {
-
-  rclcpp::ExecutorOptions opts;
-
   // Because timer expiration was typically tied to the waitsets for
   // the SingleThreadedExecutor and MultiThreadedExecutor,
   // We specifically want to test with the EventsExecutor here
   // so we can verify the timer based goal expiration works
   // and expired goals are properly cleared.
+  auto node = std::make_shared<rclcpp::Node>("expire_goals", "/rclcpp_action/expire_goals");
+  rclcpp::ExecutorOptions opts;
+  opts.context = node->get_node_base_interface()->get_context();
 
   rclcpp::experimental::executors::EventsExecutor executor(opts);
-  auto node = std::make_shared<rclcpp::Node>("expire_goals", "/rclcpp_action/expire_goals");
+  executor.add_node(node);
   const std::vector<GoalUUID> uuids{
     {{1, 2, 3, 40, 5, 6, 70, 8, 9, 1, 11, 120, 13, 140, 15, 160}},
     {{10, 2, 3, 40, 50, 6, 70, 8, 9, 1, 11, 12, 13, 140, 15, 160}},
@@ -1078,7 +1090,8 @@ TEST_F(TestServer, goals_expired_with_events_executor)
 
 
   for (const auto & uuid : uuids) {
-    send_goal_request(node, uuid, executor);
+    constexpr bool owns_node {true};
+    send_goal_request(node, uuid, executor, std::chrono::milliseconds(-1), owns_node);
 
     EXPECT_TRUE(received_handle->is_active());
     EXPECT_TRUE(received_handle->is_executing());
@@ -1099,9 +1112,6 @@ TEST_F(TestServer, goals_expired_with_events_executor)
     received_handle->succeed(result);
 
     // Wait for the result request to be received
-
-    executor.add_node(node);
-
     ASSERT_EQ(
       rclcpp::FutureReturnCode::SUCCESS,
       executor.spin_until_future_complete(future));
@@ -1110,17 +1120,17 @@ TEST_F(TestServer, goals_expired_with_events_executor)
     EXPECT_EQ(action_msgs::msg::GoalStatus::STATUS_SUCCEEDED, response->status);
     EXPECT_EQ(result->sequence, response->result.sequence);
 
-    ASSERT_TRUE(as->get_number_of_goal_handles() != 0);
+    ASSERT_NE(as->get_number_of_goal_handles(), 0);
 
     // Wait for goal expiration
     rclcpp::sleep_for(2 * result_timeout);
 
     // Allow for expiration to take place
     executor.spin_some();
-    executor.remove_node(node);
   }
+  executor.remove_node(node);
 
-  ASSERT_TRUE(as->get_number_of_goal_handles() == 0);
+  ASSERT_EQ(as->get_number_of_goal_handles(), 0);
 }
 
 

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -1049,7 +1049,10 @@ TEST_F(TestServer, goals_expired_with_events_executor)
   rclcpp::ExecutorOptions opts;
   opts.context = node->get_node_base_interface()->get_context();
 
-  rclcpp::experimental::executors::EventsExecutor executor(opts);
+  rclcpp::experimental::executors::EventsQueue::UniquePtr events_queue =
+    std::make_unique<rclcpp::experimental::executors::SimpleEventsQueue>();
+  rclcpp::experimental::executors::EventsExecutor executor
+    (std::move(events_queue), false, opts);
   executor.add_node(node);
   const std::vector<GoalUUID> uuids{
     {{1, 2, 3, 40, 5, 6, 70, 8, 9, 1, 11, 120, 13, 140, 15, 160}},

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -49,6 +49,7 @@ protected:
   std::shared_ptr<Fibonacci::Impl::SendGoalService::Request>
   send_goal_request(
     rclcpp::Node::SharedPtr node, GoalUUID uuid,
+    rclcpp::Executor & executor,
     std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
   {
     auto client = node->create_client<Fibonacci::Impl::SendGoalService>(
@@ -59,7 +60,8 @@ protected:
     auto request = std::make_shared<Fibonacci::Impl::SendGoalService::Request>();
     request->goal_id.uuid = uuid;
     auto future = client->async_send_request(request);
-    auto return_code = rclcpp::spin_until_future_complete(node, future, timeout);
+    auto return_code = rclcpp::executors::spin_node_until_future_complete(executor,
+      node->get_node_base_interface(), future, timeout);
     if (rclcpp::FutureReturnCode::SUCCESS == return_code) {
       return request;
     } else if (rclcpp::FutureReturnCode::TIMEOUT == return_code) {
@@ -69,9 +71,19 @@ protected:
     }
   }
 
+  std::shared_ptr<Fibonacci::Impl::SendGoalService::Request>
+  send_goal_request(
+    rclcpp::Node::SharedPtr node, GoalUUID uuid,
+    std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
+  {
+    rclcpp::executors::SingleThreadedExecutor ex;
+    return send_goal_request(node, uuid, ex, timeout);
+  }
+
   CancelResponse::SharedPtr
   send_cancel_request(
     rclcpp::Node::SharedPtr node, GoalUUID uuid,
+    rclcpp::Executor & executor,
     std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
   {
     auto cancel_client = node->create_client<Fibonacci::Impl::CancelGoalService>(
@@ -82,7 +94,8 @@ protected:
     auto request = std::make_shared<Fibonacci::Impl::CancelGoalService::Request>();
     request->goal_info.goal_id.uuid = uuid;
     auto future = cancel_client->async_send_request(request);
-    auto return_code = rclcpp::spin_until_future_complete(node, future, timeout);
+    auto return_code = rclcpp::executors::spin_node_until_future_complete(executor,
+      node->get_node_base_interface(), future, timeout);
     if (rclcpp::FutureReturnCode::SUCCESS == return_code) {
       return future.get();
     } else if (rclcpp::FutureReturnCode::TIMEOUT == return_code) {
@@ -90,6 +103,15 @@ protected:
     } else {
       throw std::runtime_error("cancel request future didn't complete succesfully");
     }
+  }
+
+  CancelResponse::SharedPtr
+  send_cancel_request(
+    rclcpp::Node::SharedPtr node, GoalUUID uuid,
+    std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
+  {
+    rclcpp::executors::SingleThreadedExecutor ex;
+    return send_cancel_request(node, uuid, ex, timeout);
   }
 };
 
@@ -1003,6 +1025,104 @@ TEST_F(TestServer, deferred_execution)
   received_handle->execute();
   EXPECT_TRUE(received_handle->is_executing());
 }
+
+TEST_F(TestServer, goals_expired_with_events_executor)
+{
+
+  rclcpp::ExecutorOptions opts;
+
+  // Because timer expiration was typically tied to the waitsets for
+  // the SingleThreadedExecutor and MultiThreadedExecutor,
+  // We specifically want to test with the EventsExecutor here
+  // so we can verify the timer based goal expiration works
+  // and expired goals are properly cleared.
+
+  rclcpp::experimental::executors::EventsExecutor executor(opts);
+  auto node = std::make_shared<rclcpp::Node>("expire_goals", "/rclcpp_action/expire_goals");
+  const std::vector<GoalUUID> uuids{
+    {{1, 2, 3, 40, 5, 6, 70, 8, 9, 1, 11, 120, 13, 140, 15, 160}},
+    {{10, 2, 3, 40, 50, 6, 70, 8, 9, 1, 11, 12, 13, 140, 15, 160}},
+    {{12, 23, 34, 45, 50, 6, 70, 8, 9, 100, 11, 120, 13, 140, 15, 170}},
+    {{12, 23, 34, 45, 50, 6, 70, 8, 9, 100, 11, 120, 13, 140, 115, 16}}
+  };
+
+  auto handle_goal = [](
+    const GoalUUID &, std::shared_ptr<const Fibonacci::Goal>)
+    {
+      return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+    };
+
+  using GoalHandle = rclcpp_action::ServerGoalHandle<Fibonacci>;
+
+  auto handle_cancel = [](std::shared_ptr<GoalHandle>)
+    {
+      return rclcpp_action::CancelResponse::ACCEPT;
+    };
+
+  std::shared_ptr<GoalHandle> received_handle;
+  auto handle_accepted = [&received_handle](std::shared_ptr<GoalHandle> handle)
+    {
+      received_handle = handle;
+    };
+
+  const std::chrono::milliseconds result_timeout{25};
+
+  rcl_action_server_options_t options = rcl_action_server_get_default_options();
+  options.result_timeout.nanoseconds = RCL_MS_TO_NS(result_timeout.count());
+  auto as = rclcpp_action::create_server<Fibonacci>(
+    node, "fibonacci",
+    handle_goal,
+    handle_cancel,
+    handle_accepted,
+    options);
+
+
+  for (const auto & uuid : uuids) {
+    send_goal_request(node, uuid, executor);
+
+    EXPECT_TRUE(received_handle->is_active());
+    EXPECT_TRUE(received_handle->is_executing());
+
+    // Send result request
+    auto result_client = node->create_client<Fibonacci::Impl::GetResultService>(
+      "fibonacci/_action/get_result");
+    if (!result_client->wait_for_service(std::chrono::seconds(20))) {
+      throw std::runtime_error("get result service didn't become available");
+    }
+    auto request = std::make_shared<Fibonacci::Impl::GetResultService::Request>();
+    request->goal_id.uuid = uuid;
+    auto future = result_client->async_send_request(request);
+
+    // Send a result
+    auto result = std::make_shared<Fibonacci::Result>();
+    result->sequence = {5, 8, 13, 21};
+    received_handle->succeed(result);
+
+    // Wait for the result request to be received
+
+    executor.add_node(node);
+
+    ASSERT_EQ(
+      rclcpp::FutureReturnCode::SUCCESS,
+      executor.spin_until_future_complete(future));
+
+    auto response = future.get();
+    EXPECT_EQ(action_msgs::msg::GoalStatus::STATUS_SUCCEEDED, response->status);
+    EXPECT_EQ(result->sequence, response->result.sequence);
+
+    ASSERT_TRUE(as->get_number_of_goal_handles() != 0);
+
+    // Wait for goal expiration
+    rclcpp::sleep_for(2 * result_timeout);
+
+    // Allow for expiration to take place
+    executor.spin_some();
+    executor.remove_node(node);
+  }
+
+  ASSERT_TRUE(as->get_number_of_goal_handles() == 0);
+}
+
 
 class TestBasicServer : public TestServer
 {

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -1120,13 +1120,13 @@ TEST_F(TestServer, goals_expired_with_events_executor)
     EXPECT_EQ(action_msgs::msg::GoalStatus::STATUS_SUCCEEDED, response->status);
     EXPECT_EQ(result->sequence, response->result.sequence);
 
-    ASSERT_NE(as->get_number_of_goal_handles(), 0);
-
-    // Wait for goal expiration
-    rclcpp::sleep_for(2 * result_timeout);
-
-    // Allow for expiration to take place
-    executor.spin_some();
+    auto start = std::chrono::steady_clock::now();
+    while (as->get_number_of_goal_handles() != 0 &&
+      std::chrono::steady_clock::now() - start < std::chrono::seconds(5))
+    {
+      executor.spin_some();
+      rclcpp::sleep_for(std::chrono::milliseconds(10));
+    }
   }
   executor.remove_node(node);
 


### PR DESCRIPTION
Kilted-specific implementation of #3018 
From discussion at the Client Library WG, this fixes the EventsExecutor action goal expiration memory leak for Kilted by calling `execute_check_expired_goals` in `pimpl_->expire_timer_` on the rclcpp side.

In doing the fix this way to retain ABI compatibility, a side-effect of this fix is that there will now be an occasional extra call to `rcl_action_check_expired_goals` for all of the polling based executors.