### PR TITLE
Fix race condition when creating isolated component container

### DIFF
--- a/rclcpp_components/include/rclcpp_components/component_manager_isolated.hpp
+++ b/rclcpp_components/include/rclcpp_components/component_manager_isolated.hpp
@@ -102,7 +102,12 @@ protected:
     if constexpr (std::is_same_v<ExecutorT, rclcpp::executors::SingleThreadedExecutor>) {
       exec = std::make_shared<ExecutorT>(executor_options_);
     } else {
-      exec = std::make_shared<ExecutorT>(executor_options_, num_threads_);
+      // num_threads_ == 0 means "auto": read the `thread_num` parameter declared by
+      // ComponentManager (defaults to the hardware concurrency).
+      const size_t num_threads = num_threads_ != 0 ?
+        num_threads_ :
+        static_cast<size_t>(this->get_parameter("thread_num").as_int());
+      exec = std::make_shared<ExecutorT>(executor_options_, num_threads);
     }
     exec->add_node(node_wrappers_[node_id].get_node_base_interface());
 

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -143,12 +143,34 @@ int main(int argc, char * argv[])
   }
 
   std::shared_ptr<rclcpp::Executor> exec;
-  std::shared_ptr<rclcpp_components::ComponentManager> node =
-    std::make_shared<rclcpp_components::ComponentManager>();
+  std::shared_ptr<rclcpp_components::ComponentManager> node;
+
+  // Create the manager once, as its final type. The isolated managers resolve the
+  // `thread_num` parameter themselves when a component is loaded (0 == auto).
+  if (args.isolated) {
+    switch (args.executor_type) {
+      case ExecutorType::MultiThreaded:
+        node = std::make_shared<
+          rclcpp_components::ComponentManagerIsolated<rclcpp::executors::MultiThreadedExecutor>>(
+          rclcpp::ExecutorOptions(), 0);
+        break;
+      case ExecutorType::EventsCBG:
+        node = std::make_shared<
+          rclcpp_components::ComponentManagerIsolated<rclcpp::executors::EventsCBGExecutor>>(
+          rclcpp::ExecutorOptions(), 0);
+        break;
+      default:
+        node = std::make_shared<
+          rclcpp_components::ComponentManagerIsolated<rclcpp::executors::SingleThreadedExecutor>>();
+        break;
+    }
+  } else {
+    node = std::make_shared<rclcpp_components::ComponentManager>();
+  }
+
   const int64_t num_threads = (node->has_parameter("thread_num")) ?
     node->get_parameter("thread_num").as_int() :
     std::thread::hardware_concurrency();
-  std::string debug_msg;
 
   if (args.executor_type == ExecutorType::SingleThreaded &&
     num_threads > 0 &&
@@ -157,32 +179,12 @@ int main(int argc, char * argv[])
     RCUTILS_LOG_WARN_NAMED("component_container",
       "thread_num is not supported by the SingleThreadedExecutor. Ignoring...");
   }
