### PR TITLE
Fix O(N²) entity addition in CallbackGroup (#2942)

### DIFF
--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -258,11 +258,11 @@ protected:
   // Mutex to protect the subsequent vectors of pointers.
   mutable std::mutex mutex_;
   std::atomic_bool associated_with_executor_;
-  std::vector<rclcpp::SubscriptionBase::WeakPtr> subscription_ptrs_;
-  std::vector<rclcpp::TimerBase::WeakPtr> timer_ptrs_;
-  std::vector<rclcpp::ServiceBase::WeakPtr> service_ptrs_;
-  std::vector<rclcpp::ClientBase::WeakPtr> client_ptrs_;
-  std::vector<rclcpp::Waitable::WeakPtr> waitable_ptrs_;
+  mutable std::vector<rclcpp::SubscriptionBase::WeakPtr> subscription_ptrs_;
+  mutable std::vector<rclcpp::TimerBase::WeakPtr> timer_ptrs_;
+  mutable std::vector<rclcpp::ServiceBase::WeakPtr> service_ptrs_;
+  mutable std::vector<rclcpp::ClientBase::WeakPtr> client_ptrs_;
+  mutable std::vector<rclcpp::Waitable::WeakPtr> waitable_ptrs_;
   std::atomic_bool can_be_taken_from_;
   const bool automatically_add_to_executor_with_node_;
   // defer the creation of the guard condition

--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -183,7 +183,7 @@ public:
     const std::function<void(const rclcpp::ServiceBase::SharedPtr &)> & service_func,
     const std::function<void(const rclcpp::ClientBase::SharedPtr &)> & client_func,
     const std::function<void(const rclcpp::TimerBase::SharedPtr &)> & timer_func,
-    const std::function<void(const rclcpp::Waitable::SharedPtr &)> & waitable_func) const;
+    const std::function<void(const rclcpp::Waitable::SharedPtr &)> & waitable_func);
 
   /// Return a reference to the 'associated with executor' atomic boolean.
   /**
@@ -258,11 +258,11 @@ protected:
   // Mutex to protect the subsequent vectors of pointers.
   mutable std::mutex mutex_;
   std::atomic_bool associated_with_executor_;
-  mutable std::vector<rclcpp::SubscriptionBase::WeakPtr> subscription_ptrs_;
-  mutable std::vector<rclcpp::TimerBase::WeakPtr> timer_ptrs_;
-  mutable std::vector<rclcpp::ServiceBase::WeakPtr> service_ptrs_;
-  mutable std::vector<rclcpp::ClientBase::WeakPtr> client_ptrs_;
-  mutable std::vector<rclcpp::Waitable::WeakPtr> waitable_ptrs_;
+  std::vector<rclcpp::SubscriptionBase::WeakPtr> subscription_ptrs_;
+  std::vector<rclcpp::TimerBase::WeakPtr> timer_ptrs_;
+  std::vector<rclcpp::ServiceBase::WeakPtr> service_ptrs_;
+  std::vector<rclcpp::ClientBase::WeakPtr> client_ptrs_;
+  std::vector<rclcpp::Waitable::WeakPtr> waitable_ptrs_;
   std::atomic_bool can_be_taken_from_;
   const bool automatically_add_to_executor_with_node_;
   // defer the creation of the guard condition

--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -67,6 +67,30 @@ CallbackGroup::size() const
     waitable_ptrs_.size();
 }
 
+namespace
+{
+/// Iterate a vector of weak pointers, call func for each live entry,
+/// and compact expired entries out of the vector in a single pass.
+template<typename T, typename Func>
+void collect_and_compact(
+  std::vector<typename T::WeakPtr> & ptrs,
+  const Func & func)
+{
+  size_t write_idx = 0;
+  for (size_t read_idx = 0; read_idx < ptrs.size(); ++read_idx) {
+    auto ref_ptr = ptrs[read_idx].lock();
+    if (ref_ptr) {
+      func(ref_ptr);
+      if (write_idx != read_idx) {
+        ptrs[write_idx] = std::move(ptrs[read_idx]);
+      }
+      ++write_idx;
+    }
+  }
+  ptrs.resize(write_idx);
+}
+}  // namespace
+
 void CallbackGroup::collect_all_ptrs(
   const std::function<void(const rclcpp::SubscriptionBase::SharedPtr &)> & sub_func,
   const std::function<void(const rclcpp::ServiceBase::SharedPtr &)> & service_func,
@@ -76,40 +100,11 @@ void CallbackGroup::collect_all_ptrs(
 {
   std::lock_guard<std::mutex> lock(mutex_);
 
-  for (const rclcpp::SubscriptionBase::WeakPtr & weak_ptr : subscription_ptrs_) {
-    rclcpp::SubscriptionBase::SharedPtr ref_ptr = weak_ptr.lock();
-    if (ref_ptr) {
-      sub_func(ref_ptr);
-    }
-  }
-
-  for (const rclcpp::ServiceBase::WeakPtr & weak_ptr : service_ptrs_) {
-    rclcpp::ServiceBase::SharedPtr ref_ptr = weak_ptr.lock();
-    if (ref_ptr) {
-      service_func(ref_ptr);
-    }
-  }
-
-  for (const rclcpp::ClientBase::WeakPtr & weak_ptr : client_ptrs_) {
-    rclcpp::ClientBase::SharedPtr ref_ptr = weak_ptr.lock();
-    if (ref_ptr) {
-      client_func(ref_ptr);
-    }
-  }
-
-  for (const rclcpp::TimerBase::WeakPtr & weak_ptr : timer_ptrs_) {
-    rclcpp::TimerBase::SharedPtr ref_ptr = weak_ptr.lock();
-    if (ref_ptr) {
-      timer_func(ref_ptr);
-    }
-  }
-
-  for (const rclcpp::Waitable::WeakPtr & weak_ptr : waitable_ptrs_) {
-    rclcpp::Waitable::SharedPtr ref_ptr = weak_ptr.lock();
-    if (ref_ptr) {
-      waitable_func(ref_ptr);
-    }
-  }
+  collect_and_compact<rclcpp::SubscriptionBase>(subscription_ptrs_, sub_func);
+  collect_and_compact<rclcpp::ServiceBase>(service_ptrs_, service_func);
+  collect_and_compact<rclcpp::ClientBase>(client_ptrs_, client_func);
+  collect_and_compact<rclcpp::TimerBase>(timer_ptrs_, timer_func);
+  collect_and_compact<rclcpp::Waitable>(waitable_ptrs_, waitable_func);
 }
 
 std::atomic_bool &
@@ -153,12 +148,6 @@ CallbackGroup::add_subscription(
 {
   std::lock_guard<std::mutex> lock(mutex_);
   subscription_ptrs_.push_back(subscription_ptr);
-  subscription_ptrs_.erase(
-    std::remove_if(
-      subscription_ptrs_.begin(),
-      subscription_ptrs_.end(),
-      [](const rclcpp::SubscriptionBase::WeakPtr & x) {return x.expired();}),
-    subscription_ptrs_.end());
 }
 
 void
@@ -166,12 +155,6 @@ CallbackGroup::add_timer(const rclcpp::TimerBase::SharedPtr & timer_ptr)
 {
   std::lock_guard<std::mutex> lock(mutex_);
   timer_ptrs_.push_back(timer_ptr);
-  timer_ptrs_.erase(
-    std::remove_if(
-      timer_ptrs_.begin(),
-      timer_ptrs_.end(),
-      [](const rclcpp::TimerBase::WeakPtr & x) {return x.expired();}),
-    timer_ptrs_.end());
 }
 
 void
@@ -179,12 +162,6 @@ CallbackGroup::add_service(const rclcpp::ServiceBase::SharedPtr & service_ptr)
 {
   std::lock_guard<std::mutex> lock(mutex_);
   service_ptrs_.push_back(service_ptr);
-  service_ptrs_.erase(
-    std::remove_if(
-      service_ptrs_.begin(),
-      service_ptrs_.end(),
-      [](const rclcpp::ServiceBase::WeakPtr & x) {return x.expired();}),
-    service_ptrs_.end());
 }
 
 void
@@ -192,12 +169,6 @@ CallbackGroup::add_client(const rclcpp::ClientBase::SharedPtr & client_ptr)
 {
   std::lock_guard<std::mutex> lock(mutex_);
   client_ptrs_.push_back(client_ptr);
-  client_ptrs_.erase(
-    std::remove_if(
-      client_ptrs_.begin(),
-      client_ptrs_.end(),
-      [](const rclcpp::ClientBase::WeakPtr & x) {return x.expired();}),
-    client_ptrs_.end());
 }
 
 void
@@ -205,12 +176,6 @@ CallbackGroup::add_waitable(const rclcpp::Waitable::SharedPtr & waitable_ptr)
 {
   std::lock_guard<std::mutex> lock(mutex_);
   waitable_ptrs_.push_back(waitable_ptr);
-  waitable_ptrs_.erase(
-    std::remove_if(
-      waitable_ptrs_.begin(),
-      waitable_ptrs_.end(),
-      [](const rclcpp::Waitable::WeakPtr & x) {return x.expired();}),
-    waitable_ptrs_.end());
 }
 
 void

--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -67,44 +67,74 @@ CallbackGroup::size() const
     waitable_ptrs_.size();
 }
 
-namespace
-{
-/// Iterate a vector of weak pointers, call func for each live entry,
-/// and compact expired entries out of the vector in a single pass.
-template<typename T, typename Func>
-void collect_and_compact(
-  std::vector<typename T::WeakPtr> & ptrs,
-  const Func & func)
-{
-  size_t write_idx = 0;
-  for (size_t read_idx = 0; read_idx < ptrs.size(); ++read_idx) {
-    auto ref_ptr = ptrs[read_idx].lock();
-    if (ref_ptr) {
-      func(ref_ptr);
-      if (write_idx != read_idx) {
-        ptrs[write_idx] = std::move(ptrs[read_idx]);
-      }
-      ++write_idx;
-    }
-  }
-  ptrs.resize(write_idx);
-}
-}  // namespace
-
 void CallbackGroup::collect_all_ptrs(
   const std::function<void(const rclcpp::SubscriptionBase::SharedPtr &)> & sub_func,
   const std::function<void(const rclcpp::ServiceBase::SharedPtr &)> & service_func,
   const std::function<void(const rclcpp::ClientBase::SharedPtr &)> & client_func,
   const std::function<void(const rclcpp::TimerBase::SharedPtr &)> & timer_func,
-  const std::function<void(const rclcpp::Waitable::SharedPtr &)> & waitable_func) const
+  const std::function<void(const rclcpp::Waitable::SharedPtr &)> & waitable_func)
 {
   std::lock_guard<std::mutex> lock(mutex_);
 
-  collect_and_compact<rclcpp::SubscriptionBase>(subscription_ptrs_, sub_func);
-  collect_and_compact<rclcpp::ServiceBase>(service_ptrs_, service_func);
-  collect_and_compact<rclcpp::ClientBase>(client_ptrs_, client_func);
-  collect_and_compact<rclcpp::TimerBase>(timer_ptrs_, timer_func);
-  collect_and_compact<rclcpp::Waitable>(waitable_ptrs_, waitable_func);
+  for (const auto & weak_ptr : subscription_ptrs_) {
+    auto ref_ptr = weak_ptr.lock();
+    if (ref_ptr) {
+      sub_func(ref_ptr);
+    }
+  }
+  subscription_ptrs_.erase(
+    std::remove_if(
+      subscription_ptrs_.begin(), subscription_ptrs_.end(),
+      [](const auto & w) {return w.expired();}),
+    subscription_ptrs_.end());
+
+  for (const auto & weak_ptr : service_ptrs_) {
+    auto ref_ptr = weak_ptr.lock();
+    if (ref_ptr) {
+      service_func(ref_ptr);
+    }
+  }
+  service_ptrs_.erase(
+    std::remove_if(
+      service_ptrs_.begin(), service_ptrs_.end(),
+      [](const auto & w) {return w.expired();}),
+    service_ptrs_.end());
+
+  for (const auto & weak_ptr : client_ptrs_) {
+    auto ref_ptr = weak_ptr.lock();
+    if (ref_ptr) {
+      client_func(ref_ptr);
+    }
+  }
+  client_ptrs_.erase(
+    std::remove_if(
+      client_ptrs_.begin(), client_ptrs_.end(),
+      [](const auto & w) {return w.expired();}),
+    client_ptrs_.end());
+
+  for (const auto & weak_ptr : timer_ptrs_) {
+    auto ref_ptr = weak_ptr.lock();
+    if (ref_ptr) {
+      timer_func(ref_ptr);
+    }
+  }
+  timer_ptrs_.erase(
+    std::remove_if(
+      timer_ptrs_.begin(), timer_ptrs_.end(),
+      [](const auto & w) {return w.expired();}),
+    timer_ptrs_.end());
+
+  for (const auto & weak_ptr : waitable_ptrs_) {
+    auto ref_ptr = weak_ptr.lock();
+    if (ref_ptr) {
+      waitable_func(ref_ptr);
+    }
+  }
+  waitable_ptrs_.erase(
+    std::remove_if(
+      waitable_ptrs_.begin(), waitable_ptrs_.end(),
+      [](const auto & w) {return w.expired();}),
+    waitable_ptrs_.end());
 }
 
 std::atomic_bool &

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -36,6 +36,10 @@ if(TARGET test_exceptions)
   target_link_libraries(test_exceptions ${PROJECT_NAME} mimick)
 endif()
 
+ament_add_ros_isolated_gtest(test_callback_group_entity_cleanup test_callback_group_entity_cleanup.cpp)
+if(TARGET test_callback_group_entity_cleanup)
+  target_link_libraries(test_callback_group_entity_cleanup ${PROJECT_NAME} ${test_msgs_TARGETS})
+endif()
 ament_add_ros_isolated_gtest(test_allocator_memory_strategy strategies/test_allocator_memory_strategy.cpp)
 if(TARGET test_allocator_memory_strategy)
   target_link_libraries(test_allocator_memory_strategy ${PROJECT_NAME} rcpputils::rcpputils test_msgs::test_msgs)
@@ -437,6 +441,11 @@ ament_add_ros_isolated_gtest(test_time_source test_time_source.cpp
   APPEND_LIBRARY_DIRS "${append_library_dirs}")
 if(TARGET test_time_source)
   target_link_libraries(test_time_source ${PROJECT_NAME} rcl::rcl)
+endif()
+ament_add_ros_isolated_gtest(test_time_source_deadlock test_time_source_deadlock.cpp
+  TIMEOUT 60)
+if(TARGET test_time_source_deadlock)
+  target_link_libraries(test_time_source_deadlock ${PROJECT_NAME})
 endif()
 
 ament_add_ros_isolated_gtest(test_utilities test_utilities.cpp

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -442,12 +442,6 @@ ament_add_ros_isolated_gtest(test_time_source test_time_source.cpp
 if(TARGET test_time_source)
   target_link_libraries(test_time_source ${PROJECT_NAME} rcl::rcl)
 endif()
-ament_add_ros_isolated_gtest(test_time_source_deadlock test_time_source_deadlock.cpp
-  TIMEOUT 60)
-if(TARGET test_time_source_deadlock)
-  target_link_libraries(test_time_source_deadlock ${PROJECT_NAME})
-endif()
-
 ament_add_ros_isolated_gtest(test_utilities test_utilities.cpp
   APPEND_LIBRARY_DIRS "${append_library_dirs}")
 ament_add_test_label(test_utilities mimick)

--- a/rclcpp/test/rclcpp/test_callback_group_entity_cleanup.cpp
+++ b/rclcpp/test/rclcpp/test_callback_group_entity_cleanup.cpp
@@ -182,7 +182,7 @@ TEST_F(TestCallbackGroupEntityCleanup, add_many_timers_is_not_quadratic)
   // With O(N²) the old code took ~429ms for 10K timers.
   // With O(N) we expect < 100ms for 5K timers even on slow CI.
   // Use a generous threshold to avoid flakiness.
-  EXPECT_LT(ms, 5000) << "Adding " << N << " timers took " << ms
+  EXPECT_LT(ms, 5000)  << "Adding " << N << " timers took " << ms
                        << "ms — possible quadratic regression";
 }
 
@@ -215,7 +215,7 @@ TEST_F(TestCallbackGroupEntityCleanup, interleaved_add_remove_cycles)
     [](const rclcpp::SubscriptionBase::SharedPtr &) {},
     [](const rclcpp::ServiceBase::SharedPtr &) {},
     [](const rclcpp::ClientBase::SharedPtr &) {},
-    [&live](const rclcpp::TimerBase::SharedPtr &) { ++live; },
+    [&live](const rclcpp::TimerBase::SharedPtr &) {++live;},
     [](const rclcpp::Waitable::SharedPtr &) {});
 
   EXPECT_EQ(live, timers.size());

--- a/rclcpp/test/rclcpp/test_callback_group_entity_cleanup.cpp
+++ b/rclcpp/test/rclcpp/test_callback_group_entity_cleanup.cpp
@@ -1,0 +1,264 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Integration tests for CallbackGroup entity cleanup.
+ *
+ * Verifies that expired weak_ptr entries are properly cleaned up when
+ * cleanup is deferred to collect_all_ptrs (instead of running on every
+ * add_* call).
+ */
+
+#include <chrono>
+#include <memory>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "rclcpp/rclcpp.hpp"
+#include "test_msgs/msg/empty.hpp"
+#include "test_msgs/srv/empty.hpp"
+
+using namespace std::chrono_literals;
+
+class TestCallbackGroupEntityCleanup : public ::testing::Test
+{
+public:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
+
+  void SetUp() override
+  {
+    node_ = std::make_shared<rclcpp::Node>("test_node", "/test_ns");
+  }
+
+  void TearDown() override
+  {
+    node_.reset();
+  }
+
+  /// Trigger collect_all_ptrs to run cleanup on the given callback group.
+  void trigger_collection(rclcpp::CallbackGroup::SharedPtr cbg)
+  {
+    cbg->collect_all_ptrs(
+      [](const rclcpp::SubscriptionBase::SharedPtr &) {},
+      [](const rclcpp::ServiceBase::SharedPtr &) {},
+      [](const rclcpp::ClientBase::SharedPtr &) {},
+      [](const rclcpp::TimerBase::SharedPtr &) {},
+      [](const rclcpp::Waitable::SharedPtr &) {});
+  }
+
+  rclcpp::Node::SharedPtr node_;
+};
+
+/// After adding and then destroying timers, collect_all_ptrs should
+/// compact the expired entries, reducing size().
+TEST_F(TestCallbackGroupEntityCleanup, expired_timers_cleaned_on_collect)
+{
+  auto cbg = node_->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
+
+  // Add 100 timers
+  std::vector<rclcpp::TimerBase::SharedPtr> timers;
+  for (int i = 0; i < 100; ++i) {
+    timers.push_back(node_->create_wall_timer(1h, []() {}, cbg));
+  }
+  EXPECT_EQ(cbg->size(), 100u);
+
+  // Destroy half the timers (the weak_ptrs in the callback group expire)
+  timers.erase(timers.begin(), timers.begin() + 50);
+
+  // Before collection, size() still reports 100 (expired entries remain)
+  EXPECT_EQ(cbg->size(), 100u);
+
+  // Trigger collect_all_ptrs — should compact expired entries
+  trigger_collection(cbg);
+
+  // After collection, only the 50 live timers should remain
+  EXPECT_EQ(cbg->size(), 50u);
+}
+
+/// After adding and destroying subscriptions, collect_all_ptrs should
+/// compact the expired entries.  Each subscription may register
+/// additional entities (e.g. event waitables), so we use relative sizes.
+TEST_F(TestCallbackGroupEntityCleanup, expired_subscriptions_cleaned_on_collect)
+{
+  auto cbg = node_->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
+
+  std::vector<rclcpp::SubscriptionBase::SharedPtr> subs;
+  for (int i = 0; i < 20; ++i) {
+    rclcpp::SubscriptionOptions opts;
+    opts.callback_group = cbg;
+    subs.push_back(
+      node_->create_subscription<test_msgs::msg::Empty>(
+        "topic_" + std::to_string(i), 10,
+        [](test_msgs::msg::Empty::ConstSharedPtr) {}, opts));
+  }
+  const size_t size_with_all = cbg->size();
+  EXPECT_GT(size_with_all, 0u);
+
+  // Destroy all subscriptions — expired entries remain until collection
+  subs.clear();
+  EXPECT_EQ(cbg->size(), size_with_all);
+
+  trigger_collection(cbg);
+
+  EXPECT_EQ(cbg->size(), 0u);  // all cleaned up
+}
+
+/// collect_all_ptrs should only yield live entities and skip expired ones.
+TEST_F(TestCallbackGroupEntityCleanup, collect_only_yields_live_entities)
+{
+  auto cbg = node_->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
+
+  // Add 10 timers
+  std::vector<rclcpp::TimerBase::SharedPtr> timers;
+  for (int i = 0; i < 10; ++i) {
+    timers.push_back(node_->create_wall_timer(1h, []() {}, cbg));
+  }
+
+  // Destroy odd-indexed timers (0-based: 1, 3, 5, 7, 9)
+  for (int i = 9; i >= 1; i -= 2) {
+    timers.erase(timers.begin() + i);
+  }
+  ASSERT_EQ(timers.size(), 5u);
+
+  // Collect and count live timers
+  size_t collected_count = 0;
+  cbg->collect_all_ptrs(
+    [](const rclcpp::SubscriptionBase::SharedPtr &) {},
+    [](const rclcpp::ServiceBase::SharedPtr &) {},
+    [](const rclcpp::ClientBase::SharedPtr &) {},
+    [&collected_count](const rclcpp::TimerBase::SharedPtr &) {
+      ++collected_count;
+    },
+    [](const rclcpp::Waitable::SharedPtr &) {});
+
+  EXPECT_EQ(collected_count, 5u);
+  EXPECT_EQ(cbg->size(), 5u);  // compacted
+}
+
+/// Adding many entities should not exhibit quadratic slowdown.
+/// This test adds N timers and asserts the time is well under the
+/// quadratic threshold.
+TEST_F(TestCallbackGroupEntityCleanup, add_many_timers_is_not_quadratic)
+{
+  auto cbg = node_->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
+
+  const size_t N = 5000;
+  std::vector<rclcpp::TimerBase::SharedPtr> timers;
+  timers.reserve(N);
+
+  auto start = std::chrono::steady_clock::now();
+  for (size_t i = 0; i < N; ++i) {
+    timers.push_back(node_->create_wall_timer(1h, []() {}, cbg));
+  }
+  auto elapsed = std::chrono::steady_clock::now() - start;
+  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
+
+  EXPECT_EQ(cbg->size(), N);
+
+  // With O(N²) the old code took ~429ms for 10K timers.
+  // With O(N) we expect < 100ms for 5K timers even on slow CI.
+  // Use a generous threshold to avoid flakiness.
+  EXPECT_LT(ms, 5000) << "Adding " << N << " timers took " << ms
+                       << "ms — possible quadratic regression";
+}
+
+/// After interleaved add/remove cycles, collect_all_ptrs should
+/// report exactly the live entities.
+TEST_F(TestCallbackGroupEntityCleanup, interleaved_add_remove_cycles)
+{
+  auto cbg = node_->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
+
+  std::vector<rclcpp::TimerBase::SharedPtr> timers;
+
+  // Cycle 1: add 20, remove 10
+  for (int i = 0; i < 20; ++i) {
+    timers.push_back(node_->create_wall_timer(1h, []() {}, cbg));
+  }
+  timers.erase(timers.begin(), timers.begin() + 10);
+
+  // Cycle 2: add 30 more
+  for (int i = 0; i < 30; ++i) {
+    timers.push_back(node_->create_wall_timer(1h, []() {}, cbg));
+  }
+
+  // Cycle 3: remove 15
+  timers.erase(timers.begin(), timers.begin() + 15);
+
+  // Trigger cleanup
+  size_t live = 0;
+  cbg->collect_all_ptrs(
+    [](const rclcpp::SubscriptionBase::SharedPtr &) {},
+    [](const rclcpp::ServiceBase::SharedPtr &) {},
+    [](const rclcpp::ClientBase::SharedPtr &) {},
+    [&live](const rclcpp::TimerBase::SharedPtr &) { ++live; },
+    [](const rclcpp::Waitable::SharedPtr &) {});
+
+  EXPECT_EQ(live, timers.size());
+  EXPECT_EQ(cbg->size(), timers.size());
+}
+
+/// Mixed entity types: timers + subscriptions, verify independent cleanup.
+/// Subscriptions may register extra entities (event waitables), so we
+/// track relative sizes.
+TEST_F(TestCallbackGroupEntityCleanup, mixed_entity_types_cleanup)
+{
+  auto cbg = node_->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
+
+  // Add timers and subscriptions
+  std::vector<rclcpp::TimerBase::SharedPtr> timers;
+  std::vector<rclcpp::SubscriptionBase::SharedPtr> subs;
+  const int N = 10;
+  for (int i = 0; i < N; ++i) {
+    timers.push_back(node_->create_wall_timer(1h, []() {}, cbg));
+  }
+  const size_t size_timers_only = cbg->size();
+  EXPECT_EQ(size_timers_only, static_cast<size_t>(N));
+
+  for (int i = 0; i < N; ++i) {
+    rclcpp::SubscriptionOptions opts;
+    opts.callback_group = cbg;
+    subs.push_back(
+      node_->create_subscription<test_msgs::msg::Empty>(
+        "mix_topic_" + std::to_string(i), 10,
+        [](test_msgs::msg::Empty::ConstSharedPtr) {}, opts));
+  }
+  const size_t size_both = cbg->size();
+  const size_t sub_entities = size_both - size_timers_only;
+  EXPECT_GT(sub_entities, 0u);
+
+  // Destroy all timers, keep subscriptions
+  timers.clear();
+  trigger_collection(cbg);
+  EXPECT_EQ(cbg->size(), sub_entities);
+
+  // Destroy all subscriptions
+  subs.clear();
+  trigger_collection(cbg);
+  EXPECT_EQ(cbg->size(), 0u);
+}


### PR DESCRIPTION
Fixes #2942

The `add_*` methods (`add_timer`, `add_subscription`, `add_service`, `add_client`, `add_waitable`) scanned the whole entity list to drop expired `weak_ptr`s on every call, so adding N entities was O(N²). In the #2942 reproducer (10,000 timers) that scan is ~96% of the wall time.

This moves the expired-entry cleanup out of the `add_*` methods — which become a plain `push_back` — and into `collect_all_ptrs`, which already walks every entry on each executor spin and so can compact in the same pass at no extra cost (erase/`remove_if`). `collect_all_ptrs` is now non-`const`; there's no public API or ABI change.

It's safe because `collect_all_ptrs` already skipped expired entries and now also removes them, the executor calls it every spin so cleanup stays prompt, and the `find_*_ptrs_if` helpers already tolerate expired `weak_ptr`s.

Reproducer from #2942 (10,000 timers): 429 ms → 6 ms.

Adds `test_callback_group_entity_cleanup.cpp` covering compaction during `collect_all_ptrs`, live-only collection, non-quadratic insertion, interleaved add/remove, and mixed entity types.

---
Some of this change was produced with Claude Opus 4.6 (Anthropic).
