### PR TITLE
Check the notify waitable readiness even when the wait times out

### DIFF
--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -800,12 +800,17 @@ Executor::wait_for_work(std::chrono::nanoseconds timeout)
     RCUTILS_LOG_WARN_NAMED(
       "rclcpp",
       "empty wait set received in wait(). This should never happen.");
-  } else {
-    if (this->wait_result_->kind() == WaitResultKind::Ready && current_notify_waitable_) {
-      auto & rcl_wait_set = this->wait_result_->get_wait_set().get_rcl_wait_set();
-      if (current_notify_waitable_->is_ready(rcl_wait_set)) {
-        current_notify_waitable_->execute(current_notify_waitable_->take_data());
-      }
+  } else if (current_notify_waitable_) {
+    // Check the notify waitable even when the wait timed out: an rmw implementation
+    // may consume a guard condition trigger that races with the timeout while still
+    // reporting a timeout, and rcl leaves the corresponding ready slot in the wait
+    // set intact. Relying on the result kind alone would lose that notification
+    // permanently. See https://github.com/ros2/rclcpp/issues/3240.
+    // wait_set_ is used instead of wait_result_->get_wait_set() because the latter
+    // throws for non-Ready results.
+    auto & rcl_wait_set = wait_set_.get_rcl_wait_set();
+    if (current_notify_waitable_->is_ready(rcl_wait_set)) {
+      current_notify_waitable_->execute(current_notify_waitable_->take_data());
     }
   }
 }

--- a/rclcpp/test/rclcpp/test_executor.cpp
+++ b/rclcpp/test/rclcpp/test_executor.cpp
@@ -16,6 +16,7 @@
 
 #include <chrono>
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -50,6 +51,20 @@ public:
   void spin_nanoseconds(rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node)
   {
     spin_node_once_nanoseconds(node, std::chrono::milliseconds(100));
+  }
+
+  using rclcpp::Executor::wait_for_work;
+
+  rclcpp::WaitResultKind last_wait_result_kind()
+  {
+    std::lock_guard<std::mutex> guard(mutex_);
+    return wait_result_ ? wait_result_->kind() : rclcpp::WaitResultKind::Empty;
+  }
+
+  size_t collected_timers_count()
+  {
+    std::lock_guard<std::mutex> guard(mutex_);
+    return current_collection_.timers.size();
   }
 };
 
@@ -397,6 +412,38 @@ TEST_F(TestExecutor, spin_some_fail_wait) {
   RCLCPP_EXPECT_THROW_EQ(
     dummy.spin_some(std::chrono::milliseconds(1)),
     std::runtime_error("rcl_wait() failed: error not set"));
+}
+
+TEST_F(TestExecutor, wait_for_work_checks_notify_waitable_on_timeout) {
+  DummyExecutor dummy;
+  auto node = std::make_shared<rclcpp::Node>("node", "ns");
+  auto timer1 = node->create_wall_timer(std::chrono::seconds(60), [&]() {});
+  dummy.add_node(node);
+
+  // Drain pending notifications until a wait produces a clean timeout.
+  size_t attempts = 0;
+  do {
+    dummy.wait_for_work(std::chrono::milliseconds(0));
+    ASSERT_LT(++attempts, 100u);
+  } while (dummy.last_wait_result_kind() != rclcpp::WaitResultKind::Timeout);
+  ASSERT_EQ(1u, dummy.collected_timers_count());
+
+  // Adding a timer triggers the node's notify guard condition.
+  auto timer2 = node->create_wall_timer(std::chrono::seconds(60), [&]() {});
+
+  {
+    // Reproduce the race from https://github.com/ros2/rclcpp/issues/3240: the rmw
+    // layer consumes the trigger racing with a timeout, reports the timeout, and
+    // leaves the ready slots in the wait set intact.
+    auto mock = mocking_utils::patch_and_return("lib:rclcpp", rcl_wait, RCL_RET_TIMEOUT);
+    dummy.wait_for_work(std::chrono::milliseconds(0));
+    ASSERT_EQ(rclcpp::WaitResultKind::Timeout, dummy.last_wait_result_kind());
+  }
+
+  // The notification must have been recovered from the wait set despite the
+  // timeout, so the next wait rebuilds the collection and picks up the new timer.
+  dummy.wait_for_work(std::chrono::milliseconds(0));
+  EXPECT_EQ(2u, dummy.collected_timers_count());
 }
 
 TEST_F(TestExecutor, spin_until_future_complete_in_spin_until_future_complete) {


### PR DESCRIPTION
## Description

`Executor::wait_for_work()` runs the notify waitable only when the wait result kind is `Ready`. As described in the linked issue, rmw_fastrtps can consume a guard condition trigger that races with a wait timeout while still returning `RMW_RET_TIMEOUT`, and `rcl_wait()` leaves the corresponding ready slot in the wait set intact even on timeout. In that case the rebuild notification is lost permanently: entities that were dropped from the wait set while a mutually exclusive callback was executing never come back, and their timers stop firing forever.

This PR implements the fix suggested in https://github.com/ros2/rclcpp/issues/3240#issuecomment-5475869537: check `current_notify_waitable_->is_ready()` for timed-out results as well, so the notification recorded in the wait set arrays is recovered regardless of the reported result kind.

Implementation notes:

- `wait_result_->get_wait_set()` throws for non-`Ready` results, so the timeout path reads the executor's own `wait_set_` member instead. It is the same wait set the result came from.
- The race cannot be reproduced deterministically with a real rmw, so the regression test patches `rcl_wait` with mimick to return `RCL_RET_TIMEOUT` while leaving the ready slots intact, and then verifies that the entities collection is rebuilt (a timer added in the meantime gets collected). The test fails on current rolling and passes with this change.

Fixes #3240

### Is this user-facing behavior change?

No API change. Executors waiting with a finite timeout no longer lose collection rebuild notifications that race with the timeout, so entities dropped from the wait set during a mutually exclusive callback can no longer stay out of the wait set permanently.

### Did you use Generative AI?

Yes. Claude Code was used to implement the fix and the regression test, following the approach suggested by @fujitatomoya in the issue. The changes were reviewed and verified locally: the new test fails without the fix and passes with it, the full test_executor suite passes, and ament_uncrustify / ament_cpplint report no issues.

### Additional Information

A second, much narrower race exists inside the rmw_fastrtps cleanup loop and cannot be covered from rclcpp (the ready slot is already nulled when the trigger is consumed). It is being discussed in #3240.
