### PR TITLE
add support for reentrant callback group to EventsCBGExecutor (Backport #3178)

### DIFF
--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/first_in_first_out_scheduler.cpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/first_in_first_out_scheduler.cpp
@@ -145,10 +145,11 @@ get_next_ready_entity(GlobalEventIdProvider::MonotonicId max_id)
   return std::nullopt;
 }
 
-std::unique_ptr<FirstInFirstOutScheduler::CallbackGroupHandle> FirstInFirstOutScheduler::
-get_handle_for_callback_group(const rclcpp::CallbackGroup::SharedPtr &/*callback_group*/)
+std::unique_ptr<FirstInFirstOutScheduler::CallbackGroupHandle>
+FirstInFirstOutScheduler::get_handle_for_callback_group(
+  const rclcpp::CallbackGroup::SharedPtr & callback_group)
 {
-  return std::make_unique<FirstInFirstOutCallbackGroupHandle>(*this);
+  return std::make_unique<FirstInFirstOutCallbackGroupHandle>(*this, callback_group->type());
 }
 
 CBGScheduler::ExecutableEntityWithInfo FirstInFirstOutScheduler::get_next_ready_entity_intern()
@@ -159,9 +160,16 @@ CBGScheduler::ExecutableEntityWithInfo FirstInFirstOutScheduler::get_next_ready_
     FirstInFirstOutCallbackGroupHandle *ready_cbg =
       static_cast<FirstInFirstOutCallbackGroupHandle *>(ready_callback_groups.front());
     ready_callback_groups.pop_front();
+    ready_cbg->in_queue = false;
 
     std::optional<FirstInFirstOutScheduler::ExecutableEntity> ret =
       ready_cbg->get_next_ready_entity();
+
+    if (ready_cbg->get_type() == CallbackGroupType::Reentrant && ready_cbg->has_ready_entities()) {
+      ready_callback_groups.push_back(ready_cbg);
+      ready_cbg->in_queue = true;
+    }
+
     if(ret) {
       return CBGScheduler::ExecutableEntityWithInfo{std::move(ret),
         !ready_callback_groups.empty()};
@@ -187,8 +195,16 @@ CBGScheduler::ExecutableEntityWithInfo FirstInFirstOutScheduler::get_next_ready_
       ready_cbg->get_next_ready_entity(max_id);
     if(ret) {
       ready_callback_groups.erase(it);
-      return CBGScheduler::ExecutableEntityWithInfo{std::move(ret),
-        !ready_callback_groups.empty()};
+      ready_cbg->in_queue = false;
+
+      if (
+        ready_cbg->get_type() == CallbackGroupType::Reentrant && ready_cbg->has_ready_entities())
+      {
+        ready_callback_groups.push_back(ready_cbg);
+        ready_cbg->in_queue = true;
+      }
+      return CBGScheduler::ExecutableEntityWithInfo{
+        std::move(ret), !ready_callback_groups.empty()};
     }
   }
 

--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/first_in_first_out_scheduler.hpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/first_in_first_out_scheduler.hpp
@@ -32,8 +32,10 @@ namespace cbg_executor
 struct FirstInFirstOutCallbackGroupHandle final : public CBGScheduler::CallbackGroupHandle
 {
 public:
-  explicit FirstInFirstOutCallbackGroupHandle(CBGScheduler & scheduler)
-  : CallbackGroupHandle(scheduler) {}
+  explicit FirstInFirstOutCallbackGroupHandle(CBGScheduler & scheduler, CallbackGroupType type)
+  : CallbackGroupHandle(scheduler, type)
+  {
+  }
 
   std::function<void(size_t)> get_ready_callback_for_entity(
     const rclcpp::SubscriptionBase::WeakPtr & entity) final;

--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/scheduler.hpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/scheduler.hpp
@@ -59,8 +59,10 @@ public:
 
   struct CallbackGroupHandle
   {
-    explicit CallbackGroupHandle(CBGScheduler & scheduler)
-    : scheduler(scheduler) {}
+    explicit CallbackGroupHandle(CBGScheduler & scheduler, CallbackGroupType type)
+    : scheduler(scheduler), type(type)
+    {
+    }
 
     CallbackGroupHandle(const CallbackGroupHandle &) = delete;
     CallbackGroupHandle(CallbackGroupHandle &&) = delete;
@@ -101,7 +103,12 @@ public:
       scheduler.callback_group_ready(this, false);
     }
 
+    CallbackGroupType get_type() {return type;}
+
     bool is_ready();
+
+    // true if this cbg is inside the scheduler's queue
+    bool in_queue = false;
 
 protected:
     CBGScheduler & scheduler;
@@ -153,7 +160,9 @@ protected:
      */
     void mark_as_executing()
     {
-      not_ready = true;
+      if (type != CallbackGroupType::Reentrant) {
+        not_ready = true;
+      }
     }
 
     std::mutex ready_mutex;
@@ -164,6 +173,9 @@ private:
 
     // true, if nothing is beeing executed, and there are no pending events
     bool idle = true;
+
+    // type of the underlying callback group
+    CallbackGroupType type;
   };
 
   struct ExecutableEntity