+
+  std::string debug_msg;
   if (args.isolated) {
-    // we use the ComponentManager node initially to get the `thread_num` parameter,
-    // but temporarily delete it here before re-assigning it
-    // if running with a ComponentManagerIsolated.
-    // This is to avoid a possible race condition
-    // where the 2 nodes may be briefly alive at the same time,
-    node = nullptr;
     // The outer executor runs only the container manager's load/unload services.
     // Each loaded component gets its own dedicated executor of the requested type.
     exec = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-    switch (args.executor_type) {
-      case ExecutorType::MultiThreaded:
-        node = std::make_shared<
-          rclcpp_components::ComponentManagerIsolated<rclcpp::executors::MultiThreadedExecutor>>(
-          rclcpp::ExecutorOptions(), num_threads);
-        break;
-      case ExecutorType::EventsCBG:
-        node = std::make_shared<
-          rclcpp_components::ComponentManagerIsolated<rclcpp::executors::EventsCBGExecutor>>(
-          rclcpp::ExecutorOptions(), num_threads);
-        break;
-      default:
-        node = std::make_shared<
-          rclcpp_components::ComponentManagerIsolated<rclcpp::executors::SingleThreadedExecutor>>();
-        break;
-    }
 
     debug_msg = "Creating isolated component container with the following per-node settings: "
       "executor_type: " + executor_type_to_string(args.executor_type);

--- a/rclcpp_components/test/test_component_manager_api.cpp
+++ b/rclcpp_components/test/test_component_manager_api.cpp
@@ -23,6 +23,7 @@
 #include "composition_interfaces/srv/list_nodes.hpp"
 
 #include "rclcpp/executors/events_cbg_executor/events_cbg_executor.hpp"
+#include "rclcpp/executors/multi_threaded_executor.hpp"
 #include "rclcpp_components/component_manager.hpp"
 #include "rclcpp_components/component_manager_isolated.hpp"
 
@@ -419,4 +420,34 @@ TEST_F(TestComponentManager, no_throw_remove_node_twice_on_shutdown)
   // the executor removes all of its nodes on shutdown
   manager->remove_all_nodes_from_executor();
   EXPECT_NO_THROW(manager.reset());
+}
+
+// An isolated manager templated on a non-single-threaded executor and built
+// without an explicit thread count (num_threads_ == 0, "auto") must resolve the
+// `thread_num` parameter when loading a component instead of handing 0 to the
+// executor.
+TEST_F(TestComponentManager, isolated_multi_threaded_auto_thread_num)
+{
+  auto exec = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+  using IsolatedMultiThreaded =
+    rclcpp_components::ComponentManagerIsolated<rclcpp::executors::MultiThreadedExecutor>;
+  auto manager = std::make_shared<IsolatedMultiThreaded>(exec);
+  auto client_node = rclcpp::Node::make_shared("test_component_manager_isolated_mt");
+
+  exec->add_node(manager);
+  exec->add_node(client_node);
+
+  auto composition_client = client_node->create_client<composition_interfaces::srv::LoadNode>(
+    "/ComponentManager/_container/load_node");
+  ASSERT_TRUE(composition_client->wait_for_service(20s)) << "service not available after waiting";
+
+  auto request = std::make_shared<composition_interfaces::srv::LoadNode::Request>();
+  request->package_name = "rclcpp_components";
+  request->plugin_name = "test_rclcpp_components::TestComponentFoo";
+  auto future = composition_client->async_send_request(request);
+  ASSERT_EQ(exec->spin_until_future_complete(future, 5s), rclcpp::FutureReturnCode::SUCCESS);
+  auto result = future.get();
+  EXPECT_TRUE(result->success);
+  EXPECT_EQ(result->error_message, "");
+  EXPECT_EQ(result->full_node_name, "/test_component_foo");
 }


### PR DESCRIPTION
## Description

## Fix race condition when creating isolated component container

**What**

The isolated `component_container` created a throwaway `ComponentManager` solely to read the `thread_num` parameter, then destroyed it and re-created the real `ComponentManagerIsolated`. This briefly advertised the container's `~/_container/load_node` service and tore it down, racing `LoadComposableNodes` clients and silently dropping load requests.

**Changes**

- `component_container.cpp`: construct the manager **once**, directly as its final type. Isolated managers are now built with `num_threads == 0` ("auto").
- `component_manager_isolated.hpp`: in `add_node_to_executor`, `num_threads_ == 0` now resolves the `thread_num` parameter itself (defaults to hardware concurrency), so the container no longer needs to read it up front.
- Added a regression test (`isolated_multi_threaded_auto_thread_num`) covering the isolated multi-threaded "auto" path.

**Notes**

- ABI-safe: only an executable and an inline template method body change; `ComponentManager`'s layout is untouched.
- Behavior preserved, including `-p thread_num:=N` for isolated multi-threaded/events executors.
- Cleanly backportable to `lyrical` (identical baseline).

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #3222

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
