### PR TITLE
Fixed MSVC compile errors (backport #3135)

### DIFF
--- a/rclcpp/include/rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp
@@ -139,6 +139,7 @@ public:
   void
   spin(const std::function<void(const std::exception &)> & exception_handler);
 
+  RCLCPP_PUBLIC
   void
   spin_once(std::chrono::nanoseconds timeout = std::chrono::nanoseconds(-1)) override;
 
@@ -149,10 +150,12 @@ public:
   /**
    * @return true if work was available and executed
    */
+  RCLCPP_PUBLIC
   bool collect_and_execute_ready_events(
     std::chrono::nanoseconds max_duration,
     bool recollect_if_no_work_available);
 
+  RCLCPP_PUBLIC
   void
   spin_all(std::chrono::nanoseconds max_duration) override;
 
@@ -240,6 +243,7 @@ protected:
   void
   run(size_t this_thread_number, bool block_initially);
 
+  RCLCPP_PUBLIC
   void
   run(
     size_t this_thread_number,
@@ -290,6 +294,7 @@ private:
    */
   void trigger_callback_group_sync();
 
+  RCLCPP_PUBLIC
   void spin_once_internal(std::chrono::nanoseconds timeout);
 
   RCLCPP_DISABLE_COPY(EventsCBGExecutor)

--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/timer_manager.hpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/timer_manager.hpp
@@ -297,7 +297,7 @@ private:
    */
   bool remove_if_dropped(const TimerData * timer_data)
   {
-    if (timer_data->rcl_ref.unique()) {
+    if (timer_data->rcl_ref.use_count() == 1) {
       // clear on reset callback
       if(rcl_timer_set_on_reset_callback(timer_data->rcl_ref.get(), nullptr,
           nullptr) != RCL_RET_OK)


### PR DESCRIPTION
## Description

`EventsCBGExecutor` was backported to jazzy by #3163 without the `RCLCPP_PUBLIC` making `rclcpp` fail to link on Windows.

This  PR cherry-picks #3135, which:
  - adds `RCLCPP_PUBLIC` 
  - replaces the deprecated `std::shared_ptr::unique()` with `use_count() == 1`

### Is this user-facing behavior change?

The export additions are additive. The other change is internal

### Did you use Generative AI?

No
