### PR TITLE
Check for association with an executor before removing nodes in ComponentManager

### DIFF
--- a/rclcpp_components/src/component_manager.cpp
+++ b/rclcpp_components/src/component_manager.cpp
@@ -83,7 +83,10 @@ ComponentManager::~ComponentManager()
     RCLCPP_DEBUG(get_logger(), "Removing components from executor");
     if (auto exec = executor_.lock()) {
       for (auto & wrapper : node_wrappers_) {
-        exec->remove_node(wrapper.second.get_node_base_interface());
+        auto node_interface = wrapper.second.get_node_base_interface();
+        if (node_interface->get_associated_with_executor_atomic().load()) {
+          exec->remove_node(node_interface);
+        }
       }
     }
   }

--- a/rclcpp_components/test/test_component_manager_api.cpp
+++ b/rclcpp_components/test/test_component_manager_api.cpp
@@ -374,10 +374,29 @@ TEST_F(TestComponentManager, components_api)
   }
 }
 
+// Test fixture for the component manager which exercises node removal like on
+// shutdown. EventsCBGExecutor::shutdown() is protected, so this is to
+// reproduce its effect (dropping every node from the executor while the manager
+// still tracks them in node_wrappers_)
+class DoubleRemoveComponentManager : public rclcpp_components::ComponentManager
+{
+public:
+  using rclcpp_components::ComponentManager::ComponentManager;
+
+  void remove_all_nodes_from_executor()
+  {
+    if (auto exec = executor_.lock()) {
+      for (auto & wrapper : node_wrappers_) {
+        exec->remove_node(wrapper.second.get_node_base_interface());
+      }
+    }
+  }
+};
+
 TEST_F(TestComponentManager, no_throw_remove_node_twice_on_shutdown)
 {
   auto exec = std::make_shared<rclcpp::executors::EventsCBGExecutor>();
-  auto manager = std::make_shared<rclcpp_components::ComponentManager>(exec);
+  auto manager = std::make_shared<DoubleRemoveComponentManager>(exec);
   auto client_node = rclcpp::Node::make_shared("test_component_manager_3186");
 
   exec->add_node(manager);
@@ -398,7 +417,7 @@ TEST_F(TestComponentManager, no_throw_remove_node_twice_on_shutdown)
   ASSERT_TRUE(future.get()->success);
 
   // the executor removes all of its nodes on shutdown
-  exec->shutdown();
+  manager->remove_all_nodes_from_executor();
 
   // ComponentManager may remove the same node again
   EXPECT_NO_THROW(manager.reset());

--- a/rclcpp_components/test/test_component_manager_api.cpp
+++ b/rclcpp_components/test/test_component_manager_api.cpp
@@ -418,7 +418,5 @@ TEST_F(TestComponentManager, no_throw_remove_node_twice_on_shutdown)
 
   // the executor removes all of its nodes on shutdown
   manager->remove_all_nodes_from_executor();
-
-  // ComponentManager may remove the same node again
   EXPECT_NO_THROW(manager.reset());
 }

--- a/rclcpp_components/test/test_component_manager_api.cpp
+++ b/rclcpp_components/test/test_component_manager_api.cpp
@@ -22,6 +22,7 @@
 #include "composition_interfaces/srv/unload_node.hpp"
 #include "composition_interfaces/srv/list_nodes.hpp"
 
+#include "rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp"
 #include "rclcpp_components/component_manager.hpp"
 #include "rclcpp_components/component_manager_isolated.hpp"
 
@@ -371,4 +372,34 @@ TEST_F(TestComponentManager, components_api)
     SCOPED_TRACE("ComponentManagerIsolated");
     test_components_api(true);
   }
+}
+
+TEST_F(TestComponentManager, no_throw_remove_node_twice_on_shutdown)
+{
+  auto exec = std::make_shared<rclcpp::executors::EventsCBGExecutor>();
+  auto manager = std::make_shared<rclcpp_components::ComponentManager>(exec);
+  auto client_node = rclcpp::Node::make_shared("test_component_manager_3186");
+
+  exec->add_node(manager);
+  exec->add_node(client_node);
+
+  auto composition_client = client_node->create_client<composition_interfaces::srv::LoadNode>(
+    "/ComponentManager/_container/load_node");
+  ASSERT_TRUE(composition_client->wait_for_service(20s)) << "service not available after waiting";
+
+  // Load a component so the manager tracks a node that is associated with the
+  // executor (~ComponentManager only removes nodes when node_wrappers_ is
+  // non-empty).
+  auto request = std::make_shared<composition_interfaces::srv::LoadNode::Request>();
+  request->package_name = "rclcpp_components";
+  request->plugin_name = "test_rclcpp_components::TestComponentFoo";
+  auto future = composition_client->async_send_request(request);
+  ASSERT_EQ(exec->spin_until_future_complete(future, 5s), rclcpp::FutureReturnCode::SUCCESS);
+  ASSERT_TRUE(future.get()->success);
+
+  // the executor removes all of its nodes on shutdown
+  exec->shutdown();
+
+  // ComponentManager may remove the same node again
+  EXPECT_NO_THROW(manager.reset());
 }


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
This PR changes the destructor of `component_manager` to check each node it's removing for if it is already associated with an executor. 

A regression test has also been added to `test_component_manager_api` in rclcpp_components, which asserts that an exception isn't thrown during the double-removal case as outlined in #3186 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #3186 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
- Users will no longer get an exception on shutdown when using component managers with the callback group events executor

### Did you use Generative AI?
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
Claude Opus 4.8
### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
