### PR TITLE
Use common code from base executor class in `EventsCBGExecutor` and cleanup dead code

### DIFF
--- a/rclcpp/include/rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp
@@ -171,15 +171,19 @@ public:
   using rclcpp::Executor::execute_client;
 
 protected:
-  RCLCPP_PUBLIC
-  void
-  run(size_t this_thread_number, bool block_initially);
-
+  /// Worker-thread loop shared by both spin() overloads.
+  /**
+   * \param block_initially if true, block once before processing any work, so
+   *   that pool worker threads park until the scheduler hands them an entity.
+   * \param exception_handler if set, exceptions thrown by executed entities are
+   *   routed here instead of propagating; if empty, they propagate as usual.
+   */
   RCLCPP_PUBLIC
   void
   run(
     size_t this_thread_number,
-    const std::function<void(const std::exception &)> & exception_handler);
+    bool block_initially,
+    const std::function<void(const std::exception &)> & exception_handler = {});
 
   /**
    * Te be called in termination case. E.g. destructor of shutdown callback.
@@ -242,8 +246,6 @@ private:
   std::vector<CallbackGroupData> callback_groups;
 
   size_t number_of_threads_;
-
-  std::chrono::nanoseconds next_exec_timeout_;
 
   std::atomic_bool needs_callback_group_resync = false;
 

--- a/rclcpp/include/rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp
@@ -178,60 +178,6 @@ public:
     return spinning;
   }
 
-  template<typename FutureT, typename TimeRepT = int64_t, typename TimeT = std::milli>
-  FutureReturnCode
-  spin_until_future_complete(
-    const FutureT & future,
-    std::chrono::duration<TimeRepT, TimeT> timeout = std::chrono::duration<TimeRepT, TimeT>(-1))
-  {
-    // TODO(wjwwood): does not work recursively; can't call spin_node_until_future_complete
-    // inside a callback executed by an executor.
-
-    // Check the future before entering the while loop.
-    // If the future is already complete, don't try to spin.
-    std::future_status status = future.wait_for(std::chrono::seconds(0));
-    if (status == std::future_status::ready) {
-      return FutureReturnCode::SUCCESS;
-    }
-
-    auto end_time = std::chrono::steady_clock::now();
-    std::chrono::nanoseconds timeout_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-      timeout);
-    if (timeout_ns > std::chrono::nanoseconds::zero()) {
-      end_time += timeout_ns;
-    }
-    std::chrono::nanoseconds timeout_left = timeout_ns;
-
-    if (spinning.exchange(true)) {
-      throw std::runtime_error("spin_until_future_complete() called while already spinning");
-    }
-    RCPPUTILS_SCOPE_EXIT(this->spinning.store(false); );
-    while (rclcpp::ok(this->context_) && spinning.load()) {
-      // Do one item of work.
-      spin_once_internal(timeout_left);
-
-      // Check if the future is set, return SUCCESS if it is.
-      status = future.wait_for(std::chrono::seconds(0));
-      if (status == std::future_status::ready) {
-        return FutureReturnCode::SUCCESS;
-      }
-      // If the original timeout is < 0, then this is blocking, never TIMEOUT.
-      if (timeout_ns < std::chrono::nanoseconds::zero()) {
-        continue;
-      }
-      // Otherwise check if we still have time to wait, return TIMEOUT if not.
-      auto now = std::chrono::steady_clock::now();
-      if (now >= end_time) {
-        return FutureReturnCode::TIMEOUT;
-      }
-      // Subtract the elapsed time from the original timeout.
-      timeout_left = std::chrono::duration_cast<std::chrono::nanoseconds>(end_time - now);
-    }
-
-    // The future did not complete before ok() returned false, return INTERRUPTED.
-    return FutureReturnCode::INTERRUPTED;
-  }
-
   /// We need these function to be public, as we use them in the callback_group_scheduler
   using rclcpp::Executor::execute_subscription;
   using rclcpp::Executor::execute_timer;
@@ -295,7 +241,7 @@ private:
   void trigger_callback_group_sync();
 
   RCLCPP_PUBLIC
-  void spin_once_internal(std::chrono::nanoseconds timeout);
+  void spin_once_impl(std::chrono::nanoseconds timeout) override;
 
   RCLCPP_DISABLE_COPY(EventsCBGExecutor)
 
@@ -315,23 +261,9 @@ private:
 
   std::atomic_bool needs_callback_group_resync = false;
 
-  /// Spinning state, used to prevent multi threaded calls to spin and to cancel blocking spins.
-  std::atomic_bool spinning;
-
   /// set if we are shutting down.
   bool in_shutdown = false;
 
-  /// Guard condition for signaling the rmw layer to wake up for special events.
-  std::shared_ptr<rclcpp::GuardCondition> interrupt_guard_condition_;
-
-  /// Guard condition for signaling the rmw layer to wake up for system shutdown.
-  std::shared_ptr<rclcpp::GuardCondition> shutdown_guard_condition_;
-
-  /// shutdown callback handle registered to Context
-  rclcpp::OnShutdownCallbackHandle shutdown_callback_handle_;
-
-  /// The context associated with this executor.
-  std::shared_ptr<rclcpp::Context> context_;
 
   std::unique_ptr<cbg_executor::TimerManager> timer_manager;
 

--- a/rclcpp/include/rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp
@@ -52,13 +52,11 @@ public:
    * \param options common options for all executors
    * \param number_of_threads number of threads to have in the thread pool,
    *   the default 0 will use the number of cpu cores found (minimum of 2)
-   * \param timeout maximum time to wait
    */
   RCLCPP_PUBLIC
   explicit EventsCBGExecutor(
     const rclcpp::ExecutorOptions & options = rclcpp::ExecutorOptions(),
-    size_t number_of_threads = 0,
-    std::chrono::nanoseconds timeout = std::chrono::nanoseconds(-1));
+    size_t number_of_threads = 0);
 
   RCLCPP_PUBLIC
   virtual ~EventsCBGExecutor();

