### PR TITLE
clarify difference between faliure and error : issue-3086

### DIFF
--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
@@ -55,16 +55,16 @@ protected:
 public:
   enum class CallbackReturn : uint8_t
   {
-    /// The callback completed successfully.
+     /// The callback completed successfully and the transition can proceed.
     SUCCESS = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS,
 
-    /// The callback completed, but the requested transition could not
-    /// be completed. The node returns to a stable lifecycle state.
+    /// The callback completed normally, but the requested transition
+    /// could not be completed.
     FAILURE = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE,
 
-    /// An unexpected error occurred. The node enters the
-    /// error-processing state.
-    ERROR = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR
+    /// An error occurred during callback execution.
+    /// The node transitions to an error handling state.
+    ERROR = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR,
   };
 
   /// Callback function for configure transition

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp
@@ -55,8 +55,15 @@ protected:
 public:
   enum class CallbackReturn : uint8_t
   {
+    /// The callback completed successfully.
     SUCCESS = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS,
+
+    /// The callback completed, but the requested transition could not
+    /// be completed. The node returns to a stable lifecycle state.
     FAILURE = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE,
+
+    /// An unexpected error occurred. The node enters the
+    /// error-processing state.
     ERROR = lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_ERROR
   };
 


### PR DESCRIPTION
## Description

Add documentation comments to `CallbackReturn` to make the distinction between
`SUCCESS`, `FAILURE`, and `ERROR` clearer for developers implementing lifecycle
callbacks.

The new comments explain that:

- `SUCCESS` indicates the callback completed successfully.
- `FAILURE` indicates the transition could not be completed and the node returns to a stable lifecycle state.
- `ERROR` indicates an unexpected error and the node enters the error-processing state.

Fixes #3086

### Is this user-facing behavior change?

No. This change only improves documentation and does not affect runtime behavior.

### Did you use Generative AI?

Yes. ChatGPT (GPT-5.5) was used to help refine the wording of the documentation comments and PR description. The lifecycle behavior and state transitions were investigated and verified manually from the source code before making the changes.

### Additional Information

This is my first contribution to Open Robotics. I spent some time tracing the lifecycle state machine to understand the difference between `FAILURE` and `ERROR` before updating the comments. I'd really appreciate any feedback on the wording or if there's a better way to document this distinction.