### PR TITLE
Expose rosidl buffer backend metadata in TopicEndpointInfo

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
@@ -29,6 +29,8 @@
 #include "rcl/graph.h"
 #include "rcl/guard_condition.h"
 
+#include "rmw/impl/cpp/buffer_backend_metadata.hpp"
+
 #include "rclcpp/event.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/node_interfaces/detail/node_interfaces_helpers.hpp"
@@ -70,15 +72,8 @@ public:
 
     std::copy(info.endpoint_gid, info.endpoint_gid + RMW_GID_STORAGE_SIZE, endpoint_gid_.begin());
 
-    const char * current_key = rcutils_string_map_get_next_key(
-      &info.buffer_backend_metadata, nullptr);
-    while (current_key) {
-      const char * current_value = rcutils_string_map_get(
-        &info.buffer_backend_metadata, current_key);
-      buffer_backend_metadata_[current_key] = current_value ? current_value : "";
-      current_key = rcutils_string_map_get_next_key(
-        &info.buffer_backend_metadata, current_key);
-    }
+    buffer_backend_metadata_ =
+      rmw::impl::cpp::parse_buffer_backend_metadata(info.buffer_backend_metadata);
   }
 
   /// Get a mutable reference to the node name.

--- a/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_graph_interface.hpp
@@ -69,6 +69,16 @@ public:
     topic_type_ = info.topic_type;
 
     std::copy(info.endpoint_gid, info.endpoint_gid + RMW_GID_STORAGE_SIZE, endpoint_gid_.begin());
+
+    const char * current_key = rcutils_string_map_get_next_key(
+      &info.buffer_backend_metadata, nullptr);
+    while (current_key) {
+      const char * current_value = rcutils_string_map_get(
+        &info.buffer_backend_metadata, current_key);
+      buffer_backend_metadata_[current_key] = current_value ? current_value : "";
+      current_key = rcutils_string_map_get_next_key(
+        &info.buffer_backend_metadata, current_key);
+    }
   }
 
   /// Get a mutable reference to the node name.
@@ -141,6 +151,16 @@ public:
   const rosidl_type_hash_t &
   topic_type_hash() const;
 
+  /// Get a mutable reference to the buffer backend metadata.
+  RCLCPP_PUBLIC
+  std::map<std::string, std::string> &
+  buffer_backend_metadata();
+
+  /// Get a const reference to the buffer backend metadata.
+  RCLCPP_PUBLIC
+  const std::map<std::string, std::string> &
+  buffer_backend_metadata() const;
+
 private:
   std::string node_name_;
   std::string node_namespace_;
@@ -149,6 +169,7 @@ private:
   std::array<uint8_t, RMW_GID_STORAGE_SIZE> endpoint_gid_;
   rclcpp::QoS qos_profile_;
   rosidl_type_hash_t topic_type_hash_;
+  std::map<std::string, std::string> buffer_backend_metadata_;
 };
 
 /**

--- a/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
+++ b/rclcpp/src/rclcpp/node_interfaces/node_graph.cpp
@@ -956,6 +956,18 @@ rclcpp::TopicEndpointInfo::topic_type_hash() const
   return topic_type_hash_;
 }
 
+std::map<std::string, std::string> &
+rclcpp::TopicEndpointInfo::buffer_backend_metadata()
+{
+  return buffer_backend_metadata_;
+}
+
+const std::map<std::string, std::string> &
+rclcpp::TopicEndpointInfo::buffer_backend_metadata() const
+{
+  return buffer_backend_metadata_;
+}
+
 std::string &
 rclcpp::ServiceEndpointInfo::node_name()
 {


### PR DESCRIPTION
## Description

Expose buffer backend metadata through `rclcpp::TopicEndpointInfo`.

This lets C++ users of `get_publishers_info_by_topic()` and `get_subscriptions_info_by_topic()` access backend support metadata provided by the RMW graph.

### Is this user-facing behavior change?

Yes. C++ graph introspection code can now read rosidl buffer backend support information from topic endpoint info.

### Did you use Generative AI?

Yes. GPT-5.5 in Cursor was used to help draft changes in this pull request.

### Additional Information

Depending on:
- https://github.com/ros2/rmw/pull/419