--- a/rclcpp/include/rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp
@@ -43,12 +43,6 @@ public:
   RCLCPP_SMART_PTR_DEFINITIONS(EventsCBGExecutor)
 
   /**
-   * For the yield_before_execute option, when true std::this_thread::yield()
-   * will be called after acquiring work (as an AnyExecutable) and
-   * releasing the spinning lock, but before executing the work.
-   * This is useful for reproducing some bugs related to taking work more than
-   * once.
-   *
    * \param options common options for all executors
    * \param number_of_threads number of threads to have in the thread pool,
    *   the default 0 will use the number of cpu cores found (minimum of 2)

--- a/rclcpp/include/rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp
@@ -172,12 +172,6 @@ public:
   size_t
   get_number_of_threads() const;
 
-  bool
-  is_spinning()
-  {
-    return spinning;
-  }
-
   /// We need these function to be public, as we use them in the callback_group_scheduler
   using rclcpp::Executor::execute_subscription;
   using rclcpp::Executor::execute_timer;

--- a/rclcpp/include/rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp
+++ b/rclcpp/include/rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp
@@ -208,8 +208,6 @@ protected:
     Origin origin;
   };
 
-  void set_callbacks(CallbackGroupData & cgd);
-
   /**
    * This function will execute all available executables,
    * that were ready, before this function was called.

--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/events_cbg_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/events_cbg_executor.cpp
@@ -78,13 +78,11 @@ struct GlobalWeakExecutableCache
 
 EventsCBGExecutor::EventsCBGExecutor(
   const rclcpp::ExecutorOptions & options,
-  size_t number_of_threads,
-  std::chrono::nanoseconds next_exec_timeout)
+  size_t number_of_threads)
 : rclcpp::Executor(options),
   scheduler(std::make_unique<cbg_executor::FirstInFirstOutScheduler>([this] () {
       needs_callback_group_resync = true;
   })),
-  next_exec_timeout_(next_exec_timeout),
   timer_manager(std::make_unique<cbg_executor::TimerManager>(context_)),
   global_executable_cache(std::make_unique<cbg_executor::GlobalWeakExecutableCache>() ),
   nodes_executable_cache(std::make_unique<cbg_executor::GlobalWeakExecutableCache>() )

--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/events_cbg_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/events_cbg_executor.cpp
@@ -318,7 +318,10 @@ void EventsCBGExecutor::sync_callback_groups()
 }
 
 void
-EventsCBGExecutor::run(size_t this_thread_number, bool block_initially)
+EventsCBGExecutor::run(
+  size_t this_thread_number,
+  bool block_initially,
+  const std::function<void(const std::exception & e)> & exception_handler)
 {
   (void) this_thread_number;
 
@@ -340,32 +343,14 @@ EventsCBGExecutor::run(size_t this_thread_number, bool block_initially)
       scheduler->unblock_one_worker_thread();
     }
 
-    ready_entity.entity->execute_function();
-
-    scheduler->mark_entity_as_executed(*ready_entity.entity);
-  }
-}
-
-void
-EventsCBGExecutor::run(
-  size_t this_thread_number,
-  const std::function<void(const std::exception & e)> & exception_handler)
-{
-  (void) this_thread_number;
-
-  while (rclcpp::ok(this->context_) && spinning.load() ) {
-    sync_callback_groups();
-
-    auto ready_entity = scheduler->get_next_ready_entity();
-    if(!ready_entity.entity) {
-      scheduler->block_worker_thread();
-      continue;
-    }
-
-    try {
+    if (exception_handler) {
+      try {
+        ready_entity.entity->execute_function();
+      } catch (const std::exception & e) {
+        exception_handler(e);
+      }
+    } else {
       ready_entity.entity->execute_function();
-    } catch (const std::exception & e) {
-      exception_handler(e);
     }
 
     scheduler->mark_entity_as_executed(*ready_entity.entity);
@@ -499,12 +484,12 @@ void EventsCBGExecutor::spin(
   for ( ; thread_id < number_of_threads_ - 1; ++thread_id) {
     threads.emplace_back([this, thread_id, exception_handler]()
       {
-        run(thread_id, exception_handler);
+        run(thread_id, true, exception_handler);
       }
     );
   }
 
-  run(thread_id, exception_handler);
+  run(thread_id, false, exception_handler);
   for (auto & thread : threads) {
     thread.join();
   }

--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/events_cbg_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/events_cbg_executor.cpp
@@ -80,14 +80,11 @@ EventsCBGExecutor::EventsCBGExecutor(
   const rclcpp::ExecutorOptions & options,
   size_t number_of_threads,
   std::chrono::nanoseconds next_exec_timeout)
-: scheduler(std::make_unique<cbg_executor::FirstInFirstOutScheduler>([this] () {
+: rclcpp::Executor(options),
+  scheduler(std::make_unique<cbg_executor::FirstInFirstOutScheduler>([this] () {
       needs_callback_group_resync = true;
   })),
   next_exec_timeout_(next_exec_timeout),
-  spinning(false),
-  interrupt_guard_condition_(std::make_shared<rclcpp::GuardCondition>(options.context) ),
-  shutdown_guard_condition_(std::make_shared<rclcpp::GuardCondition>(options.context) ),
-  context_(options.context),
   timer_manager(std::make_unique<cbg_executor::TimerManager>(context_)),
   global_executable_cache(std::make_unique<cbg_executor::GlobalWeakExecutableCache>() ),
   nodes_executable_cache(std::make_unique<cbg_executor::GlobalWeakExecutableCache>() )
@@ -104,14 +101,6 @@ EventsCBGExecutor::EventsCBGExecutor(
   number_of_threads_ = number_of_threads > 0 ?
     number_of_threads :
     std::max(std::thread::hardware_concurrency(), 2U);
-
-  shutdown_callback_handle_ = context_->add_on_shutdown_callback(
-    [weak_gc = std::weak_ptr<rclcpp::GuardCondition> {shutdown_guard_condition_}]() {
-      auto strong_gc = weak_gc.lock();
-      if (strong_gc) {
-        strong_gc->trigger();
-      }
-    });
 }
 
 EventsCBGExecutor::~EventsCBGExecutor()
@@ -146,13 +135,6 @@ void EventsCBGExecutor::shutdown()
     callback_groups.clear();
   }
 
-  // Remove shutdown callback handle registered to Context
-  if (!context_->remove_on_shutdown_callback(shutdown_callback_handle_) ) {
-    RCUTILS_LOG_ERROR_NAMED(
-      "rclcpp",
-      "failed to remove registered on_shutdown callback");
-    rcl_reset_error();
-  }
 
   // now we may release the memory of the timer_manager,
   // as we know no thread is working on it any more
@@ -393,7 +375,7 @@ EventsCBGExecutor::run(
 }
 
 
-void EventsCBGExecutor::spin_once_internal(std::chrono::nanoseconds timeout)
+void EventsCBGExecutor::spin_once_impl(std::chrono::nanoseconds timeout)
 {
   if (!rclcpp::ok(this->context_) || !spinning.load() ) {
     return;
@@ -432,7 +414,7 @@ EventsCBGExecutor::spin_once(std::chrono::nanoseconds timeout)
   }
   RCPPUTILS_SCOPE_EXIT(this->spinning.store(false); );
 
-  spin_once_internal(timeout);
+  spin_once_impl(timeout);
 }
 
 

--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/first_in_first_out_scheduler.hpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/first_in_first_out_scheduler.hpp
@@ -17,8 +17,6 @@
 #include <deque>
 #include <memory>
 
-#include <vector>
-
 #include "ready_entity.hpp"
 #include "scheduler.hpp"
 #include "global_event_id_provider.hpp"
@@ -75,8 +73,6 @@ public:
 private:
   std::unique_ptr<CallbackGroupHandle> get_handle_for_callback_group(
     const rclcpp::CallbackGroup::SharedPtr & callback_group) final;
-
-  std::vector<std::unique_ptr<FirstInFirstOutCallbackGroupHandle>> callback_group_handles;
 };
 }  // namespace cbg_executor
 }  // namespace executors

--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/global_event_id_provider.hpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/global_event_id_provider.hpp
@@ -30,7 +30,7 @@ class GlobalEventIdProvider
 public:
   using MonotonicId = uint64_t;
 
-  // Returns the last id, returnd by getNextId
+  // Returns the last id, returned by get_next_id
   static uint64_t get_last_id()
   {
     return last_event_id;
@@ -39,7 +39,7 @@ public:
   // increases the Id by one and returns the Id
   static uint64_t get_next_id()
   {
-    return  ++last_event_id;
+    return ++last_event_id;
   }
 };
 }  // namespace cbg_executor

--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/ready_entity.hpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/ready_entity.hpp
@@ -33,11 +33,6 @@ struct ReadyEntity
     rclcpp::TimerBase::WeakPtr timer_ptr;
         // must be called by the after executing the timer callback
     std::function<void()> timer_was_executed;
-
-    bool expired() const
-    {
-      return timer_ptr.expired();
-    }
   };
 
   std::variant<rclcpp::SubscriptionBase::WeakPtr, ReadyTimerWithExecutedCallback,
@@ -122,14 +117,6 @@ struct ReadyEntity
   }
 
   GlobalEventIdProvider::MonotonicId id;
-
-    /**
-     * Returns true if the event has expired / does not need to be executed any more
-     */
-  bool expired() const
-  {
-    return std::visit([](const auto & entity) {return entity.expired();}, entity);
-  }
 };
 }  // namespace cbg_executor
 }  // namespace executors