@@ -218,9 +230,11 @@ private:
    */
   void callback_group_ready(CallbackGroupHandle *handle, bool callback_group_was_idle)
   {
-    {
+    if (!handle->in_queue) {
       std::lock_guard l(ready_callback_groups_mutex);
+
       ready_callback_groups.push_back(handle);
+      handle->in_queue = true;
     }
 
     if(callback_group_was_idle) {

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -547,6 +547,12 @@ if(TARGET test_multi_threaded_executor)
   target_link_libraries(test_multi_threaded_executor ${PROJECT_NAME})
 endif()
 
+ament_add_gtest(test_events_cbg_executor_reentrant executors/test_events_cbg_executor_reentrant.cpp
+  APPEND_LIBRARY_DIRS "${append_library_dirs}")
+if(TARGET test_events_cbg_executor_reentrant)
+  target_link_libraries(test_events_cbg_executor_reentrant ${PROJECT_NAME} ${test_msgs_TARGETS})
+endif()
+
 ament_add_gtest(test_entities_collector executors/test_entities_collector.cpp
   APPEND_LIBRARY_DIRS "${append_library_dirs}" TIMEOUT 120)
 if(TARGET test_entities_collector)

--- a/rclcpp/test/rclcpp/executors/test_events_cbg_executor_reentrant.cpp
+++ b/rclcpp/test/rclcpp/executors/test_events_cbg_executor_reentrant.cpp
@@ -1,0 +1,123 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include "rclcpp/rclcpp.hpp"
+#include "test_msgs/msg/empty.hpp"
+
+using namespace std::chrono_literals;
+
+class TestEventsCBGExecutorReentrant : public testing::Test
+{
+protected:
+  static void SetUpTestCase() {rclcpp::init(0, nullptr);}
+
+  static void TearDownTestCase() {rclcpp::shutdown();}
+};
+
+/*
+ * Test that multiple callbacks from the same reentrant callback group can
+ * be executed at the same time.
+ *
+ * The test creates two subscribers in a single reentrant callback group that
+ * listen to the same topic. Whichever subscriber executes first waits for
+ * the other to also start executing. If this waiting results in a timeout,
+ * then we know that the second subscriber wasn't able to execute because the
+ * executor handled the callback group incorrectly.
+ *
+ * Related issue: https://github.com/ros2/rclcpp/issues/3175
+ */
+TEST_F(TestEventsCBGExecutorReentrant, reentract_callback_group_runs_concurrently)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_events_cbg_executor_reentrant");
+
+  std::mutex rendezvous_mutex;
+  std::condition_variable rendezvous_cv;
+  auto rendezvous = [&](bool & own_started, const bool & other_started) {
+      std::unique_lock<std::mutex> lock(rendezvous_mutex);
+      own_started = true;
+      rendezvous_cv.notify_all();
+      return rendezvous_cv.wait_for(lock, 2s, [&other_started]() {return other_started;});
+    };
+
+  rclcpp::SubscriptionOptions sub_opt;
+  auto cbg = node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
+  sub_opt.callback_group = cbg;
+
+  bool sub1_started = false;
+  bool sub2_started = false;
+  std::atomic_bool sub1_finished{false};
+  std::atomic_bool sub2_finished{false};
+  std::atomic_bool sub1_timed_out{false};
+  std::atomic_bool sub2_timed_out{false};
+
+  auto sub_1 = node->create_subscription<test_msgs::msg::Empty>(
+    "empty", 10,
+    [&](test_msgs::msg::Empty) {
+      if (!rendezvous(sub1_started, sub2_started)) {
+        sub1_timed_out = true;
+      }
+      sub1_finished = true;
+    },
+    sub_opt);
+
+  auto sub_2 = node->create_subscription<test_msgs::msg::Empty>(
+    "empty", 10,
+    [&](test_msgs::msg::Empty) {
+      if (!rendezvous(sub2_started, sub1_started)) {
+        sub2_timed_out = true;
+      }
+      sub2_finished = true;
+    },
+    sub_opt);
+
+  auto pub = node->create_publisher<test_msgs::msg::Empty>("empty", 10);
+
+  auto executor = rclcpp::executors::EventsCBGExecutor(rclcpp::ExecutorOptions(), 2u);
+  ASSERT_GT(executor.get_number_of_threads(), 1u);
+
+  executor.add_node(node);
+  std::thread spin_thread([&executor]() {executor.spin();});
+
+  /*
+   * Publish (and re-publish, in case discovery hasn't completed yet) until
+   * both callbacks have run to completion
+   */
+  test_msgs::msg::Empty msg;
+  auto deadline = std::chrono::steady_clock::now() + 5s;
+  while (std::chrono::steady_clock::now() < deadline &&
+    !(sub1_finished.load() && sub2_finished.load()))
+  {
+    pub->publish(msg);
+    std::this_thread::sleep_for(500ms);
+  }
+
+  executor.cancel();
+  spin_thread.join();
+
+  EXPECT_TRUE(sub1_finished.load()) << "sub 1 never ran";
+  EXPECT_TRUE(sub2_finished.load()) << "sub 2 never ran";
+  EXPECT_FALSE(sub1_timed_out.load()) << "sub 1 timed out waiting for sub 2 to start running -- "
+                                         "the reentrant callback group appears to be serialized";
+  EXPECT_FALSE(sub2_timed_out.load()) << "sub 2 timed out waiting for sub 1 to start running -- "
+                                         "the reentrant callback group appears to be serialized";
+}


### PR DESCRIPTION
## Description
Kilted backport of #3178 removing C++20 features
<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
