### PR TITLE
Performance: Eliminate atomic reference-counting overhead in EventsExecutor collection updates

### DIFF
--- a/rclcpp/src/rclcpp/experimental/executors/events_executor/events_executor.cpp
+++ b/rclcpp/src/rclcpp/experimental/executors/events_executor/events_executor.cpp
@@ -452,35 +452,35 @@ EventsExecutor::refresh_current_collection(
 
   current_entities_collection_->timers.update(
     new_collection.timers,
-    [this](rclcpp::TimerBase::SharedPtr timer) {timers_manager_->add_timer(timer);},
-    [this](rclcpp::TimerBase::SharedPtr timer) {timers_manager_->remove_timer(timer);});
+    [this](const rclcpp::TimerBase::SharedPtr & timer) {timers_manager_->add_timer(timer);},
+    [this](const rclcpp::TimerBase::SharedPtr & timer) {timers_manager_->remove_timer(timer);});
 
   current_entities_collection_->subscriptions.update(
     new_collection.subscriptions,
-    [this](auto subscription) {
+    [this](const auto & subscription) {
       subscription->set_on_new_message_callback(
         this->create_entity_callback(
           subscription->get_subscription_handle().get(), ExecutorEventType::SUBSCRIPTION_EVENT));
     },
-    [](auto subscription) {subscription->clear_on_new_message_callback();});
+    [](const auto & subscription) {subscription->clear_on_new_message_callback();});
 
   current_entities_collection_->clients.update(
     new_collection.clients,
-    [this](auto client) {
+    [this](const auto & client) {
       client->set_on_new_response_callback(
         this->create_entity_callback(
           client->get_client_handle().get(), ExecutorEventType::CLIENT_EVENT));
     },
-    [](auto client) {client->clear_on_new_response_callback();});
+    [](const auto & client) {client->clear_on_new_response_callback();});
 
   current_entities_collection_->services.update(
     new_collection.services,
-    [this](auto service) {
+    [this](const auto & service) {
       service->set_on_new_request_callback(
         this->create_entity_callback(
           service->get_service_handle().get(), ExecutorEventType::SERVICE_EVENT));
     },
-    [](auto service) {service->clear_on_new_request_callback();});
+    [](const auto & service) {service->clear_on_new_request_callback();});
 
   // DO WE NEED THIS? WE ARE NOT DOING ANYTHING WITH GUARD CONDITIONS
   /*
@@ -491,11 +491,11 @@ EventsExecutor::refresh_current_collection(
 
   current_entities_collection_->waitables.update(
     new_collection.waitables,
-    [this](auto waitable) {
+    [this](const auto & waitable) {
       waitable->set_on_ready_callback(
         this->create_waitable_callback(waitable.get()));
     },
-    [](auto waitable) {waitable->clear_on_ready_callback();});
+    [](const auto & waitable) {waitable->clear_on_ready_callback();});
 }
 
 std::function<void(size_t)>


### PR DESCRIPTION
Issue : 
During a performance review of the EventsExecutor hot paths, it was observed that std::shared_ptr entities (timers, subscriptions, clients, services, waitables) were being passed by value into lambda callbacks during refresh_current_collection().

Impact :
Passing std::shared_ptr by value triggers an atomic increment and subsequent decrement of the control block's reference counter. In high-frequency spin loops, these atomic Read-Modify-Write operations force hardware-level cache synchronization barriers, resulting in avoidable instruction pressure and cache-line bouncing across CPU cores.

Fix :
Updated lambda signatures within refresh_current_collection() to capture collection entities via const auto & or const rclcpp::TimerBase::SharedPtr &. This does zero-copy, read-only references to the underlying resources already owned structurally by the collection container, completely bypassing unnecessary atomic operations.

Testing & Verification : 
Compiled using colcon on Ubuntu 24.04 / ROS 2 Jazzy.

Profiled utilizing a dedicated Google Benchmark rig scaling the active entity footprint up to 1,000 entities to isolate the micro-architectural behavior from background kernel scheduling noise.

Results: The zero-copy optimization demonstrated a measurable CPU execution latency reduction, saving ~3.64 ms per processing cycle on the magnified payload (amounting to a ~1.9% throughput enhancement).

The patch operates strictly internal to events_executor.cpp and maintains absolute public API and ABI compatibility.
<img width="1367" height="585" alt="Screenshot 2026-07-14 235140" src="https://github.com/user-attachments/assets/5745b49c-a5da-43ed-9b16-fe5e2c54c503" />