--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/ready_entity.hpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/ready_entity.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <utility>
+#include <variant>
 
 #include "scheduler.hpp"
 #include "global_event_id_provider.hpp"

--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/registered_entity_cache.hpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/registered_entity_cache.hpp
@@ -207,7 +207,7 @@ struct RegisteredEntityCache
     std::vector<rclcpp::ServiceBase::SharedPtr> services;
     std::vector<rclcpp::Waitable::SharedPtr> waitables;
 
-    // we reserve to much memory here, but this should be fine
+    // we reserve too much memory here, but this should be fine
     const size_t max_size = callback_group->size();
     timers.reserve(max_size);
     subscribers.reserve(max_size);

--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/scheduler.hpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/scheduler.hpp
@@ -13,10 +13,15 @@
 // limitations under the License.
 #pragma once
 
+#include <algorithm>
+#include <chrono>
+#include <condition_variable>
 #include <deque>
 #include <functional>
 #include <list>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <utility>
 
 #include <rclcpp/callback_group.hpp>

--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/scheduler.hpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/scheduler.hpp
@@ -35,11 +35,6 @@ public:
   {
     rclcpp::Waitable::WeakPtr waitable;
     int internal_event_type;
-
-    bool expired() const
-    {
-      return waitable.expired();
-    }
   };
 
   struct CallbackEventType
