### PR TITLE
Qualify ShutdownCallbackHandle in context.cpp

### DIFF
--- a/rclcpp/src/rclcpp/context.cpp
+++ b/rclcpp/src/rclcpp/context.cpp
@@ -425,7 +425,7 @@ Context::add_shutdown_callback(
   const ShutdownCallback & callback)
 {
   auto callback_shared_ptr =
-    std::make_shared<ShutdownCallbackHandle::ShutdownCallbackType>(callback);
+    std::make_shared<rclcpp::ShutdownCallbackHandle::ShutdownCallbackType>(callback);
 
   static_assert(
     shutdown_type == ShutdownType::pre_shutdown || shutdown_type == ShutdownType::on_shutdown);
@@ -438,7 +438,7 @@ Context::add_shutdown_callback(
     on_shutdown_callbacks_.emplace_back(callback_shared_ptr);
   }
 
-  ShutdownCallbackHandle callback_handle;
+  rclcpp::ShutdownCallbackHandle callback_handle;
   callback_handle.callback = callback_shared_ptr;
   return callback_handle;
 }


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

This upstreams `patch/ros-rolling-rclcpp.win.patch`, authored in RoboStack by wep21 `<daisuke.nishimatsu1021@gmail.com>`.

Qualifying `ShutdownCallbackHandle` through the `rclcpp` namespace avoids dependent-name lookup issues on stricter C++ compilers while keeping the existing callback behavior unchanged.