### PR TITLE
Fix topic statistics source collision for multiple subscriptions

### DIFF
--- a/rclcpp/include/rclcpp/create_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_subscription.hpp
@@ -92,7 +92,9 @@ create_subscription(
 
     subscription_topic_stats =
       std::make_shared<rclcpp::topic_statistics::SubscriptionTopicStatistics>(
-      node_topics_interface->get_node_base_interface()->get_name(), publisher);
+        node_topics_interface->get_node_base_interface()->get_name(),
+        topic_name,
+        publisher);
 
     std::weak_ptr<
       rclcpp::topic_statistics::SubscriptionTopicStatistics

--- a/rclcpp/include/rclcpp/create_subscription.hpp
+++ b/rclcpp/include/rclcpp/create_subscription.hpp
@@ -92,7 +92,7 @@ create_subscription(
 
     subscription_topic_stats =
       std::make_shared<rclcpp::topic_statistics::SubscriptionTopicStatistics>(
-        node_topics_interface->get_node_base_interface()->get_name(),
+        node_topics_interface->get_node_base_interface()->get_fully_qualified_name(),
         topic_name,
         publisher);
 

--- a/rclcpp/include/rclcpp/topic_statistics/subscription_topic_statistics.hpp
+++ b/rclcpp/include/rclcpp/topic_statistics/subscription_topic_statistics.hpp
@@ -62,16 +62,18 @@ public:
    * measure, and publish topic statistics data. This throws an invalid_argument
    * if the input publisher is null.
    *
-   * \param node_name the name of the node, which created this instance, in order to denote
-   * topic source
+   * \param node_name the name of the node which created this instance
+   * \param topic_name the name of the subscribed topic, used to uniquely
+   * identify statistics sources for multiple subscriptions in the same node
    * \param publisher instance constructed by the node in order to publish statistics data.
    * This class owns the publisher.
    * \throws std::invalid_argument if publisher pointer is nullptr
    */
   SubscriptionTopicStatistics(
     const std::string & node_name,
+    const std::string & topic_name,
     rclcpp::Publisher<statistics_msgs::msg::MetricsMessage>::SharedPtr publisher)
-  : node_name_(node_name),
+  : node_name_(node_name + "/" + topic_name),
     publisher_(std::move(publisher))
   {
     // TODO(dbbonnie): ros-tooling/aws-roadmap/issues/226, received message age

--- a/rclcpp/include/rclcpp/topic_statistics/subscription_topic_statistics.hpp
+++ b/rclcpp/include/rclcpp/topic_statistics/subscription_topic_statistics.hpp
@@ -73,7 +73,7 @@ public:
     const std::string & node_name,
     const std::string & topic_name,
     rclcpp::Publisher<statistics_msgs::msg::MetricsMessage>::SharedPtr publisher)
-  : node_name_(node_name + "/" + topic_name),
+  : measurement_source_name_(node_name + "/" + topic_name),
     publisher_(std::move(publisher))
   {
     // TODO(dbbonnie): ros-tooling/aws-roadmap/issues/226, received message age
@@ -132,7 +132,7 @@ public:
         collector->ClearCurrentMeasurements();
 
         auto message = libstatistics_collector::collector::GenerateStatisticMessage(
-          node_name_,
+          measurement_source_name_,
           collector->GetMetricName(),
           collector->GetMetricUnit(),
           window_start_,
@@ -223,7 +223,7 @@ private:
   /// Collection of statistics collectors
   std::vector<std::unique_ptr<TopicStatsCollector>> subscriber_statistics_collectors_{};
   /// Node name used to generate topic statistics messages to be published
-  const std::string node_name_;
+  const std::string measurement_source_name_;
   /// Publisher, created by the node, used to publish topic statistics messages
   rclcpp::Publisher<statistics_msgs::msg::MetricsMessage>::SharedPtr publisher_;
   /// Timer which fires the publisher

--- a/rclcpp/test/rclcpp/topic_statistics/test_subscription_topic_statistics.cpp
+++ b/rclcpp/test/rclcpp/topic_statistics/test_subscription_topic_statistics.cpp
@@ -83,7 +83,7 @@ public:
     const std::string & node_name,
     const std::string & topic_name,
     rclcpp::Publisher<statistics_msgs::msg::MetricsMessage>::SharedPtr publisher)
-  : SubscriptionTopicStatistics<CallbackMessageT>(
+  : SubscriptionTopicStatistics(
       node_name, topic_name, publisher)
   {
   }
@@ -492,8 +492,15 @@ TEST_F(TestSubscriptionTopicStatisticsFixture, test_multiple_subscriptions_diffe
   constexpr const char kTopicB[]{"/test_topic_b"};
   constexpr const uint64_t kNumStatsMessages{4};
 
-  auto pub_a = std::make_shared<EmptyPublisher>("pub_node_a", kTopicA);
-  auto pub_b = std::make_shared<EmptyPublisher>("pub_node_b", kTopicB);
+  auto pub_a = std::make_shared<PublisherNode<Empty>>(
+    "pub_node_a",
+    kTopicA,
+    std::chrono::milliseconds{100});
+
+  auto pub_b = std::make_shared<PublisherNode<Empty>>(
+    "pub_node_b",
+    kTopicB,
+    std::chrono::milliseconds{100});
 
   auto multi_sub_node = std::make_shared<rclcpp::Node>("multi_sub_node");
 

--- a/rclcpp/test/rclcpp/topic_statistics/test_subscription_topic_statistics.cpp
+++ b/rclcpp/test/rclcpp/topic_statistics/test_subscription_topic_statistics.cpp
@@ -81,8 +81,10 @@ class TestSubscriptionTopicStatistics : public SubscriptionTopicStatistics
 public:
   TestSubscriptionTopicStatistics(
     const std::string & node_name,
+    const std::string & topic_name,
     rclcpp::Publisher<statistics_msgs::msg::MetricsMessage>::SharedPtr publisher)
-  : SubscriptionTopicStatistics(node_name, std::move(publisher))
+  : SubscriptionTopicStatistics<CallbackMessageT>(
+      node_name, topic_name, publisher)
   {
   }
 
@@ -291,6 +293,7 @@ TEST_F(TestSubscriptionTopicStatisticsFixture, test_manual_construction)
   // Construct a separate instance
   auto sub_topic_stats = std::make_unique<TestSubscriptionTopicStatistics>(
     empty_subscriber->get_name(),
+    "/test_topic",
     topic_stats_publisher);
 
   // Expect no data has been collected / no samples received
@@ -477,4 +480,82 @@ TEST_F(TestSubscriptionTopicStatisticsFixture, test_stats_with_intra_process_com
 
   EXPECT_EQ(kNumExpectedMessageAgeMessages, message_age_count);
   EXPECT_EQ(kNumExpectedMessagePeriodMessages, message_period_count);
+}
+/**
+ * Test that multiple subscriptions on the same node produce differentiated
+ * measurement_source_name values in their statistics messages.
+ * Regression test for #2756.
+ */
+TEST_F(TestSubscriptionTopicStatisticsFixture, test_multiple_subscriptions_differentiated)
+{
+  constexpr const char kTopicA[]{"/test_topic_a"};
+  constexpr const char kTopicB[]{"/test_topic_b"};
+  constexpr const uint64_t kNumStatsMessages{4};
+
+  auto pub_a = std::make_shared<EmptyPublisher>("pub_node_a", kTopicA);
+  auto pub_b = std::make_shared<EmptyPublisher>("pub_node_b", kTopicB);
+
+  auto multi_sub_node = std::make_shared<rclcpp::Node>("multi_sub_node");
+
+  auto options = rclcpp::SubscriptionOptions();
+  options.topic_stats_options.state = rclcpp::TopicStatisticsState::Enable;
+  options.topic_stats_options.publish_period = defaultStatisticsPublishPeriod;
+
+  auto cb = [](Empty::UniquePtr msg) {(void) msg;};
+
+  auto sub_a = multi_sub_node->create_subscription<Empty>(
+    kTopicA,
+    rclcpp::QoS(rclcpp::KeepAll()),
+    std::function<void(Empty::UniquePtr)>(cb),
+    options);
+
+  auto sub_b = multi_sub_node->create_subscription<Empty>(
+    kTopicB,
+    rclcpp::QoS(rclcpp::KeepAll()),
+    std::function<void(Empty::UniquePtr)>(cb),
+    options);
+
+  auto stats_listener =
+    std::make_shared<rclcpp::topic_statistics::MetricsMessageSubscriber>(
+    "multi_sub_stats_listener",
+    "/statistics",
+    kNumStatsMessages);
+
+  rclcpp::executors::SingleThreadedExecutor ex;
+  ex.add_node(pub_a);
+  ex.add_node(pub_b);
+  ex.add_node(multi_sub_node);
+  ex.add_node(stats_listener);
+
+  ex.spin_until_future_complete(stats_listener->GetFuture(), kTestTimeout);
+
+  const auto received_messages = stats_listener->GetReceivedMessages();
+  ASSERT_GE(received_messages.size(), kNumStatsMessages);
+
+  std::set<std::string> source_names;
+  for (const auto & msg : received_messages) {
+    source_names.insert(msg.measurement_source_name);
+  }
+
+  bool found_topic_a = false;
+  bool found_topic_b = false;
+
+  for (const auto & name : source_names) {
+    if (name.find("test_topic_a") != std::string::npos) {
+      found_topic_a = true;
+    }
+
+    if (name.find("test_topic_b") != std::string::npos) {
+      found_topic_b = true;
+    }
+  }
+
+  EXPECT_TRUE(found_topic_a)
+    << "No stats found containing topic_a in source name";
+
+  EXPECT_TRUE(found_topic_b)
+    << "No stats found containing topic_b in source name";
+
+  EXPECT_GT(source_names.size(), 1u)
+    << "Both subscriptions produced the same measurement_source_name";
 }


### PR DESCRIPTION
## Description

When topic statistics are enabled for multiple subscriptions within the same node,
all statistics messages currently use the same `measurement_source_name`
because `SubscriptionTopicStatistics` only uses the node name when constructing
the source identifier.

This makes it difficult to determine which subscription produced a particular
statistics message when a node subscribes to multiple topics.

This PR addresses the issue by including the subscribed topic name in the
statistics source identifier. The resulting identifier is constructed as
`node_name/topic_name`, allowing statistics from different subscriptions within
the same node to be distinguished.

Changes included in this PR:

- Update `SubscriptionTopicStatistics` to accept the subscribed topic name.
- Construct the statistics source identifier using both the node name and topic name.
- Update the subscription creation path to pass the topic name when topic statistics are enabled.
- Update existing tests affected by the constructor change.
- Add a regression test (`test_multiple_subscriptions_differentiated`) to verify that statistics generated by multiple subscriptions in the same node have distinct source identifiers.

Fixes #2756

### Is this user-facing behavior change?

Yes.

When topic statistics are enabled, statistics messages published on
`/statistics` will now contain unique `measurement_source_name` values for
different subscriptions within the same node. This makes it possible to
correctly identify which subscription produced a given statistics message.

### Did you use Generative AI?

Yes.

I used ChatGPT (GPT-5.5) to assist with investigating the issue, discussing
possible implementation approaches, reviewing code changes, and drafting parts
of the regression test and PR description. All code changes, testing, and final
content were reviewed and validated manually.

### Additional Information

A similar fix was initially proposed for the Humble branch, but it could not be
merged because the required constructor change introduces an API change that is
not suitable for a stable release. This PR targets the Rolling branch, where
such changes are permitted.