### PR TITLE
Add test for transient-local delivery with unbounded uint8 messages

### DIFF
--- a/rclcpp/test/rclcpp/test_wait_for_message.cpp
+++ b/rclcpp/test/rclcpp/test_wait_for_message.cpp
@@ -23,6 +23,7 @@
 #include "rclcpp/wait_for_message.hpp"
 
 #include "test_msgs/msg/strings.hpp"
+#include "test_msgs/msg/unbounded_sequences.hpp"
 #include "test_msgs/message_fixtures.hpp"
 
 using namespace std::chrono_literals;
@@ -131,6 +132,36 @@ TEST(TestUtilities, wait_for_last_message) {
   ASSERT_NO_THROW(wait.get());
   ASSERT_TRUE(received);
   EXPECT_EQ(out, *get_messages_strings()[0]);
+
+  rclcpp::shutdown();
+}
+
+TEST(TestUtilities, wait_for_last_message_with_unbounded_uint8_values) {
+  rclcpp::init(0, nullptr);
+
+  auto node = std::make_shared<rclcpp::Node>("wait_for_unbounded_uint8_message_node");
+  auto qos = rclcpp::QoS(1).reliable().transient_local();
+
+  using MsgT = test_msgs::msg::UnboundedSequences;
+  auto pub = node->create_publisher<MsgT>("wait_for_unbounded_uint8_message_topic", qos);
+  MsgT input;
+  input.uint8_values = {1, 2, 3};
+  input.alignment_check = 42;
+  pub->publish(input);
+
+  MsgT out;
+  auto received = false;
+  auto wait = std::async(
+    [&]() {
+      auto ret = rclcpp::wait_for_message(
+        out, node, "wait_for_unbounded_uint8_message_topic", 5s, qos);
+      EXPECT_TRUE(ret);
+      received = true;
+    });
+
+  ASSERT_NO_THROW(wait.get());
+  ASSERT_TRUE(received);
+  EXPECT_EQ(out, input);
 
   rclcpp::shutdown();
 }


### PR DESCRIPTION
## Description                                                                                                                                                                                            

Add regression coverage for transient-local delivery of messages containing an unbounded `uint8[]`.

The new test extends the existing `wait_for_message` test executable using `test_msgs::msg::UnboundedSequences`. It publishes a message before creating the subscription and verifies that the late-joining transient-local subscription receives the retained sample.

This test is specific for testing the case raised by ros2/rmw_fastrtps#897
                                                   
### Is this user-facing behavior change?
No.                                 

### Did you use Generative AI?                                                                                                                                                                            
Yes. OpenAI GPT-5.6 was used to draft the code for this PR.