### PR TITLE
Fix lock order inversion between GraphListener and Context (ABI compatible backport)

### DIFF
--- a/rclcpp/src/rclcpp/graph_listener.cpp
+++ b/rclcpp/src/rclcpp/graph_listener.cpp
@@ -71,29 +71,50 @@ void GraphListener::init_wait_set()
 void
 GraphListener::start_if_not_started()
 {
-  std::lock_guard<std::mutex> shutdown_lock(shutdown_mutex_);
-  if (is_shutdown_.load()) {
-    throw GraphListenerShutdownError();
-  }
   auto parent_context = weak_parent_context_.lock();
-  if (!is_started_ && parent_context) {
-    // Register an on_shutdown hook to shtudown the graph listener.
-    // This is important to ensure that the wait set is finalized before
-    // destruction of static objects occurs.
-    std::weak_ptr<GraphListener> weak_this = shared_from_this();
-    parent_context->on_shutdown(
-      [weak_this]() {
-        auto shared_this = weak_this.lock();
-        if (shared_this) {
-          // should not throw from on_shutdown if it can be avoided
-          shared_this->shutdown(std::nothrow);
-        }
-      });
-    // Initialize the wait set before starting.
-    init_wait_set();
-    // Start the listener thread.
-    listener_thread_ = std::thread(&GraphListener::run, this);
-    is_started_ = true;
+  {
+    std::lock_guard<std::mutex> shutdown_lock(shutdown_mutex_);
+    if (is_shutdown_.load()) {
+      throw GraphListenerShutdownError();
+    }
+    if (is_started_ || !parent_context) {
+      return;
+    }
+  }
+  // Register an on_shutdown hook to shutdown the graph listener.
+  // This is important to ensure that the wait set is finalized before
+  // destruction of static objects occurs.
+  // The hook is deliberately registered without holding shutdown_mutex_:
+  // to prevent inverting the lock order with Context::shutdown()
+  std::weak_ptr<GraphListener> weak_this = shared_from_this();
+  auto callback_handle = parent_context->add_on_shutdown_callback(
+    [weak_this]() {
+      auto shared_this = weak_this.lock();
+      if (shared_this) {
+        // should not throw from on_shutdown if it can be avoided
+        shared_this->shutdown(std::nothrow);
+      }
+    });
+
+  bool started_on_this_thread = false;
+  {
+    std::lock_guard<std::mutex> shutdown_lock(shutdown_mutex_);
+    if (!is_shutdown_.load() && !is_started_) {
+      // Initialize the wait set before starting.
+      init_wait_set();
+      // Start the listener thread.
+      listener_thread_ = std::thread(&GraphListener::run, this);
+      is_started_ = true;
+      started_on_this_thread = true;
+    }
+  }
+  if (!started_on_this_thread) {
+    // Another thread has started the listener, or the listener was
+    // shut down between registration and the lock. Drop this registration.
+    parent_context->remove_on_shutdown_callback(callback_handle);
+    if (is_shutdown_.load()) {
+      throw GraphListenerShutdownError();
+    }
   }
 }
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
Avoids inverting lock order between `GraphListener::start_if_not_started()` and `Context::shutdown()` by registering the `on_shutdown_callback` *before* acquiring `shutdown_mutex_`. To avoid duplicate callback registration, a check has been added such that the shutdown callback is de-registered if this thread wasn't the one that started the graph listener (or, if shutting down, throw `GraphListenerShutdownError`.)

Tested against my jazzy container with my reproducing example from #2946. The diff ought to cleanly apply to kilted and humble as well.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes https://github.com/ros2/rclcpp/issues/2946 / https://github.com/ros2/rclcpp/issues/3232 for humble / jazzy / kilted

### Is this user-facing behavior change?
no
<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->


### Did you use Generative AI?
Claude Fable 5
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
