### PR TITLE
Fix retrieving std::vector<int> parameters

### DIFF
--- a/rclcpp/include/rclcpp/parameter_value.hpp
+++ b/rclcpp/include/rclcpp/parameter_value.hpp
@@ -305,10 +305,11 @@ public:
   constexpr
   typename std::enable_if<
     std::is_convertible<
-      type, const std::vector<int> &>::value, const std::vector<int64_t> &>::type
+      type, const std::vector<int> &>::value, std::vector<int>>::type
   get() const
   {
-    return get<ParameterType::PARAMETER_INTEGER_ARRAY>();
+    const auto & value = get<ParameterType::PARAMETER_INTEGER_ARRAY>();
+    return std::vector<int>(value.begin(), value.end());
   }
 
   template<typename type>

--- a/rclcpp/test/rclcpp/test_node.cpp
+++ b/rclcpp/test/rclcpp/test_node.cpp
@@ -2726,6 +2726,19 @@ TEST_F(TestNode, get_parameter_undeclared_parameters_not_allowed) {
   }
 }
 
+TEST_F(TestNode, get_parameter_with_vector_int) {
+  auto node = std::make_shared<rclcpp::Node>("test_get_parameter_node"_unq);
+  auto name = "parameter"_unq;
+  const std::vector<int> expected_value = {
+    42, -99, std::numeric_limits<int>::max(), std::numeric_limits<int>::lowest(), 0};
+
+  node->declare_parameter(name, expected_value);
+
+  std::vector<int> value;
+  EXPECT_TRUE(node->get_parameter(name, value));
+  EXPECT_EQ(expected_value, value);
+}
+
 // test get_parameter with undeclared allowed
 TEST_F(TestNode, get_parameter_undeclared_parameters_allowed) {
   auto node = std::make_shared<rclcpp::Node>(


### PR DESCRIPTION
Fixes #2577.

`ParameterValue` stores both `std::vector<int>` and `std::vector<int64_t>` as ROS integer arrays backed by `std::vector<int64_t>`. However, `ParameterValue::get<std::vector<int>>()` returned the internal `std::vector<int64_t>` value.

Consequently, the templated `Node::get_parameter()` overload could not assign the result to a `std::vector<int>` and failed to compile.

Convert the stored integer array back to `std::vector<int>` when that C++ type is explicitly requested. Retrieval as `std::vector<int64_t>` remains unchanged.

A regression test covers `Node::get_parameter(name, std::vector<int> &)`, including the minimum and maximum `int` values.