### PR TITLE
Restore direct cassert include in wait_result.hpp

### DIFF
--- a/rclcpp/include/rclcpp/wait_result.hpp
+++ b/rclcpp/include/rclcpp/wait_result.hpp
@@ -15,6 +15,7 @@
 #ifndef RCLCPP__WAIT_RESULT_HPP_
 #define RCLCPP__WAIT_RESULT_HPP_
 
+#include <cassert>
 #include <functional>
 #include <iostream>
 #include <memory>


### PR DESCRIPTION
## Description

`wait_result.hpp` uses `assert()` in four places, but its direct `<cassert>` include was removed in #3179. The header currently gets the macro through a transitive `rcutils` include, which makes it fragile when dependency headers change.

This restores the direct standard-library include. Include-what-you-use reports an assert header as a required dependency of `wait_result.hpp`.

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

Yes. OpenAI Codex (GPT-5) was used to trace the missing include, make the one-line change, run validation, and draft this description.

### Additional Information

Validated in the official `ros:rolling-ros-base` image:

- `colcon build --packages-select rclcpp --cmake-args -DBUILD_TESTING=ON`
- wait-set tests plus copyright, `cpplint`, and `uncrustify`: 1,234 checks, 0 failures

The full suite completed 3,054 tests with five environment-sensitive failures in `test_time` and `test_wait_for_message`; neither area is changed by this include-only PR.