### PR TITLE
fix: prevent double-shutdown in rclcpp::Context

### DIFF
--- a/rclcpp/include/rclcpp/context.hpp
+++ b/rclcpp/include/rclcpp/context.hpp
@@ -19,6 +19,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <atomic>
 #include <string>
 #include <typeindex>
 #include <typeinfo>
@@ -365,6 +366,7 @@ private:
   std::shared_ptr<rcl_context_t> rcl_context_;
   rclcpp::InitOptions init_options_;
   std::string shutdown_reason_;
+  std::atomic<bool> is_shutting_down_{false};
 
   // Keep shared ownership of the global logging mutex.
   std::shared_ptr<std::recursive_mutex> logging_mutex_;

--- a/rclcpp/src/rclcpp/context.cpp
+++ b/rclcpp/src/rclcpp/context.cpp
@@ -299,6 +299,12 @@ Context::shutdown_reason() const
 bool
 Context::shutdown(const std::string & reason)
 {
+  // Prevent double-shutdown: the signal handler thread and the main thread
+  // may both call shutdown() during Ctrl-C.  Use an atomic flag to ensure
+  // only the first call proceeds; subsequent calls return immediately.
+  if (is_shutting_down_.exchange(true)) {
+    return false;
+  }
   // prevent races
   std::lock_guard<std::recursive_mutex> init_lock(init_mutex_);
   // ensure validity


### PR DESCRIPTION
## Description

The signal handler thread (deferred_signal_handler) and the main thread may both call Context::shutdown() during Ctrl-C, causing a double-free or heap corruption in the underlying rcl_context_t and glibc.

Add an atomic flag is_shutting_down_ to ensure only the first call to shutdown() proceeds; subsequent calls return immediately.

Steps to reproduce:
1. Launch any ROS 2 node with shutdown_on_signal=true
2. Press Ctrl-C
3. Observe SIGABRT in rclcpp::Context::shutdown() called from rclcpp::SignalHandler::deferred_signal_handler()

GDB backtrace from core dump:
  Thread 1: raise() -> abort()
    -> rclcpp::Context::shutdown()
    -> rclcpp::SignalHandler::deferred_signal_handler()


### Is this user-facing behavior change?



### Did you use Generative AI?

no
