### PR TITLE
Deprecate the experimental EventsExecutor

### DIFF
--- a/rclcpp/include/rclcpp/experimental/executors/events_executor/events_executor.hpp
+++ b/rclcpp/include/rclcpp/experimental/executors/events_executor/events_executor.hpp
@@ -56,7 +56,11 @@ namespace executors
  * executor.spin();
  * executor.remove_node(node);
  */
-class EventsExecutor : public rclcpp::Executor
+class
+[[deprecated(
+    "rclcpp::experimental::executors::EventsExecutor is deprecated and will be removed in "
+    "m-turtle. use rclcpp::executors::EventsCBGExecutor in single-threaded mode instead")]]
+EventsExecutor : public rclcpp::Executor
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(EventsExecutor)

--- a/rclcpp/src/rclcpp/experimental/executors/events_executor/events_executor.cpp
+++ b/rclcpp/src/rclcpp/experimental/executors/events_executor/events_executor.cpp
@@ -18,9 +18,13 @@
 #include <utility>
 #include <vector>
 
+#include "rcpputils/compile_warnings.hpp"
 #include "rcpputils/scope_exit.hpp"
 
 using namespace std::chrono_literals;
+
+// Disable deprecation warnings while maintaining the EventsExecutor
+RCPPUTILS_DEPRECATION_WARNING_OFF_START
 
 using rclcpp::experimental::executors::EventsExecutor;
 
@@ -454,3 +458,5 @@ EventsExecutor::add_notify_waitable_to_collection(
     {this->notify_waitable_, weak_group_ptr}
   });
 }
+
+RCPPUTILS_DEPRECATION_WARNING_OFF_STOP

--- a/rclcpp/test/rclcpp/executors/executor_types.hpp
+++ b/rclcpp/test/rclcpp/executors/executor_types.hpp
@@ -20,10 +20,15 @@
 #include <string>
 #include <type_traits>
 
+#include "rcpputils/compile_warnings.hpp"
+
 #include "rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp"
 #include "rclcpp/experimental/executors/events_executor/events_executor.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
 #include "rclcpp/executors/multi_threaded_executor.hpp"
+
+// Disable deprecation warnings while maintaining the EventsExecutor
+RCPPUTILS_DEPRECATION_WARNING_OFF_START
 
 using ExecutorTypes =
   ::testing::Types<
@@ -64,5 +69,7 @@ using StandardExecutors =
   rclcpp::executors::MultiThreadedExecutor,
   rclcpp::executors::EventsCBGExecutor,
   rclcpp::experimental::executors::EventsExecutor>;
+
+RCPPUTILS_DEPRECATION_WARNING_OFF_STOP
 
 #endif  // RCLCPP__EXECUTORS__EXECUTOR_TYPES_HPP_

--- a/rclcpp/test/rclcpp/executors/test_events_executor.cpp
+++ b/rclcpp/test/rclcpp/executors/test_events_executor.cpp
@@ -21,8 +21,13 @@
 #include "rclcpp/experimental/executors/events_executor/events_executor.hpp"
 #include "rclcpp/node.hpp"
 
+#include "rcpputils/compile_warnings.hpp"
+
 #include "test_msgs/srv/empty.hpp"
 #include "test_msgs/msg/empty.hpp"
+
+// Disable deprecation warnings while maintaining the EventsExecutor
+RCPPUTILS_DEPRECATION_WARNING_OFF_START
 
 using namespace std::chrono_literals;
 
@@ -672,3 +677,5 @@ TEST_F(TestEventsExecutor, keep_all_transient_local_receives_cached_message)
        "rmw_subscription_set_on_new_message_callback where unread_count "
        "is incorrectly clipped to depth=0 for KEEP_ALL history.";
 }
+
+RCPPUTILS_DEPRECATION_WARNING_OFF_STOP

--- a/rclcpp/test/rclcpp/executors/test_executors_warmup.cpp
+++ b/rclcpp/test/rclcpp/executors/test_executors_warmup.cpp
@@ -26,6 +26,8 @@
 #include <type_traits>
 #include <utility>
 
+#include "rcpputils/compile_warnings.hpp"
+
 #include "rclcpp/rclcpp.hpp"
 
 #include "test_msgs/msg/empty.hpp"
@@ -146,11 +148,13 @@ TYPED_TEST(TestExecutorsWarmup, spin_some_doesnt_require_warmup)
   // TODO(alsora): currently only the events-executor passes this test.
   // Enable single-threaded and multi-threaded executors
   // when https://github.com/ros2/rclcpp/pull/2595 gets merged
