### PR TITLE
rclcpp_components: Fix compilation with clang

### DIFF
--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -201,7 +201,7 @@ int main(int argc, char * argv[])
     }
   }
 
-  RCUTILS_LOG_DEBUG_NAMED("component_container", debug_msg.c_str());
+  RCUTILS_LOG_DEBUG_NAMED("component_container", "%s", debug_msg.c_str());
 
   node->set_executor(exec);
   exec->add_node(node);


### PR DESCRIPTION
## Description

This fixes the following error reported by clang:

    /ros/rclcpp/rclcpp_components/src/component_container.cpp:204:50: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
      204 |   RCUTILS_LOG_DEBUG_NAMED("component_container", debug_msg.c_str());
          |                                                  ^~~~~~~~~~~~~~~~~
    /nix/store/2xvm1s7bkzj40vswqm9ihlfmq7bxb291-ros-env/include/rcutils/rcutils/logging_macros.h:352:55: note: expanded from macro 'RCUTILS_LOG_DEBUG_NAMED'
      352 |   RCUTILS_LOG_NAMED(RCUTILS_LOG_SEVERITY_DEBUG, name, __VA_ARGS__)
          |                                                       ^~~~~~~~~~~
    /nix/store/2xvm1s7bkzj40vswqm9ihlfmq7bxb291-ros-env/include/rcutils/rcutils/logging_macros.h:56:73: note: expanded from macro 'RCUTILS_LOG_NAMED'
       56 |       rcutils_log_internal(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
          |                                                                         ^~~~~~~~~~~
    /home/wsh/src/ros/rclcpp/rclcpp_components/src/component_container.cpp:204:50: note: treat the string as an argument to avoid this
      204 |   RCUTILS_LOG_DEBUG_NAMED("component_container", debug_msg.c_str());
          |                                                  ^
          |                                                  "%s",
    /nix/store/2xvm1s7bkzj40vswqm9ihlfmq7bxb291-ros-env/include/rcutils/rcutils/logging_macros.h:352:55: note: expanded from macro 'RCUTILS_LOG_DEBUG_NAMED'
      352 |   RCUTILS_LOG_NAMED(RCUTILS_LOG_SEVERITY_DEBUG, name, __VA_ARGS__)
          |                                                       ^
    /nix/store/2xvm1s7bkzj40vswqm9ihlfmq7bxb291-ros-env/include/rcutils/rcutils/logging_macros.h:56:73: note: expanded from macro 'RCUTILS_LOG_NAMED'
       56 |       rcutils_log_internal(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
          |                                                                         ^

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No
