### PR TITLE
Fix possible race condition with reentrant callback groups in EventsCBGExecutor scheduler

### DIFF
--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/scheduler.hpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/scheduler.hpp
@@ -230,11 +230,13 @@ private:
    */
   void callback_group_ready(CallbackGroupHandle *handle, bool callback_group_was_idle)
   {
-    if (!handle->in_queue) {
+    {
       std::lock_guard l(ready_callback_groups_mutex);
 
-      ready_callback_groups.push_back(handle);
-      handle->in_queue = true;
+      if (!handle->in_queue) {
+        ready_callback_groups.push_back(handle);
+        handle->in_queue = true;
+      }
     }
 
     if(callback_group_was_idle) {

--- a/rclcpp/src/rclcpp/executors/events_cbg_executor/scheduler.hpp
+++ b/rclcpp/src/rclcpp/executors/events_cbg_executor/scheduler.hpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 #pragma once
 
+#include <algorithm>
 #include <deque>
 #include <functional>
 #include <list>
@@ -214,8 +215,12 @@ private:
   void remove_callback_group(const CallbackGroupHandle *callback_handle)
   {
     std::lock_guard lk(ready_callback_groups_mutex);
-    ready_callback_groups.erase(std::find(ready_callback_groups.begin(),
-          ready_callback_groups.end(), callback_handle));
+
+    auto cbg_it = std::find(ready_callback_groups.begin(),
+          ready_callback_groups.end(), callback_handle);
+    if (cbg_it != ready_callback_groups.end()) {
+      ready_callback_groups.erase(cbg_it);
+    }
 
     callback_groups.remove_if([&callback_handle] (const auto & e) {
         return e.get() == callback_handle;


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
Since #3178, although the setting of `handle->in_queue = true` was protected under `ready_callback_groups_mutex`, the *read* is not. This makes the following races possible with more than one worker thread:

if `handle->in_queue` is loaded stale false while another thread enqueues it and marks `handle->in_queue = true`, a duplicate handle can be pushed. Removing the callback group or node from a running executor later on can lead to a possible use-after-free if checking for work on the remaining duplicate (dangling) callback handle.

In a more rare case, if the check for `handle->in_queue` is loaded stale true by the last worker thread to touch it, while another thread sets `handle->in_queue = false`, a reentrant CBG could have ready work but not be enqueued and stay permanently starved during the lifetime of the executor.

Fixed by ensuring that `handle->in_queue` is checked under `ready_callback_groups_mutex`.

Also adds a check in `remove_callback_group` so that it is only removed from `ready_callback_groups` if it was found in the queue. previously if it wasn't ready when being removed, `std::find` could return `ready_callback_groups.end()` and unconditionally erase that from `ready_callback_groups`, which is undefined behavior.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?
fixes the possibility of duplicate reentrant groups being pushed to the queue, or a push being skipped indefinitely if the last pending worker thread loads a stale `in_queue = true`

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
This came up as a possible race while running a large benchmark sweep, partially instrumented by Claude Opus 5 
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
