### PR TITLE
Call rclcpp::shutdown() in the component containers

### DIFF
--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -205,5 +205,7 @@ int main(int argc, char * argv[])
   exec->add_node(node);
   exec->spin();
 
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/rclcpp_components/src/component_container_event.cpp
+++ b/rclcpp_components/src/component_container_event.cpp
@@ -32,5 +32,7 @@ int main(int argc, char * argv[])
   exec->add_node(node);
   exec->spin();
 
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/rclcpp_components/src/component_container_mt.cpp
+++ b/rclcpp_components/src/component_container_mt.cpp
@@ -40,5 +40,7 @@ int main(int argc, char * argv[])
   exec->add_node(node);
   exec->spin();
 
+  rclcpp::shutdown();
+
   return 0;
 }


### PR DESCRIPTION
## Description

ROS2 executables should call rclcpp::shutdown before exiting to avoid issues with some RMW, namely Zenoh. Explicitly call it in the component containers.

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No.
