### PR TITLE
Move get_log_directory to improve compilation time

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -80,6 +80,7 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/guard_condition.cpp
   src/rclcpp/init_options.cpp
   src/rclcpp/intra_process_manager.cpp
+  src/rclcpp/log_directory.cpp
   src/rclcpp/logger.cpp
   src/rclcpp/logging_mutex.cpp
   src/rclcpp/memory_strategy.cpp

--- a/rclcpp/include/rclcpp/log_directory.hpp
+++ b/rclcpp/include/rclcpp/log_directory.hpp
@@ -1,0 +1,39 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__LOG_DIRECTORY_HPP_
+#define RCLCPP__LOG_DIRECTORY_HPP_
+
+#include <filesystem>
+
+#include "rclcpp/visibility_control.hpp"
+
+namespace rclcpp
+{
+
+/// Get the current logging directory.
+/**
+ * For more details of how the logging directory is determined,
+ * see rcl_logging_get_logging_directory().
+ *
+ * \returns the logging directory being used.
+ * \throws rclcpp::exceptions::RCLError if an unexpected error occurs.
+ */
+RCLCPP_PUBLIC
+std::filesystem::path
+get_log_directory();
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__LOG_DIRECTORY_HPP_

--- a/rclcpp/include/rclcpp/logger.hpp
+++ b/rclcpp/include/rclcpp/logger.hpp
@@ -15,7 +15,6 @@
 #ifndef RCLCPP__LOGGER_HPP_
 #define RCLCPP__LOGGER_HPP_
 
-#include <filesystem>
 #include <memory>
 #include <string>
 #include <utility>
@@ -76,18 +75,6 @@ get_logger(const std::string & name);
 RCLCPP_PUBLIC
 Logger
 get_node_logger(const rcl_node_t * node);
-
-/// Get the current logging directory.
-/**
- * For more details of how the logging directory is determined,
- * see rcl_logging_get_logging_directory().
- *
- * \returns the logging directory being used.
- * \throws rclcpp::exceptions::RCLError if an unexpected error occurs.
- */
-RCLCPP_PUBLIC
-std::filesystem::path
-get_log_directory();
 
 class Logger
 {

--- a/rclcpp/include/rclcpp/rclcpp.hpp
+++ b/rclcpp/include/rclcpp/rclcpp.hpp
@@ -115,6 +115,9 @@
  *   - rclcpp::Logger
  *   - rclcpp/logger.hpp
  *   - rclcpp::Node::get_logger()
+ * - Logging directory:
+ *   - rclcpp::get_log_directory()
+ *   - rclcpp/log_directory.hpp
  *
  * Finally, there are many internal API's and utilities:
  *

--- a/rclcpp/src/rclcpp/log_directory.cpp
+++ b/rclcpp/src/rclcpp/log_directory.cpp
@@ -1,0 +1,40 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <filesystem>
+#include <string>
+
+#include "rcl_logging_interface/rcl_logging_interface.h"
+
+#include "rclcpp/exceptions.hpp"
+#include "rclcpp/log_directory.hpp"
+
+namespace rclcpp
+{
+
+std::filesystem::path
+get_log_directory()
+{
+  char * log_dir = NULL;
+  auto allocator = rcutils_get_default_allocator();
+  rcl_logging_ret_t ret = rcl_logging_get_logging_directory(allocator, &log_dir);
+  if (RCL_LOGGING_RET_OK != ret) {
+    rclcpp::exceptions::throw_from_rcl_error(ret);
+  }
+  std::string path{log_dir};
+  allocator.deallocate(log_dir, allocator.state);
+  return path;
+}
+
+}  // namespace rclcpp

--- a/rclcpp/src/rclcpp/logger.cpp
+++ b/rclcpp/src/rclcpp/logger.cpp
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <filesystem>
 #include <memory>
 #include <string>
 #include <utility>
 
-#include "rcl_logging_interface/rcl_logging_interface.h"
 #include "rcl/error_handling.h"
 #include "rcl/logging_rosout.h"
 
@@ -53,20 +51,6 @@ get_node_logger(const rcl_node_t * node)
     return logger;
   }
   return rclcpp::get_logger(logger_name);
-}
-
-std::filesystem::path
-get_log_directory()
-{
-  char * log_dir = NULL;
-  auto allocator = rcutils_get_default_allocator();
-  rcl_logging_ret_t ret = rcl_logging_get_logging_directory(allocator, &log_dir);
-  if (RCL_LOGGING_RET_OK != ret) {
-    rclcpp::exceptions::throw_from_rcl_error(ret);
-  }
-  std::string path{log_dir};
-  allocator.deallocate(log_dir, allocator.state);
-  return path;
 }
 
 Logger

--- a/rclcpp/src/rclcpp/typesupport_helpers.cpp
+++ b/rclcpp/src/rclcpp/typesupport_helpers.cpp
@@ -16,6 +16,7 @@
 #include "rclcpp/typesupport_helpers.hpp"
 
 #include <algorithm>
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <sstream>

--- a/rclcpp/test/rclcpp/test_logger.cpp
+++ b/rclcpp/test/rclcpp/test_logger.cpp
@@ -20,6 +20,7 @@
 
 #include "rcutils/env.h"
 
+#include "rclcpp/log_directory.hpp"
 #include "rclcpp/logger.hpp"
 #include "rclcpp/logging.hpp"
 #include "rclcpp/node.hpp"


### PR DESCRIPTION
## Description

Move `get_log_directory` to another cpp file, then we can avoid to include `<filesystem>` with the `rlcpp/logger.cpp`. I can't see where this function is used in the core packages.

reduce almost 25 seconds

### Did you use Generative AI?

Claude Opus 4.7
