### PR TITLE
Adding nolint to node_main.cpp.in to skip lint check

### DIFF
--- a/rclcpp_components/src/node_main.cpp.in
+++ b/rclcpp_components/src/node_main.cpp.in
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// NOLINTBEGIN
+
 #include <algorithm>
 #include <memory>
 #include <string>
@@ -79,3 +81,5 @@ int main(int argc, char * argv[])
 
   return 0;
 }
+
+// NOLINTEND


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

As ament_cmake_clang_tidy checks the generated node_main code, the test fails even if the user writes appropriate code. This PR fixes the issue by adding `// NOLINTBEGIN` and `// NOLINTEND`  in `node_main.cpp.in` .

Related PR 

- https://github.com/ament/ament_lint/pull/583

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->


<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