+  RCPPUTILS_DEPRECATION_WARNING_OFF_START
   if (
     !std::is_same<ExecutorType, rclcpp::experimental::executors::EventsExecutor>())
   {
     GTEST_SKIP();
   }
+  RCPPUTILS_DEPRECATION_WARNING_OFF_STOP
 
   ExecutorType executor;
 
@@ -191,11 +195,13 @@ TYPED_TEST(TestExecutorsWarmup, spin_some_doesnt_require_warmup_with_cbgroup)
   // TODO(alsora): currently only the events-executor passes this test.
   // Enable single-threaded and multi-threaded executors
   // when https://github.com/ros2/rclcpp/pull/2595 gets merged
+  RCPPUTILS_DEPRECATION_WARNING_OFF_START
   if (
     !std::is_same<ExecutorType, rclcpp::experimental::executors::EventsExecutor>())
   {
     GTEST_SKIP();
   }
+  RCPPUTILS_DEPRECATION_WARNING_OFF_STOP
 
   ExecutorType executor;
 

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -46,10 +46,11 @@ protected:
     rclcpp::shutdown();
   }
 
+  template<typename ExecutorType>
   std::shared_ptr<Fibonacci::Impl::SendGoalService::Request>
   send_goal_request(
     rclcpp::Node::SharedPtr node, GoalUUID uuid,
-    rclcpp::Executor & executor,
+    ExecutorType & executor,
     std::chrono::milliseconds timeout = std::chrono::milliseconds(-1),
     bool executor_owns_node = false)
   {

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -1067,7 +1067,7 @@ TEST_F(TestServer, goals_expired_with_events_executor)
   rclcpp::ExecutorOptions opts;
   opts.context = node->get_node_base_interface()->get_context();
 
-  rclcpp::experimental::executors::EventsExecutor executor(opts);
+  rclcpp::executors::EventsCBGExecutor executor(opts, 1);
   executor.add_node(node);
   const std::vector<GoalUUID> uuids{
     {{1, 2, 3, 40, 5, 6, 70, 8, 9, 1, 11, 120, 13, 140, 15, 160}},

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -1132,7 +1132,7 @@ TEST_F(TestServer, goals_expired_with_events_executor)
     // Wait for the result request to be received
     ASSERT_EQ(
       rclcpp::FutureReturnCode::SUCCESS,
-      executor.spin_until_future_complete(future));
+      executor.spin_until_future_complete(future, std::chrono::seconds(20)));
 
     auto response = future.get();
     EXPECT_EQ(action_msgs::msg::GoalStatus::STATUS_SUCCEEDED, response->status);

--- a/rclcpp_components/src/component_container_event.cpp
+++ b/rclcpp_components/src/component_container_event.cpp
@@ -14,6 +14,7 @@
 
 #include <memory>
 
+#include "rcpputils/compile_warnings.hpp"
 #include "rclcpp/utilities.hpp"
 #include "rclcpp/experimental/executors/events_executor/events_executor.hpp"
 
@@ -27,7 +28,12 @@ int main(int argc, char * argv[])
 
   /// Component container with an events executor.
   rclcpp::init(argc, argv);
+
+  // Disable deprecation warnings while maintaining the EventsExecutor
+  RCPPUTILS_DEPRECATION_WARNING_OFF_START
   auto exec = std::make_shared<rclcpp::experimental::executors::EventsExecutor>();
+  RCPPUTILS_DEPRECATION_WARNING_OFF_STOP
+
   auto node = std::make_shared<rclcpp_components::ComponentManager>(exec);
   exec->add_node(node);
   exec->spin();


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
This PR adds a compile-time deprecation warning when using the experimental EventsExecutor, warning to switch to the new Callback Group Events Executor in single-threaded mode instead. 

Tests which exercise the EventsExecutor have deprecation warnings disabled while it is still in the source tree.
Also replaces one usage of the old executor with the new one in `rclcpp_action/test_server.cpp`. 

<img width="932" height="469" alt="image" src="https://github.com/user-attachments/assets/7524b851-f131-4d6c-ba19-b26d0e119e20" />

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
Users will now get a compiler warning when using the experimental EventsExecutor in their application code

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

Claude Opus 4.8 was used to identify spots in the codebase where the deprecation warning suppression should be introduced.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

This ought to be backported to at least Lyrical