### PR TITLE
add missing header for std::function

### DIFF
--- a/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/node_parameters_interface.hpp
@@ -15,6 +15,7 @@
 #ifndef RCLCPP__NODE_INTERFACES__NODE_PARAMETERS_INTERFACE_HPP_
 #define RCLCPP__NODE_INTERFACES__NODE_PARAMETERS_INTERFACE_HPP_
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>


### PR DESCRIPTION
## Description

fix play_motion2 on nix:

```cpp
[ 60%] Built target ament_cmake_python_build_play_motion2_egg
In file included from /build/play_motion2-release-release-humble-play_motion2-1.8.5-1/src/utils/motion_loader.hpp:23,
                 from /build/play_motion2-release-release-humble-play_motion2-1.8.5-1/src/utils/motion_loader.cpp:19:
/nix/store/ifw8313yfmyarrgqscg249m9krx58sh2-ros-humble-rclcpp-16.0.19-r1/include/rclcpp/rclcpp/node_interfaces/node_parameters_interface.hpp:42:10: error: 'function' in namespace 'std' does not name a template type
   42 |     std::function<
      |          ^~~~~~~~
/nix/store/ifw8313yfmyarrgqscg249m9krx58sh2-ros-humble-rclcpp-16.0.19-r1/include/rclcpp/rclcpp/node_interfaces/node_parameters_interface.hpp:30:1: note: 'std::function' is defined in header '<functional>'; this is probably fixable by adding '#include <functional>'
   29 | #include "rclcpp/parameter.hpp"
  +++ |+#include <functional>
   30 | #include "rclcpp/visibility_control.hpp"
```



### Is this user-facing behavior change?

no

### Did you use Generative AI?

no

### Additional Information

already fixed in rolling: #2018, but still breaks when building humble with a recent compiler.