@@ -50,11 +45,6 @@ public:
     }
 
     std::function<void()> callback;
-
-    bool expired() const
-    {
-      return false;
-    }
   };
 
   struct CallbackGroupHandle
@@ -104,8 +94,6 @@ public:
     }
 
     CallbackGroupType get_type() {return type;}
-
-    bool is_ready();
 
     // true if this cbg is inside the scheduler's queue
     bool in_queue = false;

--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/scheduler.hpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/scheduler.hpp
@@ -171,7 +171,7 @@ private:
     // will be set if cbg is mutual exclusive and something is executing
     bool not_ready = false;
 
-    // true, if nothing is beeing executed, and there are no pending events
+    // true, if nothing is being executed, and there are no pending events
     bool idle = true;
 
     // type of the underlying callback group
@@ -293,8 +293,8 @@ private:
    * If this function was triggered, a worker thread must
    * be woken up, and the next call to get_next_ready_entity
    * must return a ExecutableEntityWithInfo with the sync
-   * function in it.Or reworded if this function is triggered
-   * the sync function will be executed as the next exent by
+   * function in it. Or reworded, if this function is triggered
+   * the sync function will be executed as the next event by
    * the executor.
    */
   void trigger_sync()

--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/timer_manager.hpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/timer_manager.hpp
@@ -465,7 +465,6 @@ private:
         });
       }
     }
