### PR TITLE
Add const to ServiceBase::get_service_name

### DIFF
--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -60,7 +60,7 @@ public:
   /** \return The name of the service. */
   RCLCPP_PUBLIC
   const char *
-  get_service_name();
+  get_service_name() const;
 
   /// Return the rcl_service_t service handle in a std::shared_ptr.
   /**

--- a/rclcpp/src/rclcpp/service.cpp
+++ b/rclcpp/src/rclcpp/service.cpp
@@ -54,7 +54,7 @@ ServiceBase::take_type_erased_request(void * request_out, rmw_request_id_t & req
 }
 
 const char *
-ServiceBase::get_service_name()
+ServiceBase::get_service_name() const
 {
   return rcl_service_get_service_name(this->get_service_handle().get());
 }


### PR DESCRIPTION
## Description

`ServiceBase::get_service_name` was not marked const, but I see no reason for it not to be.
(`ClientBase::get_service_name` is already const.)

### Is this user-facing behavior change?

Yes, it allows calling the function in more contexts.

### Did you use Generative AI?

No