-    thread_terminated = true;
   }
 
   rcl_clock_type_t timer_type;
@@ -478,7 +477,6 @@ private:
   std::mutex mutex;
 
   std::atomic_bool running = true;
-  std::atomic_bool thread_terminated = false;
 
   std::vector<std::unique_ptr<TimerData>> all_timers;
 

--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/timer_manager.hpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/timer_manager.hpp
@@ -16,10 +16,15 @@
 
 #include <rcl/timer.h>
 
+#include <array>
+#include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
+#include <thread>
 #include <utility>
 #include <vector>
 

--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/timer_manager.hpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/timer_manager.hpp
@@ -166,7 +166,7 @@ public:
   }
 
   /**
-   * @brief Removes a new timer from the queue.
+   * @brief Removes a timer from the queue.
    * This function is thread safe.
    *
    * Removes a timer, if it was added to this queue.

--- a/rclcpp_action/test/test_server.cpp
+++ b/rclcpp_action/test/test_server.cpp
@@ -46,11 +46,10 @@ protected:
     rclcpp::shutdown();
   }
 
-  template<typename ExecutorType>
   std::shared_ptr<Fibonacci::Impl::SendGoalService::Request>
   send_goal_request(
     rclcpp::Node::SharedPtr node, GoalUUID uuid,
-    ExecutorType & executor,
+    rclcpp::Executor & executor,
     std::chrono::milliseconds timeout = std::chrono::milliseconds(-1),
     bool executor_owns_node = false)
   {


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

Introduces a handful of changes focused on code cleanup and leveraging common executor code:

Commonization / correctness:
- Use the base `rclcpp::Executor(options)` in the `EventsCBGExecutor` constructor and drop the duplicated / shadowed copies of `spinning`, `context_`, `interrupt_guard_condition_`, `shutdown_guard_condition_`, and `shutdown_callback_handle_`
- Rename `spin_once_internal()` to `spin_once_impl()` (overridden from the base class), so the base `spin_until_future_complete()` works polymorphically through an `Executor&`, and delete the shadowed `spin_until_future_complete` template.
- Remove shadowed `is_spinning()` method
- Revert the earlier test workaround introduced in #3192, to verify that #3201 is fixed by this PR
- Collapse the duplicated `run()` overloads into one with a nullable exception handler. The exception-handler `spin()` path now also does the `moreEntitiesReady` unblock and worker `block_initially`, matching the primary spin (they had diverged).

Dead code
- removed `next_exec_timeout` / `timeout` constructor arg, as it was a copy-paste from the `MultiThreadedExecutor` and was never being read anywhere in the new executor
- removed `set_callbacks()` declaration which had no implementation or downstream references
- removed `thread_terminated` in `timer_manager.hpp` as it was only being written to and never read by anything
- removed `ReadyEntity::expired()`, `ReadyTimerWithExecutedCallback::expired()`, `WaitableWithEventType::expired()`, and `CallbackEventType::expired()`. The actual code path never used these `expired()` checks. Instead, `ReadyEntity::get_execute_function()` simply returns an empty `std::function` if the `ReadyEntity` weak pointer fails to lock, which is skipped by callers.
- Remove `FirstInFirstOutScheduler::callback_group_handles`. This vector was apparently never being read from or written to. The base `Scheduler::callback_groups` is where handles are actually being stored when `CBGScheduler::add_callback_group` is called.

Misc
- fix comment spacing, typos, and remove dead docstrings
- do an IWYU pass on dependencies / includes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #3201 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

Users will go through the proper `EventsCBGExecutor` code path and no longer experience a deadlock when calling `spin_until_future_complete` on an `rclcpp::Executor` base reference that points to an `EventsCBGExecutor`
`rclcpp::Executor` is now fully polymorphic with respect to all of its subclasses

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
Yes, Claude Opus 4.8 helped identify likely candidates for dead code removal and cosmetic cleanup

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

given the user facing deadlock bug that this fixes, I would advocate for aggressively backporting at least the polymorphism